### PR TITLE
k256/p256: use sec1::Coordinates enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.7.2"
-source = "git+https://github.com/RustCrypto/signatures#c22624e8fb3325e7e156b336193ae811f9270e3c"
+source = "git+https://github.com/RustCrypto/signatures#e8b7f6c363bc729eaa1d3a4efa5be9275279298a"
 dependencies = [
  "elliptic-curve",
  "hmac",
@@ -259,7 +259,7 @@ checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0"
-source = "git+https://github.com/RustCrypto/traits#3df75fcbb642248b6509cde13b8753e695b3f19c"
+source = "git+https://github.com/RustCrypto/traits#ab2598b62c35d8e9350937b2f632c54b84cbcb01"
 dependencies = [
  "const-oid",
  "digest",

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -132,16 +132,13 @@ impl FromEncodedPoint<Secp256k1> for AffinePoint {
     ///
     /// `None` value if `encoded_point` is not on the secp256k1 curve.
     fn from_encoded_point(encoded_point: &EncodedPoint) -> CtOption<Self> {
-        match encoded_point.tag() {
-            sec1::Tag::CompressedEvenY => {
-                AffinePoint::decompress(encoded_point.x(), Choice::from(0))
+        match encoded_point.coordinates() {
+            sec1::Coordinates::Compressed { x, y_is_odd } => {
+                AffinePoint::decompress(x, Choice::from(y_is_odd as u8))
             }
-            sec1::Tag::CompressedOddY => {
-                AffinePoint::decompress(encoded_point.x(), Choice::from(1))
-            }
-            sec1::Tag::Uncompressed => {
-                let x = FieldElement::from_bytes(encoded_point.x());
-                let y = FieldElement::from_bytes(encoded_point.y().expect("missing y-coordinate"));
+            sec1::Coordinates::Uncompressed { x, y } => {
+                let x = FieldElement::from_bytes(x);
+                let y = FieldElement::from_bytes(y);
 
                 x.and_then(|x| {
                     y.and_then(|y| {
@@ -158,7 +155,7 @@ impl FromEncodedPoint<Secp256k1> for AffinePoint {
 
 impl ToEncodedPoint<Secp256k1> for AffinePoint {
     fn to_encoded_point(&self, compress: bool) -> EncodedPoint {
-        EncodedPoint::from_affine_coords(&self.x.to_bytes(), &self.y.to_bytes(), compress)
+        EncodedPoint::from_affine_coordinates(&self.x.to_bytes(), &self.y.to_bytes(), compress)
     }
 }
 


### PR DESCRIPTION
Removes fallibility around obtaining the y-coordinate