### PR TITLE
Bump base64ct, ecdsa, elliptic-curve, and pkcs8; MSRV 1.47+

### DIFF
--- a/.github/workflows/bp256.yml
+++ b/.github/workflows/bp256.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/bp384.yml
+++ b/.github/workflows/bp384.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -76,7 +76,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.46.0 # MSRV
+            rust: 1.47.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -84,7 +84,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.46.0 # MSRV
+            rust: 1.47.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 
@@ -109,19 +109,19 @@ jobs:
         include:
           # ARM32
           - target: armv7-unknown-linux-gnueabihf
-            rust: 1.46.0 # MSRV
+            rust: 1.47.0 # MSRV
           - target: armv7-unknown-linux-gnueabihf
             rust: stable
 
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.46.0 # MSRV
+            rust: 1.47.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.46.0 # MSRV
+            rust: 1.47.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
 

--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -58,7 +58,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.46.0 # MSRV
+            rust: 1.47.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -66,7 +66,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.46.0 # MSRV
+            rust: 1.47.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 
@@ -90,19 +90,19 @@ jobs:
         include:
           # ARM32
           - target: armv7-unknown-linux-gnueabihf
-            rust: 1.46.0 # MSRV
+            rust: 1.47.0 # MSRV
           - target: armv7-unknown-linux-gnueabihf
             rust: stable
 
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.46.0 # MSRV
+            rust: 1.47.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.46.0 # MSRV
+            rust: 1.47.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
 

--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.46.0 # MSRV
+        toolchain: 1.47.0 # MSRV
         components: clippy
         override: true
         profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64ct"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fb38fd6e62e4ceec8543db40ceb714454ff173451a0f2a6c8952fdf39a2d6c"
+checksum = "d0d27fb6b6f1e43147af148af49d49329413ba781aa0d5e10979831c210173b5"
 
 [[package]]
 name = "bit-set"
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a913d3bb160fe818844197fb49d73f4160df10a99aca3ffaab9a0dc9064958"
+checksum = "9892ebdbc4623a0ccdc7b2264af26fad5281163da5cfaf7dd8428ea6b5ce60ab"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -304,9 +304,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203d2ca86d44931f12e9104dcf8f4735a632eb4dd8d8dfe583c87fe41bb8a862"
+checksum = "e96675863dd09400876af3f9348ecfa1090ee8c2f0b1febf369fef01fe271658"
 dependencies = [
  "base64ct",
  "ff",
@@ -575,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecfab38c6d0f60db6a80b1ee75f1fc980193f9963c43ee2d6f0ac6698e71d96"
+checksum = "a9c455331e3393451bdf8d49f022442a6f45870b0442820548e921de155e18a7"
 dependencies = [
  "base64ct",
  "der",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ if you are interested in curves beyond the ones listed here.
 
 ## Minimum Supported Rust Version
 
-All crates in this repository support Rust **1.46** or higher.
+All crates in this repository support Rust **1.47** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -50,7 +50,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [deps-image]: https://deps.rs/repo/github/RustCrypto/elliptic-curves/status.svg

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
 
 [dependencies]
-ecdsa = { version = "=0.11.0-pre.1", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.11.0-pre.2", optional = true, default-features = false, features = ["der"] }
 elliptic-curve = { version = "0.9", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 

--- a/bp256/README.md
+++ b/bp256/README.md
@@ -14,7 +14,7 @@ implemented in terms of traits from the [`elliptic-curve`] crate.
 
 ## Minimum Supported Rust Version
 
-Rust **1.46** or higher.
+Rust **1.47** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -46,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/bp256/badge.svg
 [docs-link]: https://docs.rs/bp256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/bp256/badge.svg?branch=master&event=push

--- a/bp256/src/lib.rs
+++ b/bp256/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.46** or higher.
+//! Rust **1.47** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
 
 [dependencies]
-ecdsa = { version = "=0.11.0-pre.1", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.11.0-pre.2", optional = true, default-features = false, features = ["der"] }
 elliptic-curve = { version = "0.9", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 

--- a/bp384/README.md
+++ b/bp384/README.md
@@ -14,7 +14,7 @@ implemented in terms of traits from the [`elliptic-curve`] crate.
 
 ## Minimum Supported Rust Version
 
-Rust **1.46** or higher.
+Rust **1.47** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -46,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/bp384/badge.svg
 [docs-link]: https://docs.rs/bp384/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/bp384/badge.svg?branch=master&event=push

--- a/bp384/src/lib.rs
+++ b/bp384/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.46** or higher.
+//! Rust **1.47** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -24,7 +24,7 @@ sha2 = { version = "0.9", optional = true, default-features = false }
 sha3 = { version = "0.9", optional = true, default-features = false }
 
 [dependencies.ecdsa-core]
-version = "=0.11.0-pre.1"
+version = "=0.11.0-pre.2"
 package = "ecdsa"
 optional = true
 default-features = false
@@ -32,7 +32,7 @@ features = ["der"]
 
 [dev-dependencies]
 criterion = "0.3"
-ecdsa-core = { version = "=0.11.0-pre.1", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.11.0-pre.2", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/k256/README.md
+++ b/k256/README.md
@@ -63,7 +63,7 @@ most popular and commonly used elliptic curves.
 
 ## Minimum Supported Rust Version
 
-Rust **1.46** or higher.
+Rust **1.47** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -95,7 +95,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/k256/badge.svg
 [docs-link]: https://docs.rs/k256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/k256/badge.svg?branch=master&event=push

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.46** or higher.
+//! Rust **1.47** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -21,14 +21,14 @@ hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [dependencies.ecdsa-core]
-version = "=0.11.0-pre.1"
+version = "=0.11.0-pre.2"
 package = "ecdsa"
 optional = true
 default-features = false
 features = ["der"]
 
 [dev-dependencies]
-ecdsa-core = { version = "=0.11.0-pre.1", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.11.0-pre.2", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p256/README.md
+++ b/p256/README.md
@@ -47,7 +47,7 @@ like TLS and the associated X.509 PKI.
 
 ## Minimum Supported Rust Version
 
-Rust **1.46** or higher.
+Rust **1.47** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -79,7 +79,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/p256/badge.svg
 [docs-link]: https://docs.rs/p256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/p256/badge.svg?branch=master&event=push

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.46** or higher.
+//! Rust **1.47** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "secp384r1"]
 
 [dependencies]
-ecdsa = { version = "=0.11.0-pre.1", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.11.0-pre.2", optional = true, default-features = false, features = ["der"] }
 elliptic-curve = { version = "0.9", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 

--- a/p384/README.md
+++ b/p384/README.md
@@ -25,7 +25,7 @@ X.509 PKI.
 
 ## Minimum Supported Rust Version
 
-Rust **1.46** or higher.
+Rust **1.47** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -57,7 +57,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/p384/badge.svg
 [docs-link]: https://docs.rs/p384/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/p384/badge.svg?branch=master&event=push

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.46** or higher.
+//! Rust **1.47** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.


### PR DESCRIPTION
This commit upgrades the following dependencies:

- `base64` v1.0
- `ecdsa` v0.11.0-pre.2
- `elliptic-curve` v0.9.5
- `pkcs8` v0.5.5