### PR TITLE
k256: use `crypto-bigint` for `scalar::MODULUS`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32a398eb1ccfbe7e4f452bc749c44d38dd732e9a253f19da224c416f00ee7f4"
+checksum = "cc209804a22c34a98fe26a32d997ac64d4284816f65cf1a529c4e31a256218a0"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -325,9 +325,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069397e10739989e400628cbc0556a817a8a64119d7a2315767f4456e1332c23"
+checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "0.10.5", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "0.10.6", default-features = false, features = ["hazmat"] }
 
 # optional dependencies
 hex-literal = { version = "0.3", optional = true }

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -5,18 +5,22 @@ use cfg_if::cfg_if;
 cfg_if! {
     if #[cfg(any(target_pointer_width = "32", feature = "force-32-bit"))] {
         mod scalar_8x32;
-        use scalar_8x32::Scalar8x32 as ScalarImpl;
-        use scalar_8x32::WideScalar16x32 as WideScalarImpl;
+        use scalar_8x32::{
+            Scalar8x32 as ScalarImpl,
+            WideScalar16x32 as WideScalarImpl,
+        };
 
         #[cfg(feature = "bits")]
-        use scalar_8x32::MODULUS;
+        use scalar_8x32::MODULUS as MODULUS_ARR;
     } else if #[cfg(target_pointer_width = "64")] {
         mod scalar_4x64;
-        use scalar_4x64::Scalar4x64 as ScalarImpl;
-        use scalar_4x64::WideScalar8x64 as WideScalarImpl;
+        use scalar_4x64::{
+            Scalar4x64 as ScalarImpl,
+            WideScalar8x64 as WideScalarImpl,
+        };
 
         #[cfg(feature = "bits")]
-        use scalar_4x64::MODULUS;
+        use scalar_4x64::MODULUS as MODULUS_ARR;
     }
 }
 
@@ -172,7 +176,7 @@ impl PrimeFieldBits for Scalar {
     }
 
     fn char_le_bits() -> ScalarBits {
-        MODULUS.into()
+        MODULUS_ARR.into()
     }
 }
 

--- a/k256/src/arithmetic/scalar/scalar_4x64.rs
+++ b/k256/src/arithmetic/scalar/scalar_4x64.rs
@@ -13,23 +13,13 @@ use elliptic_curve::zeroize::Zeroize;
 
 /// Constant representing the modulus
 /// n = FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364141
-pub const MODULUS: [u64; 4] = [
-    0xBFD2_5E8C_D036_4141,
-    0xBAAE_DCE6_AF48_A03B,
-    0xFFFF_FFFF_FFFF_FFFE,
-    0xFFFF_FFFF_FFFF_FFFF,
-];
+pub const MODULUS: [u64; 4] = crate::ORDER.to_uint_array();
 
 /// Limbs of 2^256 minus the secp256k1 order.
 pub const NEG_MODULUS: [u64; 4] = [!MODULUS[0] + 1, !MODULUS[1], !MODULUS[2], !MODULUS[3]];
 
 /// Constant representing the modulus / 2
-const FRAC_MODULUS_2: [u64; 4] = [
-    0xDFE9_2F46_681B_20A0,
-    0x5D57_6E73_57A4_501D,
-    0xFFFF_FFFF_FFFF_FFFF,
-    0x7FFF_FFFF_FFFF_FFFF,
-];
+const FRAC_MODULUS_2: [u64; 4] = crate::ORDER.shr_vartime(1).to_uint_array();
 
 /// Subtracts a (little-endian) multi-limb number from another multi-limb number,
 /// returning the result and the resulting borrow as a sinle-limb value.

--- a/k256/src/arithmetic/scalar/scalar_8x32.rs
+++ b/k256/src/arithmetic/scalar/scalar_8x32.rs
@@ -13,7 +13,7 @@ use elliptic_curve::zeroize::Zeroize;
 
 /// Constant representing the modulus
 /// n = FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364141
-// TODO(tarcieri): use `Secp256k1::ORDER.into_limbs()`
+// TODO(tarcieri): use `Secp256k1::ORDER.to_uint_array()`
 pub const MODULUS: [u32; 8] = [
     0xD036_4141,
     0xBFD2_5E8C,

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -78,7 +78,11 @@ pub use elliptic_curve::pkcs8;
 
 use elliptic_curve::{consts::U33, generic_array::GenericArray};
 
-/// K-256 (secp256k1) elliptic curve.
+/// Order of the secp256k1 elliptic curve
+const ORDER: U256 =
+    U256::from_be_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
+
+/// secp256k1 (K-256) elliptic curve.
 ///
 /// Specified in Certicom's SECG in "SEC 2: Recommended Elliptic Curve Domain Parameters":
 ///
@@ -97,8 +101,7 @@ impl elliptic_curve::Curve for Secp256k1 {
     type UInt = U256;
 
     /// Curve order
-    const ORDER: U256 =
-        U256::from_be_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
+    const ORDER: U256 = ORDER;
 }
 
 impl elliptic_curve::weierstrass::Curve for Secp256k1 {}


### PR DESCRIPTION
This commit begins the process of starting to retrofit representing the scalar modulus as a `crypto_bigint::UInt`.

It isn't a perfect fit in the current form as the `force-32-bit` cargo feature complicates things. It would probably make sense to get rid of it in the next breaking release, especially as it isn't additive. Instead it should be easy to do 32-bit testing with `cross`.

All that said, it's now possible to calculate constants like `FRAC_MODULUS_2` at compile time using `const fn` which is pretty neat.