### PR TITLE
p256 v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/p256/CHANGELOG.md
+++ b/p256/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-08-10)
+### Added
+- ECDSA support ([#73], [#101], [#104], [#105])
+- ECDSA public key recovery support ([#110])
+- OID support ([#103], [#113])
+- Elliptic Curve Diffie-Hellman ([#120])
+
+### Changed
+- Bump `elliptic-curve` crate dependency to v0.5 ([#126])
+
+[#73]: https://github.com/RustCrypto/elliptic-curves/pull/73
+[#101]: https://github.com/RustCrypto/elliptic-curves/pull/101
+[#104]: https://github.com/RustCrypto/elliptic-curves/pull/104
+[#103]: https://github.com/RustCrypto/elliptic-curves/pull/103
+[#105]: https://github.com/RustCrypto/elliptic-curves/pull/105
+[#110]: https://github.com/RustCrypto/elliptic-curves/pull/110
+[#113]: https://github.com/RustCrypto/elliptic-curves/pull/113
+[#120]: https://github.com/RustCrypto/elliptic-curves/pull/120
+[#126]: https://github.com/RustCrypto/elliptic-curves/pull/126
+
 ## 0.3.0 (2020-06-08)
 ### Changed
 - Bump `elliptic-curve` crate dependency to v0.4 ([#39])

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p256"
 description = "NIST P-256 (secp256r1) elliptic curve"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -32,7 +32,11 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_root_url = "https://docs.rs/p256/0.4.0"
+)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Added
- ECDSA support ([#73], [#101], [#104], [#105])
- ECDSA public key recovery support ([#110])
- OID support ([#103], [#113])
- Elliptic Curve Diffie-Hellman ([#120])

### Changed
- Bump `elliptic-curve` crate dependency to v0.5 ([#126])

[#73]: https://github.com/RustCrypto/elliptic-curves/pull/73
[#101]: https://github.com/RustCrypto/elliptic-curves/pull/101
[#104]: https://github.com/RustCrypto/elliptic-curves/pull/104
[#103]: https://github.com/RustCrypto/elliptic-curves/pull/103
[#105]: https://github.com/RustCrypto/elliptic-curves/pull/105
[#110]: https://github.com/RustCrypto/elliptic-curves/pull/110
[#113]: https://github.com/RustCrypto/elliptic-curves/pull/113
[#120]: https://github.com/RustCrypto/elliptic-curves/pull/120
[#126]: https://github.com/RustCrypto/elliptic-curves/pull/126