### PR TITLE
k256: normalize() before is_odd()

### DIFF
--- a/k256/src/ecdsa/signer.rs
+++ b/k256/src/ecdsa/signer.rs
@@ -131,7 +131,7 @@ impl RecoverableSignPrimitive<Secp256k1> for Scalar {
         }
 
         let signature = Signature::from_scalars(&r.into(), &s.into());
-        let r_is_odd = R.y.is_odd();
+        let r_is_odd = R.y.normalize().is_odd();
         Ok((signature, r_is_odd.into()))
     }
 }


### PR DESCRIPTION
To catch bugs like this we need to run tests with all features on but *without* `field-montgomery`, which skips normalization checks.

Another variant would be to auto-normalize in `is_odd()`. I'm kind of on the fence about it. Explicit normalization seems to be the general convention in `k256` now (except for `to_bytes()`), so I went with it. Otherwise one could as well auto-normalize in `is_zero()`.