### PR TITLE
k256+p256: add CHANGELOG.md entries for v0.7.3 release

### DIFF
--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.3 (2021-04-16)
+### Changed
+- Make `ecdsa` a default feature ([#325])
+
+[#325]: https://github.com/RustCrypto/elliptic-curves/pull/325
+
 ## 0.7.2 (2021-01-13)
 ### Changed
 - Have `std` feature activate `ecdsa-core/std` ([#273])

--- a/p256/CHANGELOG.md
+++ b/p256/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.3 (2021-04-16)
+### Changed
+- Make `ecdsa` a default feature ([#325])
+
+[#325]: https://github.com/RustCrypto/elliptic-curves/pull/325
+
 ## 0.7.2 (2021-01-13)
 ### Changed
 - Have `std` feature activate `ecdsa-core/std` ([#273])


### PR DESCRIPTION
I backported the changes from #325 to the v0.7.x releases.

This should address #326.