### PR TITLE
Bump `elliptic-curve` dependency to v0.9.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,12 +40,13 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitvec"
-version = "0.18.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2838fdd79e8776dbe07a106c784b0f8dda571a21b2750a092cc4cbaa653c8e"
+checksum = "f5011ffc90248764d7005b0e10c7294f5aa1bd87d9dd7248f4ad475b347c294d"
 dependencies = [
  "funty",
  "radium",
+ "tap",
  "wyz",
 ]
 
@@ -123,9 +124,8 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069b46dab00267d018567b1154f38b706d6ed93c4915301a2fa73bc24a03a1e7"
+version = "0.4.1"
+source = "git+https://github.com/RustCrypto/utils.git#5c174b500f50dac9cf2376dac2bbf6ac05560b6f"
 
 [[package]]
 name = "const_fn"
@@ -255,11 +255,11 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+version = "0.2.0-pre"
+source = "git+https://github.com/RustCrypto/utils.git#5c174b500f50dac9cf2376dac2bbf6ac05560b6f"
 dependencies = [
  "const-oid",
+ "typenum",
 ]
 
 [[package]]
@@ -273,10 +273,10 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fbdb4ff710acb4db8ca29f93b897529ea6d6a45626d5183b47e012aa6ae7e4"
+version = "0.11.0-pre"
+source = "git+https://github.com/RustCrypto/signatures.git#41a3646229cc4cbf4af3082e4f8f77e5c19d340c"
 dependencies = [
+ "der",
  "elliptic-curve",
  "hmac",
  "signature",
@@ -290,9 +290,8 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "592b1c857559479c056b73a3053c717108a70e4dce320ad28c79c63f5c2e62ba"
+version = "0.9.0-pre"
+source = "git+https://github.com/RustCrypto/traits.git#cd0a0aef3d480458ae21901316e4acbff77f574a"
 dependencies = [
  "bitvec",
  "digest",
@@ -300,19 +299,19 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "ff"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.6.1",
  "subtle",
 ]
 
@@ -346,17 +345,28 @@ checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "group"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+checksum = "61b3c1e8b4f1ca07e6605ea1be903a5f6956aec5c8a67fd44d56076631675ed8"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.1",
  "subtle",
 ]
 
@@ -427,7 +437,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "proptest",
- "rand_core",
+ "rand_core 0.6.1",
  "sha2",
  "sha3",
 ]
@@ -534,7 +544,7 @@ dependencies = [
  "elliptic-curve",
  "hex-literal",
  "proptest",
- "rand_core",
+ "rand_core 0.6.1",
  "sha2",
 ]
 
@@ -549,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.3.3"
+version = "0.4.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
+checksum = "9df125c6bec8ba2195e9ef3064e610c9aa00362b38f502ca348e4383eaeef102"
 dependencies = [
  "der",
  "subtle-encoding",
@@ -622,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "radium"
-version = "0.4.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64de9a0c5361e034f1aefc9f71a86871ec870e766fe31a009734a989b329286a"
+checksum = "e9e006811e1fdd12672b0820a7f44c18dde429f367d50cec003d22aa9b3c8ddc"
 
 [[package]]
 name = "rand"
@@ -632,10 +642,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.5.1",
  "rand_hc",
 ]
 
@@ -646,7 +656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -655,7 +665,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.1",
 ]
 
 [[package]]
@@ -664,7 +683,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -673,7 +692,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -862,12 +881,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -895,6 +914,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "tempfile"
@@ -978,6 +1003,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,8 @@ members = [
     "p256",
     "p384",
 ]
+
+[patch.crates-io]
+der = { git = "https://github.com/RustCrypto/utils.git" }
+ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
+elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -18,26 +18,32 @@ keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
 
 [dependencies]
 cfg-if = "1.0"
-ecdsa-core = { version = "0.10", package = "ecdsa", optional = true, default-features = false }
-elliptic-curve = { version = "0.8", default-features = false }
+elliptic-curve = { version = "=0.9.0-pre", default-features = false }
 hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 sha3 = { version = "0.9", optional = true, default-features = false }
 
+[dependencies.ecdsa-core]
+version = "=0.11.0-pre"
+package = "ecdsa"
+optional = true
+default-features = false
+features = ["der"]
+
 [dev-dependencies]
 criterion = "0.3"
