### PR TITLE
k256: unify `AffinePoint::to_pubkey` method

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -40,6 +40,7 @@ jobs:
           command: fmt
           args: --all -- --check
 
+# TODO(tarcieri): investigate why codecov is failing
 #  codecov:
 #    runs-on: ubuntu-latest
 #    steps:

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -78,7 +78,7 @@ impl Signature {
 
         // TODO(tarcieri): replace with into conversion when available (see subtle#73)
         if pk.is_some().into() {
-            Ok(pk.unwrap().to_compressed_pubkey())
+            Ok(pk.unwrap().to_pubkey(true))
         } else {
             Err(Error::new())
         }


### PR DESCRIPTION
Uses a `compress: bool` argument to enable point compression.