### PR TITLE
p384 v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/p384/CHANGELOG.md
+++ b/p384/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2020-10-08)
+### Added
+- `SecretValue` impl when `arithmetic` feature is disabled ([#222])
+
+[#222]: https://github.com/RustCrypto/elliptic-curves/pull/222
+
 ## 0.4.0 (2020-09-18)
 ### Added
 - `ecdsa::Asn1Signature` type alias ([#186])

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p384"
 description = "NIST P-384 (secp384r1) elliptic curve"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/p384/0.4.0"
+    html_root_url = "https://docs.rs/p384/0.4.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
## 0.4.1 (2020-10-08)
### Added
- `SecretValue` impl when `arithmetic` feature is disabled ([#222])

[#222]: https://github.com/RustCrypto/elliptic-curves/pull/222