### PR TITLE
k256/p256: FixedBaseScalarMul simplification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#513eb076c77f9272289272bd4abbc017f190af84"
+source = "git+https://github.com/RustCrypto/traits#23b27c07e84c078edb748d2157cf9328fe9659eb"
 dependencies = [
  "generic-array",
  "rand_core",

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -182,9 +182,6 @@ impl From<AffinePoint> for UncompressedPoint {
 }
 
 impl FixedBaseScalarMul for Secp256k1 {
-    /// Elliptic curve point type
-    type AffinePoint = AffinePoint;
-
     /// Multiply the given scalar by the generator point for this elliptic
     /// curve.
     fn mul_base(scalar_bytes: &ScalarBytes) -> CtOption<AffinePoint> {

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -172,9 +172,6 @@ impl From<AffinePoint> for UncompressedPoint {
 }
 
 impl FixedBaseScalarMul for NistP256 {
-    /// Elliptic curve point type
-    type AffinePoint = AffinePoint;
-
     /// Multiply the given scalar by the generator point for this elliptic
     /// curve.
     fn mul_base(scalar_bytes: &ScalarBytes) -> CtOption<AffinePoint> {


### PR DESCRIPTION
Implements the changes from RustCrypto/traits#227