### PR TITLE
Bump `ecdsa` dependency to v0.11.0-pre.1

### DIFF
--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -103,32 +103,31 @@ jobs:
       - run: cargo test --release --target ${{ matrix.target }} --features field-montgomery
       - run: cargo test --release --target ${{ matrix.target }} --all-features
 
-# TODO(tarcieri): re-enable when `[patch.crates-io]` directives removed from workspace Cargo.toml
-#  cross:
-#    strategy:
-#      matrix:
-#        include:
-#          # ARM64
-#          - target: aarch64-unknown-linux-gnu
-#            rust: 1.46.0 # MSRV
-#          - target: aarch64-unknown-linux-gnu
-#            rust: stable
-#
-#          # PPC32
-#          - target: aarch64-unknown-linux-gnu
-#            rust: 1.46.0 # MSRV
-#          - target: powerpc-unknown-linux-gnu
-#            rust: stable
-#
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v1
-#      - run: ${{ matrix.deps }}
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: ${{ matrix.rust }}
-#          target: ${{ matrix.target }}
-#          override: true
-#      - run: cargo install cross
-#      - run: cross test --release --target ${{ matrix.target }} --all-features
+  cross:
+    strategy:
+      matrix:
+        include:
+          # ARM64
+          - target: aarch64-unknown-linux-gnu
+            rust: 1.46.0 # MSRV
+          - target: aarch64-unknown-linux-gnu
+            rust: stable
+
+          # PPC32
+          - target: aarch64-unknown-linux-gnu
+            rust: 1.46.0 # MSRV
+          - target: powerpc-unknown-linux-gnu
+            rust: stable
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: ${{ matrix.deps }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - run: cargo install cross
+      - run: cross test --release --target ${{ matrix.target }} --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,8 +293,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#3f118b57d0347e7b804fa083e145f015097e5615"
+version = "0.11.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a913d3bb160fe818844197fb49d73f4160df10a99aca3ffaab9a0dc9064958"
 dependencies = [
  "der",
  "elliptic-curve",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ members = [
     "p256",
     "p384",
 ]
-
-[patch.crates-io]
-ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
 
 [dependencies]
-ecdsa = { version = "=0.11.0-pre", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.11.0-pre.1", optional = true, default-features = false, features = ["der"] }
 elliptic-curve = { version = "0.9", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
 
 [dependencies]
-ecdsa = { version = "=0.11.0-pre", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.11.0-pre.1", optional = true, default-features = false, features = ["der"] }
 elliptic-curve = { version = "0.9", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -24,7 +24,7 @@ sha2 = { version = "0.9", optional = true, default-features = false }
 sha3 = { version = "0.9", optional = true, default-features = false }
 
 [dependencies.ecdsa-core]
-version = "=0.11.0-pre"
+version = "=0.11.0-pre.1"
 package = "ecdsa"
 optional = true
 default-features = false
@@ -32,7 +32,7 @@ features = ["der"]
 
 [dev-dependencies]
 criterion = "0.3"
-ecdsa-core = { version = "0.11.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.11.0-pre.1", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 num-bigint = "0.3"
 num-traits = "0.2"

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -21,14 +21,14 @@ hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [dependencies.ecdsa-core]
-version = "=0.11.0-pre"
+version = "=0.11.0-pre.1"
 package = "ecdsa"
 optional = true
 default-features = false
 features = ["der"]
 
 [dev-dependencies]
-ecdsa-core = { version = "=0.11.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.11.0-pre.1", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "0.10"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "secp384r1"]
 
 [dependencies]
-ecdsa = { version = "=0.11.0-pre", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.11.0-pre.1", optional = true, default-features = false, features = ["der"] }
 elliptic-curve = { version = "0.9", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 


### PR DESCRIPTION
Uses a prerelease on crates.io rather than sourcing the dependency from `git`, which will allow us to publish prereleases of the crates in this repo for users eager to update to `rand_core` v0.6.