### PR TITLE
k256/p256: ECDH rustdoc

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -31,7 +31,7 @@ rand_core = { version = "0.5", features = ["getrandom"] }
 default = ["arithmetic", "oid", "std"]
 arithmetic = []
 digest = ["ecdsa-core/digest"]
-ecdh = ["elliptic-curve/ecdh"]
+ecdh = ["elliptic-curve/ecdh", "rand", "zeroize"]
 ecdsa = ["arithmetic", "ecdsa-core/signer", "ecdsa-core/verifier", "rand", "sha256", "zeroize"]
 endomorphism-mul = []
 field-montgomery = []

--- a/k256/src/ecdh.rs
+++ b/k256/src/ecdh.rs
@@ -1,4 +1,39 @@
 //! Elliptic Curve Diffie-Hellman (Ephemeral) Support.
+//!
+//! This module contains a high-level interface for performing ephemeral
+//! Diffie-Hellman key exchanges using the secp256k1 elliptic curve.
+//!
+//! # Usage
+//!
+//! This usage example is from the perspective of two participants in the
+//! exchange, nicknamed "Alice" and "Bob".
+//!
+//! ```
+//! # #[cfg(feature = "ecdh")]
+//! # {
+//! use k256::{PublicKey, ecdh::EphemeralSecret};
+//! use rand_core::OsRng; // requires 'getrandom' feature
+//!
+//! // Alice
+//! let alice_secret = EphemeralSecret::generate(&mut OsRng);
+//! let alice_public = PublicKey::from(&alice_secret);
+//!
+//! // Bob
+//! let bob_secret = EphemeralSecret::generate(&mut OsRng);
+//! let bob_public = PublicKey::from(&bob_secret);
+//!
+//! // Alice computes shared secret from Bob's public key
+//! let alice_shared = alice_secret.diffie_hellman(&bob_public)
+//!     .expect("bob's public key is invalid!");
+//!
+//! // Bob computes the same shared secret from Alice's public key
+//! let bob_shared = bob_secret.diffie_hellman(&alice_public)
+//!     .expect("alice's public key is invalid!");
+//!
+//! // Both participants arrive on the same shared secret
+//! assert_eq!(alice_shared.as_bytes(), bob_shared.as_bytes());
+//! # }
+//! ```
 
 use crate::Secp256k1;
 

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -26,7 +26,7 @@ rand_core = { version = "0.5", features = ["getrandom"] }
 [features]
 default = ["arithmetic", "std"]
 arithmetic = []
-ecdh = ["elliptic-curve/ecdh"]
+ecdh = ["elliptic-curve/ecdh", "rand", "zeroize"]
 ecdsa = ["arithmetic", "ecdsa-core/signer", "ecdsa-core/verifier", "rand", "sha256", "zeroize"]
 oid = ["elliptic-curve/oid"]
 rand = ["elliptic-curve/rand"]

--- a/p256/src/ecdh.rs
+++ b/p256/src/ecdh.rs
@@ -1,4 +1,39 @@
 //! Elliptic Curve Diffie-Hellman (Ephemeral) Support.
+//!
+//! This module contains a high-level interface for performing ephemeral
+//! Diffie-Hellman key exchanges using the secp256k1 elliptic curve.
+//!
+//! # Usage
+//!
+//! This usage example is from the perspective of two participants in the
+//! exchange, nicknamed "Alice" and "Bob".
+//!
+//! ```
+//! # #[cfg(feature = "ecdh")]
+//! # {
+//! use p256::{PublicKey, ecdh::EphemeralSecret};
+//! use rand_core::OsRng; // requires 'getrandom' feature
+//!
+//! // Alice
+//! let alice_secret = EphemeralSecret::generate(&mut OsRng);
+//! let alice_public = PublicKey::from(&alice_secret);
+//!
+//! // Bob
+//! let bob_secret = EphemeralSecret::generate(&mut OsRng);
+//! let bob_public = PublicKey::from(&bob_secret);
+//!
+//! // Alice computes shared secret from Bob's public key
+//! let alice_shared = alice_secret.diffie_hellman(&bob_public)
+//!     .expect("bob's public key is invalid!");
+//!
+//! // Bob computes the same shared secret from Alice's public key
+//! let bob_shared = bob_secret.diffie_hellman(&alice_public)
+//!     .expect("alice's public key is invalid!");
+//!
+//! // Both participants arrive on the same shared secret
+//! assert_eq!(alice_shared.as_bytes(), bob_shared.as_bytes());
+//! # }
+//! ```
 
 use crate::NistP256;
 


### PR DESCRIPTION
Provides a usage example for Elliptic Curve Diffie-Hellman.

This also tests that the generic implementation is wired up correctly in both crates.