### PR TITLE
Force inline mul_wide() and reduce() to get rid of performance regression

### DIFF
--- a/k256/src/arithmetic/scalar/scalar_4x64.rs
+++ b/k256/src/arithmetic/scalar/scalar_4x64.rs
@@ -251,6 +251,7 @@ impl Scalar4x64 {
     }
 
     /// Multiplies two scalars without modulo reduction, producing up to a 512-bit scalar.
+    #[inline(always)] // only used in Scalar::mul(), so won't cause binary bloat
     fn mul_wide(&self, rhs: &Self) -> WideScalar8x64 {
         /* 160 bit accumulator. */
 
@@ -421,6 +422,7 @@ impl WideScalar8x64 {
         Self(w)
     }
 
+    #[inline(always)] // only used in Scalar::mul(), so won't cause binary bloat
     pub fn reduce(&self) -> Scalar4x64 {
         let n0 = self.0[4];
         let n1 = self.0[5];

--- a/k256/src/arithmetic/scalar/scalar_8x32.rs
+++ b/k256/src/arithmetic/scalar/scalar_8x32.rs
@@ -306,6 +306,7 @@ impl Scalar8x32 {
     }
 
     /// Multiplies two scalars without modulo reduction, producing up to a 512-bit scalar.
+    #[inline(always)] // only used in Scalar::mul(), so won't cause binary bloat
     fn mul_wide(&self, rhs: &Self) -> WideScalar16x32 {
         /* 96 bit accumulator. */
         let c0 = 0;
@@ -563,6 +564,7 @@ impl WideScalar16x32 {
         Self(w)
     }
 
+    #[inline(always)] // only used in Scalar::mul(), so won't cause binary bloat
     pub fn reduce(&self) -> Scalar8x32 {
         let n0 = self.0[8];
         let n1 = self.0[9];


### PR DESCRIPTION
Noticed while checking performance in PR #164 that scalar `mul()` became slower. Seems to be caused by the compiler ceasing to inline `mul_wide()` and `reduce()` starting from commit 058669385045de6eaeb6da7446d4904c08cd5dca on. 

Adding this makes `Scalar4x64::mul()` 10% faster, but has no effect on `Scalar8x32` performance on my machine; nevertheless, I inlined these functions there as well for the sake of uniformity (may be important for a 32-bit embedded device). These functions are only used once (in `mul()`), so it won't degrade compilation. 

I usually prefer not to add explicit inlining, but 10% is a pretty solid speed-up... 