### PR TITLE
k256: implement `Scalar::sqrt`

### DIFF
--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -113,9 +113,372 @@ impl Field for Scalar {
         Scalar::invert(self)
     }
 
-    // TODO(tarcieri): stub! See: https://github.com/RustCrypto/elliptic-curves/issues/170
+    /// Tonelli-Shank's algorithm for q mod 16 = 1
+    /// https://eprint.iacr.org/2012/685.pdf (page 12, algorithm 5)
+    #[allow(clippy::many_single_char_names)]
     fn sqrt(&self) -> CtOption<Self> {
-        todo!("see RustCrypto/elliptic-curves#170");
+        // TODO(tarcieri): replace with `self.pow((t - 1) >> 1)`
+        let w = {
+            let t0 = self;
+            let t1 = t0.square();
+            let t2 = t1 * t0;
+            let t3 = t1.square();
+            let t4 = t3.square();
+            let t5 = t4 * t2;
+            let t6 = t5 * t3;
+            let t7 = t6.square();
+            let t8 = t7 * t6;
+            let t9 = t8.square();
+            let t10 = t9 * t6;
+            let t11 = t10 * t5;
+            let t12 = t11 * t6;
+            let t13 = t12.square();
+            let t14 = t13 * t11;
+            let t15 = t14.square();
+            let t16 = t15 * t12;
+            let t17 = t16.square();
+            let t18 = t17 * t16;
+            let t19 = t18.square();
+            let t21 = t19.square();
+            let t22 = t21 * t16;
+            let t23 = t22 * t14;
+            let t24 = t23 * t16;
+            let t25 = t24.square();
+            let t26 = t25 * t23;
+            let t27 = t26 * t24;
+            let t28 = t27.square();
+            let t29 = t28 * t27;
+            let t30 = t29.square();
+            let t31 = t30 * t28;
+            let t32 = t31.square();
+            let t33 = t32.square();
+            let t34 = t33 * t29;
+            let t35 = t34 * t26;
+            let t36 = t35 * t27;
+            let t37 = t36.square();
+            let t38 = t37.square();
+            let t39 = t38 * t36;
+            let t40 = t39.square();
+            let t41 = t40.square();
+            let t43 = t41 * t35;
+            let t44 = t43 * t36;
+            let t45 = t44.square();
+            let t46 = t45 * t43;
+            let t47 = t46 * t44;
+            let t48 = t47.square();
+            let t49 = t48 * t46;
+            let t50 = t49.square();
+            let t51 = t50 * t49;
+            let t52 = t51.square();
+            let t53 = t52 * t50;
+            let t54 = t53.square();
+            let t55 = t54.square();
+            let t56 = t55 * t51;
+            let t57 = t56 * t47;
+            let t58 = t57.square();
+            let t59 = t58.square();
+            let t60 = t59 * t57;
+            let t61 = t60 * t49;
+            let t62 = t61.square();
+            let t63 = t62.square();
+            let t64 = t63.square();
+            let t65 = t64 * t61;
+            let t66 = t65 * t57;
+            let t67 = t66.square();
+            let t68 = t67.square();
+            let t69 = t68 * t67;
+            let t70 = t69.square();
+            let t71 = t70 * t67;
+            let t72 = t71 * t66;
+            let t73 = t72.square();
+            let t74 = t73.square();
+            let t75 = t74 * t67;
+            let t76 = t75 * t61;
+            let t77 = t76 * t66;
+            let t78 = t77.square();
+            let t79 = t78.square();
+            let t80 = t79 * t77;
+            let t81 = t80 * t76;
+            let t82 = t81.square();
+            let t83 = t82 * t77;
+            let t84 = t83.square();
+            let t85 = t84.square();
+            let t87 = t85.square();
+            let t88 = t87.square();
+            let t89 = t88 * t84;
+            let t90 = t89 * t81;
+            let t91 = t90.square();
+            let t92 = t91 * t83;
+            let t93 = t92.square();
+            let t94 = t93 * t92;
+            let t95 = t94.square();
+            let t96 = t95 * t92;
+            let t97 = t96.square();
+            let t99 = t97.square();
+            let t100 = t99.square();
+            let t101 = t100.square();
+            let t103 = t101 * t90;
+            let t104 = t103.square();
+            let t105 = t104.square();
+            let t106 = t105.square();
+            let t107 = t106 * t103;
+            let t108 = t107 * t92;
+            let t109 = t108.square();
+            let t110 = t109 * t103;
+            let t111 = t110.square();
+            let t112 = t111.square();
+            let t113 = t112.square();
+            let t114 = t113 * t110;
+            let t115 = t114 * t108;
+            let t116 = t115 * t110;
+            let t117 = t116.square();
+            let t118 = t117.square();
+            let t119 = t118 * t116;
+            let t120 = t119 * t115;
+            let t121 = t120.square();
+            let t122 = t121 * t116;
+            let t123 = t122 * t120;
+            let t124 = t123.square();
+            let t125 = t124 * t123;
+            let t126 = t125.square();
+            let t128 = t126.square();
+            let t130 = t128 * t122;
+            let t131 = t130 * t123;
+            let t132 = t131.square();
+            let t133 = t132.square();
+            let t134 = t133.square();
+            let t135 = t134 * t131;
+            let t136 = t135.square();
+            let t137 = t136.square();
+            let t138 = t137.square();
+            let t139 = t138 * t132;
+            let t140 = t139 * t130;
+            let t141 = t140 * t131;
+            let t142 = t141.square();
+            let t143 = t142.square();
+            let t144 = t143 * t141;
+            let t145 = t144 * t140;
+            let t146 = t145.square();
+            let t147 = t146 * t145;
+            let t148 = t147.square();
+            let t149 = t148 * t145;
+            let t150 = t149 * t141;
+            let t151 = t150.square();
+            let t152 = t151 * t145;
+            let t153 = t152 * t150;
+            let t154 = t153.square();
+            let t155 = t154 * t153;
+            let t156 = t155.square();
+            let t157 = t156 * t153;
+            let t158 = t157 * t152;
+            let t159 = t158 * t153;
+            let t160 = t159.square();
+            let t161 = t160 * t159;
+            let t162 = t161 * t158;
+            let t163 = t162 * t159;
+            let t164 = t163.square();
+            let t165 = t164 * t163;
+            let t166 = t165 * t162;
+            let t167 = t166 * t163;
+            let t168 = t167.square();
+            let t169 = t168.square();
+            let t170 = t169 * t167;
+            let t171 = t170.square();
+            let t173 = t171 * t166;
+            let t174 = t173 * t167;
+            let t175 = t174.square();
+            let t176 = t175 * t174;
+            let t177 = t176.square();
+            let t178 = t177 * t174;
+            let t179 = t178.square();
+            let t180 = t179.square();
+            let t182 = t180 * t173;
+            let t183 = t182.square();
+            let t184 = t183 * t182;
+            let t185 = t184 * t174;
+            let t186 = t185 * t182;
+            let t187 = t186 * t185;
+            let t188 = t187 * t186;
+            let t189 = t188.square();
+            let t190 = t189 * t188;
+            let t191 = t190.square();
+            let t192 = t191 * t188;
+            let t193 = t192 * t187;
+            let t194 = t193.square();
+            let t195 = t194 * t188;
+            let t196 = t195.square();
+            let t197 = t196.square();
+            let t198 = t197 * t193;
+            let t199 = t198.square();
+            let t200 = t199.square();
+            let t201 = t200 * t198;
+            let t202 = t201 * t195;
+            let t203 = t202.square();
+            let t204 = t203.square();
+            let t205 = t204 * t202;
+            let t206 = t205 * t198;
+            let t207 = t206 * t202;
+            let t208 = t207 * t206;
+            let t209 = t208 * t207;
+            let t210 = t209.square();
+            let t211 = t210 * t208;
+            let t212 = t211.square();
+            let t213 = t212 * t209;
+            let t214 = t213.square();
+            let t215 = t214.square();
+            let t216 = t215.square();
+            let t217 = t216.square();
+            let t218 = t217.square();
+            let t219 = t218.square();
+            let t220 = t219.square();
+            let t221 = t220.square();
+            let t222 = t221.square();
+            let t223 = t222.square();
+            let t224 = t223.square();
+            let t225 = t224.square();
+            let t226 = t225.square();
+            let t227 = t226.square();
+            let t228 = t227.square();
+            let t229 = t228.square();
+            let t230 = t229.square();
+            let t231 = t230.square();
+            let t232 = t231.square();
+            let t233 = t232.square();
+            let t234 = t233.square();
+            let t235 = t234.square();
+            let t236 = t235.square();
+            let t237 = t236.square();
+            let t238 = t237.square();
+            let t239 = t238.square();
+            let t240 = t239.square();
+            let t241 = t240.square();
+            let t242 = t241.square();
+            let t243 = t242.square();
+            let t244 = t243.square();
+            let t245 = t244.square();
+            let t246 = t245.square();
+            let t247 = t246.square();
+            let t248 = t247.square();
+            let t249 = t248.square();
+            let t250 = t249.square();
+            let t251 = t250.square();
+            let t252 = t251.square();
+            let t253 = t252.square();
+            let t254 = t253.square();
+            let t255 = t254.square();
+            let t256 = t255.square();
+            let t257 = t256.square();
+            let t258 = t257.square();
+            let t259 = t258.square();
+            let t260 = t259.square();
+            let t261 = t260.square();
+            let t262 = t261.square();
+            let t263 = t262.square();
+            let t264 = t263.square();
+            let t265 = t264.square();
+            let t266 = t265.square();
+            let t267 = t266.square();
+            let t268 = t267.square();
+            let t269 = t268.square();
+            let t270 = t269.square();
+            let t271 = t270.square();
+            let t272 = t271.square();
+            let t273 = t272.square();
+            let t274 = t273.square();
+            let t275 = t274.square();
+            let t276 = t275.square();
+            let t277 = t276.square();
+            let t278 = t277.square();
+            let t279 = t278.square();
+            let t280 = t279.square();
+            let t281 = t280.square();
+            let t282 = t281.square();
+            let t283 = t282.square();
+            let t284 = t283.square();
+            let t285 = t284.square();
+            let t286 = t285.square();
+            let t287 = t286.square();
+            let t288 = t287.square();
+            let t289 = t288.square();
+            let t290 = t289.square();
+            let t291 = t290.square();
+            let t292 = t291.square();
+            let t293 = t292.square();
+            let t294 = t293.square();
+            let t295 = t294.square();
+            let t296 = t295.square();
+            let t297 = t296.square();
+            let t298 = t297.square();
+            let t299 = t298.square();
+            let t300 = t299.square();
+            let t301 = t300.square();
+            let t302 = t301.square();
+            let t303 = t302.square();
+            let t304 = t303.square();
+            let t305 = t304.square();
+            let t306 = t305.square();
+            let t307 = t306.square();
+            let t308 = t307.square();
+            let t309 = t308.square();
+            let t310 = t309.square();
+            let t311 = t310.square();
+            let t312 = t311.square();
+            let t313 = t312.square();
+            let t314 = t313.square();
+            let t315 = t314.square();
+            let t316 = t315.square();
+            let t317 = t316.square();
+            let t318 = t317.square();
+            let t319 = t318.square();
+            let t320 = t319.square();
+            let t321 = t320.square();
+            let t322 = t321.square();
+            let t323 = t322.square();
+            let t324 = t323.square();
+            let t325 = t324.square();
+            let t326 = t325.square();
+            let t327 = t326.square();
+            let t328 = t327.square();
+            let t329 = t328.square();
+            let t330 = t329.square();
+            let t331 = t330.square();
+            let t332 = t331.square();
+            let t333 = t332.square();
+            let t334 = t333.square();
+            let t335 = t334.square();
+            let t336 = t335.square();
+            let t337 = t336.square();
+            t337 * t211
+        };
+
+        let mut v = Self::S;
+        let mut x = *self * w;
+        let mut b = x * w;
+        let mut z = Self::root_of_unity();
+
+        for max_v in (1..=Self::S).rev() {
+            let mut k = 1;
+            let mut tmp = b.square();
+            let mut j_less_than_v = Choice::from(1);
+
+            for j in 2..max_v {
+                let tmp_is_one = tmp.ct_eq(&Self::one());
+                let squared = Self::conditional_select(&tmp, &z, tmp_is_one).square();
+                tmp = Self::conditional_select(&squared, &tmp, tmp_is_one);
+                let new_z = Self::conditional_select(&z, &squared, tmp_is_one);
+                j_less_than_v &= !j.ct_eq(&v);
+                k = u32::conditional_select(&j, &k, tmp_is_one);
+                z = Self::conditional_select(&z, &new_z, j_less_than_v);
+            }
+
+            let result = x * z;
+            x = Self::conditional_select(&result, &x, b.ct_eq(&Self::one()));
+            z = z.square();
+            b *= z;
+            v = k;
+        }
+
+        CtOption::new(x, x.square().ct_eq(self))
     }
 }
 
