### PR TITLE
Add `SecretValue` impls when `arithmetic` is disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,9 +271,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e7e174baa250269c92f2e0d59abaeb14c7d8072abd130dee996cc61141825a"
+checksum = "f12f141af758c1e9ea292735e766038ab8fea7cec0364c67d2ce9de81513162e"
 dependencies = [
  "bitvec",
  "const-oid",

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -127,3 +127,18 @@ pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<Secp256k1>;
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 pub type SecretKey = elliptic_curve::SecretKey<Secp256k1>;
+
+/// Bytes containing a secp256k1 secret scalar
+#[cfg(feature = "zeroize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
+pub type SecretBytes = elliptic_curve::secret_key::SecretBytes<Secp256k1>;
+
+#[cfg(all(not(feature = "arithmetic"), feature = "zeroize"))]
+impl elliptic_curve::secret_key::SecretValue for Secp256k1 {
+    type Secret = SecretBytes;
+
+    /// Parse the secret value from bytes
+    fn from_secret_bytes(bytes: &FieldBytes) -> Option<SecretBytes> {
+        Some(bytes.clone().into())
+    }
+}

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -130,3 +130,18 @@ pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP256>;
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 pub type SecretKey = elliptic_curve::SecretKey<NistP256>;
+
+/// Bytes containing a NIST P-256 secret scalar
+#[cfg(feature = "zeroize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
+pub type SecretBytes = elliptic_curve::secret_key::SecretBytes<NistP256>;
+
+#[cfg(all(not(feature = "arithmetic"), feature = "zeroize"))]
+impl elliptic_curve::secret_key::SecretValue for NistP256 {
+    type Secret = SecretBytes;
+
+    /// Parse the secret value from bytes
+    fn from_secret_bytes(bytes: &FieldBytes) -> Option<SecretBytes> {
+        Some(bytes.clone().into())
+    }
+}

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "ecc", "nist", "secp384r1"]
 
 [dependencies]
 ecdsa = { version = "0.8", optional = true, default-features = false }
-elliptic-curve = { version = "0.6", default-features = false }
+elliptic-curve = { version = "0.6.4", default-features = false }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [features]
@@ -21,6 +21,7 @@ default = ["oid", "std"]
 oid = ["elliptic-curve/oid"]
 sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
 std = ["elliptic-curve/std"]
+zeroize = ["elliptic-curve/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -79,3 +79,18 @@ pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP384>;
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 pub type SecretKey = elliptic_curve::SecretKey<NistP384>;
+
+/// Bytes containing a NIST P-384 secret scalar
+#[cfg(feature = "zeroize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
+pub type SecretBytes = elliptic_curve::secret_key::SecretBytes<NistP384>;
+
+#[cfg(feature = "zeroize")]
+impl elliptic_curve::secret_key::SecretValue for NistP384 {
+    type Secret = SecretBytes;
+
+    /// Parse the secret value from bytes
+    fn from_secret_bytes(bytes: &FieldBytes) -> Option<SecretBytes> {
+        Some(bytes.clone().into())
+    }
+}


### PR DESCRIPTION
This allows all crates (`k256`, `p256`, `p384`) to provide a `SecretKey` type with the `zeroize` feature alone (i.e. with `arithmetic` disabled).