### PR TITLE
k256 v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cfg-if",
  "criterion",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2020-08-10)
+### Fixed
+- secp256k1 rustdoc link ([#131])
+
+[#131]: https://github.com/RustCrypto/elliptic-curves/pull/131
+
 ## 0.4.0 (2020-08-10)
 ### Added
 - ECDSA support ([#73], [#101], [#104], [#105])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "k256"
 description = "K-256 (secp256k1) elliptic curve"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -39,7 +39,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/k256/0.4.0"
+    html_root_url = "https://docs.rs/k256/0.4.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Fixed
- secp256k1 rustdoc link ([#131])

[#131]: https://github.com/RustCrypto/elliptic-curves/pull/131