### PR TITLE
k256+p256: make `ecdsa` a default feature

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -40,7 +40,7 @@ proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
-default = ["arithmetic", "pkcs8", "std"]
+default = ["arithmetic", "ecdsa", "pkcs8", "sha256", "std"]
 arithmetic = ["elliptic-curve/arithmetic"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh", "zeroize"]

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -39,7 +39,7 @@
 //! This example requires the `ecdsa` and `sha256` Cargo features are enabled:
 //!
 //! ```
-//! # #[cfg(feature = "ecdsa")]
+//! # #[cfg(all(feature = "ecdsa", feature = "sha256"))]
 //! # {
 //! use k256::{
 //!     ecdsa::{SigningKey, Signature, signature::Signer},

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -35,7 +35,7 @@ proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
-default = ["arithmetic", "pkcs8", "std"]
+default = ["arithmetic", "ecdsa", "pkcs8", "std"]
 arithmetic = ["elliptic-curve/arithmetic"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh", "zeroize"]


### PR DESCRIPTION
We've gotten enough questions/complaints from people who had trouble figuring out feature activations for `ecdsa` it's probably easier to just turn it on by default and let people who don't want it figure out how to shut it off if they so desire.