### PR TITLE
p384 v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#73]: https://github.com/RustCrypto/elliptic-curves/pull/73
 [#82]: https://github.com/RustCrypto/elliptic-curves/pull/82
 [#101]: https://github.com/RustCrypto/elliptic-curves/pull/101
-[#104]: https://github.com/RustCrypto/elliptic-curves/pull/104
 [#103]: https://github.com/RustCrypto/elliptic-curves/pull/103
+[#104]: https://github.com/RustCrypto/elliptic-curves/pull/104
 [#105]: https://github.com/RustCrypto/elliptic-curves/pull/105
 [#110]: https://github.com/RustCrypto/elliptic-curves/pull/110
 [#113]: https://github.com/RustCrypto/elliptic-curves/pull/113

--- a/p256/CHANGELOG.md
+++ b/p256/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#73]: https://github.com/RustCrypto/elliptic-curves/pull/73
 [#101]: https://github.com/RustCrypto/elliptic-curves/pull/101
-[#104]: https://github.com/RustCrypto/elliptic-curves/pull/104
 [#103]: https://github.com/RustCrypto/elliptic-curves/pull/103
+[#104]: https://github.com/RustCrypto/elliptic-curves/pull/104
 [#105]: https://github.com/RustCrypto/elliptic-curves/pull/105
 [#110]: https://github.com/RustCrypto/elliptic-curves/pull/110
 [#113]: https://github.com/RustCrypto/elliptic-curves/pull/113

--- a/p384/CHANGELOG.md
+++ b/p384/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-08-10)
+### Added
+- ECDSA types ([#73])
+- OID support ([#103], [#113])
+
+### Changed
+- Bump `elliptic-curve` crate dependency to v0.5 ([#126])
+
+[#73]: https://github.com/RustCrypto/elliptic-curves/pull/73
+[#103]: https://github.com/RustCrypto/elliptic-curves/pull/103
+[#113]: https://github.com/RustCrypto/elliptic-curves/pull/113
+[#126]: https://github.com/RustCrypto/elliptic-curves/pull/126
+
 ## 0.2.0 (2020-06-08)
 ### Changed
 - Bump `elliptic-curve` crate dependency to v0.4 ([#39])

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p384"
 description = "NIST P-384 (secp384r1) elliptic curve"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -9,9 +9,13 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_root_url = "https://docs.rs/p384/0.3.0"
+)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 
 #[cfg(feature = "ecdsa")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]


### PR DESCRIPTION
### Added
- ECDSA types ([#73])
- OID support ([#103], [#113])

### Changed
- Bump `elliptic-curve` crate dependency to v0.5 ([#126])

[#73]: https://github.com/RustCrypto/elliptic-curves/pull/73
[#103]: https://github.com/RustCrypto/elliptic-curves/pull/103
[#113]: https://github.com/RustCrypto/elliptic-curves/pull/113
[#126]: https://github.com/RustCrypto/elliptic-curves/pull/126