### PR TITLE
Fix MSRV documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ if you are interested in curves beyond the ones listed here.
 
 ## Minimum Supported Rust Version
 
-All crates in this repository support Rust **1.47** or higher.
+All crates in this repository support Rust **1.51** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -50,7 +50,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [deps-image]: https://deps.rs/repo/github/RustCrypto/elliptic-curves/status.svg

--- a/p256/README.md
+++ b/p256/README.md
@@ -47,7 +47,7 @@ like TLS and the associated X.509 PKI.
 
 ## Minimum Supported Rust Version
 
-Rust **1.47** or higher.
+Rust **1.51** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -79,7 +79,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/p256/badge.svg
 [docs-link]: https://docs.rs/p256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/p256/badge.svg?branch=master&event=push

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.47** or higher.
+//! Rust **1.51** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.


### PR DESCRIPTION
The MSRV is 1.51+, but bumping it was missed in a few places