### PR TITLE
Use subtle 2.3's ConstantTimeEq impl on Choice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,12 +154,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -259,7 +259,7 @@ checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0"
-source = "git+https://github.com/RustCrypto/traits#80abd0a2e92202915d853cf644ec8de50c2c3324"
+source = "git+https://github.com/RustCrypto/traits#88d462bd5c94a1b1dbf3f2f5375fdfc406b35293"
 dependencies = [
  "const-oid",
  "digest",
@@ -831,15 +831,15 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.2.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
+checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -56,7 +56,7 @@ impl ConstantTimeEq for AffinePoint {
     fn ct_eq(&self, other: &AffinePoint) -> Choice {
         (self.x.negate(1) + &other.x).normalizes_to_zero()
             & (self.y.negate(1) + &other.y).normalizes_to_zero()
-            & !(self.infinity ^ other.infinity)
+            & self.infinity.ct_eq(&other.infinity)
     }
 }
 
@@ -108,8 +108,7 @@ impl Decompress<Secp256k1> for AffinePoint {
                 let y = FieldElement::conditional_select(
                     &beta.negate(1),
                     &beta,
-                    // beta.is_odd() == y_is_odd
-                    !(beta.normalize().is_odd() ^ y_is_odd),
+                    beta.normalize().is_odd().ct_eq(&y_is_odd),
                 );
 
                 Self {

--- a/p256/src/arithmetic/affine.rs
+++ b/p256/src/arithmetic/affine.rs
@@ -51,7 +51,7 @@ impl ConditionallySelectable for AffinePoint {
 
 impl ConstantTimeEq for AffinePoint {
     fn ct_eq(&self, other: &AffinePoint) -> Choice {
-        self.x.ct_eq(&other.x) & self.y.ct_eq(&other.y) & !(self.infinity ^ other.infinity)
+        self.x.ct_eq(&other.x) & self.y.ct_eq(&other.y) & self.infinity.ct_eq(&other.infinity)
     }
 }
 
@@ -103,8 +103,7 @@ impl Decompress<NistP256> for AffinePoint {
                 let y = FieldElement::conditional_select(
                     &(MODULUS - &beta),
                     &beta,
-                    // beta.is_odd() == y_is_odd
-                    !(beta.is_odd() ^ y_is_odd),
+                    beta.is_odd().ct_eq(&y_is_odd),
                 );
 
                 Self {


### PR DESCRIPTION
Replaces previous usage of XNOR on Choice to provide `ConstantTimeEq` with a newly released upstream impl of the same behavior:

https://github.com/dalek-cryptography/subtle/pull/76