### PR TITLE
Fix a bug in scalar addition

### DIFF
--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -414,6 +414,23 @@ mod tests {
         assert_eq!(modulus_minus_one_neg, Scalar::one());
     }
 
+    #[test]
+    fn add_result_within_256_bits() {
+        // A regression for a bug where reduction was not applied
+        // when the unreduced result of addition was in the range `[modulus, 2^256)`.
+        let t = 1.to_biguint().unwrap() << 255;
+        let one = 1.to_biguint().unwrap();
+
+        let a = Scalar::from(&t - &one);
+        let b = Scalar::from(&t);
+        let res = &a + &b;
+
+        let m = Scalar::modulus_as_biguint();
+        let res_ref = Scalar::from((&t + &t - &one) % &m);
+
+        assert_eq!(res, res_ref);
+    }
+
     #[cfg(feature = "rand")]
     #[test]
     fn generate_biased() {

--- a/k256/src/arithmetic/scalar/scalar_4x64.rs
+++ b/k256/src/arithmetic/scalar/scalar_4x64.rs
@@ -221,8 +221,8 @@ impl Scalar4x64 {
     /// Sums two scalars.
     pub fn add(&self, rhs: &Self) -> Self {
         let (res1, overflow) = adc_array_with_overflow(&(self.0), &(rhs.0));
-        let (res2, _) = sbb_array(&res1, &MODULUS);
-        Self(conditional_select(&res1, &res2, overflow))
+        let (res2, underflow) = sbb_array_with_underflow(&res1, &MODULUS);
+        Self(conditional_select(&res1, &res2, overflow | !underflow))
     }
 
     /// Subtracts one scalar from the other.

--- a/k256/src/arithmetic/scalar/scalar_8x32.rs
+++ b/k256/src/arithmetic/scalar/scalar_8x32.rs
@@ -272,8 +272,8 @@ impl Scalar8x32 {
     /// Sums two scalars.
     pub fn add(&self, rhs: &Self) -> Self {
         let (res1, overflow) = adc_array_with_overflow(&(self.0), &(rhs.0));
-        let (res2, _) = sbb_array(&res1, &MODULUS);
-        Self(conditional_select(&res1, &res2, overflow))
+        let (res2, underflow) = sbb_array_with_underflow(&res1, &MODULUS);
+        Self(conditional_select(&res1, &res2, overflow | !underflow))
     }
 
     /// Subtracts one scalar from the other.


### PR DESCRIPTION
If the unreduced result ended up in range [modulus, 2^256), it was not reduced.

