### PR TITLE
k256: impl `Eq`/`PartialEq`/`ConstantTimeEq` for `SigningKey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,9 +323,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b6eb4853ca589eb02b325b0cff21e560180907a3640f8bfc8f5969ddd0c6ee"
+checksum = "59029dd05f60215bbe37eda4b32ba1a142abc8b01a938955b20b92ff0d713e8e"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "0.10", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "0.10.2", default-features = false, features = ["hazmat"] }
 
 # optional dependencies
 hex-literal = { version = "0.3", optional = true }

--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -18,6 +18,7 @@ use elliptic_curve::{
     consts::U32,
     ops::Invert,
     rand_core::{CryptoRng, RngCore},
+    subtle::{Choice, ConstantTimeEq},
 };
 
 #[cfg(any(feature = "keccak256", feature = "sha256"))]
@@ -189,10 +190,24 @@ impl RecoverableSignPrimitive<Secp256k1> for Scalar {
     }
 }
 
+impl ConstantTimeEq for SigningKey {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.inner.ct_eq(&other.inner)
+    }
+}
+
 impl Debug for SigningKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO(tarcieri): use `finish_non_exhaustive` when stable
         f.debug_tuple("SigningKey").field(&"...").finish()
+    }
+}
+
+impl Eq for SigningKey {}
+
+impl PartialEq for SigningKey {
+    fn eq(&self, other: &SigningKey) -> bool {
+        self.ct_eq(other).into()
     }
 }
 


### PR DESCRIPTION
The `Eq`/`PartialEq` impls use `ConstantTimeEq` internally.

This is useful for writing tests that need to compare keys.