### PR TITLE
p256 v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/p256/CHANGELOG.md
+++ b/p256/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.2 (2020-10-08)
+### Fixed
+- Regenerate `rustdoc` on https://docs.rs after nightly breakage
+
 ## 0.5.1 (2020-10-08)
 ### Added
 - `SecretValue` impl when `arithmetic` feature is disabled ([#222])

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -5,7 +5,7 @@ Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve with support for ECDH, ECDSA signing/verification, and general
 purpose curve arithmetic
 """
-version = "0.5.1"
+version = "0.5.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/p256/0.5.1"
+    html_root_url = "https://docs.rs/p256/0.5.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Fixed
- Regenerate `rustdoc` on https://docs.rs after nightly breakage