### PR TITLE
Bump `elliptic-curve` to v0.7.0-pre; `ecdsa` to v0.9.0-pre

### DIFF
--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.44.0 # MSRV
+          - 1.46.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.44.0 # MSRV
+          - 1.46.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -73,7 +73,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.44.0 # MSRV
+            rust: 1.46.0 # MSRV
             deps: sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -81,7 +81,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.44.0 # MSRV
+            rust: 1.46.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 
@@ -101,29 +101,32 @@ jobs:
       - run: cargo test --release --target ${{ matrix.target }} --all-features
 
   # Cross-compiled tests
-  cross:
-    strategy:
-      matrix:
-        include:
-          # ARM64
-          - target: aarch64-unknown-linux-gnu
-            rust: 1.43.0 # MSRV
-          - target: aarch64-unknown-linux-gnu
-            rust: stable
-
-          # PPC32 (TODO: doesn't build on MSRV)
-          - target: powerpc-unknown-linux-gnu
-            rust: stable
-
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - run: ${{ matrix.deps }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
-      - run: cargo install cross
-      - run: cross test --release --target ${{ matrix.target }} --all-features
+  # TODO(tarcieri): re-enable these after deps are no longer git-sourced
+#  cross:
+#    strategy:
+#      matrix:
+#        include:
+#          # ARM64
+#          - target: aarch64-unknown-linux-gnu
+#            rust: 1.46.0 # MSRV
+#          - target: aarch64-unknown-linux-gnu
+#            rust: stable
+#
+#          # PPC32
+#          - target: aarch64-unknown-linux-gnu
+#            rust: 1.46.0 # MSRV
+#          - target: powerpc-unknown-linux-gnu
+#            rust: stable
+#
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v1
+#      - run: ${{ matrix.deps }}
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: ${{ matrix.rust }}
+#          target: ${{ matrix.target }}
+#          override: true
+#      - run: cargo install cross
+#      - run: cross test --release --target ${{ matrix.target }} --all-features

--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.44.0 # MSRV
+          - 1.46.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.44.0 # MSRV
+          - 1.46.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.44.0 # MSRV
+          - 1.46.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.44.0 # MSRV
+          - 1.46.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-audit-v0.12.0
+          key: ${{ runner.os }}-cargo-audit-v0.13.1
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -20,9 +20,10 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
-        toolchain: 1.44.0 # MSRV
+        toolchain: 1.46.0 # MSRV
         components: clippy
+        override: true
+        profile: minimal
     - run: cargo clippy --all --all-features -- -D warnings
 
   rustfmt:
@@ -34,9 +35,10 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           components: rustfmt
+          profile: minimal
+          override: true
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
@@ -47,44 +49,18 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-coverage-cargo-build-target-${{ hashFiles('Cargo.lock') }}
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          profile: minimal
           override: true
-
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+      - uses: actions-rs/tarpaulin@v0.1
         with:
-          version: 'latest'
+          version: latest
           args: --all --all-features -- --test-threads 1
-
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.13
-
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v1
+      - uses: codecov/codecov-action@v1
+      - uses: actions/upload-artifact@v1
         with:
           name: code-coverage-report
           path: cobertura.xml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bstr"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
+checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -128,6 +128,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2d9162b7289a46e86208d6af2c686ca5bfde445878c41a458a9fac706252d0b"
 
 [[package]]
+name = "const-oid"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc33f77ab0b4232f30cb9049a156775c5ad814b030e929d234d14cd6d7ec17f"
+
+[[package]]
+name = "const_fn"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
+
+[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,56 +183,56 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
+ "cfg-if 1.0.0",
  "crossbeam-utils",
- "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
- "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
 dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
+ "const_fn",
  "crossbeam-utils",
  "lazy_static",
- "maybe-uninit",
  "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
 dependencies = [
  "autocfg",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
+ "const_fn",
  "lazy_static",
 ]
 
 [[package]]
 name = "crypto-mac"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array",
  "subtle",
@@ -228,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
 dependencies = [
  "bstr",
  "csv-core",
@@ -263,7 +275,16 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87bf8bfb05ea8a6f74ddf48c7d1774851ba77bbe51ac984fdfa6c30310e1ff5f"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.6.6",
+ "signature",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.9.0-pre"
+source = "git+https://github.com/RustCrypto/signatures#a91afc59583ef1c2a8c95d8c180e5db0a7fbd21c"
+dependencies = [
+ "elliptic-curve 0.7.0-pre",
  "hmac",
  "signature",
 ]
@@ -280,8 +301,21 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396db09c483e7fca5d4fdb9112685632b3e76c9a607a2649c1bf904404a01366"
 dependencies = [
+ "const-oid 0.1.0",
+ "digest",
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/traits#c32065643e207ac4d0bbec8da4847afd02322cb8"
+dependencies = [
  "bitvec",
- "const-oid",
+ "const-oid 0.2.0",
  "digest",
  "ff",
  "generic-array",
@@ -394,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -432,8 +466,8 @@ version = "0.5.10"
 dependencies = [
  "cfg-if 1.0.0",
  "criterion",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.9.0-pre",
+ "elliptic-curve 0.7.0-pre",
  "hex",
  "hex-literal 0.2.1",
  "num-bigint",
@@ -458,9 +492,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "log"
@@ -472,16 +506,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
@@ -505,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -548,8 +576,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 name = "p256"
 version = "0.5.2"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.9.0-pre",
+ "elliptic-curve 0.7.0-pre",
  "hex",
  "hex-literal 0.3.1",
  "proptest",
@@ -561,8 +589,8 @@ dependencies = [
 name = "p384"
 version = "0.4.1"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.8.5",
+ "elliptic-curve 0.6.6",
  "sha2",
 ]
 
@@ -580,15 +608,15 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -692,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf6960dc9a5b4ee8d3e4c5787b4a112a8818e0290a42ff664ad60692fdf2032"
+checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -704,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
+checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -723,9 +751,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "regex-syntax",
 ]
@@ -741,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "remove_dir_all"
@@ -813,9 +841,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 
 [[package]]
 name = "serde_cbor"
@@ -829,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -840,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",
@@ -892,9 +920,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,7 @@ members = [
     "p256",
     "p384",
 ]
+
+[patch.crates-io]
+ecdsa = { git = "https://github.com/RustCrypto/signatures" }
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ if you are interested in curves beyond the ones listed here.
 
 ## Minimum Supported Rust Version
 
-All crates in this repository support Rust **1.44** or higher.
+All crates in this repository support Rust **1.46** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -48,7 +48,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[rustc-image]: https://img.shields.io/badge/rustc-1.44+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -18,14 +18,14 @@ keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
 
 [dependencies]
 cfg-if = "1.0"
-ecdsa-core = { version = "0.8.1", package = "ecdsa", optional = true, default-features = false }
-elliptic-curve = { version = "0.6.6", default-features = false }
+ecdsa-core = { version = "=0.9.0-pre", package = "ecdsa", optional = true, default-features = false }
+elliptic-curve = { version = "=0.7.0-pre", default-features = false }
 sha2 = { version = "0.9", optional = true, default-features = false }
 sha3 = { version = "0.9", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
-ecdsa-core = { version = "0.8.2", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.9.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4" # TODO: switch to hex-literal
 hex-literal = "0.2"
 num-bigint = "0.3"
@@ -39,7 +39,6 @@ arithmetic = ["elliptic-curve/arithmetic"]
 digest = ["elliptic-curve/digest", "ecdsa-core/digest"]
 ecdh = ["elliptic-curve/ecdh", "zeroize"]
 ecdsa = ["arithmetic", "digest", "ecdsa-core/sign", "ecdsa-core/verify", "zeroize"]
-endomorphism-mul = [] # TODO(tarcieri): remove before v0.6 release
 expose-field = ["arithmetic"]
 field-montgomery = []
 force-32-bit = []

--- a/k256/README.md
+++ b/k256/README.md
@@ -63,7 +63,7 @@ most popular and commonly used elliptic curves.
 
 ## Minimum Supported Rust Version
 
-Rust **1.44** or higher.
+Rust **1.46** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -95,7 +95,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/k256/badge.svg
 [docs-link]: https://docs.rs/k256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.44+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/k256/badge.svg?branch=master&event=push

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -121,10 +121,10 @@ impl FromEncodedPoint<Secp256k1> for AffinePoint {
     /// # Returns
     ///
     /// `None` value if `encoded_point` is not on the secp256k1 curve.
-    fn from_encoded_point(encoded_point: &EncodedPoint) -> CtOption<Self> {
+    fn from_encoded_point(encoded_point: &EncodedPoint) -> Option<Self> {
         match encoded_point.coordinates() {
             sec1::Coordinates::Compressed { x, y_is_odd } => {
-                AffinePoint::decompress(x, Choice::from(y_is_odd as u8))
+                AffinePoint::decompress(x, Choice::from(y_is_odd as u8)).into()
             }
             sec1::Coordinates::Uncompressed { x, y } => {
                 let x = FieldElement::from_bytes(x);
@@ -143,6 +143,7 @@ impl FromEncodedPoint<Secp256k1> for AffinePoint {
                         CtOption::new(point, (lhs + &rhs).normalizes_to_zero())
                     })
                 })
+                .into()
             }
         }
     }

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -12,7 +12,7 @@ use elliptic_curve::{
     point::ProjectiveArithmetic,
     rand_core::RngCore,
     sec1::FromEncodedPoint,
-    subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
+    subtle::{Choice, ConditionallySelectable, ConstantTimeEq},
 };
 
 #[rustfmt::skip]
@@ -48,7 +48,7 @@ impl From<AffinePoint> for ProjectivePoint {
 }
 
 impl FromEncodedPoint<Secp256k1> for ProjectivePoint {
-    fn from_encoded_point(p: &EncodedPoint) -> CtOption<Self> {
+    fn from_encoded_point(p: &EncodedPoint) -> Option<Self> {
         AffinePoint::from_encoded_point(p).map(ProjectivePoint::from)
     }
 }

--- a/k256/src/ecdh.rs
+++ b/k256/src/ecdh.rs
@@ -11,24 +11,28 @@
 //! ```
 //! # #[cfg(feature = "ecdh")]
 //! # {
-//! use k256::{EncodedPoint, ecdh::EphemeralSecret};
+//! use k256::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
 //! use rand_core::OsRng; // requires 'getrandom' feature
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::random(&mut OsRng);
-//! let alice_public = EncodedPoint::from(&alice_secret);
+//! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
 //!
 //! // Bob
 //! let bob_secret = EphemeralSecret::random(&mut OsRng);
-//! let bob_public = EncodedPoint::from(&bob_secret);
+//! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
-//! // Alice computes shared secret from Bob's public key
-//! let alice_shared = alice_secret.diffie_hellman(&bob_public)
-//!     .expect("bob's public key is invalid!");
+//! // Alice decodes Bob's serialized public key and computes a shared secret from it
+//! let bob_public = PublicKey::new(bob_pk_bytes.as_ref())
+//!     .expect("bob's public key is invalid!"); // In real usage, don't panic, handle this!
 //!
-//! // Bob computes the same shared secret from Alice's public key
-//! let bob_shared = bob_secret.diffie_hellman(&alice_public)
-//!     .expect("alice's public key is invalid!");
+//! let alice_shared = alice_secret.diffie_hellman(&bob_public);
+//!
+//! // Bob deocdes Alice's serialized public key and computes the same shared secret
+//! let alice_public = PublicKey::new(alice_pk_bytes.as_ref())
+//!     .expect("alice's public key is invalid!"); // In real usage, don't panic, handle this!
+//!
+//! let bob_shared = bob_secret.diffie_hellman(&alice_public);
 //!
 //! // Both participants arrive on the same shared secret
 //! assert_eq!(alice_shared.as_bytes(), bob_shared.as_bytes());

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.44** or higher.
+//! Rust **1.46** or higher.
 //!
 //! Minimum supported Rust version can be changed in the future, but it will be
 //! done with a minor version bump.
@@ -122,6 +122,10 @@ pub type FieldBytes = elliptic_curve::FieldBytes<Secp256k1>;
 
 /// SEC1-encoded secp256k1 (K-256) curve point.
 pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<Secp256k1>;
+
+/// secp256k1 (K-256) public key.
+#[cfg(feature = "arithmetic")]
+pub type PublicKey = elliptic_curve::PublicKey<Secp256k1>;
 
 /// secp256k1 (K-256) secret key.
 #[cfg(feature = "zeroize")]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -16,12 +16,12 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
 
 [dependencies]
-ecdsa-core = { version = "0.8", package = "ecdsa", optional = true, default-features = false }
-elliptic-curve = { version = "0.6", default-features = false }
+ecdsa-core = { version = "=0.9.0-pre", package = "ecdsa", optional = true, default-features = false }
+elliptic-curve = { version = "=0.7.0-pre", default-features = false }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.8", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.9.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4" # TODO: switch to hex-literal
 hex-literal = "0.3"
 proptest = "0.10"

--- a/p256/README.md
+++ b/p256/README.md
@@ -47,7 +47,7 @@ like TLS and the associated X.509 PKI.
 
 ## Minimum Supported Rust Version
 
-Rust **1.44** or higher.
+Rust **1.46** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -79,7 +79,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/p256/badge.svg
 [docs-link]: https://docs.rs/p256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.44+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/p256/badge.svg?branch=master&event=push

--- a/p256/src/arithmetic/affine.rs
+++ b/p256/src/arithmetic/affine.rs
@@ -119,10 +119,10 @@ impl FromEncodedPoint<NistP256> for AffinePoint {
     /// # Returns
     ///
     /// `None` value if `encoded_point` is not on the secp256r1 curve.
-    fn from_encoded_point(encoded_point: &EncodedPoint) -> CtOption<Self> {
+    fn from_encoded_point(encoded_point: &EncodedPoint) -> Option<Self> {
         match encoded_point.coordinates() {
             sec1::Coordinates::Compressed { x, y_is_odd } => {
-                AffinePoint::decompress(x, Choice::from(y_is_odd as u8))
+                AffinePoint::decompress(x, Choice::from(y_is_odd as u8)).into()
             }
             sec1::Coordinates::Uncompressed { x, y } => {
                 let x = FieldElement::from_bytes(x);
@@ -141,6 +141,7 @@ impl FromEncodedPoint<NistP256> for AffinePoint {
                         CtOption::new(point, lhs.ct_eq(&rhs))
                     })
                 })
+                .into()
             }
         }
     }

--- a/p256/src/ecdh.rs
+++ b/p256/src/ecdh.rs
@@ -11,24 +11,28 @@
 //! ```
 //! # #[cfg(feature = "ecdh")]
 //! # {
-//! use p256::{EncodedPoint, ecdh::EphemeralSecret};
+//! use p256::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
 //! use rand_core::OsRng; // requires 'getrandom' feature
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::random(&mut OsRng);
-//! let alice_public = EncodedPoint::from(&alice_secret);
+//! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
 //!
 //! // Bob
 //! let bob_secret = EphemeralSecret::random(&mut OsRng);
-//! let bob_public = EncodedPoint::from(&bob_secret);
+//! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
-//! // Alice computes shared secret from Bob's public key
-//! let alice_shared = alice_secret.diffie_hellman(&bob_public)
-//!     .expect("bob's public key is invalid!");
+//! // Alice decodes Bob's serialized public key and computes a shared secret from it
+//! let bob_public = PublicKey::new(bob_pk_bytes.as_ref())
+//!     .expect("bob's public key is invalid!"); // In real usage, don't panic, handle this!
 //!
-//! // Bob computes the same shared secret from Alice's public key
-//! let bob_shared = bob_secret.diffie_hellman(&alice_public)
-//!     .expect("alice's public key is invalid!");
+//! let alice_shared = alice_secret.diffie_hellman(&bob_public);
+//!
+//! // Bob deocdes Alice's serialized public key and computes the same shared secret
+//! let alice_public = PublicKey::new(alice_pk_bytes.as_ref())
+//!     .expect("alice's public key is invalid!"); // In real usage, don't panic, handle this!
+//!
+//! let bob_shared = bob_secret.diffie_hellman(&alice_public);
 //!
 //! // Both participants arrive on the same shared secret
 //! assert_eq!(alice_shared.as_bytes(), bob_shared.as_bytes());

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.44** or higher.
+//! Rust **1.46** or higher.
 //!
 //! Minimum supported Rust version can be changed in the future, but it will be
 //! done with a minor version bump.
@@ -123,10 +123,14 @@ impl elliptic_curve::Identifier for NistP256 {
 /// Byte array containing a serialized field element value (base field or scalar).
 pub type FieldBytes = elliptic_curve::FieldBytes<NistP256>;
 
-/// NIST P-256 SEC1 Encoded Point.
+/// NIST P-256 SEC1 encoded point.
 pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP256>;
 
-/// NIST P-256 Secret Key.
+/// NIST P-256 public key.
+#[cfg(feature = "arithmetic")]
+pub type PublicKey = elliptic_curve::PublicKey<NistP256>;
+
+/// NIST P-256 secret key.
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 pub type SecretKey = elliptic_curve::SecretKey<NistP256>;

--- a/p384/README.md
+++ b/p384/README.md
@@ -25,7 +25,7 @@ X.509 PKI.
 
 ## Minimum Supported Rust Version
 
-Rust **1.44** or higher.
+Rust **1.46** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -57,7 +57,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/p384/badge.svg
 [docs-link]: https://docs.rs/p384/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.44+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/p384/badge.svg?branch=master&event=push

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.44** or higher.
+//! Rust **1.46** or higher.
 //!
 //! Minimum supported Rust version can be changed in the future, but it will be
 //! done with a minor version bump.
@@ -67,15 +67,15 @@ impl elliptic_curve::Identifier for NistP384 {
     const OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 3, 132, 0, 34]);
 }
 
-/// NIST P-384 Serialized Field Element.
+/// NIST P-384 field element serialized as bytes.
 ///
 /// Byte array containing a serialized field element value (base field or scalar).
 pub type FieldBytes = elliptic_curve::FieldBytes<NistP384>;
 
-/// NIST P-384 SEC1 Encoded Point.
+/// NIST P-384 SEC1 encoded point.
 pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP384>;
 
-/// NIST P-384 Secret Key
+/// NIST P-384 secret key.
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 pub type SecretKey = elliptic_curve::SecretKey<NistP384>;

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,3 +4,7 @@ members = [
     "p256_no_std",
     "p384_no_std",
 ]
+
+[patch.crates-io]
+ecdsa = { git = "https://github.com/RustCrypto/signatures" }
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }


### PR DESCRIPTION
Bumps all crates to use the new prereleases of these crates, as sourced from git.