### PR TITLE
k256/p256: update code and examples to use new ECDSA key APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.7.2"
-source = "git+https://github.com/RustCrypto/signatures#67585389af8c47b4d1cc490f89149ff96ee711f2"
+source = "git+https://github.com/RustCrypto/signatures#ff2b61de5c5fe0621387b4e52e31a36793d3ec1b"
 dependencies = [
  "elliptic-curve",
  "hmac",
@@ -259,7 +259,7 @@ checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0"
-source = "git+https://github.com/RustCrypto/traits#b9f71bd73969649a34d46230900fd3f9ab6b1340"
+source = "git+https://github.com/RustCrypto/traits#3df75fcbb642248b6509cde13b8753e695b3f19c"
 dependencies = [
  "const-oid",
  "digest",

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -28,8 +28,7 @@
 //! use rand_core::OsRng; // requires 'getrandom' feature
 //!
 //! // Signing
-//! let secret_key = SecretKey::generate(&mut OsRng);
-//! let signing_key = SigningKey::from_secret_key(&secret_key).expect("secret key invalid");
+//! let signing_key = SigningKey::generate(&mut OsRng); // Serialize with `::to_bytes()`
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //!
 //! // Note: the signature type must be annotated or otherwise inferrable as
@@ -40,9 +39,7 @@
 //! // Verification
 //! use k256::{EncodedPoint, ecdsa::{VerifyKey, signature::Verifier}};
 //!
-//! let public_key = EncodedPoint::from_secret_key(&secret_key, true).expect("secret key invalid");
-//! let verify_key = VerifyKey::from_encoded_point(&public_key).expect("public key invalid");
-//!
+//! let verify_key = VerifyKey::from(&signing_key); // Serialize with `::to_encoded_point()`
 //! assert!(verify_key.verify(message, &signature).is_ok());
 //! # }
 //! ```

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -11,22 +11,20 @@
 //! # #[cfg(feature = "ecdsa")]
 //! # {
 //! use k256::{
-//!     ecdsa::{SigningKey, recoverable, signature::Signer as _},
+//!     ecdsa::{SigningKey, recoverable, signature::Signer},
 //!     elliptic_curve::{Generate, rand_core::OsRng},
-//!     SecretKey, EncodedPoint
+//!     EncodedPoint
 //! };
 //!
 //! // Signing
-//! let secret_key = SecretKey::generate(&mut OsRng);
-//! let public_key = EncodedPoint::from_secret_key(&secret_key, true).expect("secret key invalid");
-//!
-//! let signer = SigningKey::from_secret_key(&secret_key).expect("secret key invalid");
+//! let signing_key = SigningKey::generate(&mut OsRng); // Serialize with `::to_bytes()`
+//! let public_key = EncodedPoint::from(&signing_key.verify_key());
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //!
 //! // Note: the signature type must be annotated or otherwise inferrable as
 //! // `Signer` has many impls of the `Signer` trait (for both regular and
 //! // recoverable signature types).
-//! let signature: recoverable::Signature = signer.sign(message);
+//! let signature: recoverable::Signature = signing_key.sign(message);
 //! let recovered_pubkey = signature.recover_public_key(message).expect("couldn't recover pubkey");
 //!
 //! assert_eq!(&public_key, &recovered_pubkey);

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -22,24 +22,19 @@
 //! # {
 //! use p256::{
 //!     ecdsa::{SigningKey, Signature, signature::Signer},
-//!     elliptic_curve::{Generate},
-//!     SecretKey,
+//!     elliptic_curve::Generate,
 //! };
 //! use rand_core::OsRng; // requires 'getrandom' feature
 //!
 //! // Signing
-//! let secret_key = SecretKey::generate(&mut OsRng);
-//! let signing_key = SigningKey::from_secret_key(&secret_key).expect("secret key invalid");
+//! let signing_key = SigningKey::generate(&mut OsRng); // Serialize with `::to_bytes()`
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
-//!
-//! let signature: Signature = signing_key.sign(message);
+//! let signature = signing_key.sign(message);
 //!
 //! // Verification
-//! use p256::{EncodedPoint, ecdsa::{VerifyKey, signature::Verifier}};
+//! use p256::ecdsa::{VerifyKey, signature::Verifier};
 //!
-//! let public_key = EncodedPoint::from_secret_key(&secret_key, true).expect("secret key invalid");
-//! let verify_key = VerifyKey::from_encoded_point(&public_key).expect("public key invalid");
-//!
+//! let verify_key = VerifyKey::from(&signing_key); // Serialize with `::to_encoded_point()`
 //! assert!(verify_key.verify(message, &signature).is_ok());
 //! # }
 //! ```


### PR DESCRIPTION
These methods simplify ECDSA usages.