### PR TITLE
k256 v0.9.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "blobby",
  "cfg-if",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.6 (2021-07-22)
+### Added
+- Wycheproof test vectors ([#384])
+
+### Fixed
+- Edge case in `Scalar::is_high` ([#385])
+- Bug in overflow check during 32-bit multiplication ([#388])
+
+[#384]: https://github.com/RustCrypto/elliptic-curves/pull/384
+[#385]: https://github.com/RustCrypto/elliptic-curves/pull/385
+[#388]: https://github.com/RustCrypto/elliptic-curves/pull/388
+
 ## 0.9.5 (2021-07-18)
 ### Changed
 - Optimize ECDSA using linear combination of points ([#380])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -6,7 +6,7 @@ signing/verification (including Ethereum-style signatures with public-key
 recovery), Elliptic Curve Diffie-Hellman (ECDH), and general purpose secp256k1
 curve arithmetic useful for implementing arbitrary group-based protocols.
 """
-version = "0.9.5" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.6" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/k256/0.9.5"
+    html_root_url = "https://docs.rs/k256/0.9.6"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- Wycheproof test vectors ([#384])

### Fixed
- Edge case in `Scalar::is_high` ([#385])
- Bug in overflow check during 32-bit multiplication ([#388])

[#384]: https://github.com/RustCrypto/elliptic-curves/pull/384
[#385]: https://github.com/RustCrypto/elliptic-curves/pull/385
[#388]: https://github.com/RustCrypto/elliptic-curves/pull/388