### PR TITLE
Bump `elliptic-curve` dependency to v0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#19558849ad46bd054f2f68faa55f5c28f262f9ff"
+source = "git+https://github.com/RustCrypto/signatures.git#eaaf5b8699720d9cdc7c5733f35842f8245f11bf"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -310,8 +310,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.9.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#c577e14f887a0f984c6f403617aa02e893536704"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c237c70e5a4013efd3e8f1e49e79b58d0bfd601c6783d82fb819d04a29b85297"
 dependencies = [
  "base64ct",
  "ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,3 @@ members = [
 
 [patch.crates-io]
 ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
-elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -12,14 +12,9 @@ categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
 
 [dependencies]
-elliptic-curve = { version = "=0.9.0-pre", default-features = false, features = ["hazmat"] }
+ecdsa = { version = "=0.11.0-pre", optional = true, default-features = false, features = ["der"] }
+elliptic-curve = { version = "0.9", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
-
-[dependencies.ecdsa]
-version = "=0.11.0-pre"
-optional = true
-default-features = false
-features = ["der"]
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -12,14 +12,9 @@ categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
 
 [dependencies]
-elliptic-curve = { version = "=0.9.0-pre", default-features = false, features = ["hazmat"] }
+ecdsa = { version = "=0.11.0-pre", optional = true, default-features = false, features = ["der"] }
+elliptic-curve = { version = "0.9", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
-
-[dependencies.ecdsa]
-version = "=0.11.0-pre"
-optional = true
-default-features = false
-features = ["der"]
 
 [features]
 default = ["pkcs8", "std"]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "=0.9.0-pre", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "0.9", default-features = false, features = ["hazmat"] }
 hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 sha3 = { version = "0.9", optional = true, default-features = false }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
 
 [dependencies]
-elliptic-curve = { version = "=0.9.0-pre", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "0.9", default-features = false, features = ["hazmat"] }
 hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -12,14 +12,9 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "secp384r1"]
 
 [dependencies]
-elliptic-curve = { version = "=0.9.0-pre", default-features = false, features = ["hazmat"] }
+ecdsa = { version = "=0.11.0-pre", optional = true, default-features = false, features = ["der"] }
+elliptic-curve = { version = "0.9", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
-
-[dependencies.ecdsa]
-version = "=0.11.0-pre"
-optional = true
-default-features = false
-features = ["der"]
 
 [features]
 default = ["pkcs8", "std"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,5 +9,3 @@ members = [
 
 [patch.crates-io]
 ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
-elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
-pkcs8 = { git = "https://github.com/RustCrypto/utils.git" }


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/traits/pull/535