### PR TITLE
add impl for DigestPrimitive on keccak feature

### DIFF
--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -96,6 +96,11 @@ impl ecdsa_core::hazmat::DigestPrimitive for Secp256k1 {
     type Digest = sha2::Sha256;
 }
 
+#[cfg(all(feature = "ecdsa", feature = "keccak256"))]
+impl ecdsa_core::hazmat::DigestPrimitive for Secp256k1 {
+    type Digest = sha3::Keccak256;
+}
+
 /// Validate that the scalars of an ECDSA signature are modulo the order
 #[cfg(feature = "ecdsa")]
 fn check_scalars(signature: &Signature) -> Result<(), Error> {


### PR DESCRIPTION
## Abstract

This PR adds an `impl DigestPrimitive` when the feature `keccak256` is used. This should resolve a build error when using the feature.