### PR TITLE
p384 v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "elliptic-curve",
 ]

--- a/p384/CHANGELOG.md
+++ b/p384/CHANGELOG.md
@@ -4,5 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2020-06-08)
+### Changed
+- Bump `elliptic-curve` crate dependency to v0.4 ([#39])
+
+[#39]: https://github.com/RustCrypto/elliptic-curves/pull/39
+
 ## 0.1.0 (2020-01-15)
 - Initial release

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p384"
 description = "NIST P-384 elliptic curve"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"


### PR DESCRIPTION
### Changed
- Bump `elliptic-curve` crate dependency to v0.4 ([#39])

[#39]: https://github.com/RustCrypto/elliptic-curves/pull/39