### PR TITLE
Implement `EncodedPoint` changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bit-set"
@@ -88,9 +88,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "clap"
-version = "2.33.2"
+version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10040cdf04294b565d9e0319955430099ec3813a64c952b86a41200ad714ae48"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "bitflags",
  "textwrap",
@@ -146,6 +146,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,17 +179,6 @@ dependencies = [
  "maybe-uninit",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "maybe-uninit",
 ]
 
 [[package]]
@@ -227,8 +226,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c7b18ecf0bb8dae3a2e41e7ec2b8fdb1988a6537c88d3c341e50feb8ee355a"
+source = "git+https://github.com/RustCrypto/signatures#352631b07ddec1529702624c19bb40822dad5a20"
 dependencies = [
  "elliptic-curve",
  "signature",
@@ -243,8 +241,7 @@ checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abe4578ed343c7a2c9d617cd2b1895ba0a87a6a4dee97bde156d65f608c7b2d"
+source = "git+https://github.com/RustCrypto/traits#a0cfce36dad42df4e3ee565eecf8309ffda592f1"
 dependencies = [
  "const-oid",
  "generic-array",
@@ -261,9 +258,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "generic-array"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
@@ -356,9 +353,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.74"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
+checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
 name = "log"
@@ -478,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
+checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
 name = "proc-macro2"
@@ -578,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080"
+checksum = "cfd016f0c045ad38b5251be2c9c0ab806917f82da4d36b2a327e5166adad9270"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -590,12 +587,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280"
+checksum = "91739a34c4355b5434ce54c9086c5895604a9c278586d1f1aa95e04f66b525a0"
 dependencies = [
+ "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-queue",
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
@@ -766,9 +763,9 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "syn"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
+checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,7 @@ members = [
     "p256",
     "p384",
 ]
+
+[patch.crates-io]
+ecdsa = { git = "https://github.com/RustCrypto/signatures" }
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -63,7 +63,7 @@ impl FieldElement {
         self.0.is_zero()
     }
 
-    /// Determine if this `FieldElement10x26` is odd in the SEC-1 sense: `self mod 2 == 1`.
+    /// Determine if this `FieldElement10x26` is odd in the SEC1 sense: `self mod 2 == 1`.
     ///
     /// # Returns
     ///
@@ -72,13 +72,13 @@ impl FieldElement {
         self.0.is_odd()
     }
 
-    /// Attempts to parse the given byte array as an SEC-1-encoded field element.
+    /// Attempts to parse the given byte array as an SEC1-encoded field element.
     /// Does not check the result for being in the correct range.
     pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         Self(FieldElementImpl::from_bytes_unchecked(bytes))
     }
 
-    /// Attempts to parse the given byte array as an SEC-1-encoded field element.
+    /// Attempts to parse the given byte array as an SEC1-encoded field element.
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
@@ -86,7 +86,7 @@ impl FieldElement {
         FieldElementImpl::from_bytes(bytes).map(Self)
     }
 
-    /// Returns the SEC-1 encoding of this field element.
+    /// Returns the SEC1 encoding of this field element.
     pub fn to_bytes(&self) -> ElementBytes {
         self.0.normalize().to_bytes()
     }

--- a/k256/src/arithmetic/field/field_10x26.rs
+++ b/k256/src/arithmetic/field/field_10x26.rs
@@ -26,7 +26,7 @@ impl FieldElement10x26 {
         Self([1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
     }
 
-    /// Attempts to parse the given byte array as an SEC-1-encoded field element.
+    /// Attempts to parse the given byte array as an SEC1-encoded field element.
     /// Does not check the result for being in the correct range.
     pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         let w0 = (bytes[31] as u32)
@@ -72,7 +72,7 @@ impl FieldElement10x26 {
         Self([w0, w1, w2, w3, w4, w5, w6, w7, w8, w9])
     }
 
-    /// Attempts to parse the given byte array as an SEC-1-encoded field element.
+    /// Attempts to parse the given byte array as an SEC1-encoded field element.
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
@@ -83,7 +83,7 @@ impl FieldElement10x26 {
         CtOption::new(res, !overflow)
     }
 
-    /// Returns the SEC-1 encoding of this field element.
+    /// Returns the SEC1 encoding of this field element.
     pub fn to_bytes(&self) -> ElementBytes {
         let mut r = ElementBytes::default();
         r[0] = (self.0[9] >> 14) as u8;
@@ -269,7 +269,7 @@ impl FieldElement10x26 {
         )
     }
 
-    /// Determine if this `FieldElement10x26` is odd in the SEC-1 sense: `self mod 2 == 1`.
+    /// Determine if this `FieldElement10x26` is odd in the SEC1 sense: `self mod 2 == 1`.
     ///
     /// # Returns
     ///

--- a/k256/src/arithmetic/field/field_5x52.rs
+++ b/k256/src/arithmetic/field/field_5x52.rs
@@ -26,7 +26,7 @@ impl FieldElement5x52 {
         Self([1, 0, 0, 0, 0])
     }
 
-    /// Attempts to parse the given byte array as an SEC-1-encoded field element.
+    /// Attempts to parse the given byte array as an SEC1-encoded field element.
     /// Does not check the result for being in the correct range.
     pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         let w0 = (bytes[31] as u64)
@@ -71,7 +71,7 @@ impl FieldElement5x52 {
         Self([w0, w1, w2, w3, w4])
     }
 
-    /// Attempts to parse the given byte array as an SEC-1-encoded field element.
+    /// Attempts to parse the given byte array as an SEC1-encoded field element.
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
@@ -81,7 +81,7 @@ impl FieldElement5x52 {
         CtOption::new(res, !overflow)
     }
 
-    /// Returns the SEC-1 encoding of this field element.
+    /// Returns the SEC1 encoding of this field element.
     pub fn to_bytes(&self) -> ElementBytes {
         let mut ret = ElementBytes::default();
         ret[0] = (self.0[4] >> 40) as u8;
@@ -220,7 +220,7 @@ impl FieldElement5x52 {
         Choice::from(((self.0[0] | self.0[1] | self.0[2] | self.0[3] | self.0[4]) == 0) as u8)
     }
 
-    /// Determine if this `FieldElement5x52` is odd in the SEC-1 sense: `self mod 2 == 1`.
+    /// Determine if this `FieldElement5x52` is odd in the SEC1 sense: `self mod 2 == 1`.
     ///
     /// # Returns
     ///

--- a/k256/src/arithmetic/field/field_montgomery.rs
+++ b/k256/src/arithmetic/field/field_montgomery.rs
@@ -75,7 +75,7 @@ impl FieldElementMontgomery {
         Self(bytes_to_words(bytes)).mul(&R2)
     }
 
-    /// Attempts to parse the given byte array as an SEC-1-encoded field element.
+    /// Attempts to parse the given byte array as an SEC1-encoded field element.
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
@@ -94,7 +94,7 @@ impl FieldElementMontgomery {
         CtOption::new(Self(words).mul(&R2), Choice::from(is_some))
     }
 
-    /// Returns the SEC-1 encoding of this field element.
+    /// Returns the SEC1 encoding of this field element.
     pub fn to_bytes(&self) -> ElementBytes {
         let res = Self::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
         let mut ret = ElementBytes::default();
@@ -118,7 +118,7 @@ impl FieldElementMontgomery {
         self.is_zero()
     }
 
-    /// Determine if this `FieldElement` is odd in the SEC-1 sense: `self mod 2 == 1`.
+    /// Determine if this `FieldElement` is odd in the SEC1 sense: `self mod 2 == 1`.
     ///
     /// # Returns
     ///

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -100,7 +100,7 @@ impl Scalar {
         Self::from_bytes_reduced(&digest.finalize())
     }
 
-    /// Returns the SEC-1 encoding of this scalar.
+    /// Returns the SEC1 encoding of this scalar.
     pub fn to_bytes(&self) -> ElementBytes {
         self.0.to_bytes()
     }
@@ -250,7 +250,7 @@ impl Scalar {
 impl FromBytes for Scalar {
     type Size = U32;
 
-    /// Attempts to parse the given byte array as an SEC-1-encoded scalar.
+    /// Attempts to parse the given byte array as an SEC1-encoded scalar.
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).

--- a/k256/src/arithmetic/scalar/scalar_4x64.rs
+++ b/k256/src/arithmetic/scalar/scalar_4x64.rs
@@ -175,7 +175,7 @@ impl Scalar4x64 {
         Self([w0, w1, w2, w3])
     }
 
-    /// Attempts to parse the given byte array as an SEC-1-encoded scalar.
+    /// Attempts to parse the given byte array as an SEC1-encoded scalar.
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, modulus).
@@ -208,7 +208,7 @@ impl Scalar4x64 {
         Self(conditional_select(&w, &r2, !underflow))
     }
 
-    /// Returns the SEC-1 encoding of this scalar.
+    /// Returns the SEC1 encoding of this scalar.
     pub fn to_bytes(&self) -> ElementBytes {
         let mut ret = ElementBytes::default();
         ret[0..8].copy_from_slice(&self.0[3].to_be_bytes());

--- a/k256/src/arithmetic/scalar/scalar_8x32.rs
+++ b/k256/src/arithmetic/scalar/scalar_8x32.rs
@@ -208,7 +208,7 @@ impl Scalar8x32 {
         Self([w0, w1, w2, w3, w4, w5, w6, w7])
     }
 
-    /// Attempts to parse the given byte array as an SEC-1-encoded scalar.
+    /// Attempts to parse the given byte array as an SEC1-encoded scalar.
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, modulus).
@@ -249,7 +249,7 @@ impl Scalar8x32 {
         Self(conditional_select(&w, &r2, !underflow))
     }
 
-    /// Returns the SEC-1 encoding of this scalar.
+    /// Returns the SEC1 encoding of this scalar.
     pub fn to_bytes(&self) -> ElementBytes {
         let mut ret = ElementBytes::default();
         ret[0..4].copy_from_slice(&self.0[7].to_be_bytes());

--- a/k256/src/ecdh.rs
+++ b/k256/src/ecdh.rs
@@ -11,16 +11,16 @@
 //! ```
 //! # #[cfg(feature = "ecdh")]
 //! # {
-//! use k256::{PublicKey, ecdh::EphemeralSecret};
+//! use k256::{EncodedPoint, ecdh::EphemeralSecret};
 //! use rand_core::OsRng; // requires 'getrandom' feature
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::generate(&mut OsRng);
-//! let alice_public = PublicKey::from(&alice_secret);
+//! let alice_public = EncodedPoint::from(&alice_secret);
 //!
 //! // Bob
 //! let bob_secret = EphemeralSecret::generate(&mut OsRng);
-//! let bob_public = PublicKey::from(&bob_secret);
+//! let bob_public = EncodedPoint::from(&bob_secret);
 //!
 //! // Alice computes shared secret from Bob's public key
 //! let alice_shared = alice_secret.diffie_hellman(&bob_public)

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -38,9 +38,9 @@
 //! let signature: Signature = signer.sign_with_rng(&mut OsRng, message);
 //!
 //! // Verification
-//! use k256::{PublicKey, ecdsa::{Verifier, signature::Verifier as _}};
+//! use k256::{EncodedPoint, ecdsa::{Verifier, signature::Verifier as _}};
 //!
-//! let public_key = PublicKey::from_secret_key(&secret_key, true).expect("secret key invalid");
+//! let public_key = EncodedPoint::from_secret_key(&secret_key, true).expect("secret key invalid");
 //! let verifier = Verifier::new(&public_key).expect("public key invalid");
 //!
 //! assert!(verifier.verify(message, &signature).is_ok());

--- a/k256/src/ecdsa/signer.rs
+++ b/k256/src/ecdsa/signer.rs
@@ -1,7 +1,7 @@
 //! ECDSA signer
 
 use super::{recoverable, Error, Signature};
-use crate::{ElementBytes, ProjectivePoint, PublicKey, Scalar, Secp256k1, SecretKey};
+use crate::{ElementBytes, EncodedPoint, ProjectivePoint, Scalar, Secp256k1, SecretKey};
 use core::borrow::Borrow;
 use ecdsa_core::{hazmat::RecoverableSignPrimitive, signature::RandomizedSigner};
 use elliptic_curve::{
@@ -22,13 +22,14 @@ pub struct Signer {
     secret_key: SecretKey,
 
     /// Public key
-    public_key: PublicKey,
+    public_key: EncodedPoint,
 }
 
 impl Signer {
     /// Create a new signer
     pub fn new(secret_key: &SecretKey) -> Result<Self, Error> {
-        let public_key = PublicKey::from_secret_key(secret_key, true).map_err(|_| Error::new())?;
+        let public_key =
+            EncodedPoint::from_secret_key(secret_key, true).map_err(|_| Error::new())?;
         Ok(Self {
             secret_key: secret_key.clone(),
             public_key,
@@ -36,7 +37,7 @@ impl Signer {
     }
 
     /// Get the public key for this signer
-    pub fn public_key(&self) -> &PublicKey {
+    pub fn public_key(&self) -> &EncodedPoint {
         &self.public_key
     }
 }
@@ -81,8 +82,8 @@ impl RandomizedSigner<recoverable::Signature> for Signer {
     }
 }
 
-impl From<&Signer> for PublicKey {
-    fn from(signer: &Signer) -> PublicKey {
+impl From<&Signer> for EncodedPoint {
+    fn from(signer: &Signer) -> EncodedPoint {
         signer.public_key
     }
 }

--- a/k256/src/ecdsa/verifier.rs
+++ b/k256/src/ecdsa/verifier.rs
@@ -1,7 +1,7 @@
 //! ECDSA verifier
 
 use super::{recoverable, Error, Signature};
-use crate::{AffinePoint, ElementBytes, ProjectivePoint, PublicKey, Scalar, Secp256k1};
+use crate::{AffinePoint, ElementBytes, EncodedPoint, ProjectivePoint, Scalar, Secp256k1};
 use ecdsa_core::{hazmat::VerifyPrimitive, signature};
 use elliptic_curve::{subtle::CtOption, FromBytes};
 
@@ -14,7 +14,7 @@ pub struct Verifier {
 
 impl Verifier {
     /// Create a new verifier
-    pub fn new(public_key: &PublicKey) -> Result<Self, Error> {
+    pub fn new(public_key: &EncodedPoint) -> Result<Self, Error> {
         Ok(Self {
             verifier: ecdsa_core::Verifier::new(public_key)?,
         })
@@ -78,7 +78,7 @@ impl VerifyPrimitive<Secp256k1> for AffinePoint {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_vectors::ecdsa::ECDSA_TEST_VECTORS, AffinePoint, UncompressedPoint};
+    use crate::{test_vectors::ecdsa::ECDSA_TEST_VECTORS, AffinePoint};
     use ecdsa_core::generic_array::GenericArray;
 
     ecdsa_core::new_verification_test!(ECDSA_TEST_VECTORS);

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -103,19 +103,13 @@ impl elliptic_curve::Identifier for Secp256k1 {
     const OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 3, 132, 0, 10]);
 }
 
-/// K-256 (secp256k1) Secret Key.
-pub type SecretKey = elliptic_curve::SecretKey<Secp256k1>;
-
-/// K-256 (secp256k1) Public Key.
-pub type PublicKey = elliptic_curve::weierstrass::PublicKey<Secp256k1>;
-
 /// K-256 Serialized Field Element.
 ///
 /// Byte array containing a serialized field element value (base field or scalar).
 pub type ElementBytes = elliptic_curve::ElementBytes<Secp256k1>;
 
-/// K-256 Compressed Curve Point.
-pub type CompressedPoint = elliptic_curve::weierstrass::CompressedPoint<Secp256k1>;
+/// K-256 (secp256k1) SEC1 Encoded Point.
+pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<Secp256k1>;
 
-/// K-256 Uncompressed Curve Point.
-pub type UncompressedPoint = elliptic_curve::weierstrass::UncompressedPoint<Secp256k1>;
+/// K-256 (secp256k1) Secret Key.
+pub type SecretKey = elliptic_curve::SecretKey<Secp256k1>;

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -4,17 +4,17 @@ mod field;
 pub(crate) mod scalar;
 mod util;
 
-use core::convert::TryInto;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use elliptic_curve::{
     generic_array::arr,
     point::Generator,
+    sec1::{self, FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
-    weierstrass::public_key::FromPublicKey,
+    weierstrass::point::Decompress,
     Arithmetic,
 };
 
-use crate::{CompressedPoint, NistP256, PublicKey, UncompressedPoint};
+use crate::{ElementBytes, EncodedPoint, NistP256};
 use field::{FieldElement, MODULUS};
 use scalar::{NonZeroScalar, Scalar};
 
@@ -94,14 +94,9 @@ impl Generator for AffinePoint {
     }
 }
 
-impl AffinePoint {
-    /// Attempts to parse the given [`CompressedPoint`] as a SEC-1 encoded [`AffinePoint`]
-    pub fn from_compressed_point(point: &CompressedPoint) -> CtOption<Self> {
-        let bytes = point.as_bytes();
-        let y_is_odd = Choice::from(bytes[0] & 0x01);
-        let x = FieldElement::from_bytes(bytes[1..33].try_into().unwrap());
-
-        x.and_then(|x| {
+impl Decompress<NistP256> for AffinePoint {
+    fn decompress(x_bytes: &ElementBytes, y_is_odd: Choice) -> CtOption<Self> {
+        FieldElement::from_bytes(x_bytes).and_then(|x| {
             let alpha = x * &x * &x + &(CURVE_EQUATION_A * &x) + &CURVE_EQUATION_B;
             let beta = alpha.sqrt();
 
@@ -113,67 +108,53 @@ impl AffinePoint {
                     !(beta.is_odd() ^ y_is_odd),
                 );
 
-                AffinePoint { x, y }
+                Self { x, y }
             })
         })
     }
-
-    /// Attempts to parse the given [`UncompressedPoint`] as a SEC-1 encoded [`AffinePoint`]
-    pub fn from_uncompressed_point(point: &UncompressedPoint) -> CtOption<Self> {
-        let bytes = point.as_bytes();
-        let x = FieldElement::from_bytes(bytes[1..33].try_into().unwrap());
-        let y = FieldElement::from_bytes(bytes[33..65].try_into().unwrap());
-
-        x.and_then(|x| {
-            y.and_then(|y| {
-                // Check that the point is on the curve
-                let lhs = y * &y;
-                let rhs = x * &x * &x + &(CURVE_EQUATION_A * &x) + &CURVE_EQUATION_B;
-                CtOption::new(AffinePoint { x, y }, lhs.ct_eq(&rhs))
-            })
-        })
-    }
-
-    /// Returns a [`PublicKey`] with the SEC-1 encoding of this point.
-    ///
-    /// If `compress` is set to `true`, point compression is applied.
-    pub fn to_pubkey(&self, compress: bool) -> PublicKey {
-        if compress {
-            PublicKey::Compressed(self.clone().into())
-        } else {
-            PublicKey::Uncompressed(self.clone().into())
-        }
-    }
 }
 
-impl From<AffinePoint> for CompressedPoint {
-    /// Returns the SEC-1 compressed encoding of this point.
-    fn from(affine_point: AffinePoint) -> CompressedPoint {
-        CompressedPoint::from_affine_coords(&affine_point.x.to_bytes(), &affine_point.y.to_bytes())
-    }
-}
-
-impl From<AffinePoint> for UncompressedPoint {
-    /// Returns the SEC-1 uncompressed encoding of this point.
-    fn from(affine_point: AffinePoint) -> UncompressedPoint {
-        UncompressedPoint::from_affine_coords(
-            &affine_point.x.to_bytes(),
-            &affine_point.y.to_bytes(),
-        )
-    }
-}
-
-impl FromPublicKey<NistP256> for AffinePoint {
-    /// Attempts to parse the given [`PublicKey`] as an SEC-1-encoded [`AffinePoint`].
+impl FromEncodedPoint<NistP256> for AffinePoint {
+    /// Attempts to parse the given [`EncodedPoint`] as an SEC1-encoded [`AffinePoint`].
     ///
     /// # Returns
     ///
-    /// `None` value if `pubkey` is not on the NIST P-256 curve.
-    fn from_public_key(pubkey: &PublicKey) -> CtOption<Self> {
-        match pubkey {
-            PublicKey::Compressed(point) => Self::from_compressed_point(point),
-            PublicKey::Uncompressed(point) => Self::from_uncompressed_point(point),
+    /// `None` value if `encoded_point` is not on the secp256r1 curve.
+    fn from_encoded_point(encoded_point: &EncodedPoint) -> CtOption<Self> {
+        match encoded_point.tag() {
+            sec1::Tag::CompressedEvenY => {
+                AffinePoint::decompress(encoded_point.x(), Choice::from(0))
+            }
+            sec1::Tag::CompressedOddY => {
+                AffinePoint::decompress(encoded_point.x(), Choice::from(1))
+            }
+            sec1::Tag::Uncompressed => {
+                let x = FieldElement::from_bytes(encoded_point.x());
+                let y = FieldElement::from_bytes(encoded_point.y().expect("missing y-coordinate"));
+
+                x.and_then(|x| {
+                    y.and_then(|y| {
+                        // Check that the point is on the curve
+                        let lhs = y * &y;
+                        let rhs = x * &x * &x + &(CURVE_EQUATION_A * &x) + &CURVE_EQUATION_B;
+                        CtOption::new(AffinePoint { x, y }, lhs.ct_eq(&rhs))
+                    })
+                })
+            }
         }
+    }
+}
+
+impl ToEncodedPoint<NistP256> for AffinePoint {
+    fn to_encoded_point(&self, compress: bool) -> EncodedPoint {
+        EncodedPoint::from_affine_coords(&self.x.to_bytes(), &self.y.to_bytes(), compress)
+    }
+}
+
+impl From<AffinePoint> for EncodedPoint {
+    /// Returns the SEC1 compressed encoding of this point.
+    fn from(affine_point: AffinePoint) -> EncodedPoint {
+        affine_point.to_encoded_point(false)
     }
 }
 
@@ -553,9 +534,13 @@ mod tests {
     use super::{AffinePoint, ProjectivePoint, Scalar, CURVE_EQUATION_A, CURVE_EQUATION_B};
     use crate::{
         test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
-        PublicKey,
+        EncodedPoint,
     };
-    use elliptic_curve::{point::Generator, weierstrass::public_key::FromPublicKey, FromBytes};
+    use elliptic_curve::{
+        point::Generator,
+        sec1::{FromEncodedPoint, ToEncodedPoint},
+        FromBytes,
+    };
 
     const CURVE_EQUATION_A_BYTES: &str =
         "FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC";
@@ -581,31 +566,33 @@ mod tests {
 
     #[test]
     fn uncompressed_round_trip() {
-        let pubkey = PublicKey::from_bytes(&hex::decode(UNCOMPRESSED_BASEPOINT).unwrap()).unwrap();
-        let point = AffinePoint::from_public_key(&pubkey).unwrap();
+        let pubkey =
+            EncodedPoint::from_bytes(&hex::decode(UNCOMPRESSED_BASEPOINT).unwrap()).unwrap();
+        let point = AffinePoint::from_encoded_point(&pubkey).unwrap();
         assert_eq!(point, AffinePoint::generator());
 
-        let res: PublicKey = point.to_pubkey(false).into();
+        let res: EncodedPoint = point.into();
         assert_eq!(res, pubkey);
     }
 
     #[test]
     fn compressed_round_trip() {
-        let pubkey = PublicKey::from_bytes(&hex::decode(COMPRESSED_BASEPOINT).unwrap()).unwrap();
-        let point = AffinePoint::from_public_key(&pubkey).unwrap();
+        let pubkey = EncodedPoint::from_bytes(&hex::decode(COMPRESSED_BASEPOINT).unwrap()).unwrap();
+        let point = AffinePoint::from_encoded_point(&pubkey).unwrap();
         assert_eq!(point, AffinePoint::generator());
 
-        let res: PublicKey = point.to_pubkey(true).into();
+        let res: EncodedPoint = point.to_encoded_point(true).into();
         assert_eq!(res, pubkey);
     }
 
     #[test]
     fn uncompressed_to_compressed() {
-        let encoded = PublicKey::from_bytes(&hex::decode(UNCOMPRESSED_BASEPOINT).unwrap()).unwrap();
+        let encoded =
+            EncodedPoint::from_bytes(&hex::decode(UNCOMPRESSED_BASEPOINT).unwrap()).unwrap();
 
-        let res = AffinePoint::from_public_key(&encoded)
+        let res = AffinePoint::from_encoded_point(&encoded)
             .unwrap()
-            .to_pubkey(true);
+            .to_encoded_point(true);
 
         assert_eq!(
             hex::encode(res.as_bytes()).to_uppercase(),
@@ -615,11 +602,12 @@ mod tests {
 
     #[test]
     fn compressed_to_uncompressed() {
-        let encoded = PublicKey::from_bytes(&hex::decode(COMPRESSED_BASEPOINT).unwrap()).unwrap();
+        let encoded =
+            EncodedPoint::from_bytes(&hex::decode(COMPRESSED_BASEPOINT).unwrap()).unwrap();
 
-        let res = AffinePoint::from_public_key(&encoded)
+        let res = AffinePoint::from_encoded_point(&encoded)
             .unwrap()
-            .to_pubkey(false);
+            .to_encoded_point(false);
 
         assert_eq!(
             hex::encode(res.as_bytes()).to_uppercase(),

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -114,7 +114,7 @@ impl FieldElement {
         )
     }
 
-    /// Attempts to parse the given byte array as an SEC-1-encoded field element.
+    /// Attempts to parse the given byte array as an SEC1-encoded field element.
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
@@ -139,7 +139,7 @@ impl FieldElement {
         CtOption::new(FieldElement(w).mul(&R2), Choice::from(is_some))
     }
 
-    /// Returns the SEC-1 encoding of this field element.
+    /// Returns the SEC1 encoding of this field element.
     pub fn to_bytes(&self) -> ElementBytes {
         // Convert from Montgomery form to canonical form
         let tmp =
@@ -162,7 +162,7 @@ impl FieldElement {
         self.ct_eq(&FieldElement::zero())
     }
 
-    /// Determine if this `FieldElement` is odd in the SEC-1 sense: `self mod 2 == 1`.
+    /// Determine if this `FieldElement` is odd in the SEC1 sense: `self mod 2 == 1`.
     ///
     /// # Returns
     ///

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -136,7 +136,7 @@ impl Ord for Scalar {
 impl FromBytes for Scalar {
     type Size = U32;
 
-    /// Attempts to parse the given byte array as an SEC-1-encoded scalar.
+    /// Attempts to parse the given byte array as an SEC1-encoded scalar.
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
@@ -199,7 +199,7 @@ impl Scalar {
         )
     }
 
-    /// Returns the SEC-1 encoding of this scalar.
+    /// Returns the SEC1 encoding of this scalar.
     fn to_bytes(&self) -> ElementBytes {
         let mut ret = ElementBytes::default();
         ret[0..8].copy_from_slice(&self.0[3].to_be_bytes());

--- a/p256/src/ecdh.rs
+++ b/p256/src/ecdh.rs
@@ -11,16 +11,16 @@
 //! ```
 //! # #[cfg(feature = "ecdh")]
 //! # {
-//! use p256::{PublicKey, ecdh::EphemeralSecret};
+//! use p256::{EncodedPoint, ecdh::EphemeralSecret};
 //! use rand_core::OsRng; // requires 'getrandom' feature
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::generate(&mut OsRng);
-//! let alice_public = PublicKey::from(&alice_secret);
+//! let alice_public = EncodedPoint::from(&alice_secret);
 //!
 //! // Bob
 //! let bob_secret = EphemeralSecret::generate(&mut OsRng);
-//! let bob_public = PublicKey::from(&bob_secret);
+//! let bob_public = EncodedPoint::from(&bob_secret);
 //!
 //! // Alice computes shared secret from Bob's public key
 //! let alice_shared = alice_secret.diffie_hellman(&bob_public)

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -38,9 +38,9 @@
 //! let signature: Signature = signer.sign_with_rng(&mut OsRng, message);
 //!
 //! // Verification
-//! use p256::{PublicKey, ecdsa::{Verifier, signature::Verifier as _}};
+//! use p256::{EncodedPoint, ecdsa::{Verifier, signature::Verifier as _}};
 //!
-//! let public_key = PublicKey::from_secret_key(&secret_key, true).expect("secret key invalid");
+//! let public_key = EncodedPoint::from_secret_key(&secret_key, true).expect("secret key invalid");
 //! let verifier = Verifier::new(&public_key).expect("public key invalid");
 //!
 //! assert!(verifier.verify(message, &signature).is_ok());

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -108,19 +108,13 @@ impl elliptic_curve::Identifier for NistP256 {
     const OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 2, 840, 10045, 3, 1, 7]);
 }
 
-/// NIST P-256 Secret Key
-pub type SecretKey = elliptic_curve::SecretKey<NistP256>;
-
-/// NIST P-256 Public Key
-pub type PublicKey = elliptic_curve::weierstrass::PublicKey<NistP256>;
-
 /// NIST P-256 Serialized Field Element.
 ///
 /// Byte array containing a serialized field element value (base field or scalar).
 pub type ElementBytes = elliptic_curve::ElementBytes<NistP256>;
 
-/// NIST P-256 Compressed Curve Point
-pub type CompressedPoint = elliptic_curve::weierstrass::CompressedPoint<NistP256>;
+/// NIST P-256 SEC1 Encoded Point.
+pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP256>;
 
-/// NIST P-256 Uncompressed Curve Point
-pub type UncompressedPoint = elliptic_curve::weierstrass::UncompressedPoint<NistP256>;
+/// NIST P-256 Secret Key.
+pub type SecretKey = elliptic_curve::SecretKey<NistP256>;

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -65,19 +65,13 @@ impl elliptic_curve::weierstrass::Curve for NistP384 {
     const COMPRESS_POINTS: bool = false;
 }
 
-/// NIST P-384 Secret Key
-pub type SecretKey = elliptic_curve::SecretKey<NistP384>;
-
-/// NIST P-384 Public Key
-pub type PublicKey = elliptic_curve::weierstrass::PublicKey<NistP384>;
-
-/// NIST P-384 Scalar Bytes.
+/// NIST P-384 Serialized Field Element.
 ///
-/// Byte array containing a serialized scalar value (i.e. an integer)
+/// Byte array containing a serialized field element value (base field or scalar).
 pub type ElementBytes = elliptic_curve::ElementBytes<NistP384>;
 
-/// NIST P-384 Compressed Curve Point
-pub type CompressedPoint = elliptic_curve::weierstrass::CompressedPoint<NistP384>;
+/// NIST P-384 SEC1 Encoded Point.
+pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP384>;
 
-/// NIST P-384 Uncompressed Curve Point
-pub type UncompressedPoint = elliptic_curve::weierstrass::UncompressedPoint<NistP384>;
+/// NIST P-384 Secret Key
+pub type SecretKey = elliptic_curve::SecretKey<NistP384>;


### PR DESCRIPTION
Replaces the previous `PublicKey` type with `sec1::EncodedPoint`, as introduced in RustCrypto/traits#264.

This clears the way for a higher-level PublicKey type.