### PR TITLE
p256 v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.5.0-rc"
+version = "0.5.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.5.0 (2020-09-17)
 ### Added
-- `ecdsa::Asn1Signature` type aliases ([#186])
+- `ecdsa::Asn1Signature` type alias ([#186])
 - `ff` and `group` crate dependencies; MSRV 1.44+ ([#164], [#174])
 - `AffinePoint::identity()` and `::is_identity()` ([#165])
 - `expose-field` feature ([#161])
@@ -19,10 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `ElementBytes` => `FieldBytes` ([#176])
 - Factor out a `from_digest_trial_recovery` method ([#168])
 - Rename `ecdsa::{Signer, Verifier}` => `::{SigningKey, VerifyKey}` ([#153])
-- Rename Curve::ElementSize => FieldSize ([#150])
+- Rename `Curve::ElementSize` => `FieldSize` ([#150])
 - Implement RFC6979 deterministic ECDSA ([#146])
 - Use `NonZeroScalar` for ECDSA signature components ([#144])
 - Eagerly verify ECDSA scalars are in range ([#143])
+- Rename `PublicKey` to `EncodedPoint` ([#141])
 
 ### Removed
 - `rand` feature ([#162])
@@ -44,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#144]: https://github.com/RustCrypto/elliptic-curves/pull/144
 [#143]: https://github.com/RustCrypto/elliptic-curves/pull/143
 [#142]: https://github.com/RustCrypto/elliptic-curves/pull/142
+[#141]: https://github.com/RustCrypto/elliptic-curves/pull/141
 
 ## 0.4.2 (2020-08-11)
 ### Fixed

--- a/p256/CHANGELOG.md
+++ b/p256/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-09-18)
+### Added
+- `ecdsa::Asn1Signature` type alias ([#186])
+- `ff` and `group` crate dependencies; MSRV 1.44+ ([#169], [#174])
+- `AffinePoint::identity()` and `::is_identity()` ([#167])
+
+### Changed
+- Bump `elliptic-curve` crate to v0.6; `ecdsa` to v0.8 ([#180])
+- Refactor ProjectiveArithmetic trait ([#179])
+- Support generic inner type for `elliptic_curve::SecretKey<C>` ([#177])
+- Rename `ElementBytes` => `FieldBytes` ([#176])
+- Rename `ecdsa::{Signer, Verifier}` => `::{SigningKey, VerifyKey}` ([#153])
+- Rename `Curve::ElementSize` => `FieldSize` ([#150])
+- Implement RFC6979 deterministic ECDSA ([#146], [#147])
+- Rename `PublicKey` to `EncodedPoint` ([#141])
+
+### Removed
+- `rand` feature ([#162])
+
+[#186]: https://github.com/RustCrypto/elliptic-curves/pull/186
+[#180]: https://github.com/RustCrypto/elliptic-curves/pull/180
+[#179]: https://github.com/RustCrypto/elliptic-curves/pull/179
+[#177]: https://github.com/RustCrypto/elliptic-curves/pull/177
+[#176]: https://github.com/RustCrypto/elliptic-curves/pull/176
+[#174]: https://github.com/RustCrypto/elliptic-curves/pull/174
+[#169]: https://github.com/RustCrypto/elliptic-curves/pull/164
+[#167]: https://github.com/RustCrypto/elliptic-curves/pull/167
+[#162]: https://github.com/RustCrypto/elliptic-curves/pull/162
+[#153]: https://github.com/RustCrypto/elliptic-curves/pull/153
+[#150]: https://github.com/RustCrypto/elliptic-curves/pull/150
+[#147]: https://github.com/RustCrypto/elliptic-curves/pull/147
+[#146]: https://github.com/RustCrypto/elliptic-curves/pull/146
+[#141]: https://github.com/RustCrypto/elliptic-curves/pull/141
+
 ## 0.4.1 (2020-08-11)
 ### Fixed
 - Builds with either `ecdsa-core` or `sha256` in isolation ([#133])

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -5,7 +5,7 @@ Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve with support for ECDH, ECDSA signing/verification, and general
 purpose curve arithmetic
 """
-version = "0.5.0-rc"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/p256/0.5.0-rc"
+    html_root_url = "https://docs.rs/p256/0.5.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `ecdsa::Asn1Signature` type alias ([#186])
- `ff` and `group` crate dependencies; MSRV 1.44+ ([#169], [#174])
- `AffinePoint::identity()` and `::is_identity()` ([#167])

### Changed
- Bump `elliptic-curve` crate to v0.6; `ecdsa` to v0.8 ([#180])
- Refactor ProjectiveArithmetic trait ([#179])
- Support generic inner type for `elliptic_curve::SecretKey<C>` ([#177])
- Rename `ElementBytes` => `FieldBytes` ([#176])
- Rename `ecdsa::{Signer, Verifier}` => `::{SigningKey, VerifyKey}` ([#153])
- Rename `Curve::ElementSize` => `FieldSize` ([#150])
- Implement RFC6979 deterministic ECDSA ([#146], [#147])
- Rename `PublicKey` to `EncodedPoint` ([#141])

### Removed
- `rand` feature ([#162])

[#186]: https://github.com/RustCrypto/elliptic-curves/pull/186
[#180]: https://github.com/RustCrypto/elliptic-curves/pull/180
[#179]: https://github.com/RustCrypto/elliptic-curves/pull/179
[#177]: https://github.com/RustCrypto/elliptic-curves/pull/177
[#176]: https://github.com/RustCrypto/elliptic-curves/pull/176
[#174]: https://github.com/RustCrypto/elliptic-curves/pull/174
[#169]: https://github.com/RustCrypto/elliptic-curves/pull/164
[#167]: https://github.com/RustCrypto/elliptic-curves/pull/167
[#162]: https://github.com/RustCrypto/elliptic-curves/pull/162
[#153]: https://github.com/RustCrypto/elliptic-curves/pull/153
[#150]: https://github.com/RustCrypto/elliptic-curves/pull/150
[#147]: https://github.com/RustCrypto/elliptic-curves/pull/147
[#146]: https://github.com/RustCrypto/elliptic-curves/pull/146
[#141]: https://github.com/RustCrypto/elliptic-curves/pull/141