### PR TITLE
p256: impl `ff` and `group` traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 name = "p256"
 version = "0.4.1"
 dependencies = [
+ "byteorder",
  "ecdsa",
  "elliptic-curve",
  "hex",

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -7,7 +7,8 @@ use core::{
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
 };
 use elliptic_curve::{
-    group::{self, Group},
+    ff::Field,
+    group::{Curve, Group},
     point::Generator,
     rand_core::RngCore,
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq},
@@ -240,8 +241,8 @@ impl ProjectivePoint {
 impl Group for ProjectivePoint {
     type Scalar = Scalar;
 
-    fn random(rng: impl RngCore) -> Self {
-        Self::generator() * Scalar::generate_vartime(rng)
+    fn random(mut rng: impl RngCore) -> Self {
+        Self::generator() * Scalar::random(&mut rng)
     }
 
     fn identity() -> Self {
@@ -262,7 +263,7 @@ impl Group for ProjectivePoint {
     }
 }
 
-impl group::Curve for ProjectivePoint {
+impl Curve for ProjectivePoint {
     type AffineRepr = AffinePoint;
 
     fn to_affine(&self) -> AffinePoint {

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
 
 [dependencies]
+byteorder = { version = "1", default-features = false }
 ecdsa-core = { version = "0.7", package = "ecdsa", optional = true, default-features = false }
 elliptic-curve = { version = "0.5", default-features = false }
 sha2 = { version = "0.9", optional = true, default-features = false }

--- a/p256/src/arithmetic/scalar/blinding.rs
+++ b/p256/src/arithmetic/scalar/blinding.rs
@@ -50,9 +50,9 @@ impl Invert for BlindedScalar {
     fn invert(&self) -> CtOption<Scalar> {
         // prevent side channel analysis of scalar inversion by pre-and-post-multiplying
         // with the random masking scalar
-        (self.scalar * &self.mask)
+        (self.scalar * self.mask)
             .invert_vartime()
-            .map(|s| s * &self.mask)
+            .map(|s| s * self.mask)
     }
 }
 

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -96,7 +96,7 @@ impl SignPrimitive<NistP256> for Scalar {
         let r = Scalar::from_bytes_reduced(&x.to_bytes());
 
         // Compute `s` as a signature over `r` and `z`.
-        let s = k_inverse * &(z + &(r * self));
+        let s = k_inverse * (z + &(r * self));
 
         if s.is_zero().into() {
             return Err(Error::new());
@@ -113,9 +113,9 @@ impl VerifyPrimitive<NistP256> for AffinePoint {
         let s = signature.s();
         let s_inv = s.invert().unwrap();
         let u1 = z * &s_inv;
-        let u2 = *r * &s_inv;
+        let u2 = *r * s_inv;
 
-        let x = ((&ProjectivePoint::generator() * &u1) + &(ProjectivePoint::from(*self) * &u2))
+        let x = ((ProjectivePoint::generator() * u1) + (ProjectivePoint::from(*self) * u2))
             .to_affine()
             .x;
 


### PR DESCRIPTION
Corresponding change to #164, but for the `p256` crate.

- Impls `ff::{Field, PrimeField}` on `Scalar`
- Impls `group::{Group, Curve}` on `ProjectivePoint`