### PR TITLE
Bump `elliptic-curve` to v0.5; `ecdsa` to v0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,8 +226,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/signatures#5bd96712bba5b667bd532c68400bd604f4d06437"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a06af0f48740a4d6585bcc5e728ed1cd695eb281ca21264c4a21d750edf4fd6"
 dependencies = [
  "elliptic-curve",
  "signature",
@@ -241,8 +242,9 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#5cf63df92be944bfbde8262f4931c45dadc88469"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9abe4578ed343c7a2c9d617cd2b1895ba0a87a6a4dee97bde156d65f608c7b2d"
 dependencies = [
  "const-oid",
  "generic-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,3 @@ members = [
     "p256",
     "p384",
 ]
-
-[patch.crates-io]
-ecdsa = { git = "https://github.com/RustCrypto/signatures" }
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -13,13 +13,13 @@ keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
 
 [dependencies]
 cfg-if = "0.1"
-ecdsa-core = { version = "= 0.7.0-pre", package = "ecdsa", optional = true, default-features = false }
-elliptic-curve = { version = "= 0.5.0-pre", default-features = false, features = ["weierstrass"] }
+ecdsa-core = { version = "0.7", package = "ecdsa", optional = true, default-features = false }
+elliptic-curve = { version = "0.5", default-features = false, features = ["weierstrass"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
-ecdsa-core = { version = "= 0.7.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.7", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4" # TODO: switch to hex-literal
 hex-literal = "0.2"
 num-bigint = "0.3"

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -12,12 +12,12 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
 
 [dependencies]
-ecdsa-core = { version = "= 0.7.0-pre", package = "ecdsa", optional = true, default-features = false }
-elliptic-curve = { version = "= 0.5.0-pre", default-features = false, features = ["weierstrass"] }
+ecdsa-core = { version = "0.7", package = "ecdsa", optional = true, default-features = false }
+elliptic-curve = { version = "0.5", default-features = false, features = ["weierstrass"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "= 0.7.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.7", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4" # TODO: switch to hex-literal
 hex-literal = "0.2"
 proptest = "0.10"

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -11,19 +11,10 @@ edition = "2018"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "secp384r1"]
 
-[dependencies.ecdsa]
-version = "= 0.7.0-pre"
-optional = true
-default-features = false
-
-[dependencies.elliptic-curve]
-version = "= 0.5.0-pre"
-default-features = false
-features = ["weierstrass"]
-
-[dependencies.sha2]
-version = "0.9"
-optional = true
+[dependencies]
+ecdsa = { version = "0.7", optional = true, default-features = false }
+elliptic-curve = { version = "0.5", default-features = false, features = ["weierstrass"] }
+sha2 = { version = "0.9", optional = true, default-features = false }
 
 [features]
 oid = ["elliptic-curve/oid"]


### PR DESCRIPTION
Release notes:

- `elliptic-curve` v0.5.0: https://github.com/RustCrypto/traits/pull/254
- `ecdsa` v0.7.0: https://github.com/RustCrypto/signatures/pull/125