### PR TITLE
k256/p256: remove `Generate` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.7.2"
-source = "git+https://github.com/RustCrypto/signatures#e6151cdfaf003fa350bc1a1d5146d31b6c311518"
+source = "git+https://github.com/RustCrypto/signatures#2fb7d2ae73b5edce854f7604cbd3e3157282b2e8"
 dependencies = [
  "elliptic-curve",
  "hmac",
@@ -270,7 +270,7 @@ checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0"
-source = "git+https://github.com/RustCrypto/traits#548e11779ea85d411daa39214afcd7cc6c72c2b8"
+source = "git+https://github.com/RustCrypto/traits#a866a23ab066bc89d000f0931dec9f915d6a8986"
 dependencies = [
  "bitvec",
  "const-oid",

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -48,8 +48,8 @@ mod tests {
     #[test]
     fn generate_secret_key() {
         use crate::SecretKey;
-        use elliptic_curve::{rand_core::OsRng, Generate};
-        let key = SecretKey::generate(&mut OsRng);
+        use elliptic_curve::rand_core::OsRng;
+        let key = SecretKey::random(&mut OsRng);
 
         // Sanity check
         assert!(!key.as_bytes().iter().all(|b| *b == 0))

--- a/k256/src/ecdh.rs
+++ b/k256/src/ecdh.rs
@@ -15,11 +15,11 @@
 //! use rand_core::OsRng; // requires 'getrandom' feature
 //!
 //! // Alice
-//! let alice_secret = EphemeralSecret::generate(&mut OsRng);
+//! let alice_secret = EphemeralSecret::random(&mut OsRng);
 //! let alice_public = EncodedPoint::from(&alice_secret);
 //!
 //! // Bob
-//! let bob_secret = EphemeralSecret::generate(&mut OsRng);
+//! let bob_secret = EphemeralSecret::random(&mut OsRng);
 //! let bob_public = EncodedPoint::from(&bob_secret);
 //!
 //! // Alice computes shared secret from Bob's public key

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -22,13 +22,12 @@
 //! # {
 //! use k256::{
 //!     ecdsa::{SigningKey, Signature, signature::Signer},
-//!     elliptic_curve::Generate,
 //!     SecretKey,
 //! };
 //! use rand_core::OsRng; // requires 'getrandom' feature
 //!
 //! // Signing
-//! let signing_key = SigningKey::generate(&mut OsRng); // Serialize with `::to_bytes()`
+//! let signing_key = SigningKey::random(&mut OsRng); // Serialize with `::to_bytes()`
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //!
 //! // Note: the signature type must be annotated or otherwise inferrable as

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -15,12 +15,12 @@
 //! # {
 //! use k256::{
 //!     ecdsa::{SigningKey, recoverable, signature::Signer},
-//!     elliptic_curve::{Generate, rand_core::OsRng},
 //!     EncodedPoint
 //! };
+//! use rand_core::OsRng; // requires 'getrandom' feature
 //!
 //! // Signing
-//! let signing_key = SigningKey::generate(&mut OsRng); // Serialize with `::to_bytes()`
+//! let signing_key = SigningKey::random(&mut OsRng); // Serialize with `::to_bytes()`
 //! let verify_key = signing_key.verify_key();
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //!

--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -13,7 +13,7 @@ use elliptic_curve::{
     digest::{BlockInput, FixedOutput, Reset, Update},
     ops::Invert,
     rand_core::{CryptoRng, RngCore},
-    FromBytes, FromDigest, Generate,
+    FromBytes, FromDigest,
 };
 use signature::PrehashSignature;
 
@@ -28,7 +28,14 @@ pub struct SigningKey {
 }
 
 impl SigningKey {
-    /// Initialize signing key from a raw scalar serialized as a byte slice.
+    /// Generate a cryptographically random [`SigningKey`].
+    pub fn random(rng: impl CryptoRng + RngCore) -> Self {
+        Self {
+            secret_scalar: NonZeroScalar::random(rng),
+        }
+    }
+
+    /// Initialize [`SigningKey`] from a raw scalar value (big endian).
     // TODO(tarcieri): PKCS#8 support
     pub fn new(bytes: &[u8]) -> Result<Self, Error> {
         bytes
@@ -55,14 +62,6 @@ impl SigningKey {
     /// Serialize this [`SigningKey`] as bytes
     pub fn to_bytes(&self) -> ElementBytes {
         self.secret_scalar.to_bytes()
-    }
-}
-
-impl Generate for SigningKey {
-    fn generate(rng: impl CryptoRng + RngCore) -> Self {
-        Self {
-            secret_scalar: NonZeroScalar::generate(rng),
-        }
     }
 }
 

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -57,9 +57,9 @@ mod tests {
     #[test]
     fn generate_secret_key() {
         use crate::SecretKey;
-        use elliptic_curve::{rand_core::OsRng, Generate};
+        use elliptic_curve::rand_core::OsRng;
 
-        let key = SecretKey::generate(&mut OsRng);
+        let key = SecretKey::random(&mut OsRng);
 
         // Sanity check
         assert!(!key.as_bytes().iter().all(|b| *b == 0))

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -10,11 +10,10 @@ use core::{
 use elliptic_curve::{
     consts::U32,
     ff::{Field, PrimeField},
-    ops::Invert,
-    rand_core::{CryptoRng, RngCore},
+    rand_core::RngCore,
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     util::{adc64, mac64, sbb64},
-    FromBytes, Generate,
+    FromBytes,
 };
 
 #[cfg(feature = "digest")]
@@ -848,14 +847,6 @@ impl ConstantTimeEq for Scalar {
     }
 }
 
-impl Invert for Scalar {
-    type Output = Self;
-
-    fn invert(&self) -> CtOption<Self> {
-        Scalar::invert(self)
-    }
-}
-
 #[cfg(target_pointer_width = "32")]
 impl From<&Scalar> for ScalarBits {
     fn from(scalar: &Scalar) -> ScalarBits {
@@ -886,12 +877,6 @@ impl From<Scalar> for ElementBytes {
 impl From<&Scalar> for ElementBytes {
     fn from(scalar: &Scalar) -> Self {
         scalar.to_bytes()
-    }
-}
-
-impl Generate for Scalar {
-    fn generate(mut rng: impl CryptoRng + RngCore) -> Self {
-        Self::random(&mut rng)
     }
 }
 

--- a/p256/src/arithmetic/scalar/blinding.rs
+++ b/p256/src/arithmetic/scalar/blinding.rs
@@ -6,10 +6,10 @@
 use super::Scalar;
 use core::borrow::Borrow;
 use elliptic_curve::{
+    ff::Field,
     ops::Invert,
     rand_core::{CryptoRng, RngCore},
     subtle::CtOption,
-    Generate,
 };
 
 #[cfg(feature = "zeroize")]
@@ -33,7 +33,7 @@ impl BlindedScalar {
     pub fn new(scalar: Scalar, rng: impl CryptoRng + RngCore) -> Self {
         Self {
             scalar,
-            mask: Scalar::generate(rng),
+            mask: Scalar::random(rng),
         }
     }
 }

--- a/p256/src/ecdh.rs
+++ b/p256/src/ecdh.rs
@@ -15,11 +15,11 @@
 //! use rand_core::OsRng; // requires 'getrandom' feature
 //!
 //! // Alice
-//! let alice_secret = EphemeralSecret::generate(&mut OsRng);
+//! let alice_secret = EphemeralSecret::random(&mut OsRng);
 //! let alice_public = EncodedPoint::from(&alice_secret);
 //!
 //! // Bob
-//! let bob_secret = EphemeralSecret::generate(&mut OsRng);
+//! let bob_secret = EphemeralSecret::random(&mut OsRng);
 //! let bob_public = EncodedPoint::from(&bob_secret);
 //!
 //! // Alice computes shared secret from Bob's public key

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -22,12 +22,11 @@
 //! # {
 //! use p256::{
 //!     ecdsa::{SigningKey, Signature, signature::Signer},
-//!     elliptic_curve::Generate,
 //! };
 //! use rand_core::OsRng; // requires 'getrandom' feature
 //!
 //! // Signing
-//! let signing_key = SigningKey::generate(&mut OsRng); // Serialize with `::to_bytes()`
+//! let signing_key = SigningKey::random(&mut OsRng); // Serialize with `::to_bytes()`
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature = signing_key.sign(message);
 //!


### PR DESCRIPTION
It's been replaced by methods like `Field::random` and `Group::random`.

See: RustCrypto/traits#295