### PR TITLE
Add `weierstrass::GenerateSecretKey` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ version = "0.4.0"
 dependencies = [
  "generic-array",
  "hex",
+ "rand_core 0.5.1",
  "subtle",
  "zeroize",
 ]
@@ -116,6 +117,7 @@ dependencies = [
  "fiat-crypto",
  "hex",
  "proptest",
+ "rand_core 0.5.1",
  "zeroize",
 ]
 
@@ -147,6 +149,7 @@ dependencies = [
  "elliptic-curve",
  "hex",
  "proptest",
+ "rand_core 0.5.1",
  "zeroize",
 ]
 

--- a/elliptic-curve-crate/Cargo.toml
+++ b/elliptic-curve-crate/Cargo.toml
@@ -19,6 +19,11 @@ keywords      = ["crypto", "ecc", "elliptic", "weierstrass"]
 version = "0.14"
 default-features = false
 
+[dependencies.rand_core]
+version = "0.5"
+optional = true
+default-features = false
+
 [dependencies.subtle]
 version = "2.2.2"
 default-features = false
@@ -38,3 +43,4 @@ std = []
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/elliptic-curve-crate/src/error.rs
+++ b/elliptic-curve-crate/src/error.rs
@@ -1,4 +1,4 @@
-//! Elliptic curve error types (opaque)
+//! Error type
 
 use core::fmt::{self, Display};
 

--- a/elliptic-curve-crate/src/lib.rs
+++ b/elliptic-curve-crate/src/lib.rs
@@ -10,6 +10,7 @@
 //! done with a minor version bump.
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
@@ -20,6 +21,9 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "rand_core")]
+pub use rand_core;
+
 pub mod error;
 pub mod secret_key;
 
@@ -28,6 +32,7 @@ pub use subtle;
 
 // TODO(tarcieri): other curve forms
 #[cfg(feature = "weierstrass")]
+#[cfg_attr(docsrs, doc(cfg(feature = "weierstrass")))]
 pub mod weierstrass;
 
 pub use self::{error::Error, secret_key::SecretKey};

--- a/elliptic-curve-crate/src/weierstrass.rs
+++ b/elliptic-curve-crate/src/weierstrass.rs
@@ -13,6 +13,12 @@ use core::ops::Add;
 use generic_array::ArrayLength;
 use subtle::{ConditionallySelectable, CtOption};
 
+#[cfg(feature = "rand_core")]
+use crate::secret_key::SecretKey;
+
+#[cfg(feature = "rand_core")]
+use rand_core::{CryptoRng, RngCore};
+
 /// Fixed-base scalar multiplication
 pub trait FixedBaseScalarMul: Curve
 where
@@ -28,4 +34,13 @@ where
     /// Multiply the given scalar by the generator point for this elliptic
     /// curve.
     fn mul_base(scalar: &ScalarBytes<Self::ScalarSize>) -> CtOption<Self::Point>;
+}
+
+/// Generate a secret key for this elliptic curve
+#[cfg(feature = "rand_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
+pub trait GenerateSecretKey: Curve {
+    /// Generate a random [`SecretKey`] for this elliptic curve using the
+    /// provided [`CryptoRng`]
+    fn generate_secret_key(rng: &mut (impl CryptoRng + RngCore)) -> SecretKey<Self::ScalarSize>;
 }

--- a/elliptic-curve-crate/src/weierstrass/curve.rs
+++ b/elliptic-curve-crate/src/weierstrass/curve.rs
@@ -6,6 +6,9 @@ use generic_array::{
     ArrayLength,
 };
 
+#[cfg(docsrs)]
+use crate::ScalarBytes;
+
 /// Elliptic curve in short Weierstrass form
 pub trait Curve: Clone + Debug + Default + Eq + Ord + Send + Sync {
     /// Size of [`ScalarBytes`] for this curve, i.e. a serialized integer

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -23,13 +23,15 @@ optional = true
 default-features = false
 
 [dev-dependencies]
+fiat-crypto = "0.1.0"
 hex = "0.4"
 proptest = "0.9"
-fiat-crypto = "0.1.0"
+rand_core = { version = "0.5", features = ["getrandom" ]}
 
 [features]
 default = ["arithmetic", "std"]
 arithmetic = []
+rand = ["elliptic-curve/rand_core"]
 test-vectors = []
 std = ["elliptic-curve/std"]
 

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -25,10 +25,12 @@ default-features = false
 [dev-dependencies]
 hex = "0.4"
 proptest = "0.9"
+rand_core = { version = "0.5", features = ["getrandom" ]}
 
 [features]
 default = ["arithmetic", "std"]
 arithmetic = []
+rand = ["elliptic-curve/rand_core"]
 test-vectors = []
 std = ["elliptic-curve/std"]
 


### PR DESCRIPTION
Adds a `SecretKey` generation trait for Weierstrass curves supporting curve-specific logic.

The trait is implemented for the `k256` and `p256` crates using a trial generation method ("generate-and-pray") which attempts to decode a randomly generated bytestring as a `Scalar` and loops until it succeeds.

This approach is suboptimal as it's non-constant-time, however this should not pose a practical security concern as the timing sidechannel shouldn't reveal any useful information (so long as RNG outputs do not reveal information about subsequent or prior RNG outputs, which is a property required for any secure CSPRNG).

It would be good to replace this with a truly constant-time approach (e.g. using a modular reduction to ensure the scalar is in range, rather than brute force)