### PR TITLE
p384 v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.4.0-rc"
+version = "0.4.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/p384/CHANGELOG.md
+++ b/p384/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-09-18)
+### Added
+- `ecdsa::Asn1Signature` type alias ([#186])
+
+### Changed
+- Rename `ElementBytes` => `FieldBytes` ([#176])
+- Rename `Curve::ElementSize` => `FieldSize` ([#150])
+
+[#186]: https://github.com/RustCrypto/elliptic-curves/pull/186
+[#176]: https://github.com/RustCrypto/elliptic-curves/pull/176
+[#150]: https://github.com/RustCrypto/elliptic-curves/pull/150
+
 ## 0.3.0 (2020-08-10)
 ### Added
 - ECDSA types ([#73])

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p384"
 description = "NIST P-384 (secp384r1) elliptic curve"
-version = "0.4.0-rc"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/p384/0.4.0-rc"
+    html_root_url = "https://docs.rs/p384/0.4.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `ecdsa::Asn1Signature` type alias ([#186])

### Changed
- Rename `ElementBytes` => `FieldBytes` ([#176])
- Rename `Curve::ElementSize` => `FieldSize` ([#150])

[#186]: https://github.com/RustCrypto/elliptic-curves/pull/186
[#176]: https://github.com/RustCrypto/elliptic-curves/pull/176
[#150]: https://github.com/RustCrypto/elliptic-curves/pull/150