### PR TITLE
k256/p256/p384: add curve point type aliases

### DIFF
--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -14,8 +14,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use elliptic_curve::generic_array::GenericArray;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
-use super::{PublicKey, Secp256k1};
-use elliptic_curve::weierstrass::{CompressedCurvePoint, UncompressedCurvePoint};
+use crate::{CompressedCurvePoint, PublicKey, UncompressedCurvePoint};
 use field::{FieldElement, MODULUS};
 
 /// b = 7 in Montgomery form (aR mod p, where R = 2**256.
@@ -126,7 +125,7 @@ impl AffinePoint {
     }
 
     /// Returns the SEC-1 compressed encoding of this point.
-    pub fn to_compressed_pubkey(&self) -> CompressedCurvePoint<Secp256k1> {
+    pub fn to_compressed_pubkey(&self) -> CompressedCurvePoint {
         let mut encoded = [0; 33];
         encoded[0] = if self.y.is_odd().into() { 0x03 } else { 0x02 };
         encoded[1..33].copy_from_slice(&self.x.to_bytes());
@@ -136,7 +135,7 @@ impl AffinePoint {
     }
 
     /// Returns the SEC-1 uncompressed encoding of this point.
-    pub fn to_uncompressed_pubkey(&self) -> UncompressedCurvePoint<Secp256k1> {
+    pub fn to_uncompressed_pubkey(&self) -> UncompressedCurvePoint {
         let mut encoded = [0; 65];
         encoded[0] = 0x04;
         encoded[1..33].copy_from_slice(&self.x.to_bytes());

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -40,8 +40,14 @@ impl Curve for Secp256k1 {
     type ScalarSize = U32;
 }
 
-/// secp256k1 secret keys
-pub type SecretKey = elliptic_curve::SecretKey<<Secp256k1 as Curve>::ScalarSize>;
+/// K-256 (secp256k1) Secret Key
+pub type SecretKey = elliptic_curve::SecretKey<U32>;
 
-/// secp256k1 public keys
+/// K-256 (secp256k1) Public Key
 pub type PublicKey = elliptic_curve::weierstrass::PublicKey<Secp256k1>;
+
+/// K-256 Compressed Curve Point
+pub type CompressedCurvePoint = elliptic_curve::weierstrass::CompressedCurvePoint<Secp256k1>;
+
+/// K-256 Uncompressed Curve Point
+pub type UncompressedCurvePoint = elliptic_curve::weierstrass::UncompressedCurvePoint<Secp256k1>;

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -14,8 +14,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use elliptic_curve::generic_array::GenericArray;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
-use super::{NistP256, PublicKey};
-use elliptic_curve::weierstrass::{CompressedCurvePoint, UncompressedCurvePoint};
+use crate::{CompressedCurvePoint, PublicKey, UncompressedCurvePoint};
 use field::{FieldElement, MODULUS};
 
 /// a = -3
@@ -132,7 +131,7 @@ impl AffinePoint {
     }
 
     /// Returns the SEC-1 compressed encoding of this point.
-    pub fn to_compressed_pubkey(&self) -> CompressedCurvePoint<NistP256> {
+    pub fn to_compressed_pubkey(&self) -> CompressedCurvePoint {
         let mut encoded = [0; 33];
         encoded[0] = if self.y.is_odd().into() { 0x03 } else { 0x02 };
         encoded[1..33].copy_from_slice(&self.x.to_bytes());
@@ -142,7 +141,7 @@ impl AffinePoint {
     }
 
     /// Returns the SEC-1 uncompressed encoding of this point.
-    pub fn to_uncompressed_pubkey(&self) -> UncompressedCurvePoint<NistP256> {
+    pub fn to_uncompressed_pubkey(&self) -> UncompressedCurvePoint {
         let mut encoded = [0; 65];
         encoded[0] = 0x04;
         encoded[1..33].copy_from_slice(&self.x.to_bytes());

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -48,8 +48,14 @@ impl Curve for NistP256 {
     type ScalarSize = U32;
 }
 
-/// NIST P-256 secret keys
-pub type SecretKey = elliptic_curve::SecretKey<<NistP256 as Curve>::ScalarSize>;
+/// NIST P-256 Secret Key
+pub type SecretKey = elliptic_curve::SecretKey<U32>;
 
-/// NIST P-256 public keys
+/// NIST P-256 Public Key
 pub type PublicKey = elliptic_curve::weierstrass::PublicKey<NistP256>;
+
+/// NIST P-256 Compressed Curve Point
+pub type CompressedCurvePoint = elliptic_curve::weierstrass::CompressedCurvePoint<NistP256>;
+
+/// NIST P-256 Uncompressed Curve Point
+pub type UncompressedCurvePoint = elliptic_curve::weierstrass::UncompressedCurvePoint<NistP256>;

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -44,8 +44,14 @@ impl Curve for NistP384 {
     type ScalarSize = U48;
 }
 
-/// NIST P-384 secret keys
-pub type SecretKey = elliptic_curve::SecretKey<<NistP384 as Curve>::ScalarSize>;
+/// NIST P-384 Secret Key
+pub type SecretKey = elliptic_curve::SecretKey<U48>;
 
-/// NIST P-384 public keys
+/// NIST P-384 Public Key
 pub type PublicKey = elliptic_curve::weierstrass::PublicKey<NistP384>;
+
+/// NIST P-384 Compressed Curve Point
+pub type CompressedCurvePoint = elliptic_curve::weierstrass::CompressedCurvePoint<NistP384>;
+
+/// NIST P-384 Uncompressed Curve Point
+pub type UncompressedCurvePoint = elliptic_curve::weierstrass::UncompressedCurvePoint<NistP384>;


### PR DESCRIPTION
Adds `CompressedCurvePoint` and `UncompressedCurvePoint` type aliases to each crate, which helps simplify the type signatures.