### PR TITLE
p384 v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.7.0 (2020-12-16)
 ### Changed
 - Bump `elliptic-curve` dependency to v0.8 ([#260])
-- `ecdsa` to v0.10 ([#260])
+- Bump `ecdsa` to v0.10 ([#260])
 
 [#260]: https://github.com/RustCrypto/elliptic-curves/pull/260
 

--- a/p256/CHANGELOG.md
+++ b/p256/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.7.0 (2020-12-16)
 ### Changed
 - Bump `elliptic-curve` dependency to v0.8 ([#260])
-- `ecdsa` to v0.10 ([#260])
+- Bump `ecdsa` to v0.10 ([#260])
 
 [#260]: https://github.com/RustCrypto/elliptic-curves/pull/260
 

--- a/p384/CHANGELOG.md
+++ b/p384/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-12-16)
+### Changed
+- Bump `elliptic-curve` dependency to v0.8 ([#260])
+- Bump `ecdsa` to v0.10 ([#260])
+
+[#260]: https://github.com/RustCrypto/elliptic-curves/pull/260
+
 ## 0.5.0 (2020-12-06)
 ### Added
 - PKCS#8 support ([#243], [#244])

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p384"
 description = "NIST P-384 (secp384r1) elliptic curve"
-version = "0.5.0"
+version = "0.6.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/p384/0.5.0"
+    html_root_url = "https://docs.rs/p384/0.6.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Bump `elliptic-curve` dependency to v0.8 ([#260])
- Bump `ecdsa` to v0.10 ([#260])

[#260]: https://github.com/RustCrypto/elliptic-curves/pull/260