### PR TITLE
p256: private/public key serialization tests

### DIFF
--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -76,10 +76,10 @@ jobs:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
             rust: 1.46.0 # MSRV
-            deps: sudo apt install gcc-multilib
+            deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
-            deps: sudo apt install gcc-multilib
+            deps: sudo apt update && sudo apt install gcc-multilib
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+dependencies = [
+ "const-oid",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39be153f0e278ffba17d1c05e8999641fcf3df7584a7251b5e660742fcab1ef"
+checksum = "41fbdb4ff710acb4db8ca29f93b897529ea6d6a45626d5183b47e012aa6ae7e4"
 dependencies = [
  "elliptic-curve",
  "hmac",
@@ -281,9 +290,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b76528f382c916bbb94470b4e7ad107a3d01619503f7ffba86c93aea04e215"
+checksum = "0fe963e4221e6518695d10fdd47558a0a1e8edcbb87faba1dc7a15052f63dc72"
 dependencies = [
  "bitvec",
  "digest",
@@ -540,11 +549,11 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9911ed9965aeee333588f226ad2baeabda478bf5ec151550735ed1760df759ba"
+checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
 dependencies = [
- "const-oid",
+ "der",
  "subtle-encoding",
  "zeroize",
 ]
@@ -863,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "subtle-encoding"

--- a/p256/tests/pkcs8.rs
+++ b/p256/tests/pkcs8.rs
@@ -8,6 +8,9 @@ use p256::{
     pkcs8::{FromPrivateKey, FromPublicKey},
 };
 
+#[cfg(feature = "pem")]
+use p256::elliptic_curve::pkcs8::{ToPrivateKey, ToPublicKey};
+
 /// DER-encoded PKCS#8 private key
 const PKCS8_PRIVATE_KEY_DER: &[u8; 138] = include_bytes!("examples/pkcs8-private-key.der");
 
@@ -23,14 +26,14 @@ const PKCS8_PRIVATE_KEY_PEM: &str = include_str!("examples/pkcs8-private-key.pem
 const PKCS8_PUBLIC_KEY_PEM: &str = include_str!("examples/pkcs8-public-key.pem");
 
 #[test]
-fn parse_pkcs8_private_key_from_der() {
+fn decode_pkcs8_private_key_from_der() {
     let secret_key = p256::SecretKey::from_pkcs8_der(&PKCS8_PRIVATE_KEY_DER[..]).unwrap();
     let expected_scalar = hex!("69624171561A63340DE0E7D869F2A05492558E1A04868B6A9F854A866788188D");
     assert_eq!(secret_key.to_bytes().as_slice(), &expected_scalar[..]);
 }
 
 #[test]
-fn parse_pkcs8_public_key_from_der() {
+fn decode_pkcs8_public_key_from_der() {
     let public_key = p256::PublicKey::from_public_key_der(&PKCS8_PUBLIC_KEY_DER[..]).unwrap();
     let expected_sec1_point = hex!("041CACFFB55F2F2CEFD89D89EB374B2681152452802DEEA09916068137D839CF7FC481A44492304D7EF66AC117BEFE83A8D08F155F2B52F9F618DD447029048E0F");
     assert_eq!(
@@ -41,7 +44,7 @@ fn parse_pkcs8_public_key_from_der() {
 
 #[test]
 #[cfg(feature = "pem")]
-fn parse_pkcs8_private_key_from_pem() {
+fn decode_pkcs8_private_key_from_pem() {
     let secret_key = PKCS8_PRIVATE_KEY_PEM.parse::<p256::SecretKey>().unwrap();
 
     // Ensure key parses equivalently to DER
@@ -51,10 +54,50 @@ fn parse_pkcs8_private_key_from_pem() {
 
 #[test]
 #[cfg(feature = "pem")]
-fn parse_pkcs8_public_key_from_pem() {
+fn decode_pkcs8_public_key_from_pem() {
     let public_key = PKCS8_PUBLIC_KEY_PEM.parse::<p256::PublicKey>().unwrap();
 
     // Ensure key parses equivalently to DER
     let der_key = p256::PublicKey::from_public_key_der(&PKCS8_PUBLIC_KEY_DER[..]).unwrap();
     assert_eq!(public_key, der_key);
+}
+
+#[test]
+#[cfg(feature = "pem")]
+fn encode_pkcs8_private_key_to_der() {
+    let original_secret_key = p256::SecretKey::from_pkcs8_der(&PKCS8_PRIVATE_KEY_DER[..]).unwrap();
+    let reencoded_secret_key = original_secret_key.to_pkcs8_der();
+    assert_eq!(reencoded_secret_key.as_ref(), &PKCS8_PRIVATE_KEY_DER[..]);
+}
+
+#[test]
+#[cfg(feature = "pem")]
+fn encode_pkcs8_public_key_to_der() {
+    let original_public_key =
+        p256::PublicKey::from_public_key_der(&PKCS8_PUBLIC_KEY_DER[..]).unwrap();
+    let reencoded_public_key = original_public_key.to_public_key_der();
+    assert_eq!(reencoded_public_key.as_ref(), &PKCS8_PUBLIC_KEY_DER[..]);
+}
+
+#[test]
+#[cfg(feature = "pem")]
+fn encode_pkcs8_private_key_to_pem() {
+    let original_secret_key = p256::SecretKey::from_pkcs8_der(&PKCS8_PRIVATE_KEY_DER[..]).unwrap();
+    let reencoded_secret_key = original_secret_key.to_pkcs8_pem();
+    assert_eq!(
+        reencoded_secret_key.as_str(),
+        PKCS8_PRIVATE_KEY_PEM.trim_end()
+    );
+}
+
+#[test]
+#[cfg(feature = "pem")]
+fn encode_pkcs8_public_key_to_pem() {
+    let original_public_key =
+        p256::PublicKey::from_public_key_der(&PKCS8_PUBLIC_KEY_DER[..]).unwrap();
+    let reencoded_public_key = original_public_key.to_string();
+    assert_eq!(
+        reencoded_public_key.as_str(),
+        PKCS8_PUBLIC_KEY_PEM.trim_end()
+    );
 }


### PR DESCRIPTION
Adds tests which exercise the generic impls of the `pkcs8` key serialization traits for the `PublicKey` and `SecretKey` types.