### PR TITLE
p256: implement `AffinePoint::identity()` and `::is_identity()`

### DIFF
--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -139,8 +139,11 @@ impl FromEncodedPoint<Secp256k1> for AffinePoint {
                         // Check that the point is on the curve
                         let lhs = (y * &y).negate(1);
                         let rhs = x * &x * &x + &CURVE_EQUATION_B;
-                        let infinity = Choice::from(0);
-                        let point = AffinePoint { x, y, infinity };
+                        let point = AffinePoint {
+                            x,
+                            y,
+                            infinity: Choice::from(0),
+                        };
                         CtOption::new(point, (lhs + &rhs).normalizes_to_zero())
                     })
                 })

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -27,11 +27,12 @@ pub struct ProjectivePoint {
 
 impl From<AffinePoint> for ProjectivePoint {
     fn from(p: AffinePoint) -> Self {
-        ProjectivePoint {
+        let projective = ProjectivePoint {
             x: p.x,
             y: p.y,
             z: FieldElement::one(),
-        }
+        };
+        Self::conditional_select(&projective, &Self::identity(), p.infinity)
     }
 }
 

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -89,7 +89,7 @@ impl SignPrimitive<NistP256> for Scalar {
         let k_inverse = k_inverse.unwrap();
 
         // Compute `x`-coordinate of affine point 𝑘×𝑮
-        let x = (ProjectivePoint::generator() * k).to_affine().unwrap().x;
+        let x = (ProjectivePoint::generator() * k).to_affine().x;
 
         // Lift `x` (element of base field) to serialized big endian integer,
         // then reduce it to an element of the scalar field
@@ -117,7 +117,6 @@ impl VerifyPrimitive<NistP256> for AffinePoint {
 
         let x = ((&ProjectivePoint::generator() * &u1) + &(ProjectivePoint::from(*self) * &u2))
             .to_affine()
-            .unwrap()
             .x;
 
         if Scalar::from_bytes_reduced(&x.to_bytes()) == *r {


### PR DESCRIPTION
This is a corresponding change ala #165, but for the `p256` crate.