### PR TITLE
k256+p256: impl PrimeCurve traits

### DIFF
--- a/k256/src/ecdsa/verify.rs
+++ b/k256/src/ecdsa/verify.rs
@@ -42,9 +42,7 @@ impl VerifyingKey {
     /// Serialize this [`VerifyingKey`] as a SEC1-encoded bytestring
     /// (with point compression applied)
     pub fn to_bytes(&self) -> CompressedPoint {
-        let mut result = [0u8; 33];
-        result.copy_from_slice(EncodedPoint::from(self).as_ref());
-        result
+        CompressedPoint::clone_from_slice(EncodedPoint::from(self).as_bytes())
     }
 }
 

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -76,6 +76,8 @@ pub use arithmetic::FieldElement;
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub use elliptic_curve::pkcs8;
 
+use elliptic_curve::{consts::U33, generic_array::GenericArray};
+
 /// K-256 (secp256k1) elliptic curve.
 ///
 /// Specified in Certicom's SECG in "SEC 2: Recommended Elliptic Curve Domain Parameters":
@@ -117,8 +119,8 @@ impl elliptic_curve::AlgorithmParameters for Secp256k1 {
     const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::new("1.3.132.0.10");
 }
 
-/// Compressed SEC1-encoded secp256k1 (K-256) point.
-pub type CompressedPoint = [u8; 33];
+/// Compressed SEC1-encoded secp256k1 (K-256) curve point.
+pub type CompressedPoint = GenericArray<u8, U33>;
 
 /// secp256k1 (K-256) field element serialized as bytes.
 ///

--- a/p256/src/arithmetic/affine.rs
+++ b/p256/src/arithmetic/affine.rs
@@ -1,10 +1,11 @@
 //! Affine points
 
 use super::{FieldElement, ProjectivePoint, CURVE_EQUATION_A, CURVE_EQUATION_B, MODULUS};
