### PR TITLE
k256: add Scalar::from_digest

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -28,10 +28,11 @@ criterion = "0.3"
 [features]
 default = ["arithmetic", "std"]
 arithmetic = []
+digest = ["ecdsa/digest"]
 field-montgomery = []
 force-32-bit = []
 rand = ["elliptic-curve/rand_core"]
-sha256 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
+sha256 = ["digest", "ecdsa/hazmat", "sha2"]
 test-vectors = []
 std = ["elliptic-curve/std"]
 

--- a/k256/src/arithmetic/scalar/scalar_4x64.rs
+++ b/k256/src/arithmetic/scalar/scalar_4x64.rs
@@ -174,6 +174,23 @@ impl Scalar4x64 {
         CtOption::new(Self(w), underflow)
     }
 
+    /// Parses the given byte array as a scalar.
+    ///
+    /// Subtracts the modulus when the byte array is larger than the modulus.
+    #[cfg(feature = "digest")]
+    pub fn from_bytes_reduced(bytes: &[u8; 32]) -> Self {
+        // Interpret the bytes as a big-endian integer w.
+        let w3 = u64::from_be_bytes(bytes[0..8].try_into().unwrap());
+        let w2 = u64::from_be_bytes(bytes[8..16].try_into().unwrap());
+        let w1 = u64::from_be_bytes(bytes[16..24].try_into().unwrap());
+        let w0 = u64::from_be_bytes(bytes[24..32].try_into().unwrap());
+        let w = [w0, w1, w2, w3];
+
+        // If w is in the range [0, n) then w - n will underflow
+        let (r2, underflow) = sbb_array_with_underflow(&w, &MODULUS);
+        Self(conditional_select(&w, &r2, !underflow))
+    }
+
     /// Returns the SEC-1 encoding of this scalar.
     pub fn to_bytes(&self) -> [u8; 32] {
         let mut ret = [0; 32];

--- a/k256/src/arithmetic/scalar/scalar_8x32.rs
+++ b/k256/src/arithmetic/scalar/scalar_8x32.rs
@@ -207,6 +207,27 @@ impl Scalar8x32 {
         CtOption::new(Self(w), underflow)
     }
 
+    /// Parses the given byte array as a scalar.
+    ///
+    /// Subtracts the modulus when the byte array is larger than the modulus.
+    #[cfg(feature = "digest")]
+    pub fn from_bytes_reduced(bytes: &[u8; 32]) -> Self {
+        // Interpret the bytes as a big-endian integer w.
+        let w7 = u32::from_be_bytes(bytes[0..4].try_into().unwrap());
+        let w6 = u32::from_be_bytes(bytes[4..8].try_into().unwrap());
+        let w5 = u32::from_be_bytes(bytes[8..12].try_into().unwrap());
+        let w4 = u32::from_be_bytes(bytes[12..16].try_into().unwrap());
+        let w3 = u32::from_be_bytes(bytes[16..20].try_into().unwrap());
+        let w2 = u32::from_be_bytes(bytes[20..24].try_into().unwrap());
+        let w1 = u32::from_be_bytes(bytes[24..28].try_into().unwrap());
+        let w0 = u32::from_be_bytes(bytes[28..32].try_into().unwrap());
+        let w = [w0, w1, w2, w3, w4, w5, w6, w7];
+
+        // If w is in the range [0, n) then w - n will underflow
+        let (r2, underflow) = sbb_array_with_underflow(&w, &MODULUS);
+        Self(conditional_select(&w, &r2, !underflow))
+    }
+
     /// Returns the SEC-1 encoding of this scalar.
     pub fn to_bytes(&self) -> [u8; 32] {
         let mut ret = [0; 32];


### PR DESCRIPTION
This PR is an alternative to #76 

This method is intended for use when implementing ECDSA, namely for computing a `Scalar` from the hash of the message:

https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm#Signature_generation_algorithm

1. Calculate 𝑒 = HASH(𝑚)
2. Let 𝐳 be the 𝐋𝑛 leftmost bits of 𝑒, where 𝐋𝑛 is the bit length of the group order 𝑛