### PR TITLE
OIDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#2eb31349c6bef08f910a84caa8678f8aa12b13c5"
+source = "git+https://github.com/RustCrypto/traits#a65edce5d5ee2f5daec882d68fe00f860674f542"
 dependencies = [
  "generic-array",
  "rand_core",

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -32,7 +32,7 @@ pub use elliptic_curve;
 #[cfg(feature = "arithmetic")]
 pub use arithmetic::{field::FieldElement, scalar::Scalar, AffinePoint, ProjectivePoint};
 
-use elliptic_curve::consts::U32;
+use elliptic_curve::{consts::U32, ObjectIdentifier};
 
 /// K-256 (secp256k1) elliptic curve.
 ///
@@ -51,6 +51,10 @@ pub struct Secp256k1;
 impl elliptic_curve::Curve for Secp256k1 {
     /// 256-bit (32-byte)
     type ElementSize = U32;
+}
+
+impl elliptic_curve::Identifier for Secp256k1 {
+    const OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 3, 132, 0, 10]);
 }
 
 impl elliptic_curve::weierstrass::Curve for Secp256k1 {}

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -32,7 +32,7 @@ pub use arithmetic::{scalar::Scalar, AffinePoint, ProjectivePoint};
 #[cfg(all(feature = "arithmetic", feature = "rand"))]
 pub use arithmetic::scalar::blinding::BlindedScalar;
 
-use elliptic_curve::consts::U32;
+use elliptic_curve::{consts::U32, oid::ObjectIdentifier};
 
 /// NIST P-256 elliptic curve.
 ///
@@ -59,6 +59,10 @@ pub struct NistP256;
 impl elliptic_curve::Curve for NistP256 {
     /// 256-bit (32-byte)
     type ElementSize = U32;
+}
+
+impl elliptic_curve::Identifier for NistP256 {
+    const OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 2, 840, 10045, 3, 1, 7]);
 }
 
 impl elliptic_curve::weierstrass::Curve for NistP256 {}

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -19,7 +19,7 @@ pub mod ecdsa;
 
 pub use elliptic_curve;
 
-use elliptic_curve::consts::U48;
+use elliptic_curve::{consts::U48, ObjectIdentifier};
 
 /// NIST P-384 elliptic curve.
 ///
@@ -47,6 +47,10 @@ pub struct NistP384;
 impl elliptic_curve::Curve for NistP384 {
     /// 384-bit (48-byte)
     type ElementSize = U48;
+}
+
+impl elliptic_curve::Identifier for NistP384 {
+    const OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 3, 132, 0, 34]);
 }
 
 impl elliptic_curve::weierstrass::Curve for NistP384 {}


### PR DESCRIPTION
Impls the `elliptic_curve::Identifier` trait for all curves, providing access to an `ObjectIdentifier` const.