### PR TITLE
k256: gate ecdsa::{Signer, Verifier} impls on `sha256` feature

### DIFF
--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -6,7 +6,7 @@ use core::{borrow::Borrow, convert::TryInto};
 use ecdsa_core::{
     hazmat::SignPrimitive,
     rfc6979,
-    signature::{self, DigestSigner, RandomizedDigestSigner},
+    signature::{DigestSigner, RandomizedDigestSigner},
 };
 use elliptic_curve::{
     consts::U32,
@@ -15,10 +15,9 @@ use elliptic_curve::{
     rand_core::{CryptoRng, RngCore},
     FromDigest,
 };
-use signature::PrehashSignature;
 
-#[cfg(feature = "digest")]
-use signature::digest::Digest;
+#[cfg(feature = "sha256")]
+use ecdsa_core::signature::{self, digest::Digest, PrehashSignature};
 
 /// ECDSA/secp256k1 signing key
 #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
@@ -67,6 +66,7 @@ impl From<&SecretKey> for SigningKey {
     }
 }
 
+#[cfg(feature = "sha256")]
 impl<S> signature::Signer<S> for SigningKey
 where
     S: PrehashSignature,

--- a/k256/src/ecdsa/verify.rs
+++ b/k256/src/ecdsa/verify.rs
@@ -5,7 +5,10 @@ use crate::{AffinePoint, CompressedPoint, EncodedPoint, ProjectivePoint, Scalar,
 use core::convert::TryFrom;
 use ecdsa_core::{hazmat::VerifyPrimitive, signature};
 use elliptic_curve::{consts::U32, ops::Invert, sec1::ToEncodedPoint};
-use signature::{digest::Digest, DigestVerifier, PrehashSignature};
+use signature::{digest::Digest, DigestVerifier};
+
+#[cfg(feature = "sha256")]
+use signature::PrehashSignature;
 
 /// ECDSA/secp256k1 verification key (i.e. public key)
 #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
@@ -35,6 +38,7 @@ impl VerifyKey {
     }
 }
 
+#[cfg(feature = "sha256")]
 impl<S> signature::Verifier<S> for VerifyKey
 where
     S: PrehashSignature,


### PR DESCRIPTION
They don't work otherwise.

This isn't a SemVer breaking change, because they still didn't work without the feature enabled. This change provides a slightly better error message.