### PR TITLE
Improved k256 point-scalar multiplication

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -30,6 +30,7 @@ criterion = "0.3"
 default = ["arithmetic", "std"]
 arithmetic = []
 digest = ["ecdsa/digest"]
+endomorphism-mul = []
 field-montgomery = []
 force-32-bit = []
 rand = ["elliptic-curve/rand_core"]

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -6,7 +6,7 @@ pub(crate) mod scalar;
 mod util;
 
 use core::convert::TryInto;
-use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Neg, Sub, SubAssign};
 use elliptic_curve::{
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     weierstrass::FixedBaseScalarMul,
@@ -348,7 +348,8 @@ impl ProjectivePoint {
     }
 
     /// Doubles this point.
-    fn double(&self) -> ProjectivePoint {
+    #[inline]
+    pub fn double(&self) -> ProjectivePoint {
         // We implement the complete addition formula from Renes-Costello-Batina 2015
         // (https://eprint.iacr.org/2015/1060 Algorithm 9).
 
@@ -388,40 +389,6 @@ impl ProjectivePoint {
     /// Returns `self - other`.
     fn sub_mixed(&self, other: &AffinePoint) -> ProjectivePoint {
         self.add_mixed(&other.neg())
-    }
-
-    /// Returns `[k] self`.
-    fn mul(&self, k: &Scalar) -> ProjectivePoint {
-        const LOG_MUL_WINDOW_SIZE: usize = 4;
-        const MUL_STEPS: usize = (256 - 1) / LOG_MUL_WINDOW_SIZE + 1;
-        const MUL_PRECOMP_SIZE: usize = 1 << LOG_MUL_WINDOW_SIZE;
-
-        let mut precomp = [ProjectivePoint::identity(); MUL_PRECOMP_SIZE];
-        let mask = (1u32 << LOG_MUL_WINDOW_SIZE) - 1u32;
-
-        precomp[0] = ProjectivePoint::identity();
-        precomp[1] = *self;
-        for i in 2..MUL_PRECOMP_SIZE {
-            precomp[i] = precomp[i - 1] + self;
-        }
-
-        let mut acc = ProjectivePoint::identity();
-        for idx in (0..MUL_STEPS).rev() {
-            for _j in 0..LOG_MUL_WINDOW_SIZE {
-                acc = acc.double();
-            }
-            let di = ((k >> (idx * LOG_MUL_WINDOW_SIZE)).truncate_to_u32() & mask) as usize;
-
-            // Constant-time array indexing
-            let mut elem = ProjectivePoint::identity();
-            for i in 0..MUL_PRECOMP_SIZE {
-                elem = ProjectivePoint::conditional_select(&elem, &(precomp[di]), i.ct_eq(&di));
-            }
-
-            acc += elem;
-        }
-
-        acc
     }
 }
 
@@ -522,34 +489,6 @@ impl Sub<&AffinePoint> for ProjectivePoint {
 impl SubAssign<AffinePoint> for ProjectivePoint {
     fn sub_assign(&mut self, rhs: AffinePoint) {
         *self = ProjectivePoint::sub_mixed(self, &rhs);
-    }
-}
-
-impl Mul<&Scalar> for &ProjectivePoint {
-    type Output = ProjectivePoint;
-
-    fn mul(self, other: &Scalar) -> ProjectivePoint {
-        ProjectivePoint::mul(self, other)
-    }
-}
-
-impl Mul<&Scalar> for ProjectivePoint {
-    type Output = ProjectivePoint;
-
-    fn mul(self, other: &Scalar) -> ProjectivePoint {
-        ProjectivePoint::mul(&self, other)
-    }
-}
-
-impl MulAssign<Scalar> for ProjectivePoint {
-    fn mul_assign(&mut self, rhs: Scalar) {
-        *self = ProjectivePoint::mul(self, &rhs);
-    }
-}
-
-impl MulAssign<&Scalar> for ProjectivePoint {
-    fn mul_assign(&mut self, rhs: &Scalar) {
-        *self = ProjectivePoint::mul(self, rhs);
     }
 }
 

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -35,6 +35,15 @@ pub(crate) const CURVE_EQUATION_B: FieldElement = FieldElement::from_bytes_unche
     0, 0, 0, 0, 0, 0, 0, CURVE_EQUATION_B_SINGLE as u8,
 ]);
 
+#[rustfmt::skip]
+#[cfg(feature = "endomorphism-mul")]
+const ENDOMORPHISM_BETA: FieldElement = FieldElement::from_bytes_unchecked(&[
+    0x7a, 0xe9, 0x6a, 0x2b, 0x65, 0x7c, 0x07, 0x10,
+    0x6e, 0x64, 0x47, 0x9e, 0xac, 0x34, 0x34, 0xe9,
+    0x9c, 0xf0, 0x49, 0x75, 0x12, 0xf5, 0x89, 0x95,
+    0xc1, 0x39, 0x6c, 0x28, 0x71, 0x95, 0x01, 0xee,
+]);
+
 /// A point on the secp256k1 curve in affine coordinates.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
@@ -389,6 +398,16 @@ impl ProjectivePoint {
     /// Returns `self - other`.
     fn sub_mixed(&self, other: &AffinePoint) -> ProjectivePoint {
         self.add_mixed(&other.neg())
+    }
+
+    /// Calculates SECP256k1 endomorphism: `self * lambda`.
+    #[cfg(feature = "endomorphism-mul")]
+    pub fn endomorphism(&self) -> Self {
+        Self {
+            x: self.x * &ENDOMORPHISM_BETA,
+            y: self.y,
+            z: self.z,
+        }
     }
 }
 

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -70,7 +70,7 @@ impl FieldElement {
 
     /// Attempts to parse the given byte array as an SEC-1-encoded field element.
     /// Does not check the result for being in the correct range.
-    pub const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
+    pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         Self(FieldElementImpl::from_bytes_unchecked(bytes))
     }
 

--- a/k256/src/arithmetic/field/field_10x26.rs
+++ b/k256/src/arithmetic/field/field_10x26.rs
@@ -24,7 +24,7 @@ impl FieldElement10x26 {
 
     /// Attempts to parse the given byte array as an SEC-1-encoded field element.
     /// Does not check the result for being in the correct range.
-    pub const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
+    pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         let w0 = (bytes[31] as u32)
             | ((bytes[30] as u32) << 8)
             | ((bytes[29] as u32) << 16)

--- a/k256/src/arithmetic/field/field_5x52.rs
+++ b/k256/src/arithmetic/field/field_5x52.rs
@@ -24,7 +24,7 @@ impl FieldElement5x52 {
 
     /// Attempts to parse the given byte array as an SEC-1-encoded field element.
     /// Does not check the result for being in the correct range.
-    pub const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
+    pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         let w0 = (bytes[31] as u64)
             | ((bytes[30] as u64) << 8)
             | ((bytes[29] as u64) << 16)

--- a/k256/src/arithmetic/field/field_impl.rs
+++ b/k256/src/arithmetic/field/field_impl.rs
@@ -56,7 +56,7 @@ impl FieldElementImpl {
         Self::new_normalized(&FieldElementUnsafeImpl::one())
     }
 
-    pub const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
+    pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         let value = FieldElementUnsafeImpl::from_bytes_unchecked(bytes);
         Self::new_normalized(&value)
     }

--- a/k256/src/arithmetic/field/field_montgomery.rs
+++ b/k256/src/arithmetic/field/field_montgomery.rs
@@ -69,7 +69,7 @@ impl FieldElementMontgomery {
         R
     }
 
-    pub const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
+    pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         Self(bytes_to_words(bytes)).mul(&R2)
     }
 

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -66,7 +66,8 @@ impl Scalar {
 
     /// Attempts to parse the given byte array as a scalar.
     /// Does not check the result for being in the correct range.
-    pub const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
+    #[cfg(feature = "endomorphism-mul")]
+    pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         Self(ScalarImpl::from_bytes_unchecked(bytes))
     }
 
@@ -510,6 +511,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg(feature = "endomorphism-mul")]
         fn fuzzy_roundtrip_to_bytes_unchecked(a in scalar()) {
             let bytes = a.to_bytes();
             let a_back = Scalar::from_bytes_unchecked(&bytes);

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -64,6 +64,12 @@ impl Scalar {
         self.0.truncate_to_u32()
     }
 
+    /// Attempts to parse the given byte array as a scalar.
+    /// Does not check the result for being in the correct range.
+    pub const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
+        Self(ScalarImpl::from_bytes_unchecked(bytes))
+    }
+
     /// Attempts to parse the given byte array as an SEC-1-encoded scalar.
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
@@ -224,6 +230,18 @@ impl Scalar {
             }
         }
     }