@@ -148,9 +511,9 @@ impl PrimeField for Scalar {
 
     fn root_of_unity() -> Self {
         Scalar::from_repr(arr![u8;
-            0xc1, 0xdc, 0x06, 0x0e, 0x7a, 0x91, 0x98, 0x6d, 0xf9, 0x87, 0x9a, 0x3f, 0xbc, 0x48,
-            0x3a, 0x89, 0x8b, 0xde, 0xab, 0x68, 0x07, 0x56, 0x04, 0x59, 0x92, 0xf4, 0xb5, 0x40,
-            0x2b, 0x05, 0x2f, 0x2,
+            0x0c, 0x1d, 0xc0, 0x60, 0xe7, 0xa9, 0x19, 0x86, 0xdf, 0x98, 0x79, 0xa3, 0xfb, 0xc4,
+            0x83, 0xa8, 0x98, 0xbd, 0xea, 0xb6, 0x80, 0x75, 0x60, 0x45, 0x99, 0x2f, 0x4b, 0x54,
+            0x02, 0xb0, 0x52, 0xf2
         ])
         .unwrap()
     }
@@ -575,7 +938,7 @@ impl Zeroize for Scalar {
 mod tests {
     use super::Scalar;
     use crate::arithmetic::util::{biguint_to_bytes, bytes_to_biguint};
-    use elliptic_curve::group::ff::PrimeField;
+    use elliptic_curve::group::ff::{Field, PrimeField};
     use num_bigint::{BigUint, ToBigUint};
     use proptest::prelude::*;
 
@@ -624,6 +987,16 @@ mod tests {
         // MODULUS - 1 is high
         let high: bool = Scalar::from(&m - &one).is_high().into();
         assert!(high);
+    }
+
+    /// Basic tests that sqrt works.
+    #[test]
+    fn sqrt() {
+        for &n in &[1u64, 4, 9, 16, 25, 36, 49, 64] {
+            let scalar = Scalar::from(n);
+            let sqrt = scalar.sqrt().unwrap();
+            assert_eq!(sqrt.square(), scalar);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Implements Tonelli-Shank's algorithm for q mod 16 = 1 as synthesized using the `ff_derive` crate, similar to #392 which implements it for the `p256`.

Like in `p256`, as part of implementing this it was discovered that `root_of_unity()` was incorrect. Here it is (re)calculated with sage:

```sage
sage: n = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
sage: GF(n).primitive_element()
7
sage: s = 6
sage: t = (n - 1) >> s
sage: power_mod(7,t,n)
5480320495727936603795231718619559942670027629901634955707709633242980176626
```

Note that the value was computed correctly originally, but the hex digits were shifted such that the resulting value was left shifted by 4-bits. This has now been corrected.