### PR TITLE
p256/k256: prep for 2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # RustCrypto: Elliptic Curves
 
 [![Build Status][build-image]][build-link]
-[![Dependency Status][deps-image]][deps-link]
 ![Rust Version][rustc-image]
 
 General purpose Elliptic Curve Cryptography (ECC) support, including types
@@ -50,8 +49,6 @@ dual licensed as above, without any additional terms or conditions.
 
 [build-image]: https://travis-ci.com/RustCrypto/elliptic-curves.svg?branch=master
 [build-link]: https://travis-ci.com/RustCrypto/elliptic-curves
-[deps-image]: https://deps.rs/repo/github/RustCrypto/elliptic-curves/status.svg
-[deps-link]: https://deps.rs/repo/github/RustCrypto/elliptic-curves
 [rustc-image]: https://img.shields.io/badge/rustc-1.37+-blue.svg
 
 [//]: # (crates)

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -35,3 +35,4 @@ std = ["elliptic-curve/std"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -1,9 +1,4 @@
 //! A pure-Rust implementation of group operations on secp256k1.
-//!
-//! # Status
-//!
-//! Currently, no actual group operations are implemented. Only point compression and
-//! decompression is supported.
 
 mod field;
 mod scalar;
@@ -11,6 +6,8 @@ mod util;
 
 #[cfg(any(feature = "test-vectors", test))]
 pub mod test_vectors;
+
+pub use self::scalar::Scalar;
 
 use core::convert::TryInto;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
@@ -332,7 +329,7 @@ impl ProjectivePoint {
     }
 
     /// Returns `[k] self`.
-    fn mul(&self, k: &scalar::Scalar) -> ProjectivePoint {
+    fn mul(&self, k: &Scalar) -> ProjectivePoint {
         let mut ret = ProjectivePoint::identity();
 
         for limb in k.0.iter().rev() {
@@ -446,30 +443,30 @@ impl SubAssign<AffinePoint> for ProjectivePoint {
     }
 }
 
-impl Mul<&scalar::Scalar> for &ProjectivePoint {
+impl Mul<&Scalar> for &ProjectivePoint {
     type Output = ProjectivePoint;
 
-    fn mul(self, other: &scalar::Scalar) -> ProjectivePoint {
+    fn mul(self, other: &Scalar) -> ProjectivePoint {
         ProjectivePoint::mul(self, other)
     }
 }
 
-impl Mul<&scalar::Scalar> for ProjectivePoint {
+impl Mul<&Scalar> for ProjectivePoint {
     type Output = ProjectivePoint;
 
-    fn mul(self, other: &scalar::Scalar) -> ProjectivePoint {
+    fn mul(self, other: &Scalar) -> ProjectivePoint {
         ProjectivePoint::mul(&self, other)
     }
 }
 
-impl MulAssign<scalar::Scalar> for ProjectivePoint {
-    fn mul_assign(&mut self, rhs: scalar::Scalar) {
+impl MulAssign<Scalar> for ProjectivePoint {
+    fn mul_assign(&mut self, rhs: Scalar) {
         *self = ProjectivePoint::mul(self, &rhs);
     }
 }
 
-impl MulAssign<&scalar::Scalar> for ProjectivePoint {
-    fn mul_assign(&mut self, rhs: &scalar::Scalar) {
+impl MulAssign<&Scalar> for ProjectivePoint {
+    fn mul_assign(&mut self, rhs: &Scalar) {
         *self = ProjectivePoint::mul(self, rhs);
     }
 }
@@ -494,7 +491,7 @@ impl<'a> Neg for &'a ProjectivePoint {
 mod tests {
     use core::convert::TryInto;
 
-    use super::{scalar::Scalar, AffinePoint, ProjectivePoint, CURVE_EQUATION_B};
+    use super::{AffinePoint, ProjectivePoint, Scalar, CURVE_EQUATION_B};
     use crate::{
         arithmetic::test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
         PublicKey,

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -2,17 +2,19 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.34** or higher.
+//! Rust **1.37** or higher.
 //!
 //! Minimum supported Rust version can be changed in the future, but it will be
 //! done with a minor version bump.
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 
 #[cfg(feature = "arithmetic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub mod arithmetic;
 
 pub use elliptic_curve;

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -34,3 +34,4 @@ std = ["elliptic-curve/std"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -1,13 +1,4 @@
 //! A pure-Rust implementation of group operations on secp256r1.
-//!
-//! # Status
-//!
-//! Implemented:
-//! - Compression and decompression.
-//! - Addition and subtraction.
-//!
-//! Not yet implemented:
-//! - Scalar multiplication.
 
 mod field;
 mod scalar;
@@ -15,6 +6,8 @@ mod util;
 
 #[cfg(any(feature = "test-vectors", test))]
 pub mod test_vectors;
+
+pub use self::scalar::Scalar;
 
 use core::convert::TryInto;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
@@ -346,7 +339,7 @@ impl ProjectivePoint {
     }
 
     /// Returns `[k] self`.
-    fn mul(&self, k: &scalar::Scalar) -> ProjectivePoint {
+    fn mul(&self, k: &Scalar) -> ProjectivePoint {
         let mut ret = ProjectivePoint::identity();
 
         for limb in k.0.iter().rev() {
@@ -460,30 +453,30 @@ impl SubAssign<AffinePoint> for ProjectivePoint {
     }
 }
 
-impl Mul<&scalar::Scalar> for &ProjectivePoint {
+impl Mul<&Scalar> for &ProjectivePoint {
     type Output = ProjectivePoint;
 
-    fn mul(self, other: &scalar::Scalar) -> ProjectivePoint {
+    fn mul(self, other: &Scalar) -> ProjectivePoint {
         ProjectivePoint::mul(self, other)
     }
 }
 
-impl Mul<&scalar::Scalar> for ProjectivePoint {
+impl Mul<&Scalar> for ProjectivePoint {
     type Output = ProjectivePoint;
 
-    fn mul(self, other: &scalar::Scalar) -> ProjectivePoint {
+    fn mul(self, other: &Scalar) -> ProjectivePoint {
         ProjectivePoint::mul(&self, other)
     }
 }
 
-impl MulAssign<scalar::Scalar> for ProjectivePoint {
-    fn mul_assign(&mut self, rhs: scalar::Scalar) {
+impl MulAssign<Scalar> for ProjectivePoint {
+    fn mul_assign(&mut self, rhs: Scalar) {
         *self = ProjectivePoint::mul(self, &rhs);
     }
 }
 
-impl MulAssign<&scalar::Scalar> for ProjectivePoint {
-    fn mul_assign(&mut self, rhs: &scalar::Scalar) {
+impl MulAssign<&Scalar> for ProjectivePoint {
+    fn mul_assign(&mut self, rhs: &Scalar) {
         *self = ProjectivePoint::mul(self, rhs);
     }
 }
@@ -508,7 +501,7 @@ impl<'a> Neg for &'a ProjectivePoint {
 mod tests {
     use core::convert::TryInto;
 
-    use super::{scalar::Scalar, AffinePoint, ProjectivePoint, CURVE_EQUATION_A, CURVE_EQUATION_B};
+    use super::{AffinePoint, ProjectivePoint, Scalar, CURVE_EQUATION_A, CURVE_EQUATION_B};
     use crate::{
         arithmetic::test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
         PublicKey,

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -2,17 +2,19 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.34** or higher.
+//! Rust **1.37** or higher.
 //!
 //! Minimum supported Rust version can be changed in the future, but it will be
 //! done with a minor version bump.
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 
 #[cfg(feature = "arithmetic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub mod arithmetic;
 
 pub use elliptic_curve;


### PR DESCRIPTION
- Make `Scalar` types a `pub` export
- Adds docs.rs config for `arithmetic` feature gating
- Remove obsolete comments about arithmetic status
- Remove broken deps.rs badge
- Update MSRV to 1.37