### PR TITLE
bp256 + bp384 v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bp256"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "bp384"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/bp256/CHANGELOG.md
+++ b/bp256/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 (2021-04-29)
+### Added
+- `Order` constant ([#328])
+
+### Changed
+- Bump `ecdsa` crate dependency to v0.11 ([#330])
+
+[#328]: https://github.com/RustCrypto/elliptic-curves/pull/328
+[#330]: https://github.com/RustCrypto/elliptic-curves/pull/330
+
 ## 0.0.2 (2021-03-22)
 ### Changed
 - Bump `base64ct`, `ecdsa`, `elliptic-curve`, and `pkcs8`; MSRV 1.47+ ([#318])

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bp256"
 description = "Brainpool P-256 (brainpoolP256r1 and brainpoolP256t1) elliptic curves"
-version = "0.0.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/bp256/src/lib.rs
+++ b/bp256/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/bp256/0.0.1"
+    html_root_url = "https://docs.rs/bp256/0.1.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/bp384/CHANGELOG.md
+++ b/bp384/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 (2021-04-29)
+### Added
+- `Order` constant ([#328])
+
+### Changed
+- Bump `ecdsa` crate dependency to v0.11 ([#330])
+
+[#328]: https://github.com/RustCrypto/elliptic-curves/pull/328
+[#330]: https://github.com/RustCrypto/elliptic-curves/pull/330
+
 ## 0.0.2 (2021-03-22)
 ### Changed
 - Bump `base64ct`, `ecdsa`, `elliptic-curve`, and `pkcs8`; MSRV 1.47+ ([#318])

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bp384"
 description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
-version = "0.0.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/bp384/src/lib.rs
+++ b/bp384/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/bp384/0.0.1"
+    html_root_url = "https://docs.rs/bp384/0.1.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `Order` constant ([#328])

### Changed
- Bump `ecdsa` crate dependency to v0.11 ([#330])

[#328]: https://github.com/RustCrypto/elliptic-curves/pull/328
[#330]: https://github.com/RustCrypto/elliptic-curves/pull/330