### PR TITLE
Bump `ecdsa` dependency to v0.11.0-pre.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.11.0-pre.4"
+version = "0.11.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cae6ee8d621666ce49476f2611056a95e7ba7f0f37356d5085b3cd2fdbac797"
+checksum = "459366967368f4e945fa494430aa8ea1b9dcd1a4a845edfcdb24d76800814e6c"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -312,9 +312,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.9.7"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fdd441b650cf8d7c1d46836e2bb6df9c1d061faac35bacd02d2d6d7164455e"
+checksum = "ee681bf25de1aad7cd02ccc7525d7b4bfab7be2493dbe3ee18d93f86eb3dcf3e"
 dependencies = [
  "base64ct",
  "bitvec",

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
 
 [dependencies]
-ecdsa = { version = "=0.11.0-pre.4", optional = true, default-features = false, features = ["der"] }
-elliptic-curve = { version = "0.9.7", default-features = false, features = ["hazmat"] }
+ecdsa = { version = "=0.11.0-pre.6", optional = true, default-features = false, features = ["der"] }
+elliptic-curve = { version = "0.9.11", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [features]

--- a/bp256/src/r1/ecdsa.rs
+++ b/bp256/src/r1/ecdsa.rs
@@ -8,8 +8,6 @@ pub type Signature = ecdsa::Signature<BrainpoolP256r1>;
 /// ECDSA/brainpoolP256r1 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa::der::Signature<BrainpoolP256r1>;
 
-impl ecdsa::CheckSignatureBytes for BrainpoolP256r1 {}
-
 #[cfg(feature = "sha256")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sha256")))]
 impl ecdsa::hazmat::DigestPrimitive for BrainpoolP256r1 {

--- a/bp256/src/t1/ecdsa.rs
+++ b/bp256/src/t1/ecdsa.rs
@@ -8,8 +8,6 @@ pub type Signature = ecdsa::Signature<BrainpoolP256t1>;
 /// ECDSA/brainpoolP256t1 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa::der::Signature<BrainpoolP256t1>;
 
-impl ecdsa::CheckSignatureBytes for BrainpoolP256t1 {}
-
 #[cfg(feature = "sha256")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sha256")))]
 impl ecdsa::hazmat::DigestPrimitive for BrainpoolP256t1 {

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
 
 [dependencies]
-ecdsa = { version = "=0.11.0-pre.4", optional = true, default-features = false, features = ["der"] }
-elliptic-curve = { version = "0.9.7", default-features = false, features = ["hazmat"] }
+ecdsa = { version = "=0.11.0-pre.6", optional = true, default-features = false, features = ["der"] }
+elliptic-curve = { version = "0.9.11", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [features]

--- a/bp384/src/r1/ecdsa.rs
+++ b/bp384/src/r1/ecdsa.rs
@@ -8,8 +8,6 @@ pub type Signature = ecdsa::Signature<BrainpoolP384r1>;
 /// ECDSA/brainpoolP384r1 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa::der::Signature<BrainpoolP384r1>;
 
-impl ecdsa::CheckSignatureBytes for BrainpoolP384r1 {}
-
 #[cfg(feature = "sha384")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sha384")))]
 impl ecdsa::hazmat::DigestPrimitive for BrainpoolP384r1 {

--- a/bp384/src/t1/ecdsa.rs
+++ b/bp384/src/t1/ecdsa.rs
@@ -8,8 +8,6 @@ pub type Signature = ecdsa::Signature<BrainpoolP384t1>;
 /// ECDSA/brainpoolP384t1 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa::der::Signature<BrainpoolP384t1>;
 
-impl ecdsa::CheckSignatureBytes for BrainpoolP384t1 {}
-
 #[cfg(feature = "sha384")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sha384")))]
 impl ecdsa::hazmat::DigestPrimitive for BrainpoolP384t1 {

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -18,13 +18,13 @@ keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "0.9.7", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "0.9.11", default-features = false, features = ["hazmat"] }
 hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 sha3 = { version = "0.9", optional = true, default-features = false }
 
 [dependencies.ecdsa-core]
-version = "=0.11.0-pre.4"
+version = "=0.11.0-pre.6"
 package = "ecdsa"
 optional = true
 default-features = false
@@ -32,7 +32,7 @@ features = ["der"]
 
 [dev-dependencies]
 criterion = "0.3"
-ecdsa-core = { version = "=0.11.0-pre.4", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.11.0-pre.6", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -94,9 +94,6 @@ pub type Signature = ecdsa_core::Signature<Secp256k1>;
 /// ECDSA/secp256k1 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa_core::der::Signature<Secp256k1>;
 
-#[cfg(not(feature = "arithmetic"))]
-impl ecdsa_core::CheckSignatureBytes for Secp256k1 {}
-
 #[cfg(feature = "sha256")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sha256")))]
 impl ecdsa_core::hazmat::DigestPrimitive for Secp256k1 {

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -16,12 +16,12 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
 
 [dependencies]
-elliptic-curve = { version = "0.9.7", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "0.9.11", default-features = false, features = ["hazmat"] }
 hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [dependencies.ecdsa-core]
-version = "=0.11.0-pre.4"
+version = "=0.11.0-pre.6"
 package = "ecdsa"
 optional = true
 default-features = false
@@ -29,7 +29,7 @@ features = ["der"]
 
 [dev-dependencies]
 blobby = "0.3"
-ecdsa-core = { version = "=0.11.0-pre.4", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.11.0-pre.6", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -67,9 +67,6 @@ pub type SigningKey = ecdsa_core::SigningKey<NistP256>;
 #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub type VerifyingKey = ecdsa_core::VerifyingKey<NistP256>;
 
-#[cfg(not(feature = "arithmetic"))]
-impl ecdsa_core::CheckSignatureBytes for NistP256 {}
-
 #[cfg(feature = "sha256")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sha256")))]
 impl ecdsa_core::hazmat::DigestPrimitive for NistP256 {

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "secp384r1"]
 
 [dependencies]
-ecdsa = { version = "=0.11.0-pre.4", optional = true, default-features = false, features = ["der"] }
-elliptic-curve = { version = "0.9.7", default-features = false, features = ["hazmat"] }
+ecdsa = { version = "=0.11.0-pre.6", optional = true, default-features = false, features = ["der"] }
+elliptic-curve = { version = "0.9.11", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [features]

--- a/p384/src/ecdsa.rs
+++ b/p384/src/ecdsa.rs
@@ -8,8 +8,6 @@ pub type Signature = ecdsa::Signature<NistP384>;
 /// ECDSA/P-384 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa::der::Signature<NistP384>;
 
-impl ecdsa::CheckSignatureBytes for NistP384 {}
-
 #[cfg(feature = "sha384")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sha384")))]
 impl ecdsa::hazmat::DigestPrimitive for NistP384 {


### PR DESCRIPTION
Eliminates the `CheckSignatureBytes` trait, replacing it with `elliptic_curve::Order`:

https://github.com/RustCrypto/signatures/pull/281