### PR TITLE
k256/p256: use Arithmetic trait-based ECDSA SignPrimitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/signatures#3800528655f34696877fbc2c8a6921088d503f0c"
+source = "git+https://github.com/RustCrypto/signatures#12b96e3ac5cfb4b7f5076355bce127ea5a33db53"
 dependencies = [
  "elliptic-curve",
  "signature",

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -25,8 +25,6 @@ impl ecdsa::hazmat::DigestPrimitive for Secp256k1 {
 
 #[cfg(feature = "arithmetic")]
 impl SignPrimitive<Secp256k1> for Scalar {
-    type Scalar = Scalar;
-
     #[allow(clippy::many_single_char_names)]
     fn try_sign_prehashed(
         &self,

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -23,8 +23,6 @@ impl ecdsa::hazmat::DigestPrimitive for NistP256 {
 
 #[cfg(feature = "arithmetic")]
 impl SignPrimitive<NistP256> for Scalar {
-    type Scalar = Scalar;
-
     #[allow(clippy::many_single_char_names)]
     fn try_sign_prehashed(
         &self,


### PR DESCRIPTION
Incorporates changes from RustCrypto/signatures#106

The `ecdsa::hazmat::SignPrimitive` now bounds the elliptic curve generic parameter on `Arithmetic`, from which it sources an associated `Scalar` type.