### PR TITLE
k256: use Decompress to impl ECDSA pubkey recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.7.2"
-source = "git+https://github.com/RustCrypto/signatures#e8b7f6c363bc729eaa1d3a4efa5be9275279298a"
+source = "git+https://github.com/RustCrypto/signatures#b724ece13a0b39e8a8cc39cb0a2adfe366d8f44e"
 dependencies = [
  "elliptic-curve",
  "hmac",
@@ -517,9 +517,9 @@ checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
 dependencies = [
  "unicode-xid",
 ]

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -10,8 +10,8 @@
 //!   [`signature::Signer`] trait. Example use cases for this include other
 //!   software implementations of ECDSA/secp256k1 and wrappers for cloud KMS
 //!   services or hardware devices (HSM or crypto hardware wallet).
-//! - `ecdsa`: provides the [`Signature`], [`Signer`], and [`Verifier`] types
-//!   which natively implement ECDSA/secp256k1 signing and verification.
+//! - `ecdsa`: provides `ecdsa-core` plus the [`SigningKey`] and [`VerifyKey`]
+//!   types which natively implement ECDSA/secp256k1 signing and verification.
 //!
 //! ## Signing/Verification Example
 //!

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -104,13 +104,16 @@ impl elliptic_curve::Identifier for Secp256k1 {
     const OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 3, 132, 0, 10]);
 }
 
-/// K-256 Serialized Field Element.
+/// Compressed SEC1-encoded secp256k1 (K-256) point (i.e. public key)
+pub type CompressedPoint = [u8; 33];
+
+/// secp256k1 (K-256) serialized field element.
 ///
 /// Byte array containing a serialized field element value (base field or scalar).
 pub type ElementBytes = elliptic_curve::ElementBytes<Secp256k1>;
 
-/// K-256 (secp256k1) SEC1 Encoded Point.
+/// SEC1-encoded secp256k1 (K-256) curve point.
 pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<Secp256k1>;
 
-/// K-256 (secp256k1) Secret Key.
+/// secp256k1 (K-256) secret key.
 pub type SecretKey = elliptic_curve::SecretKey<Secp256k1>;


### PR DESCRIPTION
Uses the point decompression trait rather than duplicating the point decompression logic.