### PR TITLE
elliptic-curve v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "generic-array",
  "getrandom",

--- a/elliptic-curve-crate/CHANGES.md
+++ b/elliptic-curve-crate/CHANGES.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-06-04)
+### Changed
+- Bump `generic-array` dependency from v0.12 to v0.14 ([#38])
+
+[#38]: https://github.com/RustCrypto/elliptic-curves/pull/38
+
 ## 0.3.0 (2020-01-15)
 ### Added
 - `Scalar` struct type ([#5])

--- a/elliptic-curve-crate/Cargo.toml
+++ b/elliptic-curve-crate/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version       = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/elliptic-curve-crate/src/lib.rs
+++ b/elliptic-curve-crate/src/lib.rs
@@ -14,7 +14,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/elliptic-curve/0.3.0"
+    html_root_url = "https://docs.rs/elliptic-curve/0.4.0"
 )]
 
 #[cfg(feature = "std")]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "cryptography::cryptocurrencies", "no-std"]
 keywords = ["bitcoin", "crypto", "ecc", "ethereum"]
 
 [dependencies.elliptic-curve]
-version = "0.3"
+version = "0.4"
 path = "../elliptic-curve-crate"
 default-features = false
 features = ["weierstrass"]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist"]
 
 [dependencies.elliptic-curve]
-version = "0.3"
+version = "0.4"
 path = "../elliptic-curve-crate"
 default-features = false
 features = ["weierstrass"]

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist"]
 
 [dependencies.elliptic-curve]
-version = "0.3"
+version = "0.4"
 path = "../elliptic-curve-crate"
 default-features = false
 features = ["weierstrass"]

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist"]
 
 [dependencies.elliptic-curve]
-version = "0.3"
+version = "0.4"
 path = "../elliptic-curve-crate"
 default-features = false
 features = ["weierstrass"]


### PR DESCRIPTION
### Changed
- Bump `generic-array` dependency from v0.12 to v0.14 ([#38])

[#38]: https://github.com/RustCrypto/elliptic-curves/pull/38