### PR TITLE
k256 v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.5.0-rc"
+version = "0.5.0"
 dependencies = [
  "cfg-if",
  "criterion",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-09-17)
+### Added
+- `ecdsa::Asn1Signature` type aliases ([#186])
+- `ff` and `group` crate dependencies; MSRV 1.44+ ([#164], [#174])
+- `AffinePoint::identity()` and `::is_identity()` ([#165])
+- `expose-field` feature ([#161])
+- `keccak256` feature ([#142])
+
+### Changed
+- Bump `elliptic-curve` crate to v0.6; `ecdsa` to v0.8 ([#180])
+- Refactor ProjectiveArithmetic trait ([#179])
+- Support generic inner type for `elliptic_curve::SecretKey<C>` ([#177])
+- Rename `ElementBytes` => `FieldBytes` ([#176])
+- Factor out a `from_digest_trial_recovery` method ([#168])
+- Rename `ecdsa::{Signer, Verifier}` => `::{SigningKey, VerifyKey}` ([#153])
+- Rename Curve::ElementSize => FieldSize ([#150])
+- Implement RFC6979 deterministic ECDSA ([#146])
+- Use `NonZeroScalar` for ECDSA signature components ([#144])
+- Eagerly verify ECDSA scalars are in range ([#143])
+
+### Removed
+- `rand` feature ([#162])
+
+[#186]: https://github.com/RustCrypto/elliptic-curves/pull/186
+[#180]: https://github.com/RustCrypto/elliptic-curves/pull/180
+[#179]: https://github.com/RustCrypto/elliptic-curves/pull/179
+[#177]: https://github.com/RustCrypto/elliptic-curves/pull/177
+[#176]: https://github.com/RustCrypto/elliptic-curves/pull/176
+[#174]: https://github.com/RustCrypto/elliptic-curves/pull/174
+[#168]: https://github.com/RustCrypto/elliptic-curves/pull/168
+[#165]: https://github.com/RustCrypto/elliptic-curves/pull/165
+[#164]: https://github.com/RustCrypto/elliptic-curves/pull/164
+[#162]: https://github.com/RustCrypto/elliptic-curves/pull/162
+[#161]: https://github.com/RustCrypto/elliptic-curves/pull/161
+[#153]: https://github.com/RustCrypto/elliptic-curves/pull/153
+[#150]: https://github.com/RustCrypto/elliptic-curves/pull/150
+[#146]: https://github.com/RustCrypto/elliptic-curves/pull/146
+[#144]: https://github.com/RustCrypto/elliptic-curves/pull/144
+[#143]: https://github.com/RustCrypto/elliptic-curves/pull/143
+[#142]: https://github.com/RustCrypto/elliptic-curves/pull/142
+
 ## 0.4.2 (2020-08-11)
 ### Fixed
 - Builds with either `ecdsa-core` or `sha256` in isolation ([#133])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -5,7 +5,7 @@ Pure Rust implementation of the secp256k1 elliptic curve with support for ECDH,
 ECDSA signing/verification support (including Ethereum-style signatures with
 public-key recovery), and general purpose curve arithmetic
 """
-version = "0.5.0-rc"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/k256/0.5.0-rc"
+    html_root_url = "https://docs.rs/k256/0.5.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `ecdsa::Asn1Signature` type aliases ([#186])
- `ff` and `group` crate dependencies; MSRV 1.44+ ([#164], [#174])
- `AffinePoint::identity()` and `::is_identity()` ([#165])
- `expose-field` feature ([#161])
- `keccak256` feature ([#142])

### Changed
- Bump `elliptic-curve` crate to v0.6; `ecdsa` to v0.8 ([#180])
- Refactor ProjectiveArithmetic trait ([#179])
- Support generic inner type for `elliptic_curve::SecretKey<C>` ([#177])
- Rename `ElementBytes` => `FieldBytes` ([#176])
- Factor out a `from_digest_trial_recovery` method ([#168])
- Rename `ecdsa::{Signer, Verifier}` => `::{SigningKey, VerifyKey}` ([#153])
- Rename Curve::ElementSize => FieldSize ([#150])
- Implement RFC6979 deterministic ECDSA ([#146])
- Use `NonZeroScalar` for ECDSA signature components ([#144])
- Eagerly verify ECDSA scalars are in range ([#143])

### Removed
- `rand` feature ([#162])

[#186]: https://github.com/RustCrypto/elliptic-curves/pull/186
[#180]: https://github.com/RustCrypto/elliptic-curves/pull/180
[#179]: https://github.com/RustCrypto/elliptic-curves/pull/179
[#177]: https://github.com/RustCrypto/elliptic-curves/pull/177
[#176]: https://github.com/RustCrypto/elliptic-curves/pull/176
[#174]: https://github.com/RustCrypto/elliptic-curves/pull/174
[#168]: https://github.com/RustCrypto/elliptic-curves/pull/168
[#165]: https://github.com/RustCrypto/elliptic-curves/pull/165
[#164]: https://github.com/RustCrypto/elliptic-curves/pull/164
[#162]: https://github.com/RustCrypto/elliptic-curves/pull/162
[#161]: https://github.com/RustCrypto/elliptic-curves/pull/161
[#153]: https://github.com/RustCrypto/elliptic-curves/pull/153
[#150]: https://github.com/RustCrypto/elliptic-curves/pull/150
[#146]: https://github.com/RustCrypto/elliptic-curves/pull/146
[#144]: https://github.com/RustCrypto/elliptic-curves/pull/144
[#143]: https://github.com/RustCrypto/elliptic-curves/pull/143
[#142]: https://github.com/RustCrypto/elliptic-curves/pull/142