### PR TITLE
bp384: fix Cargo.toml description

### DIFF
--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp384"
-description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP256t1) elliptic curves"
+description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
 version = "0.0.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
Typo/copypasta: `brainpoolP256t1` => `brainpoolP384t1`