### PR TITLE
k256/p256: impl Generate for Scalar types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#d009349c109f557b4f223c27969df613808a9931"
+source = "git+https://github.com/RustCrypto/traits#8d67bb6c48fc54bfe76a52eebeb4cee0f8cd579c"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -494,9 +494,9 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.16"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro2"
@@ -742,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
+checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
 dependencies = [
  "itoa",
  "ryu",
@@ -781,9 +781,9 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "syn"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7f4c519df8c117855e19dd8cc851e89eb746fe7a73f0157e0d95fdec5369b0"
+checksum = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -23,6 +23,7 @@ use crate::SecretKey;
 use elliptic_curve::{
     rand_core::{CryptoRng, RngCore},
     weierstrass::GenerateSecretKey,
+    Generate,
 };
 
 const CURVE_EQUATION_B_SINGLE: u32 = 7u32;
@@ -538,10 +539,8 @@ impl<'a> Neg for &'a ProjectivePoint {
 
 #[cfg(feature = "rand")]
 impl GenerateSecretKey for Secp256k1 {
-    fn generate_secret_key(rng: &mut (impl CryptoRng + RngCore)) -> SecretKey {
-        // It seems that slight variable-timeness is more secure than slight non-uniformity.
-        let s = Scalar::generate_vartime(rng);
-        SecretKey::new(s.to_bytes().into())
+    fn generate_secret_key(rng: impl CryptoRng + RngCore) -> SecretKey {
+        SecretKey::new(Scalar::generate(rng).to_bytes().into())
     }
 }
 

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -22,6 +22,7 @@ use crate::SecretKey;
 use elliptic_curve::{
     rand_core::{CryptoRng, RngCore},
     weierstrass::GenerateSecretKey,
+    Generate,
 };
 
 /// a = -3
@@ -538,19 +539,8 @@ impl<'a> Neg for &'a ProjectivePoint {
 
 #[cfg(feature = "rand")]
 impl GenerateSecretKey for NistP256 {
-    fn generate_secret_key(rng: &mut (impl CryptoRng + RngCore)) -> SecretKey {
-        let mut bytes = [0u8; 32];
-
-        // "Generate-and-Pray": create random 32-byte strings, and test if they
-        // are accepted by Scalar::from_bytes
-        // TODO(tarcieri): use a modular reduction instead?
-        loop {
-            rng.fill_bytes(&mut bytes);
-
-            if Scalar::from_bytes(&bytes).is_some().into() {
-                return SecretKey::new(bytes.into());
-            }
-        }
+    fn generate_secret_key(rng: impl CryptoRng + RngCore) -> SecretKey {
+        SecretKey::new(Scalar::generate(rng).to_bytes().into())
     }
 }
 


### PR DESCRIPTION
Impls the new trait for random generation added in RustCrypto/traits#220.

This can potentially be used to completely replace the `GenerateSecretKey` trait, since that can now be made a conditionally impl'd inherent method on `SecretKey` with where bounds on `Scalar: Generate`.