### PR TITLE
k256 v0.1.1

### DIFF
--- a/k256/CHANGES.md
+++ b/k256/CHANGES.md
@@ -4,5 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2020-04-20)
+- README.md: fix typo in crate name ([#16])
+
+[#16]: https://github.com/RustCrypto/elliptic-curves/pull/16
+
 ## 0.1.0 (2020-01-15)
 - Initial release

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "k256"
 description = "secp256k1 elliptic curve"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"


### PR DESCRIPTION
- README.md: fix typo in crate name ([#16])

[#16]: https://github.com/RustCrypto/elliptic-curve/pull/16