### PR TITLE
Deactivate default features of sha2 in Cargo.toml

### DIFF
--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
 [dependencies]
 ecdsa = { version = "= 0.7.0-pre", optional = true, default-features = false }
 elliptic-curve = { version = "= 0.5.0-pre", default-features = false,  features = ["weierstrass"] }
-sha2 = { version = "0.9", optional = true }
+sha2 = { version = "0.9", default-features = false, optional = true }
 zeroize = { version = "1",  optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Set default-features = false for sha2 in Cargo.toml such that the crate builds in no_std environment.