### PR TITLE
k256 v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.8.0-pre.1"
+version = "0.8.0"
 dependencies = [
  "cfg-if",
  "criterion",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2021-04-29)
+### Added
+- `jwk` feature ([#295])
+- `Order` constant ([#328])
+
+### Changed
+- Rename `ecdsa::Asn1Signature` to `::DerSignature` ([#288])
+- Migrate to `FromDigest` trait from `ecdsa` crate ([#292])
+- Bump `elliptic-curve` to v0.9.2 ([#296])
+- Bump `pkcs8` to v0.6 ([#319])
+- Bump `ecdsa` crate dependency to v0.11 ([#330])
+
+### Fixed
+- `DigestPrimitive` feature gating ([#324])
+
+[#288]: https://github.com/RustCrypto/elliptic-curves/pull/288
+[#292]: https://github.com/RustCrypto/elliptic-curves/pull/292
+[#295]: https://github.com/RustCrypto/elliptic-curves/pull/295
+[#296]: https://github.com/RustCrypto/elliptic-curves/pull/296
+[#319]: https://github.com/RustCrypto/elliptic-curves/pull/319
+[#324]: https://github.com/RustCrypto/elliptic-curves/pull/324
+[#328]: https://github.com/RustCrypto/elliptic-curves/pull/328
+[#330]: https://github.com/RustCrypto/elliptic-curves/pull/330
+
 ## 0.7.3 (2021-04-16)
 ### Changed
 - Make `ecdsa` a default feature ([#325])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -6,7 +6,7 @@ signing/verification (including Ethereum-style signatures with public-key
 recovery), Elliptic Curve Diffie-Hellman (ECDH), and general purpose secp256k1
 curve arithmetic useful for implementing arbitrary group-based protocols.
 """
-version = "0.8.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.8.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/k256/0.8.0-pre"
+    html_root_url = "https://docs.rs/k256/0.8.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `jwk` feature ([#295])
- `Order` constant ([#328])

### Changed
- Rename `ecdsa::Asn1Signature` to `::DerSignature` ([#288])
- Migrate to `FromDigest` trait from `ecdsa` crate ([#292])
- Bump `elliptic-curve` to v0.9.2 ([#296])
- Bump `pkcs8` to v0.6 ([#319])
- Bump `ecdsa` crate dependency to v0.11 ([#330])

### Fixed
- `DigestPrimitive` feature gating ([#324])

[#288]: https://github.com/RustCrypto/elliptic-curves/pull/288
[#292]: https://github.com/RustCrypto/elliptic-curves/pull/292
[#295]: https://github.com/RustCrypto/elliptic-curves/pull/295
[#296]: https://github.com/RustCrypto/elliptic-curves/pull/296
[#319]: https://github.com/RustCrypto/elliptic-curves/pull/319
[#324]: https://github.com/RustCrypto/elliptic-curves/pull/324
[#328]: https://github.com/RustCrypto/elliptic-curves/pull/328
[#330]: https://github.com/RustCrypto/elliptic-curves/pull/330