### PR TITLE
k256: Add recoverable::Signature::recover_pubkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
+name = "hex-literal"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961de220ec9a91af2e1e5bd80d02109155695e516771762381ef8581317066e0"
+dependencies = [
+ "hex-literal-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "hex-literal-impl"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "853f769599eb31de176303197b7ba4973299c38c7a7604a6bc88c3eef05b9b46"
+dependencies = [
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +343,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "hex",
+ "hex-literal",
  "num-bigint",
  "num-traits",
  "proptest",
@@ -470,6 +490,12 @@ name = "ppv-lite86"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro2"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -19,7 +19,8 @@ sha2 = { version = "0.9", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-hex = "0.4"
+hex = "0.4" # TODO: switch to hex-literal
+hex-literal = "0.2"
 proptest = "0.10"
 num-bigint = "0.3"
 num-traits = "0.2"

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -28,7 +28,7 @@ use elliptic_curve::{
 const CURVE_EQUATION_B_SINGLE: u32 = 7u32;
 
 #[rustfmt::skip]
-const CURVE_EQUATION_B: FieldElement = FieldElement::from_bytes_unchecked(&[
+pub(crate) const CURVE_EQUATION_B: FieldElement = FieldElement::from_bytes_unchecked(&[
     0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0,
@@ -39,8 +39,8 @@ const CURVE_EQUATION_B: FieldElement = FieldElement::from_bytes_unchecked(&[
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub struct AffinePoint {
-    x: FieldElement,
-    y: FieldElement,
+    pub(crate) x: FieldElement,
+    pub(crate) y: FieldElement,
 }
 
 impl ConditionallySelectable for AffinePoint {

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -2,8 +2,6 @@
 
 pub mod recoverable;
 
-pub use recoverable::{RecoverableSignature, RecoveryId};
-
 use super::Secp256k1;
 
 #[cfg(feature = "arithmetic")]

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -1,14 +1,24 @@
 //! Ethereum-style "recoverable signatures"
 
-use super::Signature;
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{self, Debug},
 };
 use ecdsa::{signature::Signature as _, Error};
 
-#[cfg(docsrs)]
+#[cfg(feature = "arithmetic")]
+use crate::arithmetic::{
+    field::FieldElement, scalar::Scalar, AffinePoint, ProjectivePoint, CURVE_EQUATION_B,
+};
+
+#[cfg(feature = "arithmetic")]
+use elliptic_curve::subtle::{Choice, ConditionallySelectable, CtOption};
+
+#[cfg(any(feature = "arithmetic", docsrs))]
 use crate::PublicKey;
+
+#[cfg(all(feature = "arithmetic", feature = "sha256"))]
+use sha2::{Digest, Sha256};
 
 /// Size of an Ethereum-style recoverable signature in bytes
 pub const SIZE: usize = 65;
@@ -16,57 +26,122 @@ pub const SIZE: usize = 65;
 /// Ethereum-style "recoverable signatures" which allow for the recovery of
 /// the signer's [`PublicKey`] from the signature itself.
 ///
-/// This format consists of [`Signature`] followed by a 1-byte
-/// [`RecoveryId`] (65-bytes total):
+/// This format consists of [`Signature`] followed by a 1-byte recovery [`Id`]
+/// (65-bytes total):
 ///
 /// - `r`: 32-byte integer, big endian
 /// - `s`: 32-byte integer, big endian
-/// - `v`: 1-byte [`RecoveryId`]
+/// - `v`: 1-byte recovery [`Id`]
 #[derive(Copy, Clone)]
-pub struct RecoverableSignature {
+pub struct Signature {
     bytes: [u8; SIZE],
 }
 
-impl RecoverableSignature {
-    /// Get the [`RecoveryId`] for this signature
-    pub fn recovery_id(self) -> RecoveryId {
-        self.bytes[0].try_into().expect("invalid recovery ID")
+impl Signature {
+    /// Get the recovery [`Id`] for this signature
+    pub fn recovery_id(self) -> Id {
+        self.bytes[64].try_into().expect("invalid recovery ID")
+    }
+
+    /// Recover the [`PublicKey`] used to create the given signature
+    // TODO(tarcieri): accept original message rather than scalar
+    #[cfg(all(feature = "arithmetic", feature = "sha256"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic", feature = "sha256")))]
+    #[allow(non_snake_case, clippy::many_single_char_names)]
+    pub fn recover_pubkey(&self, msg: &[u8]) -> Result<PublicKey, Error> {
+        let z = Scalar::from_digest(Sha256::new().chain(msg));
+
+        let maybe_r = self.r();
+        let maybe_s = self.s();
+
+        // TODO(tarcieri): replace with into conversion when available (see subtle#73)
+        let (r, s) = if maybe_r.is_some().into() && maybe_s.is_some().into() {
+            (maybe_r.unwrap(), maybe_s.unwrap())
+        } else {
+            return Err(Error::new());
+        };
+
+        let x = FieldElement::from_bytes(&r.to_bytes());
+
+        let pk = x.and_then(|x| {
+            let y_is_odd = Choice::from(self.recovery_id().is_y_odd() as u8);
+            let alpha = (x * &x * &x) + &CURVE_EQUATION_B;
+            let beta = alpha.sqrt().unwrap();
+
+            let y = FieldElement::conditional_select(
+                &beta.negate(1),
+                &beta,
+                // beta.is_odd() == y_is_odd
+                !(beta.normalize().is_odd() ^ y_is_odd),
+            );
+
+            let R = ProjectivePoint::from(AffinePoint {
+                x,
+                y: y.normalize(),
+            });
+
+            let r_inv = r.invert().unwrap();
+            let u1 = -(r_inv * &z);
+            let u2 = r_inv * &s;
+            ((&ProjectivePoint::generator() * &u1) + &(R * &u2)).to_affine()
+        });
+
+        // TODO(tarcieri): replace with into conversion when available (see subtle#73)
+        if pk.is_some().into() {
+            Ok(pk.unwrap().to_compressed_pubkey())
+        } else {
+            Err(Error::new())
+        }
+    }
+
+    /// Parse the `r` component of this signature to a [`Scalar`]
+    #[cfg(feature = "arithmetic")]
+    fn r(&self) -> CtOption<Scalar> {
+        Scalar::from_bytes(self.bytes[..32].try_into().unwrap())
+            .and_then(|r| CtOption::new(r, !r.is_zero()))
+    }
+
+    /// Parse the `s` component of this signature to a [`Scalar`]
+    #[cfg(feature = "arithmetic")]
+    fn s(&self) -> CtOption<Scalar> {
+        Scalar::from_bytes(self.bytes[32..64].try_into().unwrap())
+            .and_then(|s| CtOption::new(s, !s.is_zero()))
     }
 }
 
-impl ecdsa::signature::Signature for RecoverableSignature {
+impl ecdsa::signature::Signature for Signature {
     fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         bytes.try_into()
     }
 }
 
-impl AsRef<[u8]> for RecoverableSignature {
+impl AsRef<[u8]> for Signature {
     fn as_ref(&self) -> &[u8] {
         &self.bytes[..]
     }
 }
 
-impl Debug for RecoverableSignature {
+impl Debug for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "RecoverableSignature {{ bytes: {:?}) }}", self.as_ref())
     }
 }
 
 // TODO(tarcieri): derive `Eq` after const generics are available
-impl Eq for RecoverableSignature {}
+impl Eq for Signature {}
 
 // TODO(tarcieri): derive `PartialEq` after const generics are available
-impl PartialEq for RecoverableSignature {
+impl PartialEq for Signature {
     fn eq(&self, other: &Self) -> bool {
         self.as_ref().eq(other.as_ref())
     }
 }
 
-impl TryFrom<&[u8]> for RecoverableSignature {
+impl TryFrom<&[u8]> for Signature {
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Error> {
-        if bytes.len() == SIZE && RecoveryId::try_from(bytes[64]).is_ok() {
+        if bytes.len() == SIZE && Id::try_from(bytes[64]).is_ok() {
             let mut arr = [0u8; SIZE];
             arr.copy_from_slice(bytes);
             Ok(Self { bytes: arr })
@@ -76,21 +151,36 @@ impl TryFrom<&[u8]> for RecoverableSignature {
     }
 }
 
-impl From<RecoverableSignature> for Signature {
-    fn from(sig: RecoverableSignature) -> Signature {
-        Signature::from_bytes(&sig.bytes[..64]).unwrap()
+impl From<Signature> for super::Signature {
+    fn from(sig: Signature) -> Self {
+        Self::from_bytes(&sig.bytes[..64]).unwrap()
     }
 }
 
-/// Identifier used to compute a `PublicKey` from a [`RecoverableSignature`]
+/// Identifier used to compute a [`PublicKey`] from a [`Signature`].
+///
+/// In practice these values are always either `0` or `1`, and indicate
+/// whether or not the y-coordinate of the original [`PublicKey`] is odd.
+///
+/// Values 2 and 3 are also defined to capture whether `r` overflowed the
+/// curve's order, however there is a vanishingly small chance of this
+/// occurring such that these values are not used in practice. As such, for
+/// simplicity's sake we do not support them.
 #[derive(Copy, Clone, Debug)]
-pub struct RecoveryId(u8);
+pub struct Id(u8);
 
-impl TryFrom<u8> for RecoveryId {
+impl Id {
+    /// Is the y-coordinate of the public key odd?
+    fn is_y_odd(self) -> bool {
+        self.0 & 1 != 0
+    }
+}
+
+impl TryFrom<u8> for Id {
     type Error = Error;
 
     fn try_from(byte: u8) -> Result<Self, Error> {
-        if byte < 4 {
+        if byte <= 1 {
             Ok(Self(byte))
         } else {
             Err(Error::new())
@@ -98,8 +188,52 @@ impl TryFrom<u8> for RecoveryId {
     }
 }
 
-impl From<RecoveryId> for u8 {
-    fn from(recovery_id: RecoveryId) -> u8 {
+impl From<Id> for u8 {
+    fn from(recovery_id: Id) -> u8 {
         recovery_id.0
+    }
+}
+
+#[cfg(all(test, feature = "arithmetic", feature = "sha256"))]
+mod tests {
+    use super::Signature;
+    use core::convert::TryFrom;
+    use hex_literal::hex;
+
+    /// Signature recovery test vectors
+    struct TestVector {
+        pk: [u8; 33],
+        sig: [u8; 65],
+        msg: &'static [u8],
+    }
+
+    const VECTORS: &[TestVector] = &[
+        // Recovery ID 0
+        TestVector {
+            pk: hex!("021a7a569e91dbf60581509c7fc946d1003b60c7dee85299538db6353538d59574"),
+            sig: hex!(
+                "ce53abb3721bafc561408ce8ff99c909f7f0b18a2f788649d6470162ab1aa03239
+                 71edc523a6d6453f3fb6128d318d9db1a5ff3386feb1047d9816e780039d5200"
+            ),
+            msg: b"example message",
+        },
+        // Recovery ID 1
+        TestVector {
+            pk: hex!("036d6caac248af96f6afa7f904f550253a0f3ef3f5aa2fe6838a95b216691468e2"),
+            sig: hex!(
+                "46c05b6368a44b8810d79859441d819b8e7cdc8bfd371e35c53196f4bcacdb5135
+                 c7facce2a97b95eacba8a586d87b7958aaf8368ab29cee481f76e871dbd9cb01"
+            ),
+            msg: b"example message",
+        },
+    ];
+
+    #[test]
+    fn public_key_recovery() {
+        for vector in VECTORS {
+            let sig = Signature::try_from(&vector.sig[..]).unwrap();
+            let pk = sig.recover_pubkey(vector.msg).unwrap();
+            assert_eq!(&vector.pk[..], pk.as_bytes());
+        }
     }
 }

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -28,7 +28,7 @@ pub mod test_vectors;
 pub use elliptic_curve;
 
 #[cfg(feature = "arithmetic")]
-pub use arithmetic::{field::FieldElement, scalar::Scalar, AffinePoint, ProjectivePoint};
+pub use arithmetic::{scalar::Scalar, AffinePoint, ProjectivePoint};
 
 use elliptic_curve::{generic_array::typenum::U32, weierstrass::Curve};
 


### PR DESCRIPTION
Conditionally implements public key recovery for `recoverable::Signature` when the `arithmetic` and `sha256` Cargo features are enabled.

Recovery is only implemented for "recovery IDs" 0 and 1, as these are the only ones that occur in practice.