### PR TITLE
k256/p256: bump `ff` and `group` deps to v0.8; MSRV 1.44+

### DIFF
--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.44.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.44.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.44.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.44.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.44.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.44.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.41.0
+        toolchain: 1.44.0 # MSRV
         components: clippy
     - run: cargo clippy --all --all-features -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f0df4bb4c441080e98d6ea2dc3281fc19bb440e69ce03075e3d705894f1cb"
+dependencies = [
+ "funty",
+ "radium",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +254,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.7.2"
-source = "git+https://github.com/RustCrypto/signatures#d1a8f0812db4f09e75e5171b182e4b9b002d9d1d"
+source = "git+https://github.com/RustCrypto/signatures#e6151cdfaf003fa350bc1a1d5146d31b6c311518"
 dependencies = [
  "elliptic-curve",
  "hmac",
@@ -259,8 +270,9 @@ checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0"
-source = "git+https://github.com/RustCrypto/traits#88d462bd5c94a1b1dbf3f2f5375fdfc406b35293"
+source = "git+https://github.com/RustCrypto/traits#548e11779ea85d411daa39214afcd7cc6c72c2b8"
 dependencies = [
+ "bitvec",
  "const-oid",
  "digest",
  "ff",
@@ -273,11 +285,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11efdc125f2647dde5a0f5f88010a5b0f89b700f86052afa1d148c4696047"
+checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
 dependencies = [
- "byteorder",
+ "bitvec",
  "rand_core",
  "subtle",
 ]
@@ -287,6 +299,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "funty"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
 
 [[package]]
 name = "generic-array"
@@ -311,10 +329,10 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.7.0"
-source = "git+https://github.com/zkcrypto/group.git#2942324876cdbb5c94140ad39ae83da642c30374"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
 dependencies = [
- "byteorder",
  "ff",
  "rand_core",
  "subtle",
@@ -374,9 +392,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
+checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -385,7 +403,6 @@ dependencies = [
 name = "k256"
 version = "0.4.2"
 dependencies = [
- "byteorder",
  "cfg-if",
  "criterion",
  "ecdsa",
@@ -504,7 +521,6 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 name = "p256"
 version = "0.4.1"
 dependencies = [
- "byteorder",
  "ecdsa",
  "elliptic-curve",
  "hex",
@@ -584,6 +600,12 @@ checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
@@ -931,9 +953,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
+checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -941,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
+checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -956,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
+checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -966,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
+checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -979,15 +1001,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
+checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 
 [[package]]
 name = "web-sys"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda38f4e5ca63eda02c059d243aa25b5f35ab98451e518c51612cd0f1bd19a47"
+checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1023,6 +1045,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,3 @@ members = [
 [patch.crates-io]
 ecdsa = { git = "https://github.com/RustCrypto/signatures" }
 elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
-group = { git = "https://github.com/zkcrypto/group.git" }

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ if you are interested in curves beyond the ones listed here.
 
 ## Minimum Supported Rust Version
 
-All crates in this repository support Rust **1.41** or higher. In future minimum
-supported Rust version can be changed, but it will be done with the minor
-version bump.
+All crates in this repository support Rust **1.44** or higher.
+
+Minimum supported Rust version can be changed in the future, but it will be
+done with a minor version bump.
 
 ## License
 
@@ -47,7 +48,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.44+-blue.svg
 
 [//]: # (crates)
 

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -16,7 +16,6 @@ categories = ["cryptography", "cryptography::cryptocurrencies", "no-std"]
 keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
 
 [dependencies]
-byteorder = { version = "1", default-features = false }
 cfg-if = "0.1"
 ecdsa-core = { version = "0.7", package = "ecdsa", optional = true, default-features = false }
 elliptic-curve = { version = "0.5", default-features = false }
@@ -35,7 +34,7 @@ rand_core = { version = "0.5", features = ["getrandom"] }
 
 [features]
 default = ["arithmetic", "oid", "std"]
-arithmetic = []
+arithmetic = ["elliptic-curve/arithmetic"]
 digest = ["elliptic-curve/digest", "ecdsa-core/digest"]
 ecdh = ["elliptic-curve/ecdh", "zeroize"]
 ecdsa = ["arithmetic", "digest", "ecdsa-core/sign", "ecdsa-core/verify", "zeroize"]

--- a/k256/README.md
+++ b/k256/README.md
@@ -52,7 +52,7 @@ particularly in conjunction with the
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.44** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -84,7 +84,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/k256/badge.svg
 [docs-link]: https://docs.rs/k256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.44+-blue.svg
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/k256/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/elliptic-curves/actions?query=workflow%3Ak256
 

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -29,6 +29,7 @@ pub(crate) const CURVE_EQUATION_B: FieldElement = FieldElement::from_bytes_unche
 impl elliptic_curve::Arithmetic for Secp256k1 {
     type Scalar = Scalar;
     type AffinePoint = AffinePoint;
+    type ProjectivePoint = ProjectivePoint;
 }
 
 #[cfg(test)]

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -2,10 +2,7 @@
 
 use super::{FieldElement, ProjectivePoint, CURVE_EQUATION_B};
 use crate::{ElementBytes, EncodedPoint, NonZeroScalar, Secp256k1};
-use core::{
-    fmt,
-    ops::{Mul, Neg},
-};
+use core::ops::{Mul, Neg};
 use elliptic_curve::{
     generic_array::arr,
     point::Generator,
@@ -184,12 +181,6 @@ impl Neg for AffinePoint {
             y: self.y.negate(1).normalize_weak(),
             infinity: self.infinity,
         }
-    }
-}
-
-impl fmt::Display for AffinePoint {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
     }
 }
 

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -2,7 +2,6 @@
 
 use super::{AffinePoint, FieldElement, Scalar, CURVE_EQUATION_B_SINGLE};
 use core::{
-    fmt,
     iter::Sum,
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
 };
@@ -446,12 +445,6 @@ impl<'a> Neg for &'a ProjectivePoint {
 
     fn neg(self) -> ProjectivePoint {
         ProjectivePoint::neg(self)
-    }
-}
-
-impl fmt::Display for ProjectivePoint {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
     }
 }
 

--- a/k256/src/arithmetic/scalar/scalar_4x64.rs
+++ b/k256/src/arithmetic/scalar/scalar_4x64.rs
@@ -4,9 +4,9 @@
 use core::convert::TryInto;
 use elliptic_curve::{
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
-    util::{adc64, sbb64}
+    util::{adc64, sbb64},
 };
-use crate::ElementBytes;
+use crate::{ScalarBits, ElementBytes};
 
 #[cfg(feature = "zeroize")]
 use elliptic_curve::zeroize::Zeroize;
@@ -418,6 +418,12 @@ impl ConstantTimeEq for Scalar4x64 {
             & self.0[1].ct_eq(&other.0[1])
             & self.0[2].ct_eq(&other.0[2])
             & self.0[3].ct_eq(&other.0[3])
+    }
+}
+
+impl From<Scalar4x64> for ScalarBits {
+    fn from(scalar: Scalar4x64) -> ScalarBits {
+        scalar.0.into()
     }
 }
 

--- a/k256/src/arithmetic/scalar/scalar_8x32.rs
+++ b/k256/src/arithmetic/scalar/scalar_8x32.rs
@@ -6,7 +6,7 @@ use elliptic_curve::{
     util::{adc32, sbb32}
 };
 use core::convert::TryInto;
-use crate::{ElementBytes};
+use crate::{ElementBytes, ScalarBits};
 
 #[cfg(feature = "zeroize")]
 use elliptic_curve::zeroize::Zeroize;
@@ -556,6 +556,12 @@ impl ConstantTimeEq for Scalar8x32 {
             & self.0[5].ct_eq(&other.0[5])
             & self.0[6].ct_eq(&other.0[6])
             & self.0[7].ct_eq(&other.0[7])
+    }
+}
+
+impl From<Scalar8x32> for ScalarBits {
+    fn from(scalar: Scalar8x32) -> ScalarBits {
+        scalar.0.into()
     }
 }
 

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.41** or higher.
+//! Rust **1.44** or higher.
 //!
 //! Minimum supported Rust version can be changed in the future, but it will be
 //! done with a minor version bump.
@@ -65,7 +65,7 @@ pub use elliptic_curve;
 pub use arithmetic::{
     affine::AffinePoint,
     projective::ProjectivePoint,
-    scalar::{NonZeroScalar, Scalar},
+    scalar::{NonZeroScalar, Scalar, ScalarBits},
 };
 
 #[cfg(feature = "expose-field")]
@@ -110,7 +110,7 @@ impl elliptic_curve::Identifier for Secp256k1 {
 /// Compressed SEC1-encoded secp256k1 (K-256) point (i.e. public key)
 pub type CompressedPoint = [u8; 33];
 
-/// secp256k1 (K-256) serialized field element.
+/// secp256k1 (K-256) field element serialized as bytes.
 ///
 /// Byte array containing a serialized field element value (base field or scalar).
 pub type ElementBytes = elliptic_curve::ElementBytes<Secp256k1>;

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -16,7 +16,6 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
 
 [dependencies]
-byteorder = { version = "1", default-features = false }
 ecdsa-core = { version = "0.7", package = "ecdsa", optional = true, default-features = false }
 elliptic-curve = { version = "0.5", default-features = false }
 sha2 = { version = "0.9", optional = true, default-features = false }
@@ -30,7 +29,7 @@ rand_core = { version = "0.5", features = ["getrandom"] }
 
 [features]
 default = ["arithmetic", "std"]
-arithmetic = []
+arithmetic = ["elliptic-curve/arithmetic"]
 digest = ["elliptic-curve/digest", "ecdsa-core/digest"]
 ecdh = ["elliptic-curve/ecdh", "zeroize"]
 ecdsa = ["arithmetic", "ecdsa-core/sign", "ecdsa-core/verify", "sha256", "zeroize"]

--- a/p256/README.md
+++ b/p256/README.md
@@ -46,7 +46,7 @@ like TLS and the associated X.509 PKI.
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.44** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -78,7 +78,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/p256/badge.svg
 [docs-link]: https://docs.rs/p256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.44+-blue.svg
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/p256/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/elliptic-curves/actions?query=workflow%3Ap256
 

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -28,6 +28,7 @@ const CURVE_EQUATION_B: FieldElement = FieldElement([
 impl elliptic_curve::Arithmetic for NistP256 {
     type Scalar = Scalar;
     type AffinePoint = AffinePoint;
+    type ProjectivePoint = ProjectivePoint;
 }
 
 #[cfg(test)]

--- a/p256/src/arithmetic/projective.rs
+++ b/p256/src/arithmetic/projective.rs
@@ -2,7 +2,6 @@
 
 use super::{AffinePoint, FieldElement, Scalar, CURVE_EQUATION_B};
 use core::{
-    fmt,
     iter::Sum,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
@@ -455,12 +454,6 @@ impl<'a> Neg for &'a ProjectivePoint {
 
     fn neg(self) -> ProjectivePoint {
         ProjectivePoint::neg(self)
-    }
-}
-
-impl fmt::Display for ProjectivePoint {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
     }
 }
 

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.41** or higher.
+//! Rust **1.44** or higher.
 //!
 //! Minimum supported Rust version can be changed in the future, but it will be
 //! done with a minor version bump.
@@ -62,7 +62,7 @@ pub use arithmetic::{
     affine::AffinePoint,
     projective::ProjectivePoint,
     scalar::blinding::BlindedScalar,
-    scalar::{NonZeroScalar, Scalar},
+    scalar::{NonZeroScalar, Scalar, ScalarBits},
 };
 
 use elliptic_curve::consts::U32;
@@ -109,7 +109,7 @@ impl elliptic_curve::Identifier for NistP256 {
     const OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 2, 840, 10045, 3, 1, 7]);
 }
 
-/// NIST P-256 Serialized Field Element.
+/// NIST P-256 field element serialized as bytes.
 ///
 /// Byte array containing a serialized field element value (base field or scalar).
 pub type ElementBytes = elliptic_curve::ElementBytes<NistP256>;

--- a/p384/README.md
+++ b/p384/README.md
@@ -24,7 +24,7 @@ X.509 PKI.
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.44** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -56,7 +56,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/p384/badge.svg
 [docs-link]: https://docs.rs/p384/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.44+-blue.svg
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/p384/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/elliptic-curves/actions?query=workflow%3Ap384
 

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.41** or higher.
+//! Rust **1.44** or higher.
 //!
 //! Minimum supported Rust version can be changed in the future, but it will be
 //! done with a minor version bump.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,4 +8,3 @@ members = [
 [patch.crates-io]
 ecdsa = { git = "https://github.com/RustCrypto/signatures" }
 elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
-group = { git = "https://github.com/zkcrypto/group.git" }


### PR DESCRIPTION
Previously the `elliptic-curve` crate was depending on pre-releases of `ff` and `group` sourced via git. It was upgraded to use the final releases in RustCrypto/traits#292.

Because these crates depend on `bitvec` and its transitive dependencies, an `arithmetic` feature was added to `elliptic-curve` in RustCrypto/traits#293.

This commit upgrades the `k256` and `p256` crates to use the final releases of `ff` and `group`. This ended up actually being a relatively straightforward upgrade because we were already running off the latest versions sourced from git.

The major notable change is `PrimeField::ReprBits` and the `to_le_bits` and `char_le_bits` methods for obtaining `bitvec`-friendly types for representing field elements.