### PR TITLE
p256 v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/p256/CHANGELOG.md
+++ b/p256/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2020-08-11)
+### Fixed
+- Builds with either `ecdsa-core` or `sha256` in isolation ([#133])
+
+[#133]: https://github.com/RustCrypto/elliptic-curves/pull/133
+
 ## 0.4.0 (2020-08-10)
 ### Added
 - ECDSA support ([#73], [#101], [#104], [#105])

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p256"
 description = "NIST P-256 (secp256r1) elliptic curve"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -35,7 +35,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/p256/0.4.0"
+    html_root_url = "https://docs.rs/p256/0.4.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Fixed
- Builds with either `ecdsa-core` or `sha256` in isolation ([#133])

[#133]: https://github.com/RustCrypto/elliptic-curves/pull/133