### PR TITLE
README.md: add links to individual curves

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ easily used for bare-metal or WebAssembly programming.
 
 ## Crates
 
-| Name     | Curve      | `arithmetic`? | Crates.io | Documentation | Build |
-|----------|------------|---------------|-----------|---------------|-------|
-| [`k256`] | [secp256k1](https://en.bitcoin.it/wiki/Secp256k1) | ✅ | [![crates.io](https://img.shields.io/crates/v/k256.svg)](https://crates.io/crates/k256) | [![Documentation](https://docs.rs/k256/badge.svg)](https://docs.rs/k256) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/k256/badge.svg?branch=master&event=push) |
-| [`p256`] | NIST P-256 | ✅ | [![crates.io](https://img.shields.io/crates/v/p256.svg)](https://crates.io/crates/p256) | [![Documentation](https://docs.rs/p256/badge.svg)](https://docs.rs/p256) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/p256/badge.svg?branch=master&event=push) |
-| [`p384`] | NIST P-384 | 🚫 | [![crates.io](https://img.shields.io/crates/v/p384.svg)](https://crates.io/crates/p384) | [![Documentation](https://docs.rs/p384/badge.svg)](https://docs.rs/p384) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/p384/badge.svg?branch=master&event=push) |
-| [`p521`] | NIST P-521 | 🚫 | [![crates.io](https://img.shields.io/crates/v/p521.svg)](https://crates.io/crates/p521) | [![Documentation](https://docs.rs/p521/badge.svg)](https://docs.rs/p521) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/p521/badge.svg?branch=master&event=push) |
+| Name     | Curve        | `arithmetic`? | Crates.io | Documentation | Build Status |
+|----------|--------------|---------------|-----------|---------------|--------------|
+| [`k256`] | [secp256k1]  | ✅ | [![crates.io](https://img.shields.io/crates/v/k256.svg)](https://crates.io/crates/k256) | [![Documentation](https://docs.rs/k256/badge.svg)](https://docs.rs/k256) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/k256/badge.svg?branch=master&event=push) |
+| [`p256`] | [NIST P-256] | ✅ | [![crates.io](https://img.shields.io/crates/v/p256.svg)](https://crates.io/crates/p256) | [![Documentation](https://docs.rs/p256/badge.svg)](https://docs.rs/p256) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/p256/badge.svg?branch=master&event=push) |
+| [`p384`] | [NIST P-384] | 🚫 | [![crates.io](https://img.shields.io/crates/v/p384.svg)](https://crates.io/crates/p384) | [![Documentation](https://docs.rs/p384/badge.svg)](https://docs.rs/p384) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/p384/badge.svg?branch=master&event=push) |
+| [`p521`] | [NIST P-521] | 🚫 | [![crates.io](https://img.shields.io/crates/v/p521.svg)](https://crates.io/crates/p521) | [![Documentation](https://docs.rs/p521/badge.svg)](https://docs.rs/p521) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/p521/badge.svg?branch=master&event=push) |
 
 NOTE: Some crates contain field/point arithmetic implementations gated under the
 `arithmetic` cargo feature as noted above.
@@ -58,6 +58,13 @@ dual licensed as above, without any additional terms or conditions.
 [`p256`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p256
 [`p384`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p384
 [`p521`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p521
+
+[//]: # (curves)
+
+[secp256k1]: https://en.bitcoin.it/wiki/Secp256k1
+[NIST P-256]: http://oid-info.com/get/1.2.840.10045.3.1.7
+[NIST P-384]: http://oid-info.com/get/1.3.132.0.34
+[NIST P-521]: http://oid-info.com/get/1.3.132.0.35
 
 [//]: # (general links)
 


### PR DESCRIPTION
Unfortunately there don't seem to be good pure-curve resources (even with anchors!) for the NIST curves as they're largely documented in standards documents published as PDFs.

This links to http://oid-info.com (which sadly doesn't support https://) which contains some information about each curve, including the curve's OIDs and where it's standardized (e.g. ANSI, IEEE, SECG, RFC).

Lacking other options, it might make sense to eventually make some pages on https://github.com/RustCrypto/elliptic-curves/wiki which contain the same information, but served over https://