### PR TITLE
Drop `*Curve*` from CompressedPoint/UncompressedPoint

### DIFF
--- a/elliptic-curve-crate/src/weierstrass.rs
+++ b/elliptic-curve-crate/src/weierstrass.rs
@@ -5,7 +5,5 @@ pub mod point;
 pub mod public_key;
 
 pub use curve::{Curve, ScalarBytes};
-pub use point::{
-    CompressedCurvePoint, CompressedPointSize, UncompressedCurvePoint, UncompressedPointSize,
-};
+pub use point::{CompressedPoint, CompressedPointSize, UncompressedPoint, UncompressedPointSize};
 pub use public_key::PublicKey;

--- a/elliptic-curve-crate/src/weierstrass/point.rs
+++ b/elliptic-curve-crate/src/weierstrass/point.rs
@@ -27,7 +27,7 @@ pub type UncompressedPointSize<ScalarSize> = <<ScalarSize as Add>::Output as Add
 ///
 /// <https://www.secg.org/sec1-v2.pdf>
 #[derive(Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct CompressedCurvePoint<C: Curve>
+pub struct CompressedPoint<C: Curve>
 where
     CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
 {
@@ -35,7 +35,7 @@ where
     bytes: GenericArray<u8, CompressedPointSize<C::ScalarSize>>,
 }
 
-impl<C: Curve> CompressedCurvePoint<C>
+impl<C: Curve> CompressedPoint<C>
 where
     CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
 {
@@ -67,7 +67,7 @@ where
     }
 }
 
-impl<C: Curve> AsRef<[u8]> for CompressedCurvePoint<C>
+impl<C: Curve> AsRef<[u8]> for CompressedPoint<C>
 where
     CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
 {
@@ -77,14 +77,14 @@ where
     }
 }
 
-impl<C: Curve> Copy for CompressedCurvePoint<C>
+impl<C: Curve> Copy for CompressedPoint<C>
 where
     CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
     <CompressedPointSize<C::ScalarSize> as ArrayLength<u8>>::ArrayType: Copy,
 {
 }
 
-impl<C: Curve> Clone for CompressedCurvePoint<C>
+impl<C: Curve> Clone for CompressedPoint<C>
 where
     CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
 {
@@ -100,7 +100,7 @@ where
 ///
 /// <https://www.secg.org/sec1-v2.pdf>
 #[derive(Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct UncompressedCurvePoint<C: Curve>
+pub struct UncompressedPoint<C: Curve>
 where
     <C::ScalarSize as Add>::Output: Add<U1>,
     UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
@@ -109,7 +109,7 @@ where
     bytes: GenericArray<u8, UncompressedPointSize<C::ScalarSize>>,
 }
 
-impl<C: Curve> UncompressedCurvePoint<C>
+impl<C: Curve> UncompressedPoint<C>
 where
     <C::ScalarSize as Add>::Output: Add<U1>,
     UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
@@ -141,7 +141,7 @@ where
     }
 }
 
-impl<C: Curve> AsRef<[u8]> for UncompressedCurvePoint<C>
+impl<C: Curve> AsRef<[u8]> for UncompressedPoint<C>
 where
     <C::ScalarSize as Add>::Output: Add<U1>,
     UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
@@ -152,7 +152,7 @@ where
     }
 }
 
-impl<C: Curve> Copy for UncompressedCurvePoint<C>
+impl<C: Curve> Copy for UncompressedPoint<C>
 where
     <C::ScalarSize as Add>::Output: Add<U1>,
     UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
@@ -160,7 +160,7 @@ where
 {
 }
 
-impl<C: Curve> Clone for UncompressedCurvePoint<C>
+impl<C: Curve> Clone for UncompressedPoint<C>
 where
     <C::ScalarSize as Add>::Output: Add<U1>,
     UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,

--- a/elliptic-curve-crate/src/weierstrass/public_key.rs
+++ b/elliptic-curve-crate/src/weierstrass/public_key.rs
@@ -2,7 +2,7 @@
 //! uncompressed elliptic curve points.
 
 use super::point::{
-    CompressedCurvePoint, CompressedPointSize, UncompressedCurvePoint, UncompressedPointSize,
+    CompressedPoint, CompressedPointSize, UncompressedPoint, UncompressedPointSize,
 };
 use super::Curve;
 use core::fmt::{self, Debug};
@@ -25,10 +25,10 @@ where
     UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
 {
     /// Compressed Weierstrass elliptic curve point
-    Compressed(CompressedCurvePoint<C>),
+    Compressed(CompressedPoint<C>),
 
     /// Uncompressed Weierstrass elliptic curve point
-    Uncompressed(UncompressedCurvePoint<C>),
+    Uncompressed(UncompressedPoint<C>),
 }
 
 impl<C: Curve> PublicKey<C>
