### PR TITLE
Cargo.toml(s): remove copypasta comment

### DIFF
--- a/p256/CHANGES.md
+++ b/p256/CHANGES.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.2.0 (2020-04-30)
-## Added
+### Added
 - Constant time scalar multiplication ([#18])
 - Group operation ([#15])
 

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p256"
 description = "NIST P-256 elliptic curve"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p384"
 description = "NIST P-384 elliptic curve"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p521"
 description = "NIST P-521 elliptic curve"
-version = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.0.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"


### PR DESCRIPTION
These crats don't actually link directly to the corresponding version of their own documentation, so these comments are irrelevant.