### PR TITLE
k256 v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "k256"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "elliptic-curve",
  "fiat-crypto",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-06-08)
+### Changed
+- Bump `elliptic-curve` crate dependency to v0.4 ([#39])
+
+[#39]: https://github.com/RustCrypto/elliptic-curves/pull/39
+
 ## 0.2.0 (2020-04-30)
 ### Added
 - Field arithmetic, point addition/doubling, and scalar multiplication ([#19])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "k256"
 description = "secp256k1 elliptic curve"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"


### PR DESCRIPTION
### Changed
- Bump `elliptic-curve` crate dependency to v0.4 ([#39])

[#39]: https://github.com/RustCrypto/elliptic-curves/pull/39