### PR TITLE
Use `const_oid` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d9162b7289a46e86208d6af2c686ca5bfde445878c41a458a9fac706252d0b"
+
+[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,8 +242,9 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#83c41ca3a5e19a5d8d776ac7f74123de8373e2e8"
+source = "git+https://github.com/RustCrypto/traits#72f1909a39571b0fe57f2751c1393680f364ee32"
 dependencies = [
+ "const-oid",
  "generic-array",
  "rand_core",
  "subtle",

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -27,13 +27,14 @@ num-traits = "0.2"
 criterion = "0.3"
 
 [features]
-default = ["arithmetic", "std"]
+default = ["arithmetic", "oid", "std"]
 arithmetic = []
 digest = ["ecdsa-core/digest"]
 ecdsa = ["arithmetic", "ecdsa-core/signer", "ecdsa-core/verifier", "rand", "sha256", "zeroize"]
 endomorphism-mul = []
 field-montgomery = []
 force-32-bit = []
+oid = ["elliptic-curve/oid"]
 rand = ["elliptic-curve/rand_core"]
 sha256 = ["digest", "sha2"]
 test-vectors = []

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -35,7 +35,10 @@ pub use arithmetic::{
     AffinePoint, ProjectivePoint,
 };
 
-use elliptic_curve::{consts::U32, ObjectIdentifier};
+use elliptic_curve::consts::U32;
+
+#[cfg(feature = "oid")]
+use elliptic_curve::oid::ObjectIdentifier;
 
 /// K-256 (secp256k1) elliptic curve.
 ///
@@ -56,11 +59,12 @@ impl elliptic_curve::Curve for Secp256k1 {
     type ElementSize = U32;
 }
 
+impl elliptic_curve::weierstrass::Curve for Secp256k1 {}
+
+#[cfg(feature = "oid")]
 impl elliptic_curve::Identifier for Secp256k1 {
     const OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 3, 132, 0, 10]);
 }
-
-impl elliptic_curve::weierstrass::Curve for Secp256k1 {}
 
 /// K-256 (secp256k1) Secret Key.
 pub type SecretKey = elliptic_curve::SecretKey<Secp256k1>;

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -26,6 +26,7 @@ proptest = "0.10"
 default = ["arithmetic", "std"]
 arithmetic = []
 ecdsa = ["arithmetic", "ecdsa-core/signer", "ecdsa-core/verifier", "rand", "sha256", "zeroize"]
+oid = ["elliptic-curve/oid"]
 rand = ["elliptic-curve/rand_core"]
 sha256 = ["ecdsa-core/digest", "ecdsa-core/hazmat", "sha2"]
 test-vectors = []

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -35,7 +35,10 @@ pub use arithmetic::{
 #[cfg(all(feature = "arithmetic", feature = "rand"))]
 pub use arithmetic::scalar::blinding::BlindedScalar;
 
-use elliptic_curve::{consts::U32, oid::ObjectIdentifier};
+use elliptic_curve::consts::U32;
+
+#[cfg(feature = "oid")]
+use elliptic_curve::oid::ObjectIdentifier;
 
 /// NIST P-256 elliptic curve.
 ///
@@ -64,11 +67,12 @@ impl elliptic_curve::Curve for NistP256 {
     type ElementSize = U32;
 }
 
+impl elliptic_curve::weierstrass::Curve for NistP256 {}
+
+#[cfg(feature = "oid")]
 impl elliptic_curve::Identifier for NistP256 {
     const OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 2, 840, 10045, 3, 1, 7]);
 }
-
-impl elliptic_curve::weierstrass::Curve for NistP256 {}
 
 /// NIST P-256 Secret Key
 pub type SecretKey = elliptic_curve::SecretKey<NistP256>;

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -26,6 +26,7 @@ version = "0.9"
 optional = true
 
 [features]
+oid = ["elliptic-curve/oid"]
 sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
 std = ["elliptic-curve/std"]
 

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -19,7 +19,10 @@ pub mod ecdsa;
 
 pub use elliptic_curve;
 
-use elliptic_curve::{consts::U48, ObjectIdentifier};
+use elliptic_curve::consts::U48;
+
+#[cfg(feature = "oid")]
+use elliptic_curve::oid::ObjectIdentifier;
 
 /// NIST P-384 elliptic curve.
 ///
@@ -49,6 +52,7 @@ impl elliptic_curve::Curve for NistP384 {
     type ElementSize = U48;
 }
 
+#[cfg(feature = "oid")]
 impl elliptic_curve::Identifier for NistP384 {
     const OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 3, 132, 0, 34]);
 }


### PR DESCRIPTION
Uses types from the `const-oid` crate to define OIDs (optionally, gated on the `oid` cargo feature)