### PR TITLE
Support generic inner type for elliptic_curve::SecretKey<C>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitvec"
-version = "0.18.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f0df4bb4c441080e98d6ea2dc3281fc19bb440e69ce03075e3d705894f1cb"
+checksum = "64143ed23541fe0c6e2235905eaae37ceae1ca69e14dce4afcd6ec9643359d00"
 dependencies = [
  "funty",
  "radium",
@@ -254,7 +254,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.7.2"
-source = "git+https://github.com/RustCrypto/signatures#84e133fc954af3fe75757be1bf8c666e51aedd17"
+source = "git+https://github.com/RustCrypto/signatures#acd8c3f82a889293fc0e546455a8da68346241e2"
 dependencies = [
  "elliptic-curve",
  "hmac",
@@ -270,7 +270,7 @@ checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0"
-source = "git+https://github.com/RustCrypto/traits#24ce4e1bda977a7f41af203eb3cbd3fa0e906b93"
+source = "git+https://github.com/RustCrypto/traits#7dd78e0097bcc9a5adb84acf043f6e11e33ceacc"
 dependencies = [
  "bitvec",
  "const-oid",
@@ -559,9 +559,9 @@ checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
+checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
  "unicode-xid",
 ]

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -46,12 +46,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "zeroize")]
     fn generate_secret_key() {
         use crate::SecretKey;
         use elliptic_curve::rand_core::OsRng;
         let key = SecretKey::random(&mut OsRng);
 
         // Sanity check
-        assert!(!key.as_bytes().iter().all(|b| *b == 0))
+        assert!(!key.to_bytes().iter().all(|b| *b == 0))
     }
 }

--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -46,12 +46,6 @@ impl SigningKey {
             .ok_or_else(Error::new)
     }
 
-    /// Create a new signing key from a [`SecretKey`].
-    // TODO(tarcieri): infallible `From` conversion from a secret key
-    pub fn from_secret_key(secret_key: &SecretKey) -> Result<Self, Error> {
-        Self::new(secret_key.as_bytes())
-    }
-
     /// Get the [`VerifyKey`] which corresponds to this [`SigningKey`]
     pub fn verify_key(&self) -> VerifyKey {
         VerifyKey {
@@ -62,6 +56,14 @@ impl SigningKey {
     /// Serialize this [`SigningKey`] as bytes
     pub fn to_bytes(&self) -> FieldBytes {
         self.secret_scalar.to_bytes()
+    }
+}
+
+impl From<&SecretKey> for SigningKey {
+    fn from(secret_key: &SecretKey) -> Self {
+        Self {
+            secret_scalar: *secret_key.secret_scalar(),
+        }
     }
 }
 

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -119,4 +119,6 @@ pub type FieldBytes = elliptic_curve::FieldBytes<Secp256k1>;
 pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<Secp256k1>;
 
 /// secp256k1 (K-256) secret key.
+#[cfg(feature = "zeroize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 pub type SecretKey = elliptic_curve::SecretKey<Secp256k1>;

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -55,6 +55,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "zeroize")]
     fn generate_secret_key() {
         use crate::SecretKey;
         use elliptic_curve::rand_core::OsRng;
@@ -62,6 +63,6 @@ mod tests {
         let key = SecretKey::random(&mut OsRng);
 
         // Sanity check
-        assert!(!key.as_bytes().iter().all(|b| *b == 0))
+        assert!(!key.to_bytes().iter().all(|b| *b == 0))
     }
 }

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -118,4 +118,6 @@ pub type FieldBytes = elliptic_curve::FieldBytes<NistP256>;
 pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP256>;
 
 /// NIST P-256 Secret Key.
+#[cfg(feature = "zeroize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 pub type SecretKey = elliptic_curve::SecretKey<NistP256>;

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -76,4 +76,6 @@ pub type FieldBytes = elliptic_curve::FieldBytes<NistP384>;
 pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP384>;
 
 /// NIST P-384 Secret Key
+#[cfg(feature = "zeroize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 pub type SecretKey = elliptic_curve::SecretKey<NistP384>;


### PR DESCRIPTION
See: RustCrypto/traits#297