### PR TITLE
Add `legacy` feature with `AffineCoordinates` trait

### DIFF
--- a/elliptic-curve-crate/Cargo.toml
+++ b/elliptic-curve-crate/Cargo.toml
@@ -37,10 +37,10 @@ default-features = false
 hex = "0.4"
 
 [features]
-default = []
+legacy = []
 weierstrass = []
 std = []
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["weierstrass", "std"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/elliptic-curve-crate/src/legacy.rs
+++ b/elliptic-curve-crate/src/legacy.rs
@@ -1,0 +1,26 @@
+//! Support for implementing legacy protocols that require direct access to
+//! coordinates of affine points on elliptic curves.
+//!
+//! These APIs violate the group abstraction and expose coordinate field
+//! elements which could be potentially misused when designing new protocols
+//! based on elliptic curve groups.
+//!
+//! For that reason, we strongly suggest they aren't used in new protocols, but
+//! only as needed when implementing legacy protocols which require them.
+
+use generic_array::ArrayLength;
+
+/// Byte array containing a serialized field element
+pub type FieldElementBytes<Size> = generic_array::GenericArray<u8, Size>;
+
+/// Access to the coordinates of an affine point
+pub trait AffineCoordinates {
+    /// Size of a field element representing an affine coordinate
+    type FieldElementSize: ArrayLength<u8>;
+
+    /// x-coordinate (field element)
+    fn x(&self) -> FieldElementBytes<Self::FieldElementSize>;
+
+    /// y-coordinate (field element)
+    fn y(&self) -> FieldElementBytes<Self::FieldElementSize>;
+}

--- a/elliptic-curve-crate/src/lib.rs
+++ b/elliptic-curve-crate/src/lib.rs
@@ -27,8 +27,9 @@ pub use rand_core;
 pub mod error;
 pub mod secret_key;
 
-pub use generic_array::{self, typenum::consts};
-pub use subtle;
+#[cfg(feature = "legacy")]
+#[cfg_attr(docsrs, doc(cfg(feature = "legacy")))]
+pub mod legacy;
 
 // TODO(tarcieri): other curve forms
 #[cfg(feature = "weierstrass")]
@@ -36,6 +37,8 @@ pub use subtle;
 pub mod weierstrass;
 
 pub use self::{error::Error, secret_key::SecretKey};
+pub use generic_array::{self, typenum::consts};
+pub use subtle;
 
 /// Byte array containing a serialized scalar value (i.e. an integer)
 pub type ScalarBytes<Size> = generic_array::GenericArray<u8, Size>;

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -30,10 +30,11 @@ proptest = "0.10"
 [features]
 default = ["arithmetic", "std"]
 arithmetic = []
+legacy = ["arithmetic", "elliptic-curve/legacy"]
 rand = ["elliptic-curve/rand_core"]
 test-vectors = []
 std = ["elliptic-curve/std"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["arithmetic", "rand", "test-vectors", "std"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -15,6 +15,9 @@ use crate::{CompressedPoint, PublicKey, ScalarBytes, Secp256k1, UncompressedPoin
 use field::{FieldElement, MODULUS};
 use scalar::Scalar;
 
+#[cfg(feature = "legacy")]
+use elliptic_curve::{consts::U32, legacy};
+
 #[cfg(feature = "rand")]
 use crate::SecretKey;
 
@@ -183,6 +186,19 @@ impl Neg for AffinePoint {
             x: self.x,
             y: -self.y,
         }
+    }
+}
+
+#[cfg(feature = "legacy")]
+impl legacy::AffineCoordinates for AffinePoint {
+    type FieldElementSize = U32;
+
+    fn x(&self) -> legacy::FieldElementBytes<U32> {
+        self.x.to_bytes().into()
+    }
+
+    fn y(&self) -> legacy::FieldElementBytes<U32> {
+        self.y.to_bytes().into()
     }
 }
 

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -29,10 +29,11 @@ proptest = "0.10"
 [features]
 default = ["arithmetic", "std"]
 arithmetic = []
+legacy = ["arithmetic", "elliptic-curve/legacy"]
 rand = ["elliptic-curve/rand_core"]
 test-vectors = []
 std = ["elliptic-curve/std"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["arithmetic", "rand", "test-vectors", "std"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -15,6 +15,9 @@ use crate::{CompressedPoint, NistP256, PublicKey, ScalarBytes, UncompressedPoint
 use field::{FieldElement, MODULUS};
 use scalar::Scalar;
 
+#[cfg(feature = "legacy")]
+use elliptic_curve::{consts::U32, legacy};
+
 #[cfg(feature = "rand")]
 use crate::SecretKey;
 
@@ -189,6 +192,19 @@ impl Neg for AffinePoint {
             x: self.x,
             y: -self.y,
         }
+    }
+}
+
+#[cfg(feature = "legacy")]
+impl legacy::AffineCoordinates for AffinePoint {
+    type FieldElementSize = U32;
+
+    fn x(&self) -> legacy::FieldElementBytes<U32> {
+        self.x.to_bytes().into()
+    }
+
+    fn y(&self) -> legacy::FieldElementBytes<U32> {
+        self.y.to_bytes().into()
     }
 }
 


### PR DESCRIPTION
Protocols like ECDSA need access to affine coordinates: the x-coordinate for ECDSA itself, but also the y-coordinate for things like recovering public keys from ECDSA signatures (as seen in Ethereum).

This commit adds support for accessing affine coordinates for use in these protocols, taking into account some feedback from the previous attempt to do this (#50):

- Trait is placed inside a `legacy` module with comments strongly suggesting it should only be used for implementing legacy protocols which explicitly need coordinate access
- Feature is hidden from https://docs.rs to discourage (mis)use
- Coordinates are represented using a `FieldElementBytes` type alias which is also defined in the `legacy` module

/cc @nickray