### PR TITLE
k256: update categories and keywords

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -8,8 +8,8 @@ documentation = "https://docs.rs/elliptic-curve"
 repository = "https://github.com/RustCrypto/elliptic-curves/tree/master/k256"
 readme = "README.md"
 edition = "2018"
-categories = ["cryptography", "no-std"]
-keywords = ["crypto", "ecc", "nist"]
+categories = ["cryptography", "cryptography::cryptocurrencies", "no-std"]
+keywords = ["bitcoin", "crypto", "ecc", "ethereum"]
 
 [dependencies.elliptic-curve]
 version = "0.3"


### PR DESCRIPTION
- Removes "nist" keyword (copypasta from the `p256`/`p384`/`p521` crates)
- Adds `cryptography::cryptocurrencies` category
- Adds `bitcoin` and `ethereum` keywords