### PR TITLE
k256: fix edge case in `Scalar::is_high`

### DIFF
--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -607,16 +607,20 @@ mod tests {
         let high: bool = Scalar::zero().is_high().into();
         assert!(!high);
 
-        let m = Scalar::modulus_as_biguint();
-        let m_by_2 = &m >> 1;
+        // 1 is not high
         let one = 1.to_biguint().unwrap();
-
-        // M / 2 - 1 is not high
-        let high: bool = Scalar::from(&m_by_2 - &one).is_high().into();
+        let high: bool = Scalar::from(&one).is_high().into();
         assert!(!high);
 
-        // M / 2 is high
+        let m = Scalar::modulus_as_biguint();
+        let m_by_2 = &m >> 1;
+
+        // M / 2 is not high
         let high: bool = Scalar::from(&m_by_2).is_high().into();
+        assert!(!high);
+
+        // M / 2 + 1 is high
+        let high: bool = Scalar::from(&m_by_2 + &one).is_high().into();
         assert!(high);
 
         // MODULUS - 1 is high

--- a/k256/src/arithmetic/scalar/scalar_4x64.rs
+++ b/k256/src/arithmetic/scalar/scalar_4x64.rs
@@ -240,8 +240,8 @@ impl Scalar4x64 {
 
     /// Is this scalar greater than or equal to n / 2?
     pub fn is_high(&self) -> Choice {
-        let (_, underflow) = sbb_array_with_underflow(&(self.0), &FRAC_MODULUS_2);
-        !underflow
+        let (_, underflow) = sbb_array_with_underflow(&FRAC_MODULUS_2, &self.0);
+        underflow
     }
 
     /// Is this scalar equal to 0?

--- a/k256/src/arithmetic/scalar/scalar_8x32.rs
+++ b/k256/src/arithmetic/scalar/scalar_8x32.rs
@@ -282,8 +282,8 @@ impl Scalar8x32 {
 
     /// Is this scalar greater than or equal to n / 2?
     pub fn is_high(&self) -> Choice {
-        let (_, underflow) = sbb_array_with_underflow(&(self.0), &FRAC_MODULUS_2);
-        !underflow
+        let (_, underflow) = sbb_array_with_underflow(&FRAC_MODULUS_2, &self.0);
+        underflow
     }
 
     /// Is this scalar equal to 0?

--- a/k256/src/ecdsa/normalize.rs
+++ b/k256/src/ecdsa/normalize.rs
@@ -47,8 +47,7 @@ mod tests {
         ]).unwrap();
 
         let mut sig_normalized = sig_hi;
-        sig_normalized.normalize_s().unwrap();
-
+        assert!(sig_normalized.normalize_s().unwrap());
         assert_eq!(sig_lo, sig_normalized);
     }
 
@@ -63,8 +62,7 @@ mod tests {
         ]).unwrap();
 
         let mut sig_normalized = sig;
-        sig_normalized.normalize_s().unwrap();
-
+        assert!(!sig_normalized.normalize_s().unwrap());
         assert_eq!(sig, sig_normalized);
     }
 }

--- a/k256/src/ecdsa/verify.rs
+++ b/k256/src/ecdsa/verify.rs
@@ -180,6 +180,22 @@ impl FromStr for VerifyingKey {
 
 #[cfg(test)]
 mod tests {
+    use super::VerifyingKey;
     use crate::{test_vectors::ecdsa::ECDSA_TEST_VECTORS, Secp256k1};
+    use ecdsa_core::signature::Verifier;
+    use hex_literal::hex;
+
     ecdsa_core::new_verification_test!(Secp256k1, ECDSA_TEST_VECTORS);
+
+    /// Wycheproof tcId: 304
+    #[test]
+    fn malleability_edge_case_valid() {
+        let verifying_key_bytes = hex!("043a3150798c8af69d1e6e981f3a45402ba1d732f4be8330c5164f49e10ec555b4221bd842bc5e4d97eff37165f60e3998a424d72a450cf95ea477c78287d0343a");
+        let verifying_key = VerifyingKey::from_sec1_bytes(&verifying_key_bytes).unwrap();
+
+        let msg = hex!("313233343030");
+        let mut sig = Signature::from_der(&hex!("304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a002207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0")).unwrap();
+        assert!(!sig.normalize_s().unwrap());
+        assert!(verifying_key.verify(&msg, &sig).is_ok());
+    }
 }


### PR DESCRIPTION
Per BIP62, the valid range for "low" scalars is:

https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Low_S_values_in_signatures

> The value S in signatures must be between 0x1 and 0x7FFFFFFF FFFFFFFF
> FFFFFFFF FFFFFFFF 5D576E73 57A4501D DFE92F46 681B20A0 (inclusive).

...where the large hex constant is the scalar modulus / 2.

However, the previous implementation was exclusive. There were tests for this particular case, but the tests confirmed it was exclusive instead of inclusive.

This commit fixes both the tests and the implementation to confirm that the scalar modulus / 2 is *NOT* considered high by `Scalar::is_high`, however scalar modulus / 2 + 1 is high.