-use crate::{EncodedPoint, FieldBytes, NistP256, NonZeroScalar};
+use crate::{CompressedPoint, EncodedPoint, FieldBytes, NistP256, Scalar};
 use core::ops::{Mul, Neg};
 use elliptic_curve::{
     generic_array::arr,
+    group::{prime::PrimeCurveAffine, GroupEncoding},
     sec1::{self, FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     weierstrass::DecompressPoint,
@@ -27,9 +28,21 @@ pub struct AffinePoint {
     pub(super) infinity: Choice,
 }
 
-impl AffinePoint {
+impl PrimeCurveAffine for AffinePoint {
+    type Scalar = Scalar;
+    type Curve = ProjectivePoint;
+
+    /// Returns the identity of the group: the point at infinity.
+    fn identity() -> AffinePoint {
+        Self {
+            x: FieldElement::zero(),
+            y: FieldElement::zero(),
+            infinity: Choice::from(1),
+        }
+    }
+
     /// Returns the base point of P-256.
-    pub fn generator() -> AffinePoint {
+    fn generator() -> AffinePoint {
         // NIST P-256 basepoint in affine coordinates:
         // x = 6b17d1f2 e12c4247 f8bce6e5 63a440f2 77037d81 2deb33a0 f4a13945 d898c296
         // y = 4fe342e2 fe1a7f9b 8ee7eb4a 7c0f9e16 2bce3357 6b315ece cbb64068 37bf51f5
@@ -50,18 +63,14 @@ impl AffinePoint {
         }
     }
 
-    /// Returns the identity of the group: the point at infinity.
-    pub fn identity() -> AffinePoint {
-        Self {
-            x: FieldElement::zero(),
-            y: FieldElement::zero(),
-            infinity: Choice::from(1),
-        }
+    /// Is this point the identity point?
+    fn is_identity(&self) -> Choice {
+        self.infinity
     }
 
-    /// Is this point the identity point?
-    pub fn is_identity(&self) -> Choice {
-        self.infinity
+    /// Convert to curve representation.
+    fn to_curve(&self) -> ProjectivePoint {
+        ProjectivePoint::from(*self)
     }
 }
 
@@ -95,6 +104,39 @@ impl PartialEq for AffinePoint {
 
 impl Eq for AffinePoint {}
 
+impl AffinePoint {
+    fn decode(encoded_point: &EncodedPoint) -> CtOption<Self> {
+        match encoded_point.coordinates() {
+            sec1::Coordinates::Identity => CtOption::new(Self::identity(), 1.into()),
+            sec1::Coordinates::Compact { .. } => {
+                // TODO(tarcieri): add decompaction support
+                CtOption::new(Self::default(), 0.into())
+            }
+            sec1::Coordinates::Compressed { x, y_is_odd } => {
+                AffinePoint::decompress(x, Choice::from(y_is_odd as u8))
+            }
+            sec1::Coordinates::Uncompressed { x, y } => {
+                let x = FieldElement::from_bytes(x);
+                let y = FieldElement::from_bytes(y);
+
+                x.and_then(|x| {
+                    y.and_then(|y| {
+                        // Check that the point is on the curve
+                        let lhs = y * &y;
+                        let rhs = x * &x * &x + &(CURVE_EQUATION_A * &x) + &CURVE_EQUATION_B;
+                        let point = AffinePoint {
+                            x,
+                            y,
+                            infinity: Choice::from(0),
+                        };
+                        CtOption::new(point, lhs.ct_eq(&rhs))
+                    })
+                })
+            }
+        }
+    }
+}
+
 impl DecompressPoint<NistP256> for AffinePoint {
     fn decompress(x_bytes: &FieldBytes, y_is_odd: Choice) -> CtOption<Self> {
         FieldElement::from_bytes(x_bytes).and_then(|x| {
@@ -118,6 +160,27 @@ impl DecompressPoint<NistP256> for AffinePoint {
     }
 }
 
+impl GroupEncoding for AffinePoint {
+    type Repr = CompressedPoint;
+
+    fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
+        let tag = bytes[0];
+        let y_is_odd = tag.ct_eq(&sec1::Tag::CompressedOddY.into());
+        let is_compressed_point = y_is_odd | tag.ct_eq(&sec1::Tag::CompressedEvenY.into());
+        Self::decompress(FieldBytes::from_slice(&bytes[1..]), y_is_odd)
+            .and_then(|point| CtOption::new(point, is_compressed_point))
+    }
+
+    fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
+        // No unchecked conversion possible for compressed points
+        Self::from_bytes(bytes)
+    }
+
+    fn to_bytes(&self) -> Self::Repr {
+        CompressedPoint::clone_from_slice(self.to_encoded_point(true).as_bytes())
+    }
+}
+
 impl FromEncodedPoint<NistP256> for AffinePoint {
     /// Attempts to parse the given [`EncodedPoint`] as an SEC1-encoded [`AffinePoint`].
     ///
@@ -125,32 +188,7 @@ impl FromEncodedPoint<NistP256> for AffinePoint {
     ///
     /// `None` value if `encoded_point` is not on the secp256r1 curve.
     fn from_encoded_point(encoded_point: &EncodedPoint) -> Option<Self> {
-        match encoded_point.coordinates() {
-            sec1::Coordinates::Identity => Some(Self::identity()),
-            sec1::Coordinates::Compact { .. } => None, // TODO(tarcieri): add support
-            sec1::Coordinates::Compressed { x, y_is_odd } => {
-                AffinePoint::decompress(x, Choice::from(y_is_odd as u8)).into()
-            }
-            sec1::Coordinates::Uncompressed { x, y } => {
-                let x = FieldElement::from_bytes(x);
-                let y = FieldElement::from_bytes(y);
-
-                x.and_then(|x| {
-                    y.and_then(|y| {
-                        // Check that the point is on the curve
-                        let lhs = y * &y;
-                        let rhs = x * &x * &x + &(CURVE_EQUATION_A * &x) + &CURVE_EQUATION_B;
-                        let point = AffinePoint {
-                            x,
-                            y,
-                            infinity: Choice::from(0),
-                        };
-                        CtOption::new(point, lhs.ct_eq(&rhs))
-                    })
-                })
-                .into()
-            }
-        }
+        Self::decode(encoded_point).into()
     }
 }
 
@@ -175,11 +213,19 @@ impl From<AffinePoint> for EncodedPoint {
     }
 }
 
-impl Mul<NonZeroScalar> for AffinePoint {
-    type Output = AffinePoint;
+impl Mul<Scalar> for AffinePoint {
+    type Output = ProjectivePoint;
 
-    fn mul(self, scalar: NonZeroScalar) -> Self {
-        (ProjectivePoint::from(self) * scalar.as_ref()).to_affine()
+    fn mul(self, scalar: Scalar) -> ProjectivePoint {
+        ProjectivePoint::from(self) * scalar
+    }
+}
+
+impl Mul<&Scalar> for AffinePoint {
+    type Output = ProjectivePoint;
+
+    fn mul(self, scalar: &Scalar) -> ProjectivePoint {
+        ProjectivePoint::from(self) * scalar
     }
 }
 
@@ -207,7 +253,10 @@ impl Zeroize for AffinePoint {
 mod tests {
     use super::AffinePoint;
     use crate::EncodedPoint;
-    use elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+    use elliptic_curve::{
+        group::prime::PrimeCurveAffine,
+        sec1::{FromEncodedPoint, ToEncodedPoint},
+    };
     use hex_literal::hex;
 
     const UNCOMPRESSED_BASEPOINT: &[u8] = &hex!(

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -77,6 +77,8 @@ pub use arithmetic::{
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub use elliptic_curve::pkcs8;
 
+use elliptic_curve::{consts::U33, generic_array::GenericArray};
+
 /// NIST P-256 elliptic curve.
 ///
 /// This curve is also known as prime256v1 (ANSI X9.62) and secp256r1 (SECG)
@@ -125,6 +127,9 @@ impl elliptic_curve::JwkParameters for NistP256 {
 impl elliptic_curve::AlgorithmParameters for NistP256 {
     const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::new("1.2.840.10045.3.1.7");
 }
+
+/// Compressed SEC1-encoded NIST P-256 curve point.
+pub type CompressedPoint = GenericArray<u8, U33>;
 
 /// NIST P-256 field element serialized as bytes.
 ///


### PR DESCRIPTION
Implements traits from the `group` crate for prime order curves:

- AffinePoint
  - GroupEncoding
  - PrimeCurveAffine
- ProjectivePoint
  - GroupEncoding
  - PrimeGroup
  - PrimeCurve