### PR TITLE
k256 v0.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cfg-if",
  "criterion",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.4 (2021-06-23)
+### Added
+- Derive `Clone` for `ecdsa::SigningKey` ([#374])
+
+[#374]: https://github.com/RustCrypto/elliptic-curves/pull/374
+
 ## 0.9.3 (2021-06-21)
 ### Added
 - `ecdsa::SigningKey::verifying_key()` method ([#363])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -6,7 +6,7 @@ signing/verification (including Ethereum-style signatures with public-key
 recovery), Elliptic Curve Diffie-Hellman (ECDH), and general purpose secp256k1
 curve arithmetic useful for implementing arbitrary group-based protocols.
 """
-version = "0.9.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.4" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -31,7 +31,7 @@
 //! g1 = round((2^272)*b2/d)
 //! g2 = round((2^272)*b1/d)
 //!
-//! (Note that 'd' is also equal to the curve order here because [a1,b1] and [a2,b2] are found
+//! (Note that 'd' is also equal to the curve order here because `[a1,b1]` and `[a2,b2]` are found
 //! as outputs of the Extended Euclidean Algorithm on inputs 'order' and 'lambda').
 //!
 //! @fjarri:

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/k256/0.9.3"
+    html_root_url = "https://docs.rs/k256/0.9.4"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
@@ -152,5 +152,7 @@ impl elliptic_curve::sec1::ValidatePublicKey for Secp256k1 {}
 pub type ScalarBits = elliptic_curve::ScalarBits<Secp256k1>;
 
 /// Scalar bytes: wrapper for [`FieldBytes`] which guarantees that the the
-/// inner byte value is within range of the [`Curve::ORDER`].
+/// inner byte value is within range of [`Secp256k1::ORDER`].
+///
+/// [`Secp256k1::ORDER`]: ./struct.Secp256k1.html#associatedconstant.ORDER
 pub type ScalarBytes = elliptic_curve::ScalarBytes<Secp256k1>;


### PR DESCRIPTION
### Added
- Derive `Clone` for `ecdsa::SigningKey` ([#374])

[#374]: https://github.com/RustCrypto/elliptic-curves/pull/374