### PR TITLE
implement compact support for p256

### DIFF
--- a/p256/src/arithmetic/affine.rs
+++ b/p256/src/arithmetic/affine.rs
@@ -4,12 +4,14 @@ use super::{FieldElement, ProjectivePoint, CURVE_EQUATION_A, CURVE_EQUATION_B, M
 use crate::{CompressedPoint, EncodedPoint, FieldBytes, NistP256, Scalar};
 use core::ops::{Mul, Neg};
 use elliptic_curve::{
+    bigint::Encoding,
     generic_array::arr,
     group::{prime::PrimeCurveAffine, GroupEncoding},
-    sec1::{self, FromEncodedPoint, ToEncodedPoint},
+    sec1::Tag,
+    sec1::{self, FromEncodedPoint, ToCompactEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
-    weierstrass::DecompressPoint,
-    AffineArithmetic,
+    weierstrass::{DecompactPoint, DecompressPoint},
+    AffineArithmetic, Curve,
 };
 
 #[cfg(feature = "zeroize")]
@@ -108,10 +110,7 @@ impl AffinePoint {
     fn decode(encoded_point: &EncodedPoint) -> CtOption<Self> {
         match encoded_point.coordinates() {
             sec1::Coordinates::Identity => CtOption::new(Self::identity(), 1.into()),
-            sec1::Coordinates::Compact { .. } => {
-                // TODO(tarcieri): add decompaction support
-                CtOption::new(Self::default(), 0.into())
-            }
+            sec1::Coordinates::Compact { x } => AffinePoint::decompact(x),
             sec1::Coordinates::Compressed { x, y_is_odd } => {
                 AffinePoint::decompress(x, Choice::from(y_is_odd as u8))
             }
@@ -181,6 +180,23 @@ impl GroupEncoding for AffinePoint {
     }
 }
 
+impl DecompactPoint<NistP256> for AffinePoint {
+    fn decompact(x_bytes: &FieldBytes) -> CtOption<Self> {
+        FieldElement::from_bytes(x_bytes).and_then(|x| {
+            let y = (x * &x * &x + &(CURVE_EQUATION_A * &x) + &CURVE_EQUATION_B).sqrt();
+            y.map(|y| {
+                let p_y = MODULUS.subtract(&y);
+                let (_, borrow) = p_y.informed_subtract(&y);
+                AffinePoint {
+                    x,
+                    y: if borrow != 0 { y } else { p_y },
+                    infinity: Choice::from(0),
+                }
+            })
+        })
+    }
+}
+
 impl FromEncodedPoint<NistP256> for AffinePoint {
     /// Attempts to parse the given [`EncodedPoint`] as an SEC1-encoded [`AffinePoint`].
     ///
@@ -203,6 +219,23 @@ impl ToEncodedPoint<NistP256> for AffinePoint {
             &EncodedPoint::identity(),
             self.infinity,
         )
+    }
+}
+
+impl ToCompactEncodedPoint<NistP256> for AffinePoint {
+    /// Serialize this value as a  SEC1 compact [`EncodedPoint`]
+    fn to_compact_encoded_point(&self) -> Option<EncodedPoint> {
+        let canonical_y = self.y.as_canonical();
+        let (p_y, borrow) = MODULUS.informed_subtract(&canonical_y);
+        assert_eq!(borrow, 0);
+        let (_, borrow) = p_y.informed_subtract(&canonical_y);
+        if borrow != 0 {
+            return None;
+        }
+        let mut bytes = CompressedPoint::default();
+        bytes[0] = Tag::Compact.into();
+        bytes[1..(<NistP256 as Curve>::UInt::BYTE_SIZE + 1)].copy_from_slice(&self.x.to_bytes());
+        Some(EncodedPoint::from_bytes(bytes).expect("compact key"))
     }
 }
 
@@ -255,7 +288,7 @@ mod tests {
     use crate::EncodedPoint;
     use elliptic_curve::{
         group::prime::PrimeCurveAffine,
-        sec1::{FromEncodedPoint, ToEncodedPoint},
+        sec1::{FromEncodedPoint, ToCompactEncodedPoint, ToEncodedPoint},
     };
     use hex_literal::hex;
 
@@ -266,6 +299,16 @@ mod tests {
 
     const COMPRESSED_BASEPOINT: &[u8] =
         &hex!("036B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296");
+
+    // Tag compact with 05 as the first byte, to trigger tag based compaction
+    const COMPACT_BASEPOINT: &[u8] =
+        &hex!("058e38fc4ffe677662dde8e1a63fbcd45959d2a4c3004d27e98c4fedf2d0c14c01");
+
+    // Tag uncompact basepoint with 04 as the first byte as it is uncompressed
+    const UNCOMPACT_BASEPOINT: &[u8] = &hex!(
+        "048e38fc4ffe677662dde8e1a63fbcd45959d2a4c3004d27e98c4fedf2d0c14c0
+        13ca9d8667de0c07aa71d98b3c8065d2e97ab7bb9cb8776bcc0577a7ac58acd4e"
+    );
 
     #[test]
     fn uncompressed_round_trip() {
@@ -320,5 +363,36 @@ mod tests {
     fn affine_negation() {
         let basepoint = AffinePoint::generator();
         assert_eq!(-(-basepoint), basepoint);
+    }
+
+    #[test]
+    fn compact_round_trip() {
+        let pubkey = EncodedPoint::from_bytes(COMPACT_BASEPOINT).unwrap();
+        assert!(pubkey.is_compact());
+
+        let point = AffinePoint::from_encoded_point(&pubkey).unwrap();
+        let res = point.to_compact_encoded_point().unwrap();
+        assert_eq!(res, pubkey)
+    }
+
+    #[test]
+    fn uncompact_to_compact() {
+        let pubkey = EncodedPoint::from_bytes(UNCOMPACT_BASEPOINT).unwrap();
+        assert_eq!(false, pubkey.is_compact());
+
+        let point = AffinePoint::from_encoded_point(&pubkey).unwrap();
+        let res = point.to_compact_encoded_point().unwrap();
+        assert_eq!(res.as_bytes(), COMPACT_BASEPOINT)
+    }
+
+    #[test]
+    fn compact_to_uncompact() {
+        let pubkey = EncodedPoint::from_bytes(COMPACT_BASEPOINT).unwrap();
+        assert!(pubkey.is_compact());
+
+        let point = AffinePoint::from_encoded_point(&pubkey).unwrap();
+        // Do not do compact encoding as we want to keep uncompressed point
+        let res = point.to_encoded_point(false);
+        assert_eq!(res.as_bytes(), UNCOMPACT_BASEPOINT);
     }
 }

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -135,7 +135,7 @@ impl FieldElement {
         let is_some = (borrow as u8) & 1;
 
         // Convert w to Montgomery form: w * R^2 * R^-1 mod p = wR mod p
-        CtOption::new(FieldElement(w).mul(&R2), Choice::from(is_some))
+        CtOption::new(FieldElement(w).as_montgomery(), Choice::from(is_some))
     }
 
     /// Returns the SEC1 encoding of this field element.
@@ -336,6 +336,10 @@ impl FieldElement {
 
     pub(crate) const fn as_canonical(&self) -> Self {
         FieldElement::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0)
+    }
+
+    pub(crate) const fn as_montgomery(&self) -> Self {
+        self.mul(&R2)
     }
 
     /// Returns self * rhs mod p

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -180,7 +180,7 @@ impl FieldElement {
         let (w3, w4) = adc(self.0[3], rhs.0[3], carry);
 
         // Attempt to subtract the modulus, to ensure the result is in the field.
-        Self::sub_inner(
+        let (result, _) = Self::sub_inner(
             w0,
             w1,
             w2,
@@ -191,7 +191,8 @@ impl FieldElement {
             MODULUS.0[2],
             MODULUS.0[3],
             0,
-        )
+        );
+        result
     }
 
     /// Returns 2*self.
@@ -201,12 +202,20 @@ impl FieldElement {
 
     /// Returns self - rhs mod p
     pub const fn subtract(&self, rhs: &Self) -> Self {
+        let (result, _) = Self::sub_inner(
+            self.0[0], self.0[1], self.0[2], self.0[3], 0, rhs.0[0], rhs.0[1], rhs.0[2], rhs.0[3],
+            0,
+        );
+        result
+    }
+
+    /// Returns self - rhs mod p
+    pub(crate) const fn informed_subtract(&self, rhs: &Self) -> (Self, u64) {
         Self::sub_inner(
             self.0[0], self.0[1], self.0[2], self.0[3], 0, rhs.0[0], rhs.0[1], rhs.0[2], rhs.0[3],
             0,
         )
     }
-
     #[inline]
     #[allow(clippy::too_many_arguments)]
     const fn sub_inner(
@@ -220,7 +229,7 @@ impl FieldElement {
         r2: u64,
         r3: u64,
         r4: u64,
-    ) -> Self {
+    ) -> (Self, u64) {
         let (w0, borrow) = sbb(l0, r0, 0);
         let (w1, borrow) = sbb(l1, r1, borrow);
         let (w2, borrow) = sbb(l2, r2, borrow);
@@ -235,7 +244,7 @@ impl FieldElement {
         let (w2, carry) = adc(w2, MODULUS.0[2] & borrow, carry);
         let (w3, _) = adc(w3, MODULUS.0[3] & borrow, carry);
 
-        FieldElement([w0, w1, w2, w3])
+        (FieldElement([w0, w1, w2, w3]), borrow)
     }
 
     /// Montgomery Reduction
@@ -310,7 +319,7 @@ impl FieldElement {
         let (r7, r8) = adc(r7, carry2, carry);
 
         // Result may be within MODULUS of the correct value
-        Self::sub_inner(
+        let (result, _) = Self::sub_inner(
             r4,
             r5,
             r6,
@@ -321,7 +330,12 @@ impl FieldElement {
             MODULUS.0[2],
             MODULUS.0[3],
             0,
-        )
+        );
+        result
+    }
+
+    pub(crate) const fn as_canonical(&self) -> Self {
+        FieldElement::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0)
     }
 
     /// Returns self * rhs mod p

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -117,6 +117,11 @@ impl elliptic_curve::weierstrass::PointCompression for NistP256 {
     const COMPRESS_POINTS: bool = false;
 }
 
+impl elliptic_curve::weierstrass::PointCompaction for NistP256 {
+    /// NIST P-256 points are typically uncompressed.
+    const COMPACT_POINTS: bool = false;
+}
+
 #[cfg(feature = "jwk")]
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl elliptic_curve::JwkParameters for NistP256 {


### PR DESCRIPTION
This may not quite be what you had in mind, especially with the modifications to field math to expose the borrow, but it was the shortest way to show what we'd done so far using the new elliptic curve traits 