### PR TITLE
k256 v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "cfg-if",
  "criterion",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2021-06-08)
+### Added
+- Derive `Ord` on `ecdsa::VerifyingKey` ([#343])
+- `AffineArithmetic` trait impl ([#347])
+- `PrimeCurve` trait impls ([#350])
+
+### Changed
+- Bump `elliptic-curve` to v0.10; MSRV 1.51+ ([#349])
+- Bump `ecdsa` to v0.12 ([#349])
+
+[#343]: https://github.com/RustCrypto/elliptic-curves/pull/343
+[#347]: https://github.com/RustCrypto/elliptic-curves/pull/347
+[#349]: https://github.com/RustCrypto/elliptic-curves/pull/349
+[#350]: https://github.com/RustCrypto/elliptic-curves/pull/350
+
 ## 0.8.1 (2021-05-10)
 ### Fixed
 - Mixed coordinate addition with the point at infinity ([#337])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -6,7 +6,7 @@ signing/verification (including Ethereum-style signatures with public-key
 recovery), Elliptic Curve Diffie-Hellman (ECDH), and general purpose secp256k1
 curve arithmetic useful for implementing arbitrary group-based protocols.
 """
-version = "0.9.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/k256/README.md
+++ b/k256/README.md
@@ -63,7 +63,7 @@ most popular and commonly used elliptic curves.
 
 ## Minimum Supported Rust Version
 
-Rust **1.47** or higher.
+Rust **1.51** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -95,7 +95,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/k256/badge.svg
 [docs-link]: https://docs.rs/k256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/k256/badge.svg?branch=master&event=push

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.47** or higher.
+//! Rust **1.51** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/k256/0.8.1"
+    html_root_url = "https://docs.rs/k256/0.9.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- Derive `Ord` on `ecdsa::VerifyingKey` ([#343])
- `AffineArithmetic` trait impl ([#347])
- `PrimeCurve` trait impls ([#350])

### Changed
- Bump `elliptic-curve` to v0.10; MSRV 1.51+ ([#349])
- Bump `ecdsa` to v0.12 ([#349])

[#343]: https://github.com/RustCrypto/elliptic-curves/pull/343
[#347]: https://github.com/RustCrypto/elliptic-curves/pull/347
[#349]: https://github.com/RustCrypto/elliptic-curves/pull/349
[#350]: https://github.com/RustCrypto/elliptic-curves/pull/350