### PR TITLE
Bump `elliptic-curve` crate to v0.6; `ecdsa` to v0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,8 +253,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.7.2"
-source = "git+https://github.com/RustCrypto/signatures#80eb3b49e258ccb458f1718226d5d6149a421a46"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cda7dd00e9ace9867955ef64a176447b45f3e385f827bc686c832213bb7ec0e"
 dependencies = [
  "elliptic-curve",
  "hmac",
@@ -269,8 +270,9 @@ checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.5.0"
-source = "git+https://github.com/RustCrypto/traits#bba389743c8156036ccd4bbb73755d8bb22fb796"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9cc9ec2c11b93118b4f8dc0665a3741bc90121d44dc0410f899274c5745454c"
 dependencies = [
  "bitvec",
  "const-oid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,3 @@ members = [
     "p256",
     "p384",
 ]
-
-[patch.crates-io]
-ecdsa = { git = "https://github.com/RustCrypto/signatures" }
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -17,14 +17,14 @@ keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
 
 [dependencies]
 cfg-if = "0.1"
-ecdsa-core = { version = "0.7", package = "ecdsa", optional = true, default-features = false }
-elliptic-curve = { version = "0.5", default-features = false }
+ecdsa-core = { version = "0.8", package = "ecdsa", optional = true, default-features = false }
+elliptic-curve = { version = "0.6", default-features = false }
 sha2 = { version = "0.9", optional = true, default-features = false }
 sha3 = { version = "0.9", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
-ecdsa-core = { version = "0.7", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.8", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4" # TODO: switch to hex-literal
 hex-literal = "0.3"
 num-bigint = "0.3"

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -16,12 +16,12 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
 
 [dependencies]
-ecdsa-core = { version = "0.7", package = "ecdsa", optional = true, default-features = false }
-elliptic-curve = { version = "0.5", default-features = false }
+ecdsa-core = { version = "0.8", package = "ecdsa", optional = true, default-features = false }
+elliptic-curve = { version = "0.6", default-features = false }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.7", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.8", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4" # TODO: switch to hex-literal
 hex-literal = "0.3"
 proptest = "0.10"

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "secp384r1"]
 
 [dependencies]
-ecdsa = { version = "0.7", optional = true, default-features = false }
-elliptic-curve = { version = "0.5", default-features = false }
+ecdsa = { version = "0.8", optional = true, default-features = false }
+elliptic-curve = { version = "0.6", default-features = false }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [features]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,7 +4,3 @@ members = [
     "p256_no_std",
     "p384_no_std",
 ]
-
-[patch.crates-io]
-ecdsa = { git = "https://github.com/RustCrypto/signatures" }
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }


### PR DESCRIPTION
Release notes:

- `elliptic-curve` v0.6.0: https://github.com/RustCrypto/traits/pull/302
- `ecdsa` v0.8.0: https://github.com/RustCrypto/signatures/pull/166