### PR TITLE
k256/p256: remove `getrandom`; use `rand` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,6 @@ dependencies = [
  "fiat-crypto",
  "hex",
  "proptest",
- "rand_core 0.5.1",
  "zeroize",
 ]
 
@@ -149,7 +148,6 @@ dependencies = [
  "elliptic-curve",
  "hex",
  "proptest",
- "rand_core 0.5.1",
  "zeroize",
 ]
 

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -26,7 +26,6 @@ default-features = false
 fiat-crypto = "0.1.0"
 hex = "0.4"
 proptest = "0.9"
-rand_core = { version = "0.5", features = ["getrandom" ]}
 
 [features]
 default = ["arithmetic", "std"]

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -537,6 +537,7 @@ impl GenerateSecretKey for Secp256k1 {
 #[cfg(test)]
 mod tests {
     use core::convert::TryInto;
+    use elliptic_curve::rand_core::OsRng;
 
     use super::{AffinePoint, ProjectivePoint, Scalar, CURVE_EQUATION_B};
     use crate::{
@@ -796,7 +797,7 @@ mod tests {
     #[test]
     fn generate_secret_key() {
         use elliptic_curve::weierstrass::GenerateSecretKey;
-        let key = Secp256k1::generate_secret_key(&mut rand_core::OsRng);
+        let key = Secp256k1::generate_secret_key(&mut OsRng);
 
         // Sanity check
         assert!(!key.secret_scalar().iter().all(|b| *b == 0))

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -4,8 +4,8 @@ use core::convert::TryInto;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
-#[cfg(feature = "getrandom")]
-use getrandom::getrandom;
+#[cfg(feature = "rand")]
+use elliptic_curve::rand_core::{CryptoRng, RngCore};
 
 use super::util::{adc, mac, mac_typemax, sbb};
 
@@ -88,16 +88,16 @@ impl FieldElement {
     }
 
     /// Returns a uniformly-random element within the field.
-    #[cfg(feature = "getrandom")]
-    pub fn generate() -> Self {
+    #[cfg(feature = "rand")]
+    pub fn generate(rng: &mut (impl CryptoRng + RngCore)) -> Self {
         // We reduce a random 512-bit value into a 256-bit field, which results in a
         // negligible bias from the uniform distribution.
         let mut buf = [0; 64];
-        getrandom(&mut buf).unwrap();
+        rng.fill_bytes(&mut buf);
         FieldElement::from_bytes_wide(buf)
     }
 
-    #[cfg(feature = "getrandom")]
+    #[cfg(feature = "rand")]
     fn from_bytes_wide(bytes: [u8; 64]) -> Self {
         FieldElement::montgomery_reduce(
             u64::from_be_bytes(bytes[0..8].try_into().unwrap()),

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -25,7 +25,6 @@ default-features = false
 [dev-dependencies]
 hex = "0.4"
 proptest = "0.9"
-rand_core = { version = "0.5", features = ["getrandom" ]}
 
 [features]
 default = ["arithmetic", "std"]

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -550,6 +550,7 @@ mod tests {
     // See the `fixed_base_scalar_mul` in `k256` crate's `arithmetic.rs` for an example
 
     use core::convert::TryInto;
+    use elliptic_curve::rand_core::OsRng;
 
     use super::{AffinePoint, ProjectivePoint, Scalar, CURVE_EQUATION_A, CURVE_EQUATION_B};
     use crate::{
@@ -790,7 +791,7 @@ mod tests {
     fn generate_secret_key() {
         use crate::NistP256;
         use elliptic_curve::weierstrass::GenerateSecretKey;
-        let key = NistP256::generate_secret_key(&mut rand_core::OsRng);
+        let key = NistP256::generate_secret_key(&mut OsRng);
 
         // Sanity check
         assert!(!key.secret_scalar().iter().all(|b| *b == 0))

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -4,8 +4,8 @@ use core::convert::TryInto;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
-#[cfg(feature = "getrandom")]
-use getrandom::getrandom;
+#[cfg(feature = "rand")]
+use elliptic_curve::rand_core::{CryptoRng, RngCore};
 
 use super::util::{adc, mac, sbb};
 
@@ -84,16 +84,16 @@ impl FieldElement {
     }
 
     /// Returns a uniformly-random element within the field.
-    #[cfg(feature = "getrandom")]
-    pub fn generate() -> Self {
+    #[cfg(feature = "rand")]
+    pub fn generate(rng: &mut (impl CryptoRng + RngCore)) -> Self {
         // We reduce a random 512-bit value into a 256-bit field, which results in a
         // negligible bias from the uniform distribution.
         let mut buf = [0; 64];
-        getrandom(&mut buf).unwrap();
+        rng.fill_bytes(&mut buf);
         FieldElement::from_bytes_wide(buf)
     }
 
-    #[cfg(feature = "getrandom")]
+    #[cfg(feature = "rand")]
     fn from_bytes_wide(bytes: [u8; 64]) -> Self {
         FieldElement::montgomery_reduce(
             u64::from_be_bytes(bytes[0..8].try_into().unwrap()),


### PR DESCRIPTION
...to implement `FieldElement::generate()`. The previous implementation was based on a legacy (and previously removed) `getrandom` feature.

The `rand_core` crate has the advantage of being able to work (ergonomically) in embedded environments.