@@ -50,11 +50,11 @@ where
 
         if length == <CompressedPointSize<C::ScalarSize>>::to_usize() {
             let array = GenericArray::clone_from_slice(slice);
-            let point = CompressedCurvePoint::from_bytes(array)?;
+            let point = CompressedPoint::from_bytes(array)?;
             Some(PublicKey::Compressed(point))
         } else if length == <UncompressedPointSize<C::ScalarSize>>::to_usize() {
             let array = GenericArray::clone_from_slice(slice);
-            let point = UncompressedCurvePoint::from_bytes(array)?;
+            let point = UncompressedPoint::from_bytes(array)?;
             Some(PublicKey::Uncompressed(point))
         } else {
             None
@@ -71,7 +71,7 @@ where
     where
         B: Into<GenericArray<u8, CompressedPointSize<C::ScalarSize>>>,
     {
-        CompressedCurvePoint::from_bytes(into_bytes).map(PublicKey::Compressed)
+        CompressedPoint::from_bytes(into_bytes).map(PublicKey::Compressed)
     }
 
     /// Decode public key from a raw uncompressed point serialized
@@ -88,7 +88,7 @@ where
         tagged_bytes.as_mut_slice()[0] = 0x04;
         tagged_bytes.as_mut_slice()[1..].copy_from_slice(bytes.as_ref());
 
-        PublicKey::Uncompressed(UncompressedCurvePoint::from_bytes(tagged_bytes).unwrap())
+        PublicKey::Uncompressed(UncompressedPoint::from_bytes(tagged_bytes).unwrap())
     }
 
     /// Obtain public key as a byte array reference
@@ -134,24 +134,24 @@ where
     }
 }
 
