### PR TITLE
k256: add `keccak256` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,8 +44,15 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bstr"
@@ -343,7 +350,14 @@ dependencies = [
  "proptest",
  "rand_core",
  "sha2",
+ "sha3",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "lazy_static"
@@ -742,6 +756,18 @@ dependencies = [
  "cfg-if",
  "cpuid-bool",
  "digest",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "keccak",
  "opaque-debug",
 ]
 

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -16,6 +16,7 @@ cfg-if = "0.1"
 ecdsa-core = { version = "0.7", package = "ecdsa", optional = true, default-features = false }
 elliptic-curve = { version = "0.5", default-features = false, features = ["weierstrass"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
+sha3 = { version = "0.9", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -32,10 +33,11 @@ default = ["arithmetic", "oid", "std"]
 arithmetic = []
 digest = ["ecdsa-core/digest"]
 ecdh = ["elliptic-curve/ecdh", "rand", "zeroize"]
-ecdsa = ["arithmetic", "ecdsa-core/signer", "ecdsa-core/verifier", "rand", "sha256", "zeroize"]
+ecdsa = ["arithmetic", "digest", "ecdsa-core/signer", "ecdsa-core/verifier", "rand", "zeroize"]
 endomorphism-mul = []
 field-montgomery = []
 force-32-bit = []
+keccak256 = ["digest", "sha3"]
 oid = ["elliptic-curve/oid"]
 rand = ["elliptic-curve/rand"]
 sha256 = ["digest", "sha2"]

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -58,6 +58,9 @@ mod verifier;
 
 pub use ecdsa_core::signature::{self, Error};
 
+#[cfg(feature = "digest")]
+pub use ecdsa_core::signature::digest;
+
 #[cfg(feature = "ecdsa")]
 pub use self::{signer::Signer, verifier::Verifier};
 

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -27,7 +27,7 @@
 //! // `Signer` has many impls of the `RandomizedSigner` trait (for both
 //! // regular and recoverable signature types).
 //! let signature: recoverable::Signature = signer.sign_with_rng(&mut OsRng, message);
-//! let recovered_pubkey = signature.recover_pubkey(message).expect("couldn't recover pubkey");
+//! let recovered_pubkey = signature.recover_public_key(message).expect("couldn't recover pubkey");
 //!
 //! assert_eq!(&public_key, &recovered_pubkey);
 //! # }
@@ -40,8 +40,12 @@ use core::{
 use ecdsa_core::{signature::Signature as _, Error};
 
 #[cfg(feature = "ecdsa")]
-use crate::arithmetic::{
-    field::FieldElement, scalar::Scalar, AffinePoint, ProjectivePoint, CURVE_EQUATION_B,
+use crate::{
+    arithmetic::{
+        field::FieldElement, scalar::Scalar, AffinePoint, ProjectivePoint, CURVE_EQUATION_B,
+    },
+    ecdsa::digest::Digest,
+    elliptic_curve::consts::U32,
 };
 
 #[cfg(feature = "ecdsa")]
@@ -53,8 +57,8 @@ use elliptic_curve::{
 #[cfg(any(feature = "ecdsa", docsrs))]
 use crate::EncodedPoint;
 
-#[cfg(feature = "ecdsa")]
-use sha2::{Digest, Sha256};
+#[cfg(feature = "keccak256")]
+use sha3::Keccak256;
 
 /// Size of an Ethereum-style recoverable signature in bytes
 pub const SIZE: usize = 65;
@@ -107,7 +111,7 @@ impl Signature {
         for recovery_id in 0..=1 {
             let recoverable_signature = Signature::new(&signature, Id(recovery_id));
 
-            if let Ok(recovered_key) = recoverable_signature.recover_pubkey(msg) {
+            if let Ok(recovered_key) = recoverable_signature.recover_public_key(msg) {
                 if public_key == &recovered_key {
                     return Ok(recoverable_signature);
                 }
@@ -117,14 +121,26 @@ impl Signature {
         Err(Error::new())
     }
 
-    /// Recover the [`EncodedPoint`] used to create the given signature
+    /// Recover the public key used to create the given signature as an
+    /// [`EncodedPoint`].
+    #[cfg(all(feature = "ecdsa", feature = "keccak256"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")), doc(cfg(feature = "keccak256")))]
+    pub fn recover_public_key(&self, msg: &[u8]) -> Result<EncodedPoint, Error> {
+        self.recover_public_key_from_prehash(Keccak256::new().chain(msg))
+    }
+
+    /// Recover the public key used to create the given signature as an
+    /// [`EncodedPoint`] from the provided precomputed [`Digest`].
     #[cfg(feature = "ecdsa")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     #[allow(non_snake_case, clippy::many_single_char_names)]
-    pub fn recover_pubkey(&self, msg: &[u8]) -> Result<EncodedPoint, Error> {
+    pub fn recover_public_key_from_prehash<D>(&self, msg_prehash: D) -> Result<EncodedPoint, Error>
+    where
+        D: Digest<OutputSize = U32>,
+    {
         let r = self.r()?;
         let s = self.s()?;
-        let z = Scalar::from_digest(Sha256::new().chain(msg));
+        let z = Scalar::from_digest(msg_prehash);
         let x = FieldElement::from_bytes(&r.to_bytes());
 
         let pk = x.and_then(|x| {
@@ -234,6 +250,11 @@ impl From<Signature> for super::Signature {
     }
 }
 
+#[cfg(feature = "keccak256")]
+impl ecdsa_core::signature::PrehashSignature for Signature {
+    type Digest = Keccak256;
+}
+
 /// Identifier used to compute a [`EncodedPoint`] from a [`Signature`].
 ///
 /// In practice these values are always either `0` or `1`, and indicate
@@ -278,11 +299,12 @@ impl From<Id> for u8 {
     }
 }
 
-#[cfg(all(test, feature = "ecdsa"))]
+#[cfg(all(test, feature = "ecdsa", feature = "sha256"))]
 mod tests {
     use super::Signature;
     use core::convert::TryFrom;
     use hex_literal::hex;
+    use sha2::{Digest, Sha256};
 
     /// Signature recovery test vectors
     struct TestVector {
@@ -316,7 +338,8 @@ mod tests {
     fn public_key_recovery() {
         for vector in VECTORS {
             let sig = Signature::try_from(&vector.sig[..]).unwrap();
-            let pk = sig.recover_pubkey(vector.msg).unwrap();
+            let prehash = Sha256::new().chain(vector.msg);
+            let pk = sig.recover_public_key_from_prehash(prehash).unwrap();
             assert_eq!(&vector.pk[..], pk.as_bytes());
         }
     }


### PR DESCRIPTION
Ethereum-style signatures (`k256::ecdsa::recoverable::Signature`) use Keccak256.

This commit adds a `keccak256` feature which can be used to compute these signatures using Keccak256 automatically.