### PR TITLE
k256/p256: add security warnings and other documentation

### DIFF
--- a/k256/README.md
+++ b/k256/README.md
@@ -11,9 +11,29 @@ from the [`elliptic-curve`] crate.
 
 Optionally includes an [`arithmetic`] feature providing scalar and
 affine/projective point types with support for constant-time scalar
-multiplication, which can be used to implement protocols such as [ECDH].
+multiplication.
 
 [Documentation][docs-link]
+
+## ⚠️ Security Warning
+
+The elliptic curve arithmetic contained in this crate has never been
+independently audited!
+
+This crate has been designed with the goal of ensuring that secret-dependent
+operations are performed in constant time (using the `subtle` crate and
+constant-time formulas). However, it has not been thoroughly assessed to ensure
+that generated assembly is constant time on common CPU architectures.
+
+USE AT YOUR OWN RISK!
+
+## Supported Algorithms
+
+- [Elliptic Curve Diffie-Hellman (ECDH)][ECDH]: gated under the `ecdh` feature.
+- [Elliptic Curve Digital Signature Algorithm (ECDSA)][ECDSA]: gated under the
+  `ecdsa` feature. Supports low-S normalized ECDSA signing and verification
+  as used in consensus-critical applications, and additionally supports
+  public key recovery from ECDSA signatures (as used by e.g. Ethereum).
 
 ## About K-256 (secp256k1)
 
@@ -73,5 +93,5 @@ dual licensed as above, without any additional terms or conditions.
 [secp256k1]: https://en.bitcoin.it/wiki/Secp256k1
 [`elliptic-curve`]: https://github.com/RustCrypto/traits/tree/master/elliptic-curve
 [`arithmetic`]: https://docs.rs/k256/latest/k256/arithmetic/index.html
-[ECDH]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman
-[ECDSA]: https://github.com/RustCrypto/signatures/tree/master/ecdsa
+[ECDH]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie-Hellman
+[ECDSA]: https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -1,4 +1,29 @@
-//! K-256 (secp256k1) elliptic curve
+//! K-256 ([secp256k1]) elliptic curve.
+//!
+//! ## ⚠️ Security Warning
+//!
+//! The elliptic curve arithmetic contained in this crate has never been
+//! independently audited!
+//!
+//! This crate has been designed with the goal of ensuring that secret-dependent
+//! operations are performed in constant time (using the `subtle` crate and
+//! constant-time formulas). However, it has not been thoroughly assessed to ensure
+//! that generated assembly is constant time on common CPU architectures.
+//!
+//! USE AT YOUR OWN RISK!
+//!
+//! ## About K-256 (secp256k1)
+//!
+//! K-256 is a Koblitz curve typically referred to as "[secp256k1]".
+//! The "K-256" name follows NIST notation where P = prime fields,
+//! B = binary fields, and K = Koblitz curves (defined over F₂).
+//!
+//! The curve is specified as `secp256k1` by Certicom's SECG in
+//! "SEC 2: Recommended Elliptic Curve Domain Parameters":
+//!
+//! <https://www.secg.org/sec2-v2.pdf>
+//!
+//! It's primarily notable for usage in Bitcoin and other cryptocurrencies.
 //!
 //! ## Minimum Supported Rust Version
 //!

--- a/p256/README.md
+++ b/p256/README.md
@@ -15,7 +15,25 @@ multiplication, which can be used to implement protocols such as [ECDH].
 
 [Documentation][docs-link]
 
-## About P-256
+## ⚠️ Security Warning
+
+The elliptic curve arithmetic contained in this crate has never been
+independently audited!
+
+This crate has been designed with the goal of ensuring that secret-dependent
+operations are performed in constant time (using the `subtle` crate and
+constant-time formulas). However, it has not been thoroughly assessed to ensure
+that generated assembly is constant time on common CPU architectures.
+
+USE AT YOUR OWN RISK!
+
+## Supported Algorithms
+
+- [Elliptic Curve Diffie-Hellman (ECDH)][ECDH]: gated under the `ecdh` feature.
+- [Elliptic Curve Digital Signature Algorithm (ECDSA)][ECDSA]: gated under the
+  `ecdsa` feature.
+
+## About NIST P-256
 
 NIST P-256 is a Weierstrass curve specified in FIPS 186-4: Digital Signature
 Standard (DSS):
@@ -68,4 +86,5 @@ dual licensed as above, without any additional terms or conditions.
 
 [`elliptic-curve`]: https://github.com/RustCrypto/traits/tree/master/elliptic-curve
 [`arithmetic`]: https://docs.rs/p256/latest/p256/arithmetic/index.html
-[ECDH]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman
+[ECDH]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie-Hellman
+[ECDSA]: https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -1,5 +1,28 @@
 //! NIST P-256 elliptic curve (a.k.a. prime256v1, secp256r1)
 //!
+//! ## ⚠️ Security Warning
+//!
+//! The elliptic curve arithmetic contained in this crate has never been
+//! independently audited!
+//!
+//! This crate has been designed with the goal of ensuring that secret-dependent
+//! operations are performed in constant time (using the `subtle` crate and
+//! constant-time formulas). However, it has not been thoroughly assessed to ensure
+//! that generated assembly is constant time on common CPU architectures.
+//!
+//! USE AT YOUR OWN RISK!
+//!
+//! ## About NIST P-256
+//!
+//! NIST P-256 is a Weierstrass curve specified in FIPS 186-4: Digital Signature
+//! Standard (DSS):
+//!
+//! <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
+//!
+//! Also known as prime256v1 (ANSI X9.62) and secp256r1 (SECG), it's included in
+//! the US National Security Agency's "Suite B" and is widely used in protocols
+//! like TLS and the associated X.509 PKI.
+//!
 //! ## Minimum Supported Rust Version
 //!
 //! Rust **1.41** or higher.


### PR DESCRIPTION
These crates now contain full-fledged cryptographic algorithm implementations, so note that they are bleeding edge, unaudited, use-at-your-own-risk, etc.

Also add additional documentation about supported features and other notable information about elliptic curves.