### PR TITLE
k256/p256: use new `elliptic_curve::encoding` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/signatures#5e2a6b5d84a483a79ef85312b3729821d07db207"
+source = "git+https://github.com/RustCrypto/signatures#a7dde254d74b05158504c6fe20bb2dde4a3fe102"
 dependencies = [
  "elliptic-curve",
  "signature",
@@ -242,7 +242,7 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#1dd4bc5ebc1f7c16e4a76fa6264b796579b4685e"
+source = "git+https://github.com/RustCrypto/traits#9bab4e821421e384096e86e92278ef20fb8f4621"
 dependencies = [
  "const-oid",
  "generic-array",
@@ -781,9 +781,9 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "syn"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239f255b9e3429350f188c27b807fc9920a15eb9145230ff1a7d054c08fec319"
+checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -8,9 +8,10 @@ mod util;
 use core::convert::TryInto;
 use core::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 use elliptic_curve::{
+    generic_array::arr,
     point::Generator,
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
-    weierstrass::FromPublicKey,
+    weierstrass::public_key::FromPublicKey,
     Arithmetic,
 };
 
@@ -81,16 +82,16 @@ impl Generator for AffinePoint {
         // x = 79be667e f9dcbbac 55a06295 ce870b07 029bfcdb 2dce28d9 59f2815b 16f81798
         // y = 483ada77 26a3c465 5da4fbfc 0e1108a8 fd17b448 a6855419 9c47d08f fb10d4b8
         AffinePoint {
-            x: FieldElement::from_bytes(&[
+            x: FieldElement::from_bytes(&arr![u8;
                 0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac, 0x55, 0xa0, 0x62, 0x95, 0xce, 0x87,
                 0x0b, 0x07, 0x02, 0x9b, 0xfc, 0xdb, 0x2d, 0xce, 0x28, 0xd9, 0x59, 0xf2, 0x81, 0x5b,
-                0x16, 0xf8, 0x17, 0x98,
+                0x16, 0xf8, 0x17, 0x98
             ])
             .unwrap(),
-            y: FieldElement::from_bytes(&[
+            y: FieldElement::from_bytes(&arr![u8;
                 0x48, 0x3a, 0xda, 0x77, 0x26, 0xa3, 0xc4, 0x65, 0x5d, 0xa4, 0xfb, 0xfc, 0x0e, 0x11,
                 0x08, 0xa8, 0xfd, 0x17, 0xb4, 0x48, 0xa6, 0x85, 0x54, 0x19, 0x9c, 0x47, 0xd0, 0x8f,
-                0xfb, 0x10, 0xd4, 0xb8,
+                0xfb, 0x10, 0xd4, 0xb8
             ])
             .unwrap(),
         }
@@ -155,10 +156,7 @@ impl AffinePoint {
 impl From<AffinePoint> for CompressedPoint {
     /// Returns the SEC-1 compressed encoding of this point.
     fn from(affine_point: AffinePoint) -> CompressedPoint {
-        CompressedPoint::from_affine_coords(
-            &affine_point.x.to_bytes().into(),
-            &affine_point.y.to_bytes().into(),
-        )
+        CompressedPoint::from_affine_coords(&affine_point.x.to_bytes(), &affine_point.y.to_bytes())
     }
 }
 
@@ -166,8 +164,8 @@ impl From<AffinePoint> for UncompressedPoint {
     /// Returns the SEC-1 uncompressed encoding of this point.
     fn from(affine_point: AffinePoint) -> UncompressedPoint {
         UncompressedPoint::from_affine_coords(
-            &affine_point.x.to_bytes().into(),
-            &affine_point.y.to_bytes().into(),
+            &affine_point.x.to_bytes(),
+            &affine_point.y.to_bytes(),
         )
     }
 }
@@ -546,7 +544,7 @@ mod tests {
         test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
         PublicKey,
     };
-    use elliptic_curve::{point::Generator, weierstrass::FromPublicKey};
+    use elliptic_curve::{point::Generator, weierstrass::public_key::FromPublicKey, FromBytes};
 
     const CURVE_EQUATION_B_BYTES: &str =
         "0000000000000000000000000000000000000000000000000000000000000007";

--- a/k256/src/arithmetic/field/field_10x26.rs
+++ b/k256/src/arithmetic/field/field_10x26.rs
@@ -1,6 +1,7 @@
 //! Field element modulo the curve internal modulus using 32-bit limbs.
 //! Ported from https://github.com/bitcoin-core/secp256k1
 
+use crate::ElementBytes;
 use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 /// Scalars modulo SECP256k1 modulus (2^256 - 2^32 - 2^9 - 2^8 - 2^7 - 2^6 - 2^4 - 1).
@@ -72,16 +73,16 @@ impl FieldElement10x26 {
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
-    pub fn from_bytes(bytes: &[u8; 32]) -> CtOption<Self> {
-        let res = Self::from_bytes_unchecked(bytes);
+    pub fn from_bytes(bytes: &ElementBytes) -> CtOption<Self> {
+        let res = Self::from_bytes_unchecked(bytes.as_ref());
         let overflow = res.get_overflow();
 
         CtOption::new(res, !overflow)
     }
 
     /// Returns the SEC-1 encoding of this field element.
-    pub fn to_bytes(&self) -> [u8; 32] {
-        let mut r = [0u8; 32];
+    pub fn to_bytes(&self) -> ElementBytes {
+        let mut r = ElementBytes::default();
         r[0] = (self.0[9] >> 14) as u8;
         r[1] = (self.0[9] >> 6) as u8;
         r[2] = ((self.0[9] as u8 & 0x3Fu8) << 2) | ((self.0[8] >> 24) as u8 & 0x3);

--- a/k256/src/arithmetic/field/field_5x52.rs
+++ b/k256/src/arithmetic/field/field_5x52.rs
@@ -1,6 +1,7 @@
 //! Field element modulo the curve internal modulus using 32-bit limbs.
 //! Ported from https://github.com/bitcoin-core/secp256k1
 
+use crate::ElementBytes;
 use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 /// Scalars modulo SECP256k1 modulus (2^256 - 2^32 - 2^9 - 2^8 - 2^7 - 2^6 - 2^4 - 1).
@@ -71,15 +72,15 @@ impl FieldElement5x52 {
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
-    pub fn from_bytes(bytes: &[u8; 32]) -> CtOption<Self> {
-        let res = Self::from_bytes_unchecked(bytes);
+    pub fn from_bytes(bytes: &ElementBytes) -> CtOption<Self> {
+        let res = Self::from_bytes_unchecked(bytes.as_ref());
         let overflow = res.get_overflow();
         CtOption::new(res, !overflow)
     }
 
     /// Returns the SEC-1 encoding of this field element.
-    pub fn to_bytes(&self) -> [u8; 32] {
-        let mut ret = [0u8; 32];
+    pub fn to_bytes(&self) -> ElementBytes {
+        let mut ret = ElementBytes::default();
         ret[0] = (self.0[4] >> 40) as u8;
         ret[1] = (self.0[4] >> 32) as u8;
         ret[2] = (self.0[4] >> 24) as u8;

--- a/k256/src/arithmetic/field/field_impl.rs
+++ b/k256/src/arithmetic/field/field_impl.rs
@@ -2,8 +2,8 @@
 //! they are not misused. Ensures the correct normalization and checks magnitudes in operations.
 //! Only enabled when `debug_assertions` feature is on.
 
+use crate::ElementBytes;
 use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
-
 use cfg_if::cfg_if;
 
 cfg_if! {
@@ -61,12 +61,12 @@ impl FieldElementImpl {
         Self::new_normalized(&value)
     }
 
-    pub fn from_bytes(bytes: &[u8; 32]) -> CtOption<Self> {
+    pub fn from_bytes(bytes: &ElementBytes) -> CtOption<Self> {
         let value = FieldElementUnsafeImpl::from_bytes(bytes);
         CtOption::map(value, |x| Self::new_normalized(&x))
     }
 
-    pub fn to_bytes(&self) -> [u8; 32] {
+    pub fn to_bytes(&self) -> ElementBytes {
         debug_assert!(self.normalized);
         self.value.to_bytes()
     }

--- a/k256/src/arithmetic/scalar/scalar_4x64.rs
+++ b/k256/src/arithmetic/scalar/scalar_4x64.rs
@@ -8,7 +8,7 @@ use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq, Ct
 #[cfg(feature = "zeroize")]
 use elliptic_curve::zeroize::Zeroize;
 
-use crate::arithmetic::util::{adc64, sbb64};
+use crate::{ElementBytes, arithmetic::util::{adc64, sbb64}};
 
 /// Constant representing the modulus
 /// n = FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364141
@@ -209,8 +209,8 @@ impl Scalar4x64 {
     }
 
     /// Returns the SEC-1 encoding of this scalar.
-    pub fn to_bytes(&self) -> [u8; 32] {
-        let mut ret = [0; 32];
+    pub fn to_bytes(&self) -> ElementBytes {
+        let mut ret = ElementBytes::default();
         ret[0..8].copy_from_slice(&self.0[3].to_be_bytes());
         ret[8..16].copy_from_slice(&self.0[2].to_be_bytes());
         ret[16..24].copy_from_slice(&self.0[1].to_be_bytes());

--- a/k256/src/arithmetic/scalar/scalar_8x32.rs
+++ b/k256/src/arithmetic/scalar/scalar_8x32.rs
@@ -3,7 +3,7 @@
 
 use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
-use crate::arithmetic::util::{adc32, sbb32};
+use crate::{ElementBytes, arithmetic::util::{adc32, sbb32}};
 
 use core::convert::TryInto;
 
@@ -250,8 +250,8 @@ impl Scalar8x32 {
     }
 
     /// Returns the SEC-1 encoding of this scalar.
-    pub fn to_bytes(&self) -> [u8; 32] {
-        let mut ret = [0; 32];
+    pub fn to_bytes(&self) -> ElementBytes {
+        let mut ret = ElementBytes::default();
         ret[0..4].copy_from_slice(&self.0[7].to_be_bytes());
         ret[4..8].copy_from_slice(&self.0[6].to_be_bytes());
         ret[8..12].copy_from_slice(&self.0[5].to_be_bytes());

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -61,7 +61,10 @@ pub use self::{signer::Signer, verifier::Verifier};
 use crate::Secp256k1;
 
 #[cfg(feature = "ecdsa")]
-use crate::{elliptic_curve::subtle::ConditionallySelectable, Scalar};
+use crate::{
+    elliptic_curve::{subtle::ConditionallySelectable, FromBytes},
+    Scalar,
+};
 
 /// ECDSA/secp256k1 signature (fixed-size)
 pub type Signature = ecdsa_core::Signature<Secp256k1>;
@@ -93,10 +96,7 @@ pub fn normalize_s(signature: &Signature) -> Result<Signature, Error> {
     let s_neg = -s;
     let low_s = Scalar::conditional_select(&s, &s_neg, s.is_high());
 
-    Ok(Signature::from_scalars(
-        signature.r(),
-        &low_s.to_bytes().into(),
-    ))
+    Ok(Signature::from_scalars(signature.r(), &low_s.to_bytes()))
 }
 
 #[cfg(all(test, feature = "ecdsa"))]

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -45,7 +45,10 @@ use crate::arithmetic::{
 };
 
 #[cfg(feature = "ecdsa")]
-use elliptic_curve::subtle::{Choice, ConditionallySelectable, CtOption};
+use elliptic_curve::{
+    subtle::{Choice, ConditionallySelectable, CtOption},
+    FromBytes,
+};
 
 #[cfg(any(feature = "ecdsa", docsrs))]
 use crate::PublicKey;

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -7,9 +7,10 @@ mod util;
 use core::convert::TryInto;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use elliptic_curve::{
+    generic_array::arr,
     point::Generator,
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
-    weierstrass::FromPublicKey,
+    weierstrass::public_key::FromPublicKey,
     Arithmetic,
 };
 
@@ -74,16 +75,16 @@ impl Generator for AffinePoint {
         // x = 6b17d1f2 e12c4247 f8bce6e5 63a440f2 77037d81 2deb33a0 f4a13945 d898c296
         // y = 4fe342e2 fe1a7f9b 8ee7eb4a 7c0f9e16 2bce3357 6b315ece cbb64068 37bf51f5
         AffinePoint {
-            x: FieldElement::from_bytes([
+            x: FieldElement::from_bytes(&arr![u8;
                 0x6b, 0x17, 0xd1, 0xf2, 0xe1, 0x2c, 0x42, 0x47, 0xf8, 0xbc, 0xe6, 0xe5, 0x63, 0xa4,
                 0x40, 0xf2, 0x77, 0x03, 0x7d, 0x81, 0x2d, 0xeb, 0x33, 0xa0, 0xf4, 0xa1, 0x39, 0x45,
-                0xd8, 0x98, 0xc2, 0x96,
+                0xd8, 0x98, 0xc2, 0x96
             ])
             .unwrap(),
-            y: FieldElement::from_bytes([
+            y: FieldElement::from_bytes(&arr![u8;
                 0x4f, 0xe3, 0x42, 0xe2, 0xfe, 0x1a, 0x7f, 0x9b, 0x8e, 0xe7, 0xeb, 0x4a, 0x7c, 0x0f,
                 0x9e, 0x16, 0x2b, 0xce, 0x33, 0x57, 0x6b, 0x31, 0x5e, 0xce, 0xcb, 0xb6, 0x40, 0x68,
-                0x37, 0xbf, 0x51, 0xf5,
+                0x37, 0xbf, 0x51, 0xf5
             ])
             .unwrap(),
         }
@@ -145,10 +146,7 @@ impl AffinePoint {
 impl From<AffinePoint> for CompressedPoint {
     /// Returns the SEC-1 compressed encoding of this point.
     fn from(affine_point: AffinePoint) -> CompressedPoint {
-        CompressedPoint::from_affine_coords(
-            &affine_point.x.to_bytes().into(),
-            &affine_point.y.to_bytes().into(),
-        )
+        CompressedPoint::from_affine_coords(&affine_point.x.to_bytes(), &affine_point.y.to_bytes())
     }
 }
 
@@ -156,8 +154,8 @@ impl From<AffinePoint> for UncompressedPoint {
     /// Returns the SEC-1 uncompressed encoding of this point.
     fn from(affine_point: AffinePoint) -> UncompressedPoint {
         UncompressedPoint::from_affine_coords(
-            &affine_point.x.to_bytes().into(),
-            &affine_point.y.to_bytes().into(),
+            &affine_point.x.to_bytes(),
+            &affine_point.y.to_bytes(),
         )
     }
 }
@@ -546,7 +544,7 @@ mod tests {
         test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
         PublicKey,
     };
-    use elliptic_curve::{point::Generator, weierstrass::FromPublicKey};
+    use elliptic_curve::{point::Generator, weierstrass::public_key::FromPublicKey, FromBytes};
 
     const CURVE_EQUATION_A_BYTES: &str =
         "FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC";


### PR DESCRIPTION
Impls the new `FromBytes` traits introduced in RustCrypto/traits#247, and changes `to_bytes()` to return `ElementBytes`.