### PR TITLE
Point releases to trigger docs.rs rebuild

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa9459c0f3be75c1ede60e02e9cd69ed1279a1421a5c2fe4d23e829adc43d36"
+checksum = "d39be153f0e278ffba17d1c05e8999641fcf3df7584a7251b5e660742fcab1ef"
 dependencies = [
  "elliptic-curve",
  "hmac",
@@ -281,9 +281,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4cf86631e1e5cf5fa77372d1d4d7bcaa26eba12d695012e93ef980a50dc5250"
+checksum = "02b76528f382c916bbb94470b4e7ad107a3d01619503f7ffba86c93aea04e215"
 dependencies = [
  "bitvec",
  "digest",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cfg-if 1.0.0",
  "criterion",
@@ -519,7 +519,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.1 (2020-12-16)
+### Fixed
+- Trigger docs.rs rebuild with nightly bugfix ([RustCrypto/traits#412])
+
+[RustCrypto/traits#412]: https://github.com/RustCrypto/traits/pull/412
+
 ## 0.7.0 (2020-12-16)
 ### Changed
 - Bump `elliptic-curve` dependency to v0.8 ([#260])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -6,7 +6,7 @@ signing/verification (including Ethereum-style signatures with public-key
 recovery), Elliptic Curve Diffie-Hellman (ECDH), and general purpose secp256k1
 curve arithmetic useful for implementing arbitrary group-based protocols.
 """
-version = "0.7.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.7.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/k256/0.7.0"
+    html_root_url = "https://docs.rs/k256/0.7.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/p256/CHANGELOG.md
+++ b/p256/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.1 (2020-12-16)
+### Fixed
+- Trigger docs.rs rebuild with nightly bugfix ([RustCrypto/traits#412])
+
+[RustCrypto/traits#412]: https://github.com/RustCrypto/traits/pull/412
+
 ## 0.7.0 (2020-12-16)
 ### Changed
 - Bump `elliptic-curve` dependency to v0.8 ([#260])

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -5,7 +5,7 @@ Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve with support for ECDH, ECDSA signing/verification, and general
 purpose curve arithmetic
 """
-version = "0.7.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.7.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/p256/0.7.0"
+    html_root_url = "https://docs.rs/p256/0.7.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/p384/CHANGELOG.md
+++ b/p384/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2020-12-16)
+### Fixed
+- Trigger docs.rs rebuild with nightly bugfix ([RustCrypto/traits#412])
+
+[RustCrypto/traits#412]: https://github.com/RustCrypto/traits/pull/412
+
 ## 0.6.0 (2020-12-16)
 ### Changed
 - Bump `elliptic-curve` dependency to v0.8 ([#260])

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p384"
 description = "NIST P-384 (secp384r1) elliptic curve"
-version = "0.6.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/p384/0.6.0"
+    html_root_url = "https://docs.rs/p384/0.6.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
This is a (re-)release of the following crates solely for the purpose of triggering a rebuild on docs.rs:

- `k256` v0.7.1
- `p256` v0.7.1
- `p384` v0.6.1

The previous builds failed due to a `nightly` regression in the upstream elliptic-curve` crate:

https://github.com/RustCrypto/traits/pull/412

Crates are otherwise unchanged from the previous releases.