### PR TITLE
k256 v0.5.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "cfg-if",
  "criterion",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.8 (2020-10-08)
+### Fixed
+- Regenerate `rustdoc` on https://docs.rs after nightly breakage
+
 ## 0.5.7 (2020-10-08)
 ### Added
 - `SecretValue` impl when `arithmetic` feature is disabled ([#222])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -6,7 +6,7 @@ signing/verification (including Ethereum-style signatures with public-key
 recovery), Elliptic Curve Diffie-Hellman (ECDH), and general purpose secp256k1
 curve arithmetic useful for implementing arbitrary group-based protocols.
 """
-version = "0.5.7"
+version = "0.5.8"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/k256/0.5.7"
+    html_root_url = "https://docs.rs/k256/0.5.8"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Fixed
- Regenerate `rustdoc` on https://docs.rs after nightly breakage