+
+    /// If `flag` evaluates to `true`, adds `(1 << bit)` to `self`.
+    pub fn conditional_add_bit(&self, bit: usize, flag: Choice) -> Self {
+        Self(self.0.conditional_add_bit(bit, flag))
+    }
+
+    /// Multiplies `self` by `b` (without modulo reduction) divide the result by `2^shift`
+    /// (rounding to the nearest integer).
+    /// Variable time in `shift`.
+    pub fn mul_shift_var(&self, b: &Scalar, shift: usize) -> Self {
+        Self(self.0.mul_shift_var(&(b.0), shift))
+    }
 }
 
 impl Shr<usize> for Scalar {
@@ -261,6 +279,14 @@ impl PartialEq for Scalar {
 }
 
 impl Neg for Scalar {
+    type Output = Scalar;
+
+    fn neg(self) -> Scalar {
+        self.negate()
+    }
+}
+
+impl Neg for &Scalar {
     type Output = Scalar;
 
     fn neg(self) -> Scalar {
@@ -480,6 +506,13 @@ mod tests {
         fn fuzzy_roundtrip_to_bytes(a in scalar()) {
             let bytes = a.to_bytes();
             let a_back = Scalar::from_bytes(&bytes).unwrap();
+            assert_eq!(a, a_back);
+        }
+
+        #[test]
+        fn fuzzy_roundtrip_to_bytes_unchecked(a in scalar()) {
+            let bytes = a.to_bytes();
+            let a_back = Scalar::from_bytes_unchecked(&bytes);
             assert_eq!(a, a_back);
         }
 

--- a/k256/src/arithmetic/scalar/scalar_4x64.rs
+++ b/k256/src/arithmetic/scalar/scalar_4x64.rs
@@ -157,6 +157,23 @@ impl Scalar4x64 {
         self.0[0] as u32
     }
 
+    pub const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
+        // Interpret the bytes as a big-endian integer w.
+        let w3 =
+            ((bytes[0] as u64) << 56) | ((bytes[1] as u64) << 48) | ((bytes[2] as u64) << 40) | ((bytes[3] as u64) << 32) |
+            ((bytes[4] as u64) << 24) | ((bytes[5] as u64) << 16) | ((bytes[6] as u64) << 8) | (bytes[7] as u64);
+        let w2 =
+            ((bytes[8] as u64) << 56) | ((bytes[9] as u64) << 48) | ((bytes[10] as u64) << 40) | ((bytes[11] as u64) << 32) |
+            ((bytes[12] as u64) << 24) | ((bytes[13] as u64) << 16) | ((bytes[14] as u64) << 8) | (bytes[15] as u64);
+        let w1 =
+            ((bytes[16] as u64) << 56) | ((bytes[17] as u64) << 48) | ((bytes[18] as u64) << 40) | ((bytes[19] as u64) << 32) |
+            ((bytes[20] as u64) << 24) | ((bytes[21] as u64) << 16) | ((bytes[22] as u64) << 8) | (bytes[23] as u64);
+        let w0 =
+            ((bytes[24] as u64) << 56) | ((bytes[25] as u64) << 48) | ((bytes[26] as u64) << 40) | ((bytes[27] as u64) << 32) |
+            ((bytes[28] as u64) << 24) | ((bytes[29] as u64) << 16) | ((bytes[30] as u64) << 8) | (bytes[31] as u64);
+        Self([w0, w1, w2, w3])
+    }
+
     /// Attempts to parse the given byte array as an SEC-1-encoded scalar.
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
@@ -313,6 +330,53 @@ impl Scalar4x64 {
 
         Self(res)
     }
+
+    pub fn conditional_add_bit(&self, bit: usize, flag: Choice) -> Self {
+        debug_assert!(bit < 256);
+
+        // Construct Scalar(1 << bit).
+        // Since the 255-th bit of the modulus is 1, this will always be within range.
+        let bit_lo = bit & 0x3F;
+        let w = Self([
+            (((bit >> 6) == 0) as u64) << bit_lo,
+            (((bit >> 6) == 1) as u64) << bit_lo,
+            (((bit >> 6) == 2) as u64) << bit_lo,
+            (((bit >> 6) == 3) as u64) << bit_lo,
+        ]);
+
+        Self::conditional_select(self, &(self.add(&w)), flag)
+    }
+
+    pub fn mul_shift_var(&self, b: &Self, shift: usize) -> Self {
+        debug_assert!(shift >= 256);
+
+        fn ifelse(c: bool, x: u64, y: u64) -> u64 { if c {x} else {y} }
+
+        let l = self.mul_wide(b);
+        let shiftlimbs = shift >> 6;
+        let shiftlow = shift & 0x3F;
+        let shifthigh = 64 - shiftlow;
+        let r0 = ifelse(
+            shift < 512,
+            (l.0[shiftlimbs] >> shiftlow) | ifelse(shift < 448 && shiftlow != 0, l.0[1 + shiftlimbs] << shifthigh, 0),
+            0);
+        let r1 = ifelse(
+            shift < 448,
+            (l.0[1 + shiftlimbs] >> shiftlow) | ifelse(shift < 448 && shiftlow != 0, l.0[2 + shiftlimbs] << shifthigh, 0),
+            0);
+        let r2 = ifelse(
+            shift < 384,
+            (l.0[2 + shiftlimbs] >> shiftlow) | ifelse(shift < 320 && shiftlow != 0, l.0[3 + shiftlimbs] << shifthigh, 0),
+            0);
+        let r3 = ifelse(shift < 320, l.0[3 + shiftlimbs] >> shiftlow, 0);
+
+        let res = Self([r0, r1, r2, r3]);
+
+        // Check the highmost discarded bit and round up if it is set.
+        let c = (l.0[(shift - 1) >> 6] >> ((shift - 1) & 0x3f)) & 1;
+        res.conditional_add_bit(0, Choice::from(c as u8))
+    }
+
 }
 
 #[cfg(feature = "zeroize")]

--- a/k256/src/arithmetic/scalar/scalar_4x64.rs
+++ b/k256/src/arithmetic/scalar/scalar_4x64.rs
@@ -157,7 +157,8 @@ impl Scalar4x64 {
         self.0[0] as u32
     }
 
-    pub const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
+    #[cfg(feature = "endomorphism-mul")]
+    pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         // Interpret the bytes as a big-endian integer w.
         let w3 =
             ((bytes[0] as u64) << 56) | ((bytes[1] as u64) << 48) | ((bytes[2] as u64) << 40) | ((bytes[3] as u64) << 32) |

--- a/k256/src/arithmetic/scalar/scalar_8x32.rs
+++ b/k256/src/arithmetic/scalar/scalar_8x32.rs
@@ -186,6 +186,27 @@ impl Scalar8x32 {
         self.0[0]
     }
 
+    pub const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
+        // Interpret the bytes as a big-endian integer w.
+        let w7 =
+            ((bytes[0] as u32) << 24) | ((bytes[1] as u32) << 16) | ((bytes[2] as u32) << 8) | (bytes[3] as u32);
+        let w6 =
+            ((bytes[4] as u32) << 24) | ((bytes[5] as u32) << 16) | ((bytes[6] as u32) << 8) | (bytes[7] as u32);
+        let w5 =
+            ((bytes[8] as u32) << 24) | ((bytes[9] as u32) << 16) | ((bytes[10] as u32) << 8) | (bytes[11] as u32);
+        let w4 =
+            ((bytes[12] as u32) << 24) | ((bytes[13] as u32) << 16) | ((bytes[14] as u32) << 8) | (bytes[15] as u32);
+        let w3 =
+            ((bytes[16] as u32) << 24) | ((bytes[17] as u32) << 16) | ((bytes[18] as u32) << 8) | (bytes[19] as u32);
+        let w2 =
+            ((bytes[20] as u32) << 24) | ((bytes[21] as u32) << 16) | ((bytes[22] as u32) << 8) | (bytes[23] as u32);
+        let w1 =
+            ((bytes[24] as u32) << 24) | ((bytes[25] as u32) << 16) | ((bytes[26] as u32) << 8) | (bytes[27] as u32);
+        let w0 =
+            ((bytes[28] as u32) << 24) | ((bytes[29] as u32) << 16) | ((bytes[30] as u32) << 8) | (bytes[31] as u32);
+        Self([w0, w1, w2, w3, w4, w5, w6, w7])
+    }
+
     /// Attempts to parse the given byte array as an SEC-1-encoded scalar.
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
@@ -422,6 +443,74 @@ impl Scalar8x32 {
 
         Self(res)
     }
+
+    pub fn conditional_add_bit(&self, bit: usize, flag: Choice) -> Self {
+        debug_assert!(bit < 256);
+
+        // Construct Scalar(1 << bit).
+        // Since the 255-th bit of the modulus is 1, this will always be within range.
+        let bit_lo = bit & 0x1F;
+        let w = Self([
+            (((bit >> 5) == 0) as u32) << bit_lo,
+            (((bit >> 5) == 1) as u32) << bit_lo,
+            (((bit >> 5) == 2) as u32) << bit_lo,
+            (((bit >> 5) == 3) as u32) << bit_lo,
+            (((bit >> 5) == 4) as u32) << bit_lo,
+            (((bit >> 5) == 5) as u32) << bit_lo,
+            (((bit >> 5) == 6) as u32) << bit_lo,
+            (((bit >> 5) == 7) as u32) << bit_lo,
+        ]);
+
+        Self::conditional_select(self, &(self.add(&w)), flag)
+    }
+
+    pub fn mul_shift_var(&self, b: &Self, shift: usize) -> Self {
+        debug_assert!(shift >= 256);
+
+        fn ifelse(c: bool, x: u32, y: u32) -> u32 { if c {x} else {y} }
+
+        let l = self.mul_wide(b);
+        let shiftlimbs = shift >> 5;
+        let shiftlow = shift & 0x1F;
+        let shifthigh = 32 - shiftlow;
+        let r0 = ifelse(
+            shift < 512,
+            (l.0[shiftlimbs] >> shiftlow) | ifelse(shift < 480 && shiftlow != 0, l.0[1 + shiftlimbs] << shifthigh, 0),
+            0);
+        let r1 = ifelse(
+            shift < 480,
+            (l.0[1 + shiftlimbs] >> shiftlow) | ifelse(shift < 448 && shiftlow != 0, l.0[2 + shiftlimbs] << shifthigh, 0),
+            0);
+        let r2 = ifelse(
+            shift < 448,
+            (l.0[2 + shiftlimbs] >> shiftlow) | ifelse(shift < 416 && shiftlow != 0, l.0[3 + shiftlimbs] << shifthigh, 0),
+            0);
+        let r3 = ifelse(
+            shift < 416,
+            (l.0[3 + shiftlimbs] >> shiftlow) | ifelse(shift < 384 && shiftlow != 0, l.0[4 + shiftlimbs] << shifthigh, 0),
+            0);
+        let r4 = ifelse(
+            shift < 384,
+            (l.0[4 + shiftlimbs] >> shiftlow) | ifelse(shift < 352 && shiftlow != 0, l.0[5 + shiftlimbs] << shifthigh, 0),
+            0);
+        let r5 = ifelse(
+            shift < 352,
+            (l.0[5 + shiftlimbs] >> shiftlow) | ifelse(shift < 320 && shiftlow != 0, l.0[6 + shiftlimbs] << shifthigh, 0),
+            0);
+        let r6 = ifelse(
+            shift < 320,
+            (l.0[6 + shiftlimbs] >> shiftlow) | ifelse(shift < 288 && shiftlow != 0, l.0[7 + shiftlimbs] << shifthigh, 0),
+            0);
+        let r7 = ifelse(
+            shift < 288, l.0[7 + shiftlimbs] >> shiftlow, 0);
+
+        let res = Self([r0, r1, r2, r3, r4, r5, r6, r7]);
+
+        // Check the highmost discarded bit and round up if it is set.
+        let c = (l.0[(shift - 1) >> 5] >> ((shift - 1) & 0x1f)) & 1;
+        res.conditional_add_bit(0, Choice::from(c as u8))
+    }
+
 }
 
 #[cfg(feature = "zeroize")]

