### PR TITLE
Cargo.toml: bump dependencies to flattened `elliptic-curve` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "bit-vec"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -86,9 +86,9 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "cast"
@@ -125,13 +125,13 @@ dependencies = [
 [[package]]
 name = "const-oid"
 version = "0.4.1"
-source = "git+https://github.com/RustCrypto/utils.git#5c174b500f50dac9cf2376dac2bbf6ac05560b6f"
+source = "git+https://github.com/RustCrypto/utils.git#b2b5fb554fad25071f4268bc6e8fb3d6def4bc7e"
 
 [[package]]
 name = "const_fn"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "cpuid-bool"
@@ -256,7 +256,7 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.2.0-pre"
-source = "git+https://github.com/RustCrypto/utils.git#5c174b500f50dac9cf2376dac2bbf6ac05560b6f"
+source = "git+https://github.com/RustCrypto/utils.git#b2b5fb554fad25071f4268bc6e8fb3d6def4bc7e"
 dependencies = [
  "const-oid",
  "typenum",
@@ -274,7 +274,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#41a3646229cc4cbf4af3082e4f8f77e5c19d340c"
+source = "git+https://github.com/RustCrypto/signatures.git#410c6762e1cdfb1d69b726dc68b635e47d4a71c4"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -291,9 +291,8 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.9.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#cd0a0aef3d480458ae21901316e4acbff77f574a"
+source = "git+https://github.com/RustCrypto/traits.git#79281260b3dd05b59ded7452a4788be5ab160e46"
 dependencies = [
- "bitvec",
  "digest",
  "ff",
  "generic-array",
@@ -323,9 +322,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "funty"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "generic-array"
@@ -339,20 +338,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -372,15 +371,15 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
+checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -412,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
@@ -456,15 +455,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
 ]
@@ -607,8 +606,8 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "quick-error",
- "rand",
- "rand_chacha",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -623,9 +622,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
@@ -642,11 +641,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -660,12 +671,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -674,7 +695,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
- "getrandom 0.2.1",
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -684,6 +705,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -722,15 +752,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "regex-syntax",
 ]
@@ -746,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "remove_dir_all"
@@ -818,9 +851,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "166b2349061381baf54a58e4b13c89369feb0ef2eaa57198899e2312aac30aab"
 
 [[package]]
 name = "serde_cbor"
@@ -834,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "0ca2a8cb5805ce9e3b95435e3765b7b553cecc762d938d409434338386cb5775"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -845,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -906,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.53"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8833e20724c24de12bbaba5ad230ea61c3eafb05b881c7c9d3cfe8638b187e68"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -923,13 +956,13 @@ checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand",
+ "rand 0.8.2",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -946,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "tinytemplate"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
+checksum = "a2ada8616fad06a2d0c455adc530de4ef57605a8120cc65da9653e0e9623ca74"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,6 +1146,6 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "=0.9.0-pre", default-features = false }
+elliptic-curve = { version = "=0.9.0-pre", default-features = false, features = ["hazmat"] }
 hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 sha3 = { version = "0.9", optional = true, default-features = false }

--- a/k256/README.md
+++ b/k256/README.md
@@ -48,7 +48,7 @@ USE AT YOUR OWN RISK!
 
 [secp256k1] is a Koblitz curve commonly used in cryptocurrency applications.
 The "K-256" name follows NIST notation where P = prime fields,
-B = binary fields, and K = Koblitz curves (defined over F₂).
+B = binary fields, and K = Koblitz curves.
 
 The curve is specified as `secp256k1` by Certicom's SECG in
 "SEC 2: Recommended Elliptic Curve Domain Parameters":

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -9,10 +9,10 @@ use core::{
 use elliptic_curve::{
     ff::Field,
     group::{Curve, Group},
-    point::ProjectiveArithmetic,
     rand_core::RngCore,
     sec1::FromEncodedPoint,
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq},
+    ProjectiveArithmetic,
 };
 
 #[rustfmt::skip]

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -35,10 +35,10 @@ use elliptic_curve::zeroize::Zeroize;
 use num_bigint::{BigUint, ToBigUint};
 
 /// Non-zero scalar value.
-pub type NonZeroScalar = elliptic_curve::scalar::NonZeroScalar<Secp256k1>;
+pub type NonZeroScalar = elliptic_curve::NonZeroScalar<Secp256k1>;
 
 /// secp256k1 field element serialized as bits.
-pub type ScalarBits = elliptic_curve::scalar::ScalarBits<Secp256k1>;
+pub type ScalarBits = elliptic_curve::ScalarBits<Secp256k1>;
 
 /// An element in the finite field modulo curve order.
 #[derive(Clone, Copy, Debug, Default)]

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! secp256k1 is a Koblitz curve commonly used in cryptocurrency applications.
 //! The "K-256" name follows NIST notation where P = prime fields,
