### PR TITLE
k256/p256: have `std` activate `ecdsa-core/std`

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -47,7 +47,7 @@ pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8", "zeroize"]
 sha256 = ["digest", "sha2"]
 test-vectors = ["hex-literal"]
-std = ["elliptic-curve/std"]
+std = ["ecdsa-core/std", "elliptic-curve/std"] # TODO: use weak activation for `ecdsa-core/std` when available
 zeroize = ["elliptic-curve/zeroize"]
 
 [package.metadata.docs.rs]

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -94,7 +94,7 @@ pub type Signature = ecdsa_core::Signature<Secp256k1>;
 /// ECDSA/secp256k1 signature (ASN.1 DER encoded)
 pub type Asn1Signature = ecdsa_core::asn1::Signature<Secp256k1>;
 
-#[cfg(not(feature = "ecdsa"))]
+#[cfg(not(feature = "arithmetic"))]
 impl ecdsa_core::CheckSignatureBytes for Secp256k1 {}
 
 #[cfg(all(feature = "ecdsa", feature = "sha256"))]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -37,7 +37,7 @@ pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8", "zeroize"]
 sha256 = ["digest", "ecdsa-core/hazmat", "sha2"]
 test-vectors = ["hex-literal"]
-std = ["elliptic-curve/std"]
+std = ["ecdsa-core/std", "elliptic-curve/std"] # TODO: use weak activation for `ecdsa-core/std` when available
 zeroize = ["elliptic-curve/zeroize"]
 
 [package.metadata.docs.rs]

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -67,7 +67,7 @@ pub type SigningKey = ecdsa_core::SigningKey<NistP256>;
 #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub type VerifyingKey = ecdsa_core::VerifyingKey<NistP256>;
 
-#[cfg(not(feature = "ecdsa"))]
+#[cfg(not(feature = "arithmetic"))]
 impl ecdsa_core::CheckSignatureBytes for NistP256 {}
 
 #[cfg(all(feature = "ecdsa", feature = "sha256"))]


### PR DESCRIPTION
Closes #271

This is needed to define a `std::error::Error` impl on errors arising from the `ecdsa` crate.

Unfortunately without weak activation this means the `ecdsa` crate gets pulled in by default, but we can circle back on that later.