### PR TITLE
Bump `elliptic-curve` and `ecdsa` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
@@ -218,13 +218,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
- "const_fn",
  "lazy_static",
 ]
 
@@ -240,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
+checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
 dependencies = [
  "bstr",
  "csv-core",
@@ -282,7 +281,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.9.0-pre"
-source = "git+https://github.com/RustCrypto/signatures#a91afc59583ef1c2a8c95d8c180e5db0a7fbd21c"
+source = "git+https://github.com/RustCrypto/signatures#be52d7c20457d47832a66cb74ec72e946969e6fa"
 dependencies = [
  "elliptic-curve 0.7.0-pre",
  "hmac",
@@ -312,7 +311,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/traits#c32065643e207ac4d0bbec8da4847afd02322cb8"
+source = "git+https://github.com/RustCrypto/traits#fdff330484c9d03f67ba1eda533a24e757f3e204"
 dependencies = [
  "bitvec",
  "const-oid 0.2.0",
@@ -453,9 +452,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -513,9 +512,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
  "autocfg",
 ]
@@ -562,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "oorandom"
-version = "11.1.2"
+version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -868,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
 dependencies = [
  "itoa",
  "ryu",
@@ -920,9 +919,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "8833e20724c24de12bbaba5ad230ea61c3eafb05b881c7c9d3cfe8638b187e68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1014,19 +1013,19 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1039,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1049,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1062,15 +1061,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/k256/src/ecdh.rs
+++ b/k256/src/ecdh.rs
@@ -23,13 +23,13 @@
 //! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it
-//! let bob_public = PublicKey::new(bob_pk_bytes.as_ref())
+//! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())
 //!     .expect("bob's public key is invalid!"); // In real usage, don't panic, handle this!
 //!
 //! let alice_shared = alice_secret.diffie_hellman(&bob_public);
 //!
 //! // Bob deocdes Alice's serialized public key and computes the same shared secret
-//! let alice_public = PublicKey::new(alice_pk_bytes.as_ref())
+//! let alice_public = PublicKey::from_sec1_bytes(alice_pk_bytes.as_ref())
 //!     .expect("alice's public key is invalid!"); // In real usage, don't panic, handle this!
 //!
 //! let bob_shared = bob_secret.diffie_hellman(&alice_public);

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -11,7 +11,7 @@
 //!   software implementations of ECDSA/secp256k1 and wrappers for cloud KMS
 //!   services or hardware devices (HSM or crypto hardware wallet).
 //! - `ecdsa`: provides `ecdsa-core` features plus the [`SigningKey`] and
-//!   [`VerifyKey`] types which natively implement ECDSA/secp256k1 signing and
+//!   [`VerifyingKey`] types which natively implement ECDSA/secp256k1 signing and
 //!   verification.
 //!
 //! Additionally, this crate contains support for computing ECDSA signatures
@@ -51,9 +51,9 @@
 //! let signature: Signature = signing_key.sign(message);
 //!
 //! // Verification
-//! use k256::{EncodedPoint, ecdsa::{VerifyKey, signature::Verifier}};
+//! use k256::{EncodedPoint, ecdsa::{VerifyingKey, signature::Verifier}};
 //!
-//! let verify_key = VerifyKey::from(&signing_key); // Serialize with `::to_encoded_point()`
+//! let verify_key = VerifyingKey::from(&signing_key); // Serialize with `::to_encoded_point()`
 //! assert!(verify_key.verify(message, &signature).is_ok());
 //! # }
 //! ```
@@ -73,7 +73,7 @@ pub use ecdsa_core::signature::{self, Error};
 pub use ecdsa_core::signature::digest;
 
 #[cfg(feature = "ecdsa")]
-pub use self::{sign::SigningKey, verify::VerifyKey};
+pub use self::{sign::SigningKey, verify::VerifyingKey};
 
 use crate::Secp256k1;
 

--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -1,6 +1,6 @@
 //! ECDSA signer
 
-use super::{recoverable, Error, Signature, VerifyKey};
+use super::{recoverable, Error, Signature, VerifyingKey};
 use crate::{FieldBytes, NonZeroScalar, ProjectivePoint, Scalar, Secp256k1, SecretKey};
 use core::{borrow::Borrow, convert::TryInto};
 use ecdsa_core::{
@@ -44,10 +44,10 @@ impl SigningKey {
             .ok_or_else(Error::new)
     }
 
-    /// Get the [`VerifyKey`] which corresponds to this [`SigningKey`]
-    pub fn verify_key(&self) -> VerifyKey {
-        VerifyKey {
-            key: ecdsa_core::SigningKey::from(self.secret_scalar).verify_key(),
+    /// Get the [`VerifyingKey`] which corresponds to this [`SigningKey`]
+    pub fn verify_key(&self) -> VerifyingKey {
+        VerifyingKey {
+            inner: ecdsa_core::SigningKey::from(self.secret_scalar).verify_key(),
         }
     }
 
@@ -155,8 +155,8 @@ impl From<&SigningKey> for SecretKey {
     }
 }
 
-impl From<&SigningKey> for VerifyKey {
-    fn from(signing_key: &SigningKey) -> VerifyKey {
+impl From<&SigningKey> for VerifyingKey {
+    fn from(signing_key: &SigningKey) -> VerifyingKey {
         signing_key.verify_key()
     }
 }

--- a/p256/src/ecdh.rs
+++ b/p256/src/ecdh.rs
@@ -23,13 +23,13 @@
 //! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it
-//! let bob_public = PublicKey::new(bob_pk_bytes.as_ref())
+//! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())
 //!     .expect("bob's public key is invalid!"); // In real usage, don't panic, handle this!
 //!
 //! let alice_shared = alice_secret.diffie_hellman(&bob_public);
 //!
 //! // Bob deocdes Alice's serialized public key and computes the same shared secret
-//! let alice_public = PublicKey::new(alice_pk_bytes.as_ref())
+//! let alice_public = PublicKey::from_sec1_bytes(alice_pk_bytes.as_ref())
 //!     .expect("alice's public key is invalid!"); // In real usage, don't panic, handle this!
 //!
 //! let bob_shared = bob_secret.diffie_hellman(&alice_public);

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -11,7 +11,7 @@
 //!   software implementations of ECDSA/P-256 and wrappers for cloud KMS
 //!   services or hardware devices (HSM or crypto hardware wallet).
 //! - `ecdsa`: provides `ecdsa-core` features plus the [`SigningKey`] and
-//!   [`VerifyKey`] types which natively implement ECDSA/P-256 signing and
+//!   [`VerifyingKey`] types which natively implement ECDSA/P-256 signing and
 //!   verification.
 //!
 //! ## Signing/Verification Example
@@ -32,9 +32,9 @@
 //! let signature = signing_key.sign(message);
 //!
 //! // Verification
-//! use p256::ecdsa::{VerifyKey, signature::Verifier};
+//! use p256::ecdsa::{VerifyingKey, signature::Verifier};
 //!
-//! let verify_key = VerifyKey::from(&signing_key); // Serialize with `::to_encoded_point()`
+//! let verify_key = VerifyingKey::from(&signing_key); // Serialize with `::to_encoded_point()`
 //! assert!(verify_key.verify(message, &signature).is_ok());
 //! # }
 //! ```
@@ -65,7 +65,7 @@ pub type SigningKey = ecdsa_core::SigningKey<NistP256>;
 /// ECDSA/P-256 verification key (i.e. public key)
 #[cfg(feature = "ecdsa")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
-pub type VerifyKey = ecdsa_core::VerifyKey<NistP256>;
+pub type VerifyingKey = ecdsa_core::VerifyingKey<NistP256>;
 
 #[cfg(not(feature = "ecdsa"))]
 impl ecdsa_core::CheckSignatureBytes for NistP256 {}


### PR DESCRIPTION
Use the latest versions from git, which include some minor name changes