### PR TITLE
p256 v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/p256/CHANGELOG.md
+++ b/p256/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-12-06)
+### Added
+- PKCS#8 support ([#243], [#244], [#245])
+- `PublicKey` type ([#239])
+
+### Changed
+- Bump `elliptic-curve` crate dependency to v0.7; MSRV 1.46+ ([#247])
+- Bump `ecdsa` crate dependency to v0.9 ([#247])
+
+[#247]: https://github.com/RustCrypto/elliptic-curves/pull/247
+[#245]: https://github.com/RustCrypto/elliptic-curves/pull/245
+[#244]: https://github.com/RustCrypto/elliptic-curves/pull/244
+[#243]: https://github.com/RustCrypto/elliptic-curves/pull/243
+[#239]: https://github.com/RustCrypto/elliptic-curves/pull/239
+
 ## 0.5.2 (2020-10-08)
 ### Fixed
 - Regenerate `rustdoc` on https://docs.rs after nightly breakage

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -5,7 +5,7 @@ Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve with support for ECDH, ECDSA signing/verification, and general
 purpose curve arithmetic
 """
-version = "0.6.0-pre"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"


### PR DESCRIPTION
### Added
- PKCS#8 support ([#243], [#244], [#245])
- `PublicKey` type ([#239])

### Changed
- Bump `elliptic-curve` crate dependency to v0.7; MSRV 1.46+ ([#247])
- Bump `ecdsa` crate dependency to v0.9 ([#247])

[#247]: https://github.com/RustCrypto/elliptic-curves/pull/247
[#245]: https://github.com/RustCrypto/elliptic-curves/pull/245
[#244]: https://github.com/RustCrypto/elliptic-curves/pull/244
[#243]: https://github.com/RustCrypto/elliptic-curves/pull/243
[#239]: https://github.com/RustCrypto/elliptic-curves/pull/239