### PR TITLE
k256/p256: add sec1::EncodedPoint::decompress test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,15 +264,14 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9cc9ec2c11b93118b4f8dc0665a3741bc90121d44dc0410f899274c5745454c"
+source = "git+https://github.com/rustcrypto/traits#797b7d900e457139e01f4a35e5d1ad76eb96e815"
 dependencies = [
  "bitvec",
  "const-oid",
@@ -460,9 +459,9 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
  "autocfg",
 ]
@@ -673,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91739a34c4355b5434ce54c9086c5895604a9c278586d1f1aa95e04f66b525a0"
+checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -782,9 +781,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 
 [[package]]
 name = "serde_cbor"
@@ -798,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -861,9 +860,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
+checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1056,6 +1055,6 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ members = [
     "p256",
     "p384",
 ]
+
+[patch.crates-io]
+elliptic-curve = { git = "https://github.com/rustcrypto/traits" }

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -246,6 +246,13 @@ mod tests {
     }
 
     #[test]
+    fn decompress() {
+        let encoded = EncodedPoint::from_bytes(COMPRESSED_BASEPOINT).unwrap();
+        let decompressed = encoded.decompress().unwrap();
+        assert_eq!(decompressed.as_bytes(), UNCOMPRESSED_BASEPOINT);
+    }
+
+    #[test]
     fn affine_negation() {
         let basepoint = AffinePoint::generator();
         assert_eq!((-(-basepoint)), basepoint);

--- a/p256/src/arithmetic/affine.rs
+++ b/p256/src/arithmetic/affine.rs
@@ -245,6 +245,13 @@ mod tests {
     }
 
     #[test]
+    fn decompress() {
+        let encoded = EncodedPoint::from_bytes(COMPRESSED_BASEPOINT).unwrap();
+        let decompressed = encoded.decompress().unwrap();
+        assert_eq!(decompressed.as_bytes(), UNCOMPRESSED_BASEPOINT);
+    }
+
+    #[test]
     fn affine_negation() {
         let basepoint = AffinePoint::generator();
         assert_eq!(-(-basepoint), basepoint);


### PR DESCRIPTION
Add tests that the upstream `sec1::EncodedPoint::decompress` method works given the trait impls in the respective crates.

The generic upstream implementation was previously broken:

https://github.com/RustCrypto/traits/pull/309

The plan is to release `elliptic-curve` v0.6.1 with the above fix, then yank the broken v0.6.1 release.