### PR TITLE
.github: bump codecov-action to v1.0.10; remove token

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -75,13 +75,11 @@ jobs:
         env:
           CARGO_INCREMENTAL: 0
         with:
-          version: 0.12.4
+          version: 0.14.2
           args: --all -- --test-threads 1
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.2
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
+        uses: codecov/codecov-action@v1.0.10
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
Presently this action fails on any PR from a fork.

Codecov fixed things upstream to where public repos no longer require a token when uploading from GitHub actions:

https://github.com/codecov/codecov-action/issues/29

Upgrading should fix builds from forks