### PR TITLE
k256: enable endomorphisms by default

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -34,12 +34,12 @@ proptest = "0.10"
 rand_core = { version = "0.5", features = ["getrandom"] }
 
 [features]
-default = ["arithmetic", "oid", "std"]
+default = ["arithmetic", "endomorphism-mul", "oid", "std"]
 arithmetic = ["elliptic-curve/arithmetic"]
 digest = ["elliptic-curve/digest", "ecdsa-core/digest"]
 ecdh = ["elliptic-curve/ecdh", "zeroize"]
 ecdsa = ["arithmetic", "digest", "ecdsa-core/sign", "ecdsa-core/verify", "zeroize"]
-endomorphism-mul = []
+endomorphism-mul = ["arithmetic"]
 expose-field = ["arithmetic"]
 field-montgomery = []
 force-32-bit = []


### PR DESCRIPTION
The reason this wasn't enabled-by-default before was due to a lingering US patent. However, as noted on #211, that patent just expired 🎉

The `bitcoin-core/secp256k1` library is also pursuing a full switch to endomorphisms: https://github.com/bitcoin-core/secp256k1/pull/826

For now this commit just switches on the feature by default, but in the future we can eventually rip out the non-endomorphism code and remove the feature entirely.