### PR TITLE
k256: impl new RecoverableSignPrimitive API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/signatures#a420b3346a7aa3428bd3f52107286b031c56dca1"
+source = "git+https://github.com/RustCrypto/signatures#5bd96712bba5b667bd532c68400bd604f4d06437"
 dependencies = [
  "elliptic-curve",
  "signature",

--- a/k256/src/ecdsa/normalize.rs
+++ b/k256/src/ecdsa/normalize.rs
@@ -6,12 +6,11 @@ use crate::Scalar;
 use ecdsa_core::NormalizeLow;
 
 impl NormalizeLow for Scalar {
-    fn normalize_low(&mut self) -> bool {
+    fn normalize_low(&self) -> (Self, bool) {
         if self.is_high().into() {
-            *self = -*self;
-            true
+            (-self, true)
         } else {
-            false
+            (*self, false)
         }
     }
 }


### PR DESCRIPTION
Implements the changes made in RustCrypto/signatures#120.

These changes have the `k256` always compute a `recoverable::Signature` via `RecoverableSignPrimitive` and use the blanket impl of `SignPrimitive` for `RecoverableSignPrimitive` to convert it to a regular `k256::ecdsa::Signature` in `ecdsa::signer::Signer<Secp256k1>`.

Ideally the `k256::ecdsa::Signer` newtype could go away and this could all be handled by `ecdsa::signer::Signer` via blanket and conditional impls, however I'm not sure how to prevent the impls of `RandomizedSigner` from overlapping in a generic context.