### PR TITLE
k256 v0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "cfg-if",
  "criterion",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.2 (2021-06-14)
+## 0.9.3 (2021-06-21)
+### Changed
+- Bump `elliptic-curve` dependency to v0.10.3 ([#371])
+
+[#371]: https://github.com/RustCrypto/elliptic-curves/pull/371
+
+## 0.9.2 (2021-06-14) [YANKED]
 ### Added
 - `Debug` impl for `ecdsa::SigningKey` ([#358])
 - `ConstantTimeEq`/`Eq`/`PartialEq` impls for `ecdsa::SigningKey` ([#359])
@@ -12,13 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#358]: https://github.com/RustCrypto/elliptic-curves/pull/358
 [#359]: https://github.com/RustCrypto/elliptic-curves/pull/359
 
-## 0.9.1 (2021-06-09)
+## 0.9.1 (2021-06-09) [YANKED]
 ### Added
 - `Copy` impl for `ecdsa::VerifyingKey` ([#355])
 
 [#355]: https://github.com/RustCrypto/elliptic-curves/pull/355
 
-## 0.9.0 (2021-06-08)
+## 0.9.0 (2021-06-08) [YANKED]
 ### Added
 - Derive `Ord` on `ecdsa::VerifyingKey` ([#343])
 - `AffineArithmetic` trait impl ([#347])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -6,7 +6,7 @@ signing/verification (including Ethereum-style signatures with public-key
 recovery), Elliptic Curve Diffie-Hellman (ECDH), and general purpose secp256k1
 curve arithmetic useful for implementing arbitrary group-based protocols.
 """
-version = "0.9.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.3" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/k256/0.9.2"
+    html_root_url = "https://docs.rs/k256/0.9.3"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Bump `elliptic-curve` dependency to v0.10.3 ([#371])

[#371]: https://github.com/RustCrypto/elliptic-curves/pull/371