### PR TITLE
k256/p256: use new `SignPrimitive` API; add `BlindedScalar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/signatures#12b96e3ac5cfb4b7f5076355bce127ea5a33db53"
+source = "git+https://github.com/RustCrypto/signatures#e33e8b2c69887cbae749126354966ddbf1c66b63"
 dependencies = [
  "elliptic-curve",
  "signature",
@@ -236,7 +236,7 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#23b27c07e84c078edb748d2157cf9328fe9659eb"
+source = "git+https://github.com/RustCrypto/traits#f8a916bbcff07aece243db24f17f663d4077baba"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -327,9 +327,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.42"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52732a3d3ad72c58ad2dc70624f9c17b46ecd0943b9a4f1ee37c4c18c5d983e2"
+checksum = "d7d8712512671fd243aa2ab95ca816506c6bd0c36221694bb6b58d9ce93df795"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -875,9 +875,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.65"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edbcc9536ab7eababcc6d2374a0b7bfe13a2b6d562c5e07f370456b1a8f33d"
+checksum = "79baa72a2f1274a76ff3e0fde524ab9dad4e6761182f334e7285c9e954890584"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -885,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.65"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ed2fb8c84bfad20ea66b26a3743f3e7ba8735a69fe7d95118c33ec8fc1244d"
+checksum = "5dd8ace32c1037c1abe65e58a42c48b2dfcab895144e63762cff2cbdd6c9d184"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -900,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.65"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb071268b031a64d92fc6cf691715ca5a40950694d8f683c5bb43db7c730929e"
+checksum = "c239a0e7818632afc1999ea4d81f4dcbde41a1298484b220558fc233a1051248"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -910,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.65"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf592c807080719d1ff2f245a687cbadb3ed28b2077ed7084b47aba8b691f2c6"
+checksum = "c4e7bfd8f80de01ef004806b4fd449cb0a20959a546265adbe25c3b31128240d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -923,15 +923,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.65"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b6c0220ded549d63860c78c38f3bcc558d1ca3f4efa74942c536ddbbb55e87"
+checksum = "62e05c256872262748a8efd455b292b37ea8aad5e0b4a59ff520cda359125236"
 
 [[package]]
 name = "web-sys"
-version = "0.3.42"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be2398f326b7ba09815d0b403095f34dd708579220d099caae89be0b32137b2"
+checksum = "f3362f54c47d0da11569b6115a1c1fbe5e7162ca720c382066e96aa2263d06c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
 [dependencies]
 cfg-if = "0.1"
 ecdsa = { version = "= 0.7.0-pre", optional = true, default-features = false, features = ["hazmat"] }
-elliptic-curve = { version = "= 0.5.0-pre",  default-features = false, features = ["weierstrass"] }
-sha2 = { version = "0.9", optional = true }
+elliptic-curve = { version = "= 0.5.0-pre", default-features = false, features = ["weierstrass"] }
+sha2 = { version = "0.9", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -18,7 +18,10 @@ cfg_if! {
 
 use crate::ScalarBytes;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, Sub, SubAssign};
-use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+use elliptic_curve::{
+    ops::Invert,
+    subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
+};
 
 #[cfg(feature = "digest")]
 use ecdsa::signature::digest::{consts::U32, Digest};
@@ -248,6 +251,12 @@ impl Scalar {
     }
 }
 
+impl AsRef<Scalar> for Scalar {
+    fn as_ref(&self) -> &Scalar {
+        self
+    }
+}
+
 impl Shr<usize> for Scalar {
     type Output = Self;
 
@@ -369,6 +378,14 @@ impl Mul<&Scalar> for Scalar {
 impl MulAssign<Scalar> for Scalar {
     fn mul_assign(&mut self, rhs: Scalar) {
         *self = Scalar::mul(self, &rhs);
+    }
+}
+
+impl Invert for Scalar {
+    type Output = Self;
+
+    fn invert(&self) -> CtOption<Self> {
+        Scalar::invert(self)
     }
 }
 

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
 
 [dependencies]
 ecdsa = { version = "= 0.7.0-pre", optional = true, default-features = false }
-elliptic-curve = { version = "= 0.5.0-pre", default-features = false,  features = ["weierstrass"] }
-sha2 = { version = "0.9", default-features = false, optional = true }
+elliptic-curve = { version = "= 0.5.0-pre", default-features = false, features = ["weierstrass"] }
+sha2 = { version = "0.9", optional = true, default-features = false }
 zeroize = { version = "1",  optional = true, default-features = false }
 
 [dev-dependencies]

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -88,7 +88,7 @@ impl FieldElement {
 
     /// Returns a uniformly-random element within the field.
     #[cfg(feature = "rand")]
-    pub fn generate(rng: &mut (impl CryptoRng + RngCore)) -> Self {
+    pub fn generate(mut rng: impl CryptoRng + RngCore) -> Self {
         // We reduce a random 512-bit value into a 256-bit field, which results in a
         // negligible bias from the uniform distribution.
         let mut buf = [0; 64];

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -1,11 +1,17 @@
 //! Scalar field arithmetic modulo n = 115792089210356248762697446949407573529996955224135760342422259061068512044369
 
+#[cfg(feature = "rand")]
+pub mod blinding;
+
 use crate::ScalarBytes;
 use core::{
     convert::TryInto,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
-use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+use elliptic_curve::{
+    ops::Invert,
+    subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
+};
 
 #[cfg(feature = "rand")]
 use elliptic_curve::{
@@ -108,6 +114,12 @@ fn shr1(u256: &mut U256) {
         let new_digit = (bit << 63) | (*digit >> 1);
         bit = *digit & 1;
         *digit = new_digit;
+    }
+}
+
+impl AsRef<Scalar> for Scalar {
+    fn as_ref(&self) -> &Scalar {
+        self
     }
 }
 
@@ -654,6 +666,14 @@ impl ConstantTimeEq for Scalar {
             & self.0[1].ct_eq(&other.0[1])
             & self.0[2].ct_eq(&other.0[2])
             & self.0[3].ct_eq(&other.0[3])
+    }
+}
+
+impl Invert for Scalar {
+    type Output = Self;
+
+    fn invert(&self) -> CtOption<Self> {
+        Scalar::invert(self)
     }
 }
 

--- a/p256/src/arithmetic/scalar/blinding.rs
+++ b/p256/src/arithmetic/scalar/blinding.rs
@@ -1,0 +1,72 @@
+//! Random blinding support for [`Scalar`]
+
+// TODO(tarcieri): make this generic (along with `Scalar::invert_vartime`)
+// and extract it into the `elliptic-curve` crate so it can be reused across curves
+
+use super::Scalar;
+use elliptic_curve::{
+    ops::Invert,
+    rand_core::{CryptoRng, RngCore},
+    subtle::CtOption,
+    Generate,
+};
+
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
+/// Scalar blinded with a randomly generated masking value.
+///
+/// This provides a randomly blinded impl of [`Invert`] which is useful for
+/// ECDSA ephemeral (`k`) scalars.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+pub struct BlindedScalar {
+    /// Actual scalar value
+    scalar: Scalar,
+
+    /// Mask value
+    mask: Scalar,
+}
+
+impl BlindedScalar {
+    /// Create a new [`BlindedScalar`] from a scalar and a [`CryptoRng`]
+    pub fn new(scalar: Scalar, rng: impl CryptoRng + RngCore) -> Self {
+        Self {
+            scalar,
+            mask: Scalar::generate(rng),
+        }
+    }
+}
+
+impl AsRef<Scalar> for BlindedScalar {
+    fn as_ref(&self) -> &Scalar {
+        &self.scalar
+    }
+}
+
+impl Invert for BlindedScalar {
+    type Output = Scalar;
+
+    fn invert(&self) -> CtOption<Scalar> {
+        // prevent side channel analysis of scalar inversion by pre-and-post-multiplying
+        // with the random masking scalar
+        (self.scalar * &self.mask)
+            .invert_vartime()
+            .map(|s| s * &self.mask)
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl Zeroize for BlindedScalar {
+    fn zeroize(&mut self) {
+        self.scalar.zeroize();
+        self.mask.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl Drop for BlindedScalar {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -29,6 +29,9 @@ pub use elliptic_curve;
 #[cfg(feature = "arithmetic")]
 pub use arithmetic::{scalar::Scalar, AffinePoint, ProjectivePoint};
 
+#[cfg(all(feature = "arithmetic", feature = "rand"))]
+pub use arithmetic::scalar::blinding::BlindedScalar;
+
 use elliptic_curve::consts::U32;
 
 /// NIST P-256 elliptic curve.


### PR DESCRIPTION
Updates both crates with the `SignPrimitive` changes from RustCrypto/signatures#107.

These changes removed the `masking_scalar` argument from the trait, and replaced it with trait bounds that make it possible to substitute a blinded scalar.

In the `p256` crate (which is the only one that presently implements a variable-time inversion) the `masking_scalar` is replaced with a `BlindedScalar` type that implements the previous blinded inversion.

The implementation it uses (including `Scalar::invert_vartime`) could potentially be made generic and extracted into the `elliptic-curve` crate, allowing it to be used with any curve which implements the arithmetic primitives used in the blinded inversion implementation.

However, for now, this PR leaves it in `p256`, and therefore at least has feature parity with the old implementation.