### PR TITLE
k256/p256: wire up ecdsa::Signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/signatures#e33e8b2c69887cbae749126354966ddbf1c66b63"
+source = "git+https://github.com/RustCrypto/signatures#b95afa61699dd63d1089fa4e26eecf6f723985ef"
 dependencies = [
  "elliptic-curve",
  "signature",
@@ -236,11 +236,12 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#129205462a5f04d3e3b6f2e4592b5d7a0d6448f0"
+source = "git+https://github.com/RustCrypto/traits#06f105843d8f90d0bb0301762f79b73519acbc3c"
 dependencies = [
  "generic-array",
  "rand_core",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -348,7 +349,6 @@ dependencies = [
  "num-traits",
  "proptest",
  "sha2",
- "zeroize",
 ]
 
 [[package]]
@@ -455,7 +455,6 @@ dependencies = [
  "hex-literal",
  "proptest",
  "sha2",
- "zeroize",
 ]
 
 [[package]]
@@ -766,11 +765,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.1.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65211b7b6fc3f14ff9fc7a2011a434e3e6880585bd2e9e9396315ae24cbf7852"
+checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 dependencies = [
  "digest",
+ "rand_core",
 ]
 
 [[package]]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -13,13 +13,12 @@ keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
 
 [dependencies]
 cfg-if = "0.1"
-ecdsa = { version = "= 0.7.0-pre", optional = true, default-features = false, features = ["hazmat"] }
+ecdsa-core = { version = "= 0.7.0-pre", package = "ecdsa", optional = true, default-features = false }
 elliptic-curve = { version = "= 0.5.0-pre", default-features = false, features = ["weierstrass"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
-zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa = { version = "= 0.7.0-pre", default-features = false, features = ["dev", "hazmat"] }
+ecdsa-core = { version = "= 0.7.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4" # TODO: switch to hex-literal
 hex-literal = "0.2"
 proptest = "0.10"
@@ -30,7 +29,8 @@ criterion = "0.3"
 [features]
 default = ["arithmetic", "std"]
 arithmetic = []
-digest = ["ecdsa/digest"]
+digest = ["ecdsa-core/digest"]
+ecdsa = ["arithmetic", "ecdsa-core/signer", "sha256", "zeroize"]
 endomorphism-mul = []
 field-montgomery = []
 force-32-bit = []
@@ -38,6 +38,7 @@ rand = ["elliptic-curve/rand_core"]
 sha256 = ["digest", "sha2"]
 test-vectors = []
 std = ["elliptic-curve/std"]
+zeroize = ["elliptic-curve/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -26,7 +26,7 @@ use elliptic_curve::{
 };
 
 #[cfg(feature = "digest")]
-use ecdsa::signature::digest::{consts::U32, Digest};
+use ecdsa_core::signature::digest::{consts::U32, Digest};
 
 #[cfg(feature = "rand")]
 use elliptic_curve::{
@@ -35,7 +35,7 @@ use elliptic_curve::{
 };
 
 #[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
+use elliptic_curve::zeroize::Zeroize;
 
 #[cfg(test)]
 use num_bigint::{BigUint, ToBigUint};
@@ -256,12 +256,6 @@ impl Scalar {
     /// Variable time in `shift`.
     pub fn mul_shift_var(&self, b: &Scalar, shift: usize) -> Self {
         Self(self.0.mul_shift_var(&(b.0), shift))
-    }
-}
-
-impl AsRef<Scalar> for Scalar {
-    fn as_ref(&self) -> &Scalar {
-        self
     }
 }
 

--- a/k256/src/arithmetic/scalar/scalar_8x32.rs
+++ b/k256/src/arithmetic/scalar/scalar_8x32.rs
@@ -8,7 +8,7 @@ use crate::arithmetic::util::{adc32, sbb32};
 use core::convert::TryInto;
 
 #[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
+use elliptic_curve::zeroize::Zeroize;
 
 /// Constant representing the modulus
 /// n = FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364141

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -4,7 +4,7 @@ use core::{
     convert::{TryFrom, TryInto},
     fmt::{self, Debug},
 };
-use ecdsa::{signature::Signature as _, Error};
+use ecdsa_core::{signature::Signature as _, Error};
 
 #[cfg(feature = "arithmetic")]
 use crate::arithmetic::{
@@ -45,7 +45,8 @@ impl Signature {
 
     /// Recover the [`PublicKey`] used to create the given signature
     #[cfg(all(feature = "arithmetic", feature = "sha256"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic", feature = "sha256")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sha256")))]
     #[allow(non_snake_case, clippy::many_single_char_names)]
     pub fn recover_pubkey(&self, msg: &[u8]) -> Result<PublicKey, Error> {
         let r = self.r()?;
@@ -112,7 +113,7 @@ impl Signature {
     }
 }
 
-impl ecdsa::signature::Signature for Signature {
+impl ecdsa_core::signature::Signature for Signature {
     fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         bytes.try_into()
     }

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -19,8 +19,8 @@ mod arithmetic;
 #[cfg(feature = "arithmetic")]
 mod mul;
 
-#[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+#[cfg(feature = "ecdsa-core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa-core")))]
 pub mod ecdsa;
 
 #[cfg(any(feature = "test-vectors", test))]

--- a/k256/src/test_vectors/ecdsa.rs
+++ b/k256/src/test_vectors/ecdsa.rs
@@ -1,6 +1,6 @@
 //! ECDSA/secp256k1 test vectors
 
-use ecdsa::dev::TestVector;
+use ecdsa_core::dev::TestVector;
 use hex_literal::hex;
 
 /// ECDSA/secp256k1 test vectors

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -12,13 +12,12 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
 
 [dependencies]
-ecdsa = { version = "= 0.7.0-pre", optional = true, default-features = false }
+ecdsa-core = { version = "= 0.7.0-pre", package = "ecdsa", optional = true, default-features = false }
 elliptic-curve = { version = "= 0.5.0-pre", default-features = false, features = ["weierstrass"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
-zeroize = { version = "1",  optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa = { version = "= 0.7.0-pre", default-features = false, features = ["dev", "hazmat"] }
+ecdsa-core = { version = "= 0.7.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4" # TODO: switch to hex-literal
 hex-literal = "0.2"
 proptest = "0.10"
@@ -26,10 +25,12 @@ proptest = "0.10"
 [features]
 default = ["arithmetic", "std"]
 arithmetic = []
+ecdsa = ["arithmetic", "ecdsa-core/signer", "sha256", "zeroize"]
 rand = ["elliptic-curve/rand_core"]
-sha256 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
+sha256 = ["ecdsa-core/digest", "ecdsa-core/hazmat", "sha2"]
 test-vectors = []
 std = ["elliptic-curve/std"]
+zeroize = ["elliptic-curve/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -22,7 +22,7 @@ use elliptic_curve::{
 };
 
 #[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
+use elliptic_curve::zeroize::Zeroize;
 
 use super::util::{adc, mac, sbb};
 
@@ -121,12 +121,6 @@ fn shr1(u256: &mut U256) {
         let new_digit = (bit << 63) | (*digit >> 1);
         bit = *digit & 1;
         *digit = new_digit;
-    }
-}
-
-impl AsRef<Scalar> for Scalar {
-    fn as_ref(&self) -> &Scalar {
-        self
     }
 }
 

--- a/p256/src/arithmetic/scalar/blinding.rs
+++ b/p256/src/arithmetic/scalar/blinding.rs
@@ -4,6 +4,7 @@
 // and extract it into the `elliptic-curve` crate so it can be reused across curves
 
 use super::Scalar;
+use core::borrow::Borrow;
 use elliptic_curve::{
     ops::Invert,
     rand_core::{CryptoRng, RngCore},
@@ -12,7 +13,7 @@ use elliptic_curve::{
 };
 
 #[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
+use elliptic_curve::zeroize::Zeroize;
 
 /// Scalar blinded with a randomly generated masking value.
 ///
@@ -38,8 +39,8 @@ impl BlindedScalar {
     }
 }
 
-impl AsRef<Scalar> for BlindedScalar {
-    fn as_ref(&self) -> &Scalar {
+impl Borrow<Scalar> for BlindedScalar {
+    fn borrow(&self) -> &Scalar {
         &self.scalar
     }
 }

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -16,8 +16,8 @@
 #[cfg(feature = "arithmetic")]
 mod arithmetic;
 
-#[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+#[cfg(feature = "ecdsa-core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa-core")))]
 pub mod ecdsa;
 
 #[cfg(any(feature = "test-vectors", test))]

--- a/p256/src/test_vectors/ecdsa.rs
+++ b/p256/src/test_vectors/ecdsa.rs
@@ -1,6 +1,6 @@
 //! ECDSA/secp256r1 test vectors
 
-use ecdsa::dev::TestVector;
+use ecdsa_core::dev::TestVector;
 use hex_literal::hex;
 
 /// ECDSA/P-256 test vectors.


### PR DESCRIPTION
Adds a type alias for `ecdsa::signer::Signer`, which provides a high-level ECDSA signing interface.