### PR TITLE
k256 v0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "cfg-if",
  "criterion",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.3 (2020-09-23)
+### Added
+- Derive `Copy` on `VerifyKey` ([#202])
+
+[#202]: https://github.com/RustCrypto/elliptic-curves/pull/202
+
 ## 0.5.2 (2020-09-22)
 ### Fixed
 - Corrected imports when using `ecdsa` + `keccak256` features ([#199])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -6,7 +6,7 @@ signing/verification (including Ethereum-style signatures with public-key
 recovery), Elliptic Curve Diffie-Hellman (ECDH), and general purpose curve
 arithmetic which can be used to implement arbitrary group-based protocols.
 """
-version = "0.5.2"
+version = "0.5.3"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/k256/0.5.2"
+    html_root_url = "https://docs.rs/k256/0.5.3"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- Derive `Copy` on `VerifyKey` ([#202])

[#202]: https://github.com/RustCrypto/elliptic-curves/pull/202
