### PR TITLE
k256 v0.5.0-rc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.5.0-pre"
+version = "0.5.0-rc"
 dependencies = [
  "cfg-if",
  "criterion",

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -5,7 +5,7 @@ Pure Rust implementation of the secp256k1 elliptic curve with support for ECDH,
 ECDSA signing/verification support (including Ethereum-style signatures with
 public-key recovery), and general purpose curve arithmetic
 """
-version = "0.5.0-pre"
+version = "0.5.0-rc"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"


### PR DESCRIPTION
This was mistakenly released as v0.5.0-pre before.