-impl<C: Curve> From<CompressedCurvePoint<C>> for PublicKey<C>
+impl<C: Curve> From<CompressedPoint<C>> for PublicKey<C>
 where
     <C::ScalarSize as Add>::Output: Add<U1>,
     CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
     UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
 {
-    fn from(point: CompressedCurvePoint<C>) -> Self {
+    fn from(point: CompressedPoint<C>) -> Self {
         PublicKey::Compressed(point)
     }
 }
 
-impl<C: Curve> From<UncompressedCurvePoint<C>> for PublicKey<C>
+impl<C: Curve> From<UncompressedPoint<C>> for PublicKey<C>
 where
     <C::ScalarSize as Add>::Output: Add<U1>,
     CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
     UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
 {
-    fn from(point: UncompressedCurvePoint<C>) -> Self {
+    fn from(point: UncompressedPoint<C>) -> Self {
         PublicKey::Uncompressed(point)
     }
 }

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -14,7 +14,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use elliptic_curve::generic_array::GenericArray;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
-use crate::{CompressedCurvePoint, PublicKey, UncompressedCurvePoint};
+use crate::{CompressedPoint, PublicKey, UncompressedPoint};
 use field::{FieldElement, MODULUS};
 
 /// b = 7 in Montgomery form (aR mod p, where R = 2**256.
@@ -125,23 +125,23 @@ impl AffinePoint {
     }
 
     /// Returns the SEC-1 compressed encoding of this point.
-    pub fn to_compressed_pubkey(&self) -> CompressedCurvePoint {
+    pub fn to_compressed_pubkey(&self) -> CompressedPoint {
         let mut encoded = [0; 33];
         encoded[0] = if self.y.is_odd().into() { 0x03 } else { 0x02 };
         encoded[1..33].copy_from_slice(&self.x.to_bytes());
 
-        CompressedCurvePoint::from_bytes(GenericArray::clone_from_slice(&encoded[..]))
+        CompressedPoint::from_bytes(GenericArray::clone_from_slice(&encoded[..]))
             .expect("we encoded it correctly")
     }
 
     /// Returns the SEC-1 uncompressed encoding of this point.
-    pub fn to_uncompressed_pubkey(&self) -> UncompressedCurvePoint {
+    pub fn to_uncompressed_pubkey(&self) -> UncompressedPoint {
         let mut encoded = [0; 65];
         encoded[0] = 0x04;
         encoded[1..33].copy_from_slice(&self.x.to_bytes());
         encoded[33..65].copy_from_slice(&self.y.to_bytes());
 
-        UncompressedCurvePoint::from_bytes(GenericArray::clone_from_slice(&encoded[..]))
+        UncompressedPoint::from_bytes(GenericArray::clone_from_slice(&encoded[..]))
             .expect("we encoded it correctly")
     }
 }

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -47,7 +47,7 @@ pub type SecretKey = elliptic_curve::SecretKey<U32>;
 pub type PublicKey = elliptic_curve::weierstrass::PublicKey<Secp256k1>;
 
 /// K-256 Compressed Curve Point
-pub type CompressedCurvePoint = elliptic_curve::weierstrass::CompressedCurvePoint<Secp256k1>;
+pub type CompressedPoint = elliptic_curve::weierstrass::CompressedPoint<Secp256k1>;
 
 /// K-256 Uncompressed Curve Point
-pub type UncompressedCurvePoint = elliptic_curve::weierstrass::UncompressedCurvePoint<Secp256k1>;
+pub type UncompressedPoint = elliptic_curve::weierstrass::UncompressedPoint<Secp256k1>;

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -14,7 +14,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use elliptic_curve::generic_array::GenericArray;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
-use crate::{CompressedCurvePoint, PublicKey, UncompressedCurvePoint};
+use crate::{CompressedPoint, PublicKey, UncompressedPoint};
 use field::{FieldElement, MODULUS};
 
 /// a = -3
@@ -131,23 +131,23 @@ impl AffinePoint {
     }
 
     /// Returns the SEC-1 compressed encoding of this point.
-    pub fn to_compressed_pubkey(&self) -> CompressedCurvePoint {
+    pub fn to_compressed_pubkey(&self) -> CompressedPoint {
         let mut encoded = [0; 33];
         encoded[0] = if self.y.is_odd().into() { 0x03 } else { 0x02 };
         encoded[1..33].copy_from_slice(&self.x.to_bytes());
 
-        CompressedCurvePoint::from_bytes(GenericArray::clone_from_slice(&encoded[..]))
+        CompressedPoint::from_bytes(GenericArray::clone_from_slice(&encoded[..]))
             .expect("we encoded it correctly")
     }
 
     /// Returns the SEC-1 uncompressed encoding of this point.
-    pub fn to_uncompressed_pubkey(&self) -> UncompressedCurvePoint {
+    pub fn to_uncompressed_pubkey(&self) -> UncompressedPoint {
         let mut encoded = [0; 65];
         encoded[0] = 0x04;
         encoded[1..33].copy_from_slice(&self.x.to_bytes());
         encoded[33..65].copy_from_slice(&self.y.to_bytes());
 
-        UncompressedCurvePoint::from_bytes(GenericArray::clone_from_slice(&encoded[..]))
+        UncompressedPoint::from_bytes(GenericArray::clone_from_slice(&encoded[..]))
             .expect("we encoded it correctly")
     }
 }

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -55,7 +55,7 @@ pub type SecretKey = elliptic_curve::SecretKey<U32>;
 pub type PublicKey = elliptic_curve::weierstrass::PublicKey<NistP256>;
 
 /// NIST P-256 Compressed Curve Point
-pub type CompressedCurvePoint = elliptic_curve::weierstrass::CompressedCurvePoint<NistP256>;
+pub type CompressedPoint = elliptic_curve::weierstrass::CompressedPoint<NistP256>;
 
 /// NIST P-256 Uncompressed Curve Point
-pub type UncompressedCurvePoint = elliptic_curve::weierstrass::UncompressedCurvePoint<NistP256>;
+pub type UncompressedPoint = elliptic_curve::weierstrass::UncompressedPoint<NistP256>;

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -51,7 +51,7 @@ pub type SecretKey = elliptic_curve::SecretKey<U48>;
 pub type PublicKey = elliptic_curve::weierstrass::PublicKey<NistP384>;
 
 /// NIST P-384 Compressed Curve Point
-pub type CompressedCurvePoint = elliptic_curve::weierstrass::CompressedCurvePoint<NistP384>;
+pub type CompressedPoint = elliptic_curve::weierstrass::CompressedPoint<NistP384>;
 
 /// NIST P-384 Uncompressed Curve Point
-pub type UncompressedCurvePoint = elliptic_curve::weierstrass::UncompressedCurvePoint<NistP384>;
+pub type UncompressedPoint = elliptic_curve::weierstrass::UncompressedPoint<NistP384>;


### PR DESCRIPTION
Rationale:

- `CompressedCurvePoint` and `UncompressedCurvePoint` are annoyingly long to type
- It's an elliptic curve library: we already know it's a curve point by definition
- More consistency with types like `AffinePoint` and `ProjectivePoint`
- Matches the `CompressedPointSize` and `UncompressedPointSize` names