### PR TITLE
k256 v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "cfg-if 1.0.0",
  "criterion",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-12-06)
+### Added
+- PKCS#8 support ([#243], [#244], [#251])
+- `PublicKey` type ([#239])
+
+### Changed
+- Bump `elliptic-curve` crate dependency to v0.7; MSRV 1.46+ ([#247])
+- Bump `ecdsa` crate dependency to v0.9 ([#247])
+- Make `SigningKey` a newtype of `elliptic_curve::SecretKey` ([#242])
+
+[#251]: https://github.com/RustCrypto/elliptic-curves/pull/251
+[#247]: https://github.com/RustCrypto/elliptic-curves/pull/247
+[#244]: https://github.com/RustCrypto/elliptic-curves/pull/244
+[#243]: https://github.com/RustCrypto/elliptic-curves/pull/243
+[#242]: https://github.com/RustCrypto/elliptic-curves/pull/242
+[#239]: https://github.com/RustCrypto/elliptic-curves/pull/239
+
 ## 0.5.10 (2020-10-25)
 ### Changed
 - Expand README.md ([#233])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -6,7 +6,7 @@ signing/verification (including Ethereum-style signatures with public-key
 recovery), Elliptic Curve Diffie-Hellman (ECDH), and general purpose secp256k1
 curve arithmetic useful for implementing arbitrary group-based protocols.
 """
-version = "0.6.0-pre"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -32,8 +32,8 @@
 //!
 //! Rust **1.46** or higher.
 //!
-//! Minimum supported Rust version can be changed in the future, but it will be
-//! done with a minor version bump.
+//! Minimum supported Rust version may be changed in the future, but it will be
+//! accompanied with a minor version bump.
 //!
 //! [secp256k1]: https://en.bitcoin.it/wiki/Secp256k1
 //! [ECDSA]: https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/k256/0.5.10"
+    html_root_url = "https://docs.rs/k256/0.6.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -33,8 +33,8 @@
 //!
 //! Rust **1.46** or higher.
 //!
-//! Minimum supported Rust version can be changed in the future, but it will be
-//! done with a minor version bump.
+//! Minimum supported Rust version may be changed in the future, but it will be
+//! accompanied with a minor version bump.
 //!
 //! [ECDSA]: https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
 //! [ECDH]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -4,8 +4,8 @@
 //!
 //! Rust **1.46** or higher.
 //!
-//! Minimum supported Rust version can be changed in the future, but it will be
-//! done with a minor version bump.
+//! Minimum supported Rust version may be changed in the future, but it will be
+//! accompanied with a minor version bump.
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
### Added
- PKCS#8 support ([#243], [#244], [#251])
- `PublicKey` type ([#239])

### Changed
- Bump `elliptic-curve` crate dependency to v0.7; MSRV 1.46+ ([#247])
- Bump `ecdsa` crate dependency to v0.9 ([#247])
- Make `SigningKey` a newtype of `elliptic_curve::SecretKey` ([#242])

[#251]: https://github.com/RustCrypto/elliptic-curves/pull/251
[#247]: https://github.com/RustCrypto/elliptic-curves/pull/247
[#244]: https://github.com/RustCrypto/elliptic-curves/pull/244
[#243]: https://github.com/RustCrypto/elliptic-curves/pull/243
[#242]: https://github.com/RustCrypto/elliptic-curves/pull/242
[#239]: https://github.com/RustCrypto/elliptic-curves/pull/239