--- a/k256/src/arithmetic/scalar/scalar_8x32.rs
+++ b/k256/src/arithmetic/scalar/scalar_8x32.rs
@@ -186,7 +186,8 @@ impl Scalar8x32 {
         self.0[0]
     }
 
-    pub const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
+    #[cfg(feature = "endomorphism-mul")]
+    pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         // Interpret the bytes as a big-endian integer w.
         let w7 =
             ((bytes[0] as u32) << 24) | ((bytes[1] as u32) << 16) | ((bytes[2] as u32) << 8) | (bytes[3] as u32);

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -30,7 +30,7 @@ pub mod test_vectors;
 pub use elliptic_curve;
 
 #[cfg(feature = "arithmetic")]
-pub use arithmetic::{scalar::Scalar, AffinePoint, ProjectivePoint};
+pub use arithmetic::{field::FieldElement, scalar::Scalar, AffinePoint, ProjectivePoint};
 
 use elliptic_curve::{generic_array::typenum::U32, weierstrass::Curve};
 

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -16,6 +16,8 @@
 
 #[cfg(feature = "arithmetic")]
 mod arithmetic;
+#[cfg(feature = "arithmetic")]
+mod mul;
 
 #[cfg(feature = "ecdsa")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]

--- a/k256/src/mul.rs
+++ b/k256/src/mul.rs
@@ -1,42 +1,256 @@
 use core::ops::{Mul, MulAssign};