-ecdsa-core = { version = "0.10", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.11.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 num-bigint = "0.3"
 num-traits = "0.2"
 proptest = "0.10"
-rand_core = { version = "0.5", features = ["getrandom"] }
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
 default = ["arithmetic", "pkcs8", "std"]
 arithmetic = ["elliptic-curve/arithmetic"]
 digest = ["elliptic-curve/digest", "ecdsa-core/digest"]
-ecdh = ["elliptic-curve/ecdh", "zeroize"]
+ecdh = ["arithmetic", "elliptic-curve/ecdh", "zeroize"]
 ecdsa = ["arithmetic", "digest", "ecdsa-core/sign", "ecdsa-core/verify", "zeroize"]
 expose-field = ["arithmetic"]
 field-montgomery = []

--- a/k256/src/ecdh.rs
+++ b/k256/src/ecdh.rs
@@ -9,8 +9,6 @@
 //! exchange, nicknamed "Alice" and "Bob".
 //!
 //! ```
-//! # #[cfg(feature = "ecdh")]
-//! # {
 //! use k256::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
 //! use rand_core::OsRng; // requires 'getrandom' feature
 //!
@@ -36,13 +34,18 @@
 //!
 //! // Both participants arrive on the same shared secret
 //! assert_eq!(alice_shared.as_bytes(), bob_shared.as_bytes());
-//! # }
 //! ```
 
-use crate::Secp256k1;
+use crate::{AffinePoint, Secp256k1};
 
 /// NIST P-256 Ephemeral Diffie-Hellman Secret.
 pub type EphemeralSecret = elliptic_curve::ecdh::EphemeralSecret<Secp256k1>;
 
 /// Shared secret value computed via ECDH key agreement.
 pub type SharedSecret = elliptic_curve::ecdh::SharedSecret<Secp256k1>;
+
+impl From<&AffinePoint> for SharedSecret {
+    fn from(affine: &AffinePoint) -> SharedSecret {
+        affine.x.to_bytes().into()
+    }
+}

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -92,7 +92,7 @@ use elliptic_curve::generic_array::GenericArray;
 pub type Signature = ecdsa_core::Signature<Secp256k1>;
 
 /// ECDSA/secp256k1 signature (ASN.1 DER encoded)
-pub type Asn1Signature = ecdsa_core::asn1::Signature<Secp256k1>;
+pub type Asn1Signature = ecdsa_core::der::Signature<Secp256k1>;
 
 #[cfg(not(feature = "arithmetic"))]
 impl ecdsa_core::CheckSignatureBytes for Secp256k1 {}

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -16,22 +16,28 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
 
 [dependencies]
-ecdsa-core = { version = "0.10", package = "ecdsa", optional = true, default-features = false }
-elliptic-curve = { version = "0.8", default-features = false }
+elliptic-curve = { version = "=0.9.0-pre", default-features = false }
 hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
+[dependencies.ecdsa-core]
+version = "=0.11.0-pre"
+package = "ecdsa"
+optional = true
+default-features = false
+features = ["der"]
+
 [dev-dependencies]
-ecdsa-core = { version = "0.10", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.11.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "0.10"
-rand_core = { version = "0.5", features = ["getrandom"] }
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
 default = ["arithmetic", "pkcs8", "std"]
 arithmetic = ["elliptic-curve/arithmetic"]
 digest = ["elliptic-curve/digest", "ecdsa-core/digest"]
-ecdh = ["elliptic-curve/ecdh", "zeroize"]
+ecdh = ["arithmetic", "elliptic-curve/ecdh", "zeroize"]
 ecdsa = ["arithmetic", "ecdsa-core/sign", "ecdsa-core/verify", "sha256", "zeroize"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8", "zeroize"]

--- a/p256/src/ecdh.rs
+++ b/p256/src/ecdh.rs
@@ -9,8 +9,6 @@
 //! exchange, nicknamed "Alice" and "Bob".
 //!
 //! ```
-//! # #[cfg(feature = "ecdh")]
-//! # {
 //! use p256::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
 //! use rand_core::OsRng; // requires 'getrandom' feature
 //!
@@ -36,13 +34,18 @@
 //!
 //! // Both participants arrive on the same shared secret
 //! assert_eq!(alice_shared.as_bytes(), bob_shared.as_bytes());
-//! # }
 //! ```
 
-use crate::NistP256;
+use crate::{AffinePoint, NistP256};
 
 /// NIST P-256 Ephemeral Diffie-Hellman Secret.
 pub type EphemeralSecret = elliptic_curve::ecdh::EphemeralSecret<NistP256>;
 
 /// Shared secret value computed via ECDH key agreement.
 pub type SharedSecret = elliptic_curve::ecdh::SharedSecret<NistP256>;
+
+impl From<&AffinePoint> for SharedSecret {
+    fn from(affine: &AffinePoint) -> SharedSecret {
+        affine.x.to_bytes().into()
+    }
+}

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -55,7 +55,7 @@ use {
 pub type Signature = ecdsa_core::Signature<NistP256>;
 
 /// ECDSA/P-256 signature (ASN.1 DER encoded)
-pub type Asn1Signature = ecdsa_core::asn1::Signature<NistP256>;
+pub type Asn1Signature = ecdsa_core::der::Signature<NistP256>;
 
 /// ECDSA/P-256 signing key
 #[cfg(feature = "ecdsa")]

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -12,9 +12,14 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "secp384r1"]
 
 [dependencies]
-ecdsa = { version = "0.10", optional = true, default-features = false }
-elliptic-curve = { version = "0.8", default-features = false }
+elliptic-curve = { version = "=0.9.0-pre", default-features = false }
 sha2 = { version = "0.9", optional = true, default-features = false }
+
+[dependencies.ecdsa]
+version = "=0.11.0-pre"
+optional = true
+default-features = false
+features = ["der"]
 
 [features]
 default = ["pkcs8", "std"]

--- a/p384/src/ecdsa.rs
+++ b/p384/src/ecdsa.rs
@@ -6,7 +6,7 @@ pub use crate::NistP384;
 pub type Signature = ecdsa::Signature<NistP384>;
 
 /// ECDSA/P-384 signature (ASN.1 DER encoded)
-pub type Asn1Signature = ecdsa::asn1::Signature<NistP384>;
+pub type Asn1Signature = ecdsa::der::Signature<NistP384>;
 
 impl ecdsa::CheckSignatureBytes for NistP384 {}
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,3 +4,8 @@ members = [
     "p256_no_std",
     "p384_no_std",
 ]
+
+[patch.crates-io]
+der = { git = "https://github.com/RustCrypto/utils.git" }
+ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
+elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }


### PR DESCRIPTION
...as sourced via git from the RustCrypto/traits repo.

Also bumps `ecdsa` to v0.11.0-pre (via git from RustCrypto/signatures)