### PR TITLE
k256: add Scalar::from_bytes_reduced

### DIFF
--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -71,6 +71,13 @@ impl Scalar {
         CtOption::map(value, Self)
     }
 
+    /// Parses the given byte array as a scalar.
+    ///
+    /// Subtracts the modulus when the byte array is larger than the modulus.
+    pub fn from_bytes_reduced(bytes: &[u8; 32]) -> Self {
+        Self(ScalarImpl::from_bytes_reduced(bytes))
+    }
+
     /// Returns the SEC-1 encoding of this scalar.
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.to_bytes()


### PR DESCRIPTION
This method is intended for use when implementing ECDSA, namely for computing a `Scalar` from the hash of the message:

https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm#Signature_generation_algorithm

> Let 𝐳 be the 𝐋𝑛 leftmost bits of 𝑒, where 𝐋𝑛 is the bit length of the group order 𝑛

See related discussion here: https://github.com/RustCrypto/elliptic-curves/pull/56/files#diff-c8893dd2f9cf0dff9549c297fc437664R160-R176

cc @fjarri @nickray