### PR TITLE
New pre-releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bp256"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "bp384"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.8.0-pre"
+version = "0.8.0-pre.1"
 dependencies = [
  "cfg-if",
  "criterion",
@@ -570,7 +570,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.8.0-pre"
+version = "0.8.0-pre.1"
 dependencies = [
  "blobby",
  "ecdsa",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.7.0-pre"
+version = "0.7.0-pre.1"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/bp256/CHANGELOG.md
+++ b/bp256/CHANGELOG.md
@@ -4,5 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.0.1 (2021-02-11)
+## 0.0.2 (2021-03-22)
+### Changed
+- Bump `base64ct`, `ecdsa`, `elliptic-curve`, and `pkcs8`; MSRV 1.47+ ([#318])
+
+[#318]: https://github.com/RustCrypto/elliptic-curves/pull/318
+
+## 0.0.1 (2021-02-11) [YANKED]
 - Initial release

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bp256"
 description = "Brainpool P-256 (brainpoolP256r1 and brainpoolP256t1) elliptic curves"
-version = "0.0.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.0.2" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/bp384/CHANGELOG.md
+++ b/bp384/CHANGELOG.md
@@ -4,5 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.0.1 (2021-02-11)
+## 0.0.2 (2021-03-22)
+### Changed
+- Bump `base64ct`, `ecdsa`, `elliptic-curve`, and `pkcs8`; MSRV 1.47+ ([#318])
+
+[#318]: https://github.com/RustCrypto/elliptic-curves/pull/318
+
+## 0.0.1 (2021-02-11) [YANKED]
 - Initial release

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bp384"
 description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
-version = "0.0.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.0.2" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -6,7 +6,7 @@ signing/verification (including Ethereum-style signatures with public-key
 recovery), Elliptic Curve Diffie-Hellman (ECDH), and general purpose secp256k1
 curve arithmetic useful for implementing arbitrary group-based protocols.
 """
-version = "0.8.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.8.0-pre.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -5,7 +5,7 @@ Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve with support for ECDH, ECDSA signing/verification, and general
 purpose curve arithmetic
 """
-version = "0.8.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.8.0-pre.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p384"
 description = "NIST P-384 (secp384r1) elliptic curve"
-version = "0.7.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.7.0-pre.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"


### PR DESCRIPTION
Cuts the following new pre-release versions

- `bp256` v0.0.2
- `bp384` v0.0.2
- `k256` v0.8.0-pre.1
- `p256` v0.8.0-pre.1
- `p384` v0.7.0-pre.1