### PR TITLE
[WIP] Add `legacy` feature with ECDSA-related traits

### DIFF
--- a/elliptic-curve-crate/Cargo.toml
+++ b/elliptic-curve-crate/Cargo.toml
@@ -37,10 +37,10 @@ default-features = false
 hex = "0.4"
 
 [features]
-default = []
+legacy = []
 weierstrass = []
 std = []
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["weierstrass", "std"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/elliptic-curve-crate/src/legacy.rs
+++ b/elliptic-curve-crate/src/legacy.rs
@@ -1,0 +1,23 @@
+//! Traits for implementing legacy protocols.
+//!
+//! These APIs could be potentially misused when designing new protocols.
+//! For that reason, we strongly suggest they aren't used in new protocols, but
+//! only as needed when implementing legacy protocols which require them.
+
+/// Reduce the field element representing the x-coordinate of an affine point
+/// into the associated scalar type
+pub trait ReduceAffineX {
+    /// Scalar type
+    type Scalar; // TODO: bounds (should we add a `ScalarArith` marker trait?)
+
+    /// Convert the element in the base field representing the x-coordinate
+    /// to the associated scalar type by lifting it into an integer and then
+    /// reducing it to an element of the scalar field
+    fn reduce_x_to_scalar(&self) -> Self::Scalar;
+}
+
+/// Determines if the y-coordinate of an affine point is odd
+pub trait IsAffineYOdd {
+    /// Is the y-coordinate odd?
+    fn is_y_odd(&self) -> bool;
+}

--- a/elliptic-curve-crate/src/lib.rs
+++ b/elliptic-curve-crate/src/lib.rs
@@ -27,8 +27,9 @@ pub use rand_core;
 pub mod error;
 pub mod secret_key;
 
-pub use generic_array::{self, typenum::consts};
-pub use subtle;
+#[cfg(feature = "legacy")]
+#[cfg_attr(docsrs, doc(cfg(feature = "legacy")))]
+pub mod legacy;
 
 // TODO(tarcieri): other curve forms
 #[cfg(feature = "weierstrass")]
@@ -36,6 +37,8 @@ pub use subtle;
 pub mod weierstrass;
 
 pub use self::{error::Error, secret_key::SecretKey};
+pub use generic_array::{self, typenum::consts};
+pub use subtle;
 
 /// Byte array containing a serialized scalar value (i.e. an integer)
 pub type ScalarBytes<Size> = generic_array::GenericArray<u8, Size>;


### PR DESCRIPTION
This is an alternative to #65 which scopes the "legacy" functionality specifically to what is needed to implement ECDSA.

ECDSA signing computes the `r` component of a signature by reducing the affine x-coordinate of an ephemeral point mod n.

This adds a `ReduceAffineX` trait for performing this reduction, with the goal of facilitating an ECDSA implementation which is generic over (prime order) elliptic curves.

Additionally, it adds an `IsAffineYOdd` trait which is useful for computing the "recovery ID" used to recover the public key which created a signature (ala point compression).