### PR TITLE
p256 v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.8.0-pre.1"
+version = "0.8.0"
 dependencies = [
  "blobby",
  "ecdsa",

--- a/p256/CHANGELOG.md
+++ b/p256/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2021-04-29)
+### Added
+- `jwk` feature ([#279])
+- Wycheproof ECDSA P-256 test vectors ([#313])
+- `Order` constant ([#328])
+
+### Changed
+- Rename `ecdsa::Asn1Signature` to `::DerSignature` ([#288])
+- Migrate to `FromDigest` trait from `ecdsa` crate ([#292])
+- Bump `elliptic-curve` to v0.9.2 ([#296])
+- Bump `pkcs8` to v0.6 ([#319])
+- Bump `ecdsa` crate dependency to v0.11 ([#330])
+
+### Fixed
+- `DigestPrimitive` feature gating ([#324])
+
+[#279]: https://github.com/RustCrypto/elliptic-curves/pull/279
+[#288]: https://github.com/RustCrypto/elliptic-curves/pull/288
+[#292]: https://github.com/RustCrypto/elliptic-curves/pull/292
+[#296]: https://github.com/RustCrypto/elliptic-curves/pull/296
+[#313]: https://github.com/RustCrypto/elliptic-curves/pull/313
+[#319]: https://github.com/RustCrypto/elliptic-curves/pull/319
+[#324]: https://github.com/RustCrypto/elliptic-curves/pull/324
+[#328]: https://github.com/RustCrypto/elliptic-curves/pull/328
+[#330]: https://github.com/RustCrypto/elliptic-curves/pull/330
+
 ## 0.7.3 (2021-04-16)
 ### Changed
 - Make `ecdsa` a default feature ([#325])

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -5,7 +5,7 @@ Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve with support for ECDH, ECDSA signing/verification, and general
 purpose curve arithmetic
 """
-version = "0.8.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.8.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/p256/0.8.0-pre"
+    html_root_url = "https://docs.rs/p256/0.8.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `jwk` feature ([#279])
- Wycheproof ECDSA P-256 test vectors ([#313])
- `Order` constant ([#328])

### Changed
- Rename `ecdsa::Asn1Signature` to `::DerSignature` ([#288])
- Migrate to `FromDigest` trait from `ecdsa` crate ([#292])
- Bump `elliptic-curve` to v0.9.2 ([#296])
- Bump `pkcs8` to v0.6 ([#319])
- Bump `ecdsa` crate dependency to v0.11 ([#330])

### Fixed
- `DigestPrimitive` feature gating ([#324])

[#279]: https://github.com/RustCrypto/elliptic-curves/pull/279
[#288]: https://github.com/RustCrypto/elliptic-curves/pull/288
[#292]: https://github.com/RustCrypto/elliptic-curves/pull/292
[#296]: https://github.com/RustCrypto/elliptic-curves/pull/296
[#313]: https://github.com/RustCrypto/elliptic-curves/pull/313
[#319]: https://github.com/RustCrypto/elliptic-curves/pull/319
[#324]: https://github.com/RustCrypto/elliptic-curves/pull/324
[#328]: https://github.com/RustCrypto/elliptic-curves/pull/328
[#330]: https://github.com/RustCrypto/elliptic-curves/pull/330