### PR TITLE
Implement RustCrypto/traits#223 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/signatures#3655c0b7a14a9641f847de5deb866e5ee7198a98"
+source = "git+https://github.com/RustCrypto/signatures#3800528655f34696877fbc2c8a6921088d503f0c"
 dependencies = [
  "elliptic-curve",
  "signature",
@@ -236,7 +236,7 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#8d67bb6c48fc54bfe76a52eebeb4cee0f8cd579c"
+source = "git+https://github.com/RustCrypto/traits#3fd8ac7fa787cfbea275306fab011a592206b1b2"
 dependencies = [
  "generic-array",
  "rand_core",

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -9,7 +9,8 @@ use core::convert::TryInto;
 use core::ops::{Add, AddAssign, Neg, Sub, SubAssign};
 use elliptic_curve::{
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
-    weierstrass::{curve::Arithmetic, FixedBaseScalarMul},
+    weierstrass::FixedBaseScalarMul,
+    Arithmetic,
 };
 
 use crate::{CompressedPoint, PublicKey, ScalarBytes, Secp256k1, UncompressedPoint};
@@ -192,11 +193,11 @@ impl From<AffinePoint> for UncompressedPoint {
 
 impl FixedBaseScalarMul for Secp256k1 {
     /// Elliptic curve point type
-    type Point = AffinePoint;
+    type AffinePoint = AffinePoint;
 
     /// Multiply the given scalar by the generator point for this elliptic
     /// curve.
-    fn mul_base(scalar_bytes: &ScalarBytes) -> CtOption<Self::Point> {
+    fn mul_base(scalar_bytes: &ScalarBytes) -> CtOption<AffinePoint> {
         Scalar::from_bytes(scalar_bytes.as_ref())
             .and_then(|scalar| (&ProjectivePoint::generator() * &scalar).to_affine())
     }

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -32,7 +32,7 @@ pub use elliptic_curve;
 #[cfg(feature = "arithmetic")]
 pub use arithmetic::{field::FieldElement, scalar::Scalar, AffinePoint, ProjectivePoint};
 
-use elliptic_curve::{generic_array::typenum::U32, weierstrass::Curve};
+use elliptic_curve::consts::U32;
 
 /// K-256 (secp256k1) elliptic curve.
 ///
@@ -48,13 +48,15 @@ use elliptic_curve::{generic_array::typenum::U32, weierstrass::Curve};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Secp256k1;
 
-impl Curve for Secp256k1 {
-    /// 256-bit (32-byte) private scalar
-    type ScalarSize = U32;
+impl elliptic_curve::Curve for Secp256k1 {
+    /// 256-bit (32-byte)
+    type ElementSize = U32;
 }
 
+impl elliptic_curve::weierstrass::Curve for Secp256k1 {}
+
 /// K-256 (secp256k1) Secret Key.
-pub type SecretKey = elliptic_curve::SecretKey<U32>;
+pub type SecretKey = elliptic_curve::SecretKey<Secp256k1>;
 
 /// K-256 (secp256k1) Public Key.
 pub type PublicKey = elliptic_curve::weierstrass::PublicKey<Secp256k1>;
@@ -62,7 +64,7 @@ pub type PublicKey = elliptic_curve::weierstrass::PublicKey<Secp256k1>;
 /// K-256 Scalar Bytes.
 ///
 /// Byte array containing a serialized scalar value (i.e. an integer)
-pub type ScalarBytes = elliptic_curve::ScalarBytes<U32>;
+pub type ScalarBytes = elliptic_curve::ScalarBytes<Secp256k1>;
 
 /// K-256 Compressed Curve Point.
 pub type CompressedPoint = elliptic_curve::weierstrass::CompressedPoint<Secp256k1>;

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -8,7 +8,8 @@ use core::convert::TryInto;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use elliptic_curve::{
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
-    weierstrass::{curve::Arithmetic, FixedBaseScalarMul},
+    weierstrass::FixedBaseScalarMul,
+    Arithmetic,
 };
 
 use crate::{CompressedPoint, NistP256, PublicKey, ScalarBytes, UncompressedPoint};
@@ -182,11 +183,11 @@ impl From<AffinePoint> for UncompressedPoint {
 
 impl FixedBaseScalarMul for NistP256 {
     /// Elliptic curve point type
-    type Point = AffinePoint;
+    type AffinePoint = AffinePoint;
 
     /// Multiply the given scalar by the generator point for this elliptic
     /// curve.
-    fn mul_base(scalar_bytes: &ScalarBytes) -> CtOption<Self::Point> {
+    fn mul_base(scalar_bytes: &ScalarBytes) -> CtOption<AffinePoint> {
         Scalar::from_bytes(scalar_bytes.as_ref())
             .and_then(|scalar| (&ProjectivePoint::generator() * &scalar).to_affine())
     }

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -29,7 +29,7 @@ pub use elliptic_curve;
 #[cfg(feature = "arithmetic")]
 pub use arithmetic::{scalar::Scalar, AffinePoint, ProjectivePoint};
 
-use elliptic_curve::{generic_array::typenum::U32, weierstrass::Curve};
+use elliptic_curve::consts::U32;
 
 /// NIST P-256 elliptic curve.
 ///
@@ -53,13 +53,15 @@ use elliptic_curve::{generic_array::typenum::U32, weierstrass::Curve};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct NistP256;
 
-impl Curve for NistP256 {
-    /// 256-bit (32-byte) private scalar
-    type ScalarSize = U32;
+impl elliptic_curve::Curve for NistP256 {
+    /// 256-bit (32-byte)
+    type ElementSize = U32;
 }
 
+impl elliptic_curve::weierstrass::Curve for NistP256 {}
+
 /// NIST P-256 Secret Key
-pub type SecretKey = elliptic_curve::SecretKey<U32>;
+pub type SecretKey = elliptic_curve::SecretKey<NistP256>;
 
 /// NIST P-256 Public Key
 pub type PublicKey = elliptic_curve::weierstrass::PublicKey<NistP256>;
@@ -67,7 +69,7 @@ pub type PublicKey = elliptic_curve::weierstrass::PublicKey<NistP256>;
 /// NIST P-256 Scalar Bytes.
 ///
 /// Byte array containing a serialized scalar value (i.e. an integer)
-pub type ScalarBytes = elliptic_curve::ScalarBytes<U32>;
+pub type ScalarBytes = elliptic_curve::ScalarBytes<NistP256>;
 
 /// NIST P-256 Compressed Curve Point
 pub type CompressedPoint = elliptic_curve::weierstrass::CompressedPoint<NistP256>;

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -19,7 +19,7 @@ pub mod ecdsa;
 
 pub use elliptic_curve;
 
-use elliptic_curve::{generic_array::typenum::U48, weierstrass::Curve};
+use elliptic_curve::consts::U48;
 
 /// NIST P-384 elliptic curve.
 ///
@@ -44,16 +44,23 @@ use elliptic_curve::{generic_array::typenum::U48, weierstrass::Curve};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct NistP384;
 
-impl Curve for NistP384 {
-    /// 384-bit (48-byte) private scalar
-    type ScalarSize = U48;
+impl elliptic_curve::Curve for NistP384 {
+    /// 384-bit (48-byte)
+    type ElementSize = U48;
 }
 
+impl elliptic_curve::weierstrass::Curve for NistP384 {}
+
 /// NIST P-384 Secret Key
-pub type SecretKey = elliptic_curve::SecretKey<U48>;
+pub type SecretKey = elliptic_curve::SecretKey<NistP384>;
 
 /// NIST P-384 Public Key
 pub type PublicKey = elliptic_curve::weierstrass::PublicKey<NistP384>;
+
+/// NIST P-384 Scalar Bytes.
+///
+/// Byte array containing a serialized scalar value (i.e. an integer)
+pub type ScalarBytes = elliptic_curve::ScalarBytes<NistP384>;
 
 /// NIST P-384 Compressed Curve Point
 pub type CompressedPoint = elliptic_curve::weierstrass::CompressedPoint<NistP384>;


### PR DESCRIPTION
Updates usages of the elliptic-curve crate API to incorporate the changes from RustCrypto/traits#223.