### PR TITLE
Bump `ecdsa` crate dependency to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "generic-array",
  "subtle",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.11.0-pre.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459366967368f4e945fa494430aa8ea1b9dcd1a4a845edfcdb24d76800814e6c"
+checksum = "6b568b5e72165dd8913ac2aad6a60cb9cb297287615544c523c37f9247b58fc8"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -408,9 +408,9 @@ checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest",

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
 
 [dependencies]
-ecdsa = { version = "=0.11.0-pre.6", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.11", optional = true, default-features = false, features = ["der"] }
 elliptic-curve = { version = "0.9.11", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
 
 [dependencies]
-ecdsa = { version = "=0.11.0-pre.6", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.11", optional = true, default-features = false, features = ["der"] }
 elliptic-curve = { version = "0.9.11", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -24,7 +24,7 @@ sha2 = { version = "0.9", optional = true, default-features = false }
 sha3 = { version = "0.9", optional = true, default-features = false }
 
 [dependencies.ecdsa-core]
-version = "=0.11.0-pre.6"
+version = "0.11"
 package = "ecdsa"
 optional = true
 default-features = false
@@ -32,7 +32,7 @@ features = ["der"]
 
 [dev-dependencies]
 criterion = "0.3"
-ecdsa-core = { version = "=0.11.0-pre.6", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.11", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -21,7 +21,7 @@ hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [dependencies.ecdsa-core]
-version = "=0.11.0-pre.6"
+version = "0.11"
 package = "ecdsa"
 optional = true
 default-features = false
@@ -29,7 +29,7 @@ features = ["der"]
 
 [dev-dependencies]
 blobby = "0.3"
-ecdsa-core = { version = "=0.11.0-pre.6", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.11", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "secp384r1"]
 
 [dependencies]
-ecdsa = { version = "=0.11.0-pre.6", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.11", optional = true, default-features = false, features = ["der"] }
 elliptic-curve = { version = "0.9.11", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/signatures/pull/288