### PR TITLE
p256/k256: fix mixed coordinate addition with the point at infinity

### DIFF
--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -186,11 +186,13 @@ impl ProjectivePoint {
             .mul_single(CURVE_EQUATION_B_SINGLE)
             .normalize_weak();
 
-        ProjectivePoint {
+        let mut ret = ProjectivePoint {
             x: ((xy_pairs * &yy_m_bzz3) + &(byz3 * &xz_pairs).negate(1)).normalize_weak(),
             y: ((yy_p_bzz3 * &yy_m_bzz3) + &(bxx9 * &xz_pairs)).normalize_weak(),
             z: ((yz_pairs * &yy_p_bzz3) + &(xx3 * &xy_pairs)).normalize_weak(),
-        }
+        };
+        ret.conditional_assign(self, other.is_identity());
+        ret
     }
 
     /// Doubles this point.
@@ -536,6 +538,14 @@ mod tests {
 
             p += &generator;
         }
+    }
+
+    #[test]
+    fn test_vector_add_mixed_identity() {
+        let generator = ProjectivePoint::generator();
+        let p0 = generator + ProjectivePoint::identity();
+        let p1 = generator + AffinePoint::identity();
+        assert_eq!(p0, p1);
     }
 
     #[test]

--- a/p256/src/arithmetic/projective.rs
+++ b/p256/src/arithmetic/projective.rs
@@ -184,11 +184,13 @@ impl ProjectivePoint {
         let bxz3_part = bxz_part.double() + &bxz_part; // 23, 24
         let xx3_m_zz3 = xx.double() + &xx - &z3; // 25, 26, 27
 
-        ProjectivePoint {
+        let mut ret = ProjectivePoint {
             x: (yy_p_bzz3 * &xy_pairs) - &(yz_pairs * &bxz3_part), // 28, 32, 33
             y: (yy_p_bzz3 * &yy_m_bzz3) + &(xx3_m_zz3 * &bxz3_part), // 29, 30, 31
             z: (yy_m_bzz3 * &yz_pairs) + &(xy_pairs * &xx3_m_zz3), // 34, 35, 36
-        }
+        };
+        ret.conditional_assign(self, other.is_identity());
+        ret
     }
 
     /// Doubles this point.
@@ -537,6 +539,14 @@ mod tests {
 
             p += &generator;
         }
+    }
+
+    #[test]
+    fn test_vector_add_mixed_identity() {
+        let generator = ProjectivePoint::generator();
+        let p0 = generator + ProjectivePoint::identity();
+        let p1 = generator + AffinePoint::identity();
+        assert_eq!(p0, p1);
     }
 
     #[test]


### PR DESCRIPTION
The mixed point additions are not complete; they assume that the point in affine coordinates is not the point at infinity.

Handle that case, if only for consistency with non-mixed addition.

Fixes #336