### PR TITLE
k256+p256: implement `AffineArithmetic` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "d0d27fb6b6f1e43147af148af49d49329413ba781aa0d5e10979831c210173b5"
 [[package]]
 name = "base64ct"
 version = "1.0.0"
-source = "git+https://github.com/rustcrypto/utils.git#99ef0f56020ab16bdea2c23a1a5c4b98e8e9b11f"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 
 [[package]]
 name = "bit-set"
@@ -156,7 +156,7 @@ dependencies = [
 [[package]]
 name = "const-oid"
 version = "0.6.0"
-source = "git+https://github.com/rustcrypto/utils.git#99ef0f56020ab16bdea2c23a1a5c4b98e8e9b11f"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 
 [[package]]
 name = "cpufeatures"
@@ -250,7 +250,7 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.1.0"
-source = "git+https://github.com/rustcrypto/utils.git#99ef0f56020ab16bdea2c23a1a5c4b98e8e9b11f"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 dependencies = [
  "generic-array",
  "subtle",
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.4.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#99ef0f56020ab16bdea2c23a1a5c4b98e8e9b11f"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 dependencies = [
  "const-oid",
 ]
@@ -308,7 +308,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.12.0-pre"
-source = "git+https://github.com/rustcrypto/signatures.git#44f49efbbdfa5e709296b9892cf03b73da55a61c"
+source = "git+https://github.com/rustcrypto/signatures.git#66c3fe28c521979a352e6a894c7c4e9b9bcea341"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -325,7 +325,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.10.0-pre"
-source = "git+https://github.com/rustcrypto/traits.git#9c0e0ed2526bcdab8b041acea79410aebdcb4427"
+source = "git+https://github.com/rustcrypto/traits.git#6dced063c1d943e04ee52e5e53bba5e08b83b450"
 dependencies = [
  "base64ct 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-bigint",
@@ -605,7 +605,7 @@ dependencies = [
 [[package]]
 name = "pkcs8"
 version = "0.7.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#99ef0f56020ab16bdea2c23a1a5c4b98e8e9b11f"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 dependencies = [
  "base64ct 1.0.0 (git+https://github.com/rustcrypto/utils.git)",
  "der",
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "spki"
 version = "0.4.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#99ef0f56020ab16bdea2c23a1a5c4b98e8e9b11f"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 dependencies = [
  "der",
 ]

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -8,10 +8,15 @@ use elliptic_curve::{
     sec1::{self, FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     weierstrass::DecompressPoint,
+    AffineArithmetic,
 };
 
 #[cfg(feature = "zeroize")]
 use elliptic_curve::zeroize::Zeroize;
+
+impl AffineArithmetic for Secp256k1 {
+    type AffinePoint = AffinePoint;
+}
 
 /// A point on the secp256k1 curve in affine coordinates.
 #[derive(Clone, Copy, Debug)]

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -46,6 +46,12 @@ impl From<AffinePoint> for ProjectivePoint {
     }
 }
 
+impl From<ProjectivePoint> for AffinePoint {
+    fn from(p: ProjectivePoint) -> AffinePoint {
+        p.to_affine()
+    }
+}
+
 impl FromEncodedPoint<Secp256k1> for ProjectivePoint {
     fn from_encoded_point(p: &EncodedPoint) -> Option<Self> {
         AffinePoint::from_encoded_point(p).map(ProjectivePoint::from)

--- a/p256/src/arithmetic/affine.rs
+++ b/p256/src/arithmetic/affine.rs
@@ -8,10 +8,15 @@ use elliptic_curve::{
     sec1::{self, FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     weierstrass::DecompressPoint,
+    AffineArithmetic,
 };
 
 #[cfg(feature = "zeroize")]
 use elliptic_curve::zeroize::Zeroize;
+
+impl AffineArithmetic for NistP256 {
+    type AffinePoint = AffinePoint;
+}
 
 /// A point on the secp256r1 curve in affine coordinates.
 #[derive(Clone, Copy, Debug)]

--- a/p256/src/arithmetic/projective.rs
+++ b/p256/src/arithmetic/projective.rs
@@ -70,6 +70,12 @@ impl From<AffinePoint> for ProjectivePoint {
     }
 }
 
+impl From<ProjectivePoint> for AffinePoint {
+    fn from(p: ProjectivePoint) -> AffinePoint {
+        p.to_affine()
+    }
+}
+
 impl ConditionallySelectable for ProjectivePoint {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         ProjectivePoint {


### PR DESCRIPTION
Implements a newly added trait in the `elliptic-curve` crate which uses an associated type to encode a baseline set of trait bounds on curve points with affine coordinates:

https://github.com/RustCrypto/traits/pull/658