### PR TITLE
Impl ecdsa::CheckSignatureBytes-related changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.7.2"
-source = "git+https://github.com/RustCrypto/signatures#b724ece13a0b39e8a8cc39cb0a2adfe366d8f44e"
+source = "git+https://github.com/RustCrypto/signatures#5046c9244904a8a6f0200d1c89024199c17e7582"
 dependencies = [
  "elliptic-curve",
  "hmac",

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -71,6 +71,9 @@ use core::convert::TryInto;
 /// ECDSA/secp256k1 signature (fixed-size)
 pub type Signature = ecdsa_core::Signature<Secp256k1>;
 
+#[cfg(not(feature = "ecdsa"))]
+impl ecdsa_core::CheckSignatureBytes for Secp256k1 {}
+
 #[cfg(all(feature = "ecdsa", feature = "sha256"))]
 impl ecdsa_core::hazmat::DigestPrimitive for Secp256k1 {
     type Digest = sha2::Sha256;

--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -186,7 +186,7 @@ impl Scalar {
             return Err(Error::new());
         }
 
-        let mut signature = Signature::from_scalars(&r.into(), &s.into());
+        let mut signature = Signature::from_scalars(r, s)?;
         let is_r_odd = bool::from(R.y.normalize().is_odd());
         let is_s_high = signature.normalize_s()?;
         let recovery_id = recoverable::Id((is_r_odd ^ is_s_high) as u8);

--- a/k256/src/ecdsa/verify.rs
+++ b/k256/src/ecdsa/verify.rs
@@ -1,12 +1,10 @@
 //! ECDSA verifier
 
 use super::{recoverable, Error, Signature};
-use crate::{
-    AffinePoint, CompressedPoint, EncodedPoint, NonZeroScalar, ProjectivePoint, Scalar, Secp256k1,
-};
+use crate::{AffinePoint, CompressedPoint, EncodedPoint, ProjectivePoint, Scalar, Secp256k1};
 use core::convert::TryFrom;
 use ecdsa_core::{hazmat::VerifyPrimitive, signature};
-use elliptic_curve::{consts::U32, ops::Invert, sec1::ToEncodedPoint, FromBytes};
+use elliptic_curve::{consts::U32, ops::Invert, sec1::ToEncodedPoint};
 use signature::{digest::Digest, DigestVerifier, PrehashSignature};
 
 /// ECDSA/secp256k1 verification key (i.e. public key)
@@ -87,15 +85,8 @@ impl TryFrom<&EncodedPoint> for VerifyKey {
 
 impl VerifyPrimitive<Secp256k1> for AffinePoint {
     fn verify_prehashed(&self, z: &Scalar, signature: &Signature) -> Result<(), Error> {
-        let maybe_r = NonZeroScalar::from_bytes(signature.r());
-        let maybe_s = NonZeroScalar::from_bytes(signature.s());
-
-        // TODO(tarcieri): replace with into conversion when available (see subtle#73)
-        let (r, s) = if maybe_r.is_some().into() && maybe_s.is_some().into() {
-            (maybe_r.unwrap(), maybe_s.unwrap())
-        } else {
-            return Err(Error::new());
-        };
+        let r = signature.r();
+        let s = signature.s();
 
         // Ensure signature is "low S" normalized ala BIP 0062
         if s.is_high().into() {

--- a/p384/src/ecdsa.rs
+++ b/p384/src/ecdsa.rs
@@ -5,6 +5,8 @@ pub use crate::NistP384;
 /// ECDSA/P-384 signature (fixed-size)
 pub type Signature = ecdsa::Signature<NistP384>;
 
+impl ecdsa::CheckSignatureBytes for NistP384 {}
+
 #[cfg(feature = "sha384")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sha384")))]
 impl ecdsa::hazmat::DigestPrimitive for NistP384 {


### PR DESCRIPTION
Corresponding `ecdsa` crate PR is RustCrypto/signatures#151.

This implements the changes which eagerly validate that ECDSA signature `r` and `s` components are in-range `NonZeroScalar` values.

This eliminates the need to do these checks as part of each ECDSA verification implementation.