-//! B = binary fields, and K = Koblitz curves (defined over F₂).
+//! B = binary fields, and K = Koblitz curves.
 //!
 //! The curve is specified as `secp256k1` by Certicom's SECG in
 //! "SEC 2: Recommended Elliptic Curve Domain Parameters":
@@ -136,10 +136,10 @@ pub type SecretKey = elliptic_curve::SecretKey<Secp256k1>;
 /// Bytes containing a secp256k1 secret scalar.
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-pub type SecretBytes = elliptic_curve::secret_key::SecretBytes<Secp256k1>;
+pub type SecretBytes = elliptic_curve::SecretBytes<Secp256k1>;
 
 #[cfg(all(not(feature = "arithmetic"), feature = "zeroize"))]
-impl elliptic_curve::secret_key::SecretValue for Secp256k1 {
+impl elliptic_curve::SecretValue for Secp256k1 {
     type Secret = SecretBytes;
 
     /// Parse the secret value from bytes
@@ -147,3 +147,6 @@ impl elliptic_curve::secret_key::SecretValue for Secp256k1 {
         Some(bytes.clone().into())
     }
 }
+
+#[cfg(all(not(feature = "arithmetic"), feature = "zeroize"))]
+impl elliptic_curve::sec1::ValidatePublicKey for Secp256k1 {}

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
 
 [dependencies]
-elliptic-curve = { version = "=0.9.0-pre", default-features = false }
+elliptic-curve = { version = "=0.9.0-pre", default-features = false, features = ["hazmat"] }
 hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 

--- a/p256/src/arithmetic/projective.rs
+++ b/p256/src/arithmetic/projective.rs
@@ -9,9 +9,9 @@ use core::{
 use elliptic_curve::{
     ff::Field,
     group::{Curve, Group},
-    point::ProjectiveArithmetic,
     rand_core::RngCore,
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq},
+    ProjectiveArithmetic,
 };
 
 impl ProjectiveArithmetic for NistP256 {

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -66,10 +66,10 @@ pub const MU: [u64; 5] = [
 ];
 
 /// Non-zero scalar value.
-pub type NonZeroScalar = elliptic_curve::scalar::NonZeroScalar<NistP256>;
+pub type NonZeroScalar = elliptic_curve::NonZeroScalar<NistP256>;
 
 /// NIST P-256 field element serialized as bits.
-pub type ScalarBits = elliptic_curve::scalar::ScalarBits<NistP256>;
+pub type ScalarBits = elliptic_curve::ScalarBits<NistP256>;
 
 /// An element in the finite field modulo n.
 // The internal representation is as little-endian ordered u64 words.

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -139,10 +139,10 @@ pub type SecretKey = elliptic_curve::SecretKey<NistP256>;
 /// Bytes containing a NIST P-256 secret scalar
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-pub type SecretBytes = elliptic_curve::secret_key::SecretBytes<NistP256>;
+pub type SecretBytes = elliptic_curve::SecretBytes<NistP256>;
 
 #[cfg(all(not(feature = "arithmetic"), feature = "zeroize"))]
-impl elliptic_curve::secret_key::SecretValue for NistP256 {
+impl elliptic_curve::SecretValue for NistP256 {
     type Secret = SecretBytes;
 
     /// Parse the secret value from bytes
@@ -150,3 +150,6 @@ impl elliptic_curve::secret_key::SecretValue for NistP256 {
         Some(bytes.clone().into())
     }
 }
+
+#[cfg(all(not(feature = "arithmetic"), feature = "zeroize"))]
+impl elliptic_curve::sec1::ValidatePublicKey for NistP256 {}

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "secp384r1"]
 
 [dependencies]
-elliptic-curve = { version = "=0.9.0-pre", default-features = false }
+elliptic-curve = { version = "=0.9.0-pre", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [dependencies.ecdsa]

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -83,10 +83,10 @@ pub type SecretKey = elliptic_curve::SecretKey<NistP384>;
 /// Bytes containing a NIST P-384 secret scalar
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-pub type SecretBytes = elliptic_curve::secret_key::SecretBytes<NistP384>;
+pub type SecretBytes = elliptic_curve::SecretBytes<NistP384>;
 
 #[cfg(feature = "zeroize")]
-impl elliptic_curve::secret_key::SecretValue for NistP384 {
+impl elliptic_curve::SecretValue for NistP384 {
     type Secret = SecretBytes;
 
     /// Parse the secret value from bytes
@@ -94,3 +94,6 @@ impl elliptic_curve::secret_key::SecretValue for NistP384 {
         Some(bytes.clone().into())
     }
 }
+
+#[cfg(feature = "zeroize")]
+impl elliptic_curve::sec1::ValidatePublicKey for NistP384 {}


### PR DESCRIPTION
See: https://github.com/RustCrypto/traits/pull/487