### PR TITLE
Use string-based OID constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e8dd5eab3bedc0f623f388e724eee9a880b3d297430e8685672e338f449a27"
+checksum = "fb27bc55bac783b7cfd5eafba8a3e94ff6d420fc4e04970a207980683145af83"
 
 [[package]]
 name = "cpuid-bool"

--- a/bp256/src/r1.rs
+++ b/bp256/src/r1.rs
@@ -26,8 +26,7 @@ impl elliptic_curve::weierstrass::PointCompression for BrainpoolP256r1 {
 
 #[cfg(feature = "pkcs8")]
 impl elliptic_curve::AlgorithmParameters for BrainpoolP256r1 {
-    const OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new(&[1, 3, 36, 3, 3, 2, 8, 1, 1, 7]);
+    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::parse("1.3.36.3.3.2.8.1.1.7");
 }
 
 /// brainpoolP256r1 field element serialized as bytes.

--- a/bp256/src/t1.rs
+++ b/bp256/src/t1.rs
@@ -26,8 +26,7 @@ impl elliptic_curve::weierstrass::PointCompression for BrainpoolP256t1 {
 
 #[cfg(feature = "pkcs8")]
 impl elliptic_curve::AlgorithmParameters for BrainpoolP256t1 {
-    const OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new(&[1, 3, 36, 3, 3, 2, 8, 1, 1, 8]);
+    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::parse("1.3.36.3.3.2.8.1.1.8");
 }
 
 /// brainpoolP256t1 field element serialized as bytes.

--- a/bp384/src/r1.rs
+++ b/bp384/src/r1.rs
@@ -26,8 +26,7 @@ impl elliptic_curve::weierstrass::PointCompression for BrainpoolP384r1 {
 
 #[cfg(feature = "pkcs8")]
 impl elliptic_curve::AlgorithmParameters for BrainpoolP384r1 {
-    const OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new(&[1, 3, 36, 3, 3, 2, 8, 1, 1, 11]);
+    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::parse("1.3.36.3.3.2.8.1.1.11");
 }
 
 /// brainpoolP384r1 field element serialized as bytes.

--- a/bp384/src/t1.rs
+++ b/bp384/src/t1.rs
@@ -26,8 +26,7 @@ impl elliptic_curve::weierstrass::PointCompression for BrainpoolP384t1 {
 
 #[cfg(feature = "pkcs8")]
 impl elliptic_curve::AlgorithmParameters for BrainpoolP384t1 {
-    const OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new(&[1, 3, 36, 3, 3, 2, 8, 1, 1, 12]);
+    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::parse("1.3.36.3.3.2.8.1.1.12");
 }
 
 /// brainpoolP384t1 field element serialized as bytes.

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -116,7 +116,7 @@ impl elliptic_curve::JwkParameters for Secp256k1 {
 
 #[cfg(feature = "pkcs8")]
 impl elliptic_curve::AlgorithmParameters for Secp256k1 {
-    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::new(&[1, 3, 132, 0, 10]);
+    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::parse("1.3.132.0.10");
 }
 
 /// Compressed SEC1-encoded secp256k1 (K-256) point.

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -122,7 +122,7 @@ impl elliptic_curve::JwkParameters for NistP256 {
 
 #[cfg(feature = "pkcs8")]
 impl elliptic_curve::AlgorithmParameters for NistP256 {
-    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::new(&[1, 2, 840, 10045, 3, 1, 7]);
+    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::parse("1.2.840.10045.3.1.7");
 }
 
 /// NIST P-256 field element serialized as bytes.

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -70,7 +70,7 @@ impl elliptic_curve::JwkParameters for NistP384 {
 
 #[cfg(feature = "pkcs8")]
 impl elliptic_curve::AlgorithmParameters for NistP384 {
-    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::new(&[1, 3, 132, 0, 34]);
+    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::parse("1.3.132.0.34");
 }
 
 /// NIST P-384 field element serialized as bytes.


### PR DESCRIPTION
Uses the new const-friendly OID string parser added in:

https://github.com/RustCrypto/utils/pull/312