### PR TITLE
k256/p256: remove GenerateSecretKey impls; use Generate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#3fd8ac7fa787cfbea275306fab011a592206b1b2"
+source = "git+https://github.com/RustCrypto/traits#513eb076c77f9272289272bd4abbc017f190af84"
 dependencies = [
  "generic-array",
  "rand_core",

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -17,16 +17,6 @@ use crate::{CompressedPoint, PublicKey, ScalarBytes, Secp256k1, UncompressedPoin
 use field::FieldElement;
 use scalar::Scalar;
 
-#[cfg(feature = "rand")]
-use crate::SecretKey;
-
-#[cfg(feature = "rand")]
-use elliptic_curve::{
-    rand_core::{CryptoRng, RngCore},
-    weierstrass::GenerateSecretKey,
-    Generate,
-};
-
 const CURVE_EQUATION_B_SINGLE: u32 = 7u32;
 
 #[rustfmt::skip]
@@ -538,13 +528,6 @@ impl<'a> Neg for &'a ProjectivePoint {
     }
 }
 
-#[cfg(feature = "rand")]
-impl GenerateSecretKey for Secp256k1 {
-    fn generate_secret_key(rng: impl CryptoRng + RngCore) -> SecretKey {
-        SecretKey::new(Scalar::generate(rng).to_bytes().into())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use core::convert::TryInto;
@@ -804,8 +787,10 @@ mod tests {
     #[cfg(feature = "rand")]
     #[test]
     fn generate_secret_key() {
-        use elliptic_curve::{rand_core::OsRng, weierstrass::GenerateSecretKey};
-        let key = Secp256k1::generate_secret_key(&mut OsRng);
+        use crate::SecretKey;
+        use elliptic_curve::{rand_core::OsRng, Generate};
+
+        let key = SecretKey::generate(&mut OsRng);
 
         // Sanity check
         assert!(!key.secret_scalar().iter().all(|b| *b == 0))

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -16,16 +16,6 @@ use crate::{CompressedPoint, NistP256, PublicKey, ScalarBytes, UncompressedPoint
 use field::{FieldElement, MODULUS};
 use scalar::Scalar;
 
-#[cfg(feature = "rand")]
-use crate::SecretKey;
-
-#[cfg(feature = "rand")]
-use elliptic_curve::{
-    rand_core::{CryptoRng, RngCore},
-    weierstrass::GenerateSecretKey,
-    Generate,
-};
-
 /// a = -3
 const CURVE_EQUATION_A: FieldElement = FieldElement::zero()
     .subtract(&FieldElement::one())
@@ -538,13 +528,6 @@ impl<'a> Neg for &'a ProjectivePoint {
     }
 }
 
-#[cfg(feature = "rand")]
-impl GenerateSecretKey for NistP256 {
-    fn generate_secret_key(rng: impl CryptoRng + RngCore) -> SecretKey {
-        SecretKey::new(Scalar::generate(rng).to_bytes().into())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     // TODO(tarcieri): test `FixedBaseScalarMul` impl
@@ -785,10 +768,10 @@ mod tests {
     #[cfg(feature = "rand")]
     #[test]
     fn generate_secret_key() {
-        use crate::NistP256;
-        use elliptic_curve::{rand_core::OsRng, weierstrass::GenerateSecretKey};
+        use crate::SecretKey;
+        use elliptic_curve::{rand_core::OsRng, Generate};
 
-        let key = NistP256::generate_secret_key(&mut OsRng);
+        let key = SecretKey::generate(&mut OsRng);
 
         // Sanity check
         assert!(!key.secret_scalar().iter().all(|b| *b == 0))


### PR DESCRIPTION
This trait was removed in https://github.com/RustCrypto/traits/pull/224

The `Generate` trait is now conditionally defined for `SecretKey` when an `Arithmetic` impl is available and its `Scalar` type impls `Generate`.