### PR TITLE
k256: fix typo in crate name

### DIFF
--- a/k256/README.md
+++ b/k256/README.md
@@ -1,4 +1,4 @@
-# RustCrypto seck256k1 crate
+# RustCrypto secp256k1 crate
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]


### PR DESCRIPTION
It was previously "seck256k1" instead of secp256k1.