-use elliptic_curve::{
-    subtle::{ConditionallySelectable, ConstantTimeEq},
-};
+use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
-use crate::arithmetic::ProjectivePoint;
 use crate::arithmetic::scalar::Scalar;
+use crate::arithmetic::ProjectivePoint;
 
-/// Returns `[k] x`.
-fn mul_window(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
-    const LOG_MUL_WINDOW_SIZE: usize = 4;
-    const MUL_STEPS: usize = (256 - 1) / LOG_MUL_WINDOW_SIZE + 1;
-    const MUL_PRECOMP_SIZE: usize = 1 << LOG_MUL_WINDOW_SIZE;
+/// Lookup table containing precomputed values `[p, 2p, 3p, ..., 8p]`
+struct LookupTable([ProjectivePoint; 8]);
 
-    let mut precomp = [ProjectivePoint::identity(); MUL_PRECOMP_SIZE];
-    let mask = (1u32 << LOG_MUL_WINDOW_SIZE) - 1u32;
+impl From<&ProjectivePoint> for LookupTable {
+    fn from(p: &ProjectivePoint) -> Self {
+        let mut points = [*p; 8];
+        for j in 0..7 {
+            points[j + 1] = p + &points[j];
+        }
+        LookupTable(points)
+    }
+}
 
-    precomp[0] = ProjectivePoint::identity();
-    precomp[1] = *x;
-    for i in 2..MUL_PRECOMP_SIZE {
-        precomp[i] = precomp[i - 1] + x;
+impl LookupTable {
+    /// Given -8 <= x <= 8, returns x * p in constant time.
+    pub fn select(&self, x: i8) -> ProjectivePoint {
+        debug_assert!(x >= -8);
+        debug_assert!(x <= 8);
+
+        // Compute xabs = |x|
+        let xmask = x >> 7;
+        let xabs = (x + xmask) ^ xmask;
+
+        // Get an array element in constant time
+        let mut t = ProjectivePoint::identity();
+        for j in 1..9 {
+            let c = (xabs as u8).ct_eq(&(j as u8));
+            t.conditional_assign(&self.0[j - 1], c);
+        }
+        // Now t == |x| * p.
+
+        let neg_mask = Choice::from((xmask & 1) as u8);
+        t.conditional_assign(&-t, neg_mask);
+        // Now t == x * p.
+
+        t
+    }
+}
+
+/// Returns `[a_0, ..., a_64]` such that `sum(a_j * 2^(j * 4)) == x`,
+/// and `-8 <= a_j <= 7`.
+#[cfg(not(feature = "endomorphism-mul"))]
+fn to_radix_16(x: &Scalar) -> [i8; 65] {
+    // `x` can have up to 256 bits, so we need an additional byte to store the carry.
+    let mut output = [0i8; 65];
+
+    // Step 1: change radix.
+    // Convert from radix 256 (bytes) to radix 16 (nibbles)
+    let bytes = x.to_bytes();
+    for i in 0..32 {
+        output[2 * i] = (bytes[31 - i] & 0xf) as i8;
+        output[2 * i + 1] = ((bytes[31 - i] >> 4) & 0xf) as i8;
     }
 
-    let mut acc = ProjectivePoint::identity();
-    for idx in (0..MUL_STEPS).rev() {
-        for _j in 0..LOG_MUL_WINDOW_SIZE {
+    // Step 2: recenter coefficients from [0,16) to [-8,8)
+    for i in 0..64 {
+        let carry = (output[i] + 8) >> 4;
+        output[i] -= carry << 4;
+        output[i + 1] += carry;
+    }
+
+    output
+}
+
+#[cfg(not(feature = "endomorphism-mul"))]
+fn mul_windowed(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
+    let scalar_digits = to_radix_16(k);
+    let lookup_table = LookupTable::from(x);
+    let mut acc = lookup_table.select(scalar_digits[64]);
+    for i in (0..64).rev() {
+        for _j in 0..4 {
             acc = acc.double();
         }
-        let di = ((k >> (idx * LOG_MUL_WINDOW_SIZE)).truncate_to_u32() & mask) as usize;
+        acc += &lookup_table.select(scalar_digits[i]);
+    }
+    acc
+}
 
-        // Constant-time array indexing
-        let mut elem = ProjectivePoint::identity();
-        for i in 0..MUL_PRECOMP_SIZE {
-            elem = ProjectivePoint::conditional_select(&elem, &(precomp[di]), i.ct_eq(&di));
-        }
+/*
+From libsecp256k1:
 
-        acc += precomp[di as usize];
+The Secp256k1 curve has an endomorphism, where lambda * (x, y) = (beta * x, y), where
+lambda is {0x53,0x63,0xad,0x4c,0xc0,0x5c,0x30,0xe0,0xa5,0x26,0x1c,0x02,0x88,0x12,0x64,0x5a,
+        0x12,0x2e,0x22,0xea,0x20,0x81,0x66,0x78,0xdf,0x02,0x96,0x7c,0x1b,0x23,0xbd,0x72}
+
+"Guide to Elliptic Curve Cryptography" (Hankerson, Menezes, Vanstone) gives an algorithm
+(algorithm 3.74) to find k1 and k2 given k, such that k1 + k2 * lambda == k mod n, and k1
+and k2 have a small size.
+It relies on constants a1, b1, a2, b2. These constants for the value of lambda above are:
+
+- a1 =      {0x30,0x86,0xd2,0x21,0xa7,0xd4,0x6b,0xcd,0xe8,0x6c,0x90,0xe4,0x92,0x84,0xeb,0x15}
+- b1 =     -{0xe4,0x43,0x7e,0xd6,0x01,0x0e,0x88,0x28,0x6f,0x54,0x7f,0xa9,0x0a,0xbf,0xe4,0xc3}
+- a2 = {0x01,0x14,0xca,0x50,0xf7,0xa8,0xe2,0xf3,0xf6,0x57,0xc1,0x10,0x8d,0x9d,0x44,0xcf,0xd8}
+- b2 =      {0x30,0x86,0xd2,0x21,0xa7,0xd4,0x6b,0xcd,0xe8,0x6c,0x90,0xe4,0x92,0x84,0xeb,0x15}
+
+The algorithm then computes c1 = round(b1 * k / n) and c2 = round(b2 * k / n), and gives
+k1 = k - (c1*a1 + c2*a2) and k2 = -(c1*b1 + c2*b2). Instead, we use modular arithmetic, and
+compute k1 as k - k2 * lambda, avoiding the need for constants a1 and a2.
+
+g1, g2 are precomputed constants used to replace division with a rounded multiplication
+when decomposing the scalar for an endomorphism-based point multiplication.
+
+The possibility of using precomputed estimates is mentioned in "Guide to Elliptic Curve
+Cryptography" (Hankerson, Menezes, Vanstone) in section 3.5.
+
+The derivation is described in the paper "Efficient Software Implementation of Public-Key
+Cryptography on Sensor Networks Using the MSP430X Microcontroller" (Gouvea, Oliveira, Lopez),
+Section 4.3 (here we use a somewhat higher-precision estimate):
+d = a1*b2 - b1*a2
+g1 = round((2^272)*b2/d)
+g2 = round((2^272)*b1/d)
+
+(Note that 'd' is also equal to the curve order here because [a1,b1] and [a2,b2] are found
+as outputs of the Extended Euclidean Algorithm on inputs 'order' and 'lambda').
+*/
+
+/*
+@fjarri:
+
+To be precise, the method used here is based on
+"An Alternate Decomposition of an Integer for Faster Point Multiplication on Certain Elliptic Curves"
+by Young-Ho Park, Sangtae Jeong, Chang Han Kim, and Jongin Lim
+(https://link.springer.com/chapter/10.1007%2F3-540-45664-3_23)
+
+The precision used for `g1` and `g2` is not enough to ensure correct approximation at all times.
+For example, `2^272 * b1 / n` used to calculate `g2` is rounded down.
+This means that the approximation `z' = k * g2 / 2^272` always slightly underestimates
+the real value `z = b1 * k / n`. Therefore, when the fractional part of `z` is just slightly above
+0.5, it will be rounded up, but `z'` will have the fractional part slightly below 0.5 and will be
+rounded down.
+
+The difference `z - z' = k * delta / 2^272`, where `delta = b1 * 2^272 mod n`.
+The closest `z` can get to the fractional part equal to .5 is `1 / (2n)` (since `n` is odd).
+Therefore, to guarantee that `z'` will always be rounded to the same value, one must have
+`delta / 2^m < 1 / (2n * (n - 1))`, where `m` is the power of 2 used for the approximation.
+This means that one should use at least `m = 512` (since `0 < delta < 1`).
+Indeed, tests show that with only `m = 272` the approximation produces off-by-1 errors occasionally.
+
+Now since `r1` is calculated as `k - r2 * lambda mod n`, the contract `r1 + r2 * lambda = k mod n`
+is always satisfied. The method guarantees both `r1` and `r2` to be less than `sqrt(n)`
+(so, fit in 128 bits) if the rounding is applied correctly - but in our case the off-by-1 errors
+will produce different `r1` and `r2` which are not necessarily bounded by `sqrt(n)`.
+
+In experiments, I was not able to detect any case where they would go outside the 128 bit bound,
+but I cannot be sure that it cannot happen.
+*/
+
+#[cfg(feature = "endomorphism-mul")]
+const MINUS_LAMBDA: Scalar = Scalar::from_bytes_unchecked(&[
+    0xac, 0x9c, 0x52, 0xb3, 0x3f, 0xa3, 0xcf, 0x1f, 0x5a, 0xd9, 0xe3, 0xfd, 0x77, 0xed, 0x9b, 0xa4,
+    0xa8, 0x80, 0xb9, 0xfc, 0x8e, 0xc7, 0x39, 0xc2, 0xe0, 0xcf, 0xc8, 0x10, 0xb5, 0x12, 0x83, 0xcf,
+]);
+
+#[cfg(feature = "endomorphism-mul")]
+const MINUS_B1: Scalar = Scalar::from_bytes_unchecked(&[
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0xe4, 0x43, 0x7e, 0xd6, 0x01, 0x0e, 0x88, 0x28, 0x6f, 0x54, 0x7f, 0xa9, 0x0a, 0xbf, 0xe4, 0xc3,
+]);
+
+#[cfg(feature = "endomorphism-mul")]
+const MINUS_B2: Scalar = Scalar::from_bytes_unchecked(&[
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe,
+    0x8a, 0x28, 0x0a, 0xc5, 0x07, 0x74, 0x34, 0x6d, 0xd7, 0x65, 0xcd, 0xa8, 0x3d, 0xb1, 0x56, 0x2c,
+]);
+
+#[cfg(feature = "endomorphism-mul")]
+const G1: Scalar = Scalar::from_bytes_unchecked(&[
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x86,
+    0xd2, 0x21, 0xa7, 0xd4, 0x6b, 0xcd, 0xe8, 0x6c, 0x90, 0xe4, 0x92, 0x84, 0xeb, 0x15, 0x3d, 0xab,
+]);
+
+#[cfg(feature = "endomorphism-mul")]
+const G2: Scalar = Scalar::from_bytes_unchecked(&[
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xe4, 0x43,
+    0x7e, 0xd6, 0x01, 0x0e, 0x88, 0x28, 0x6f, 0x54, 0x7f, 0xa9, 0x0a, 0xbf, 0xe4, 0xc4, 0x22, 0x12,
+]);
+
+/// Find r1 and r2 given k, such that r1 + r2 * lambda == k mod n.
+#[cfg(feature = "endomorphism-mul")]
+fn decompose_scalar(k: &Scalar) -> (Scalar, Scalar) {
+    // these _var calls are constant time since the shift amount is constant
+    let c1 = k.mul_shift_var(&G1, 272);
+    let c2 = k.mul_shift_var(&G2, 272);
+
+    let c1 = &c1 * &MINUS_B1;
+    let c2 = &c2 * &MINUS_B2;
+    let r2 = &c1 + &c2;
+    let r1 = k + &r2 * &MINUS_LAMBDA;
+
+    (r1, r2)
+}
+
+/// Returns `[a_0, ..., a_32]` such that `sum(a_j * 2^(j * 4)) == x`,
+/// and `-8 <= a_j <= 7`.
+/// Assumes `x < 2^128`.
+#[cfg(feature = "endomorphism-mul")]
+fn to_radix_16_half(x: &Scalar) -> [i8; 33] {
+    // `x` can have up to 256 bits, so we need an additional byte to store the carry.
+    let mut output = [0i8; 33];
+
+    // Step 1: change radix.
+    // Convert from radix 256 (bytes) to radix 16 (nibbles)
+    let bytes = x.to_bytes();
+    for i in 0..16 {
+        output[2 * i] = (bytes[31 - i] & 0xf) as i8;
+        output[2 * i + 1] = ((bytes[31 - i] >> 4) & 0xf) as i8;
     }
 
+    debug_assert!((x >> 128).is_zero().unwrap_u8() == 1);
+
+    // Step 2: recenter coefficients from [0,16) to [-8,8)
+    for i in 0..32 {
+        let carry = (output[i] + 8) >> 4;
+        output[i] -= carry << 4;
+        output[i + 1] += carry;
+    }
+
+    output
+}
+
+#[cfg(feature = "endomorphism-mul")]
+fn mul_windowed(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
+    let (r1, r2) = decompose_scalar(k);
+    let x_beta = x.endomorphism();
+
+    let r1_sign = r1.is_high();
+    let r1_c = Scalar::conditional_select(&r1, &-r1, r1_sign);
+    let r2_sign = r2.is_high();
+    let r2_c = Scalar::conditional_select(&r2, &-r2, r2_sign);
+
+    let table1 = LookupTable::from(&ProjectivePoint::conditional_select(x, &-x, r1_sign));
+    let table2 = LookupTable::from(&ProjectivePoint::conditional_select(
+        &x_beta, &-x_beta, r2_sign,
+    ));
+
+    let digits1 = to_radix_16_half(&r1_c);
+    let digits2 = to_radix_16_half(&r2_c);
+
+    let mut acc = table1.select(digits1[32]) + &table2.select(digits2[32]);
+    for i in (0..32).rev() {
+        for _j in 0..4 {
+            acc = acc.double();
+        }
+
+        acc += &table1.select(digits1[i]);
+        acc += &table2.select(digits2[i]);
+    }
     acc
 }
 
@@ -44,7 +258,7 @@ impl Mul<&Scalar> for &ProjectivePoint {
     type Output = ProjectivePoint;
 
     fn mul(self, other: &Scalar) -> ProjectivePoint {
-        mul_window(self, other)
+        mul_windowed(self, other)
     }
 }
 
@@ -52,18 +266,18 @@ impl Mul<&Scalar> for ProjectivePoint {
     type Output = ProjectivePoint;
 
     fn mul(self, other: &Scalar) -> ProjectivePoint {
-        mul_window(&self, other)
+        mul_windowed(&self, other)
     }
 }
 
 impl MulAssign<Scalar> for ProjectivePoint {
     fn mul_assign(&mut self, rhs: Scalar) {
-        *self = mul_window(self, &rhs);
+        *self = mul_windowed(self, &rhs);
     }
 }
 
 impl MulAssign<&Scalar> for ProjectivePoint {
     fn mul_assign(&mut self, rhs: &Scalar) {
-        *self = mul_window(self, rhs);
+        *self = mul_windowed(self, rhs);
     }
 }

--- a/k256/src/mul.rs
+++ b/k256/src/mul.rs
@@ -1,0 +1,69 @@
+use core::ops::{Mul, MulAssign};
+use elliptic_curve::{
+    subtle::{ConditionallySelectable, ConstantTimeEq},
+};
+
+use crate::arithmetic::ProjectivePoint;
+use crate::arithmetic::scalar::Scalar;
+
+/// Returns `[k] x`.
+fn mul_window(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
+    const LOG_MUL_WINDOW_SIZE: usize = 4;
+    const MUL_STEPS: usize = (256 - 1) / LOG_MUL_WINDOW_SIZE + 1;
+    const MUL_PRECOMP_SIZE: usize = 1 << LOG_MUL_WINDOW_SIZE;
+
+    let mut precomp = [ProjectivePoint::identity(); MUL_PRECOMP_SIZE];
+    let mask = (1u32 << LOG_MUL_WINDOW_SIZE) - 1u32;
+
+    precomp[0] = ProjectivePoint::identity();
+    precomp[1] = *x;
+    for i in 2..MUL_PRECOMP_SIZE {
+        precomp[i] = precomp[i - 1] + x;
+    }
+
+    let mut acc = ProjectivePoint::identity();
+    for idx in (0..MUL_STEPS).rev() {
+        for _j in 0..LOG_MUL_WINDOW_SIZE {
+            acc = acc.double();
+        }
+        let di = ((k >> (idx * LOG_MUL_WINDOW_SIZE)).truncate_to_u32() & mask) as usize;
+
+        // Constant-time array indexing
+        let mut elem = ProjectivePoint::identity();
+        for i in 0..MUL_PRECOMP_SIZE {
+            elem = ProjectivePoint::conditional_select(&elem, &(precomp[di]), i.ct_eq(&di));
+        }
+
+        acc += precomp[di as usize];
+    }
+
+    acc
+}
+
+impl Mul<&Scalar> for &ProjectivePoint {
+    type Output = ProjectivePoint;
+
+    fn mul(self, other: &Scalar) -> ProjectivePoint {
+        mul_window(self, other)
+    }
+}
+
+impl Mul<&Scalar> for ProjectivePoint {
+    type Output = ProjectivePoint;
+
+    fn mul(self, other: &Scalar) -> ProjectivePoint {
+        mul_window(&self, other)
+    }
+}
+
+impl MulAssign<Scalar> for ProjectivePoint {
+    fn mul_assign(&mut self, rhs: Scalar) {
+        *self = mul_window(self, &rhs);
+    }
+}
+
+impl MulAssign<&Scalar> for ProjectivePoint {
+    fn mul_assign(&mut self, rhs: &Scalar) {
+        *self = mul_window(self, rhs);
+    }
+}


### PR DESCRIPTION
May fix issue #24, or at least come close to fixing it. On my machine, the multiplication speed without endomorphism is 104us, and with endomorphism 75us.

Current version uses a simple windowed multiplication. `libsecp256k1` has the following improvements on top of that:

1. a use of the endomorphism

This is implemented, and enabled by `endomorphism-mul`. I have some doubts about the validity of the approximation used in `libsecp256k1`, see my comment in `mul.rs` ("@fjarri"). 

2. a more advanced windowing algorithm, requiring precomputation of only odd multiples of the point

I checked it out, and it performs the same as the one from Ristretto, with the latter being considerably simpler. So I used the Ristretto one. (It does have a hardcoded window size, but generalizing to other window sizes is trivial, if needed).

3. a use of isomorphism to calculate precomputed multiples in the affine form, and use `add_mixed()` later to add them to the (projective) accumulator

This introduces non-constant-timeness wrt the point, and requires a check for the point not being infinite. Not for this PR.