### PR TITLE
k256: have ecdsa::Signer cache public key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#efefde4b5088af69407f80c88ecb4d966b9016f7"
+source = "git+https://github.com/RustCrypto/traits#920522ae53f03483a27b24bc8e924db9e8aff29c"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -781,9 +781,9 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "syn"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
+checksum = "239f255b9e3429350f188c27b807fc9920a15eb9145230ff1a7d054c08fec319"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/k256/src/ecdsa/signer.rs
+++ b/k256/src/ecdsa/signer.rs
@@ -1,14 +1,12 @@
 //! ECDSA signer
 
 use super::{recoverable, Error, Signature};
-use crate::{ProjectivePoint, Scalar, ScalarBytes, Secp256k1, SecretKey};
+use crate::{ProjectivePoint, PublicKey, Scalar, ScalarBytes, Secp256k1, SecretKey};
 use core::borrow::Borrow;
 use ecdsa_core::{hazmat::SignPrimitive, signature::RandomizedSigner};
 use elliptic_curve::{
     ops::Invert,
     rand_core::{CryptoRng, RngCore},
-    secret_key::FromSecretKey,
-    zeroize::Zeroizing,
 };
 
 /// ECDSA/secp256k1 signer
@@ -17,36 +15,21 @@ pub struct Signer {
     /// Core ECDSA signer
     signer: ecdsa_core::Signer<Secp256k1>,
 
-    /// Precomputed [`recoverable::Id`] for the public key associated with
-    /// this signer.
-    ///
-    /// We disallow recovery IDs 2 and 3 (they do not occur in practice) and
-    /// always low-S normalize signatures, so this value is static for all
-    /// recoverable signatures we produce.
-    recovery_id: recoverable::Id,
+    /// Public key
+    public_key: PublicKey,
 }
 
 impl Signer {
     /// Create a new signer
     pub fn new(secret_key: &SecretKey) -> Result<Self, Error> {
-        let public_key = Scalar::from_secret_key(secret_key).and_then(|scalar| {
-            (ProjectivePoint::generator() * &*Zeroizing::new(scalar)).to_affine()
-        });
+        let signer = ecdsa_core::Signer::new(secret_key)?;
+        let public_key = PublicKey::from_secret_key(secret_key, true).map_err(|_| Error::new())?;
+        Ok(Self { signer, public_key })
+    }
 
-        if public_key.is_none().into() {
-            return Err(Error::new());
-        }
-
-        // Since we low-S normalize all signatures, and disallow IDs 2 and 3,
-        // the recovery ID only encodes whether the y-coordinate of the public
-        // key is odd, regardless of the signature we produce.
-        let is_y_odd = public_key.unwrap().y.normalize().is_odd();
-        let recovery_id = recoverable::Id::new(is_y_odd.unwrap_u8()).expect("invalid recovery ID");
-
-        Ok(Self {
-            signer: ecdsa_core::Signer::new(secret_key)?,
-            recovery_id,
-        })
+    /// Get the public key for this signer
+    pub fn public_key(&self) -> &PublicKey {
+        &self.public_key
     }
 }
 
@@ -68,8 +51,15 @@ impl RandomizedSigner<recoverable::Signature> for Signer {
         rng: impl CryptoRng + RngCore,
         msg: &[u8],
     ) -> Result<recoverable::Signature, Error> {
-        let sig: Signature = self.try_sign_with_rng(rng, msg)?;
-        Ok(recoverable::Signature::new(&sig, self.recovery_id))
+        let sig = self.try_sign_with_rng(rng, msg)?;
+        let recovery_id = recoverable::Id::from_public_key(&self.public_key);
+        Ok(recoverable::Signature::new(&sig, recovery_id))
+    }
+}
+
+impl From<&Signer> for PublicKey {
+    fn from(signer: &Signer) -> PublicKey {
+        signer.public_key
     }
 }
 


### PR DESCRIPTION
Replaces the previous precomputed recovery ID with a stored PublicKey.

This is generally useful and makes it possible to retrieve a PublicKey from a Signer instance.