### PR TITLE
k256: clippy fixes

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.51.0 # MSRV
+        toolchain: 1.51.0
         components: clippy
         override: true
         profile: minimal

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -91,7 +91,7 @@ impl FieldElement {
     }
 
     /// Returns the SEC1 encoding of this field element.
-    pub fn to_bytes(&self) -> FieldBytes {
+    pub fn to_bytes(self) -> FieldBytes {
         self.0.normalize().to_bytes()
     }
 
@@ -204,8 +204,8 @@ impl FieldElement {
         // { 2, 22, 223 }. Use an addition chain to calculate 2^n - 1 for each block:
         // 1, [2], 3, 6, 9, 11, [22], 44, 88, 176, 220, [223]
 
-        let x2 = self.pow2k(1).mul(&self);
-        let x3 = x2.pow2k(1).mul(&self);
+        let x2 = self.pow2k(1).mul(self);
+        let x3 = x2.pow2k(1).mul(self);
         let x6 = x3.pow2k(3).mul(&x3);
         let x9 = x6.pow2k(3).mul(&x3);
         let x11 = x9.pow2k(2).mul(&x2);

--- a/k256/src/arithmetic/field/field_10x26.rs
+++ b/k256/src/arithmetic/field/field_10x26.rs
@@ -84,7 +84,7 @@ impl FieldElement10x26 {
     }
 
     /// Returns the SEC1 encoding of this field element.
-    pub fn to_bytes(&self) -> FieldBytes {
+    pub fn to_bytes(self) -> FieldBytes {
         let mut r = FieldBytes::default();
         r[0] = (self.0[9] >> 14) as u8;
         r[1] = (self.0[9] >> 6) as u8;

--- a/k256/src/arithmetic/field/field_5x52.rs
+++ b/k256/src/arithmetic/field/field_5x52.rs
@@ -82,7 +82,7 @@ impl FieldElement5x52 {
     }
 
     /// Returns the SEC1 encoding of this field element.
-    pub fn to_bytes(&self) -> FieldBytes {
+    pub fn to_bytes(self) -> FieldBytes {
         let mut ret = FieldBytes::default();
         ret[0] = (self.0[4] >> 40) as u8;
         ret[1] = (self.0[4] >> 32) as u8;

--- a/k256/src/arithmetic/field/field_impl.rs
+++ b/k256/src/arithmetic/field/field_impl.rs
@@ -66,7 +66,7 @@ impl FieldElementImpl {
         CtOption::map(value, |x| Self::new_normalized(&x))
     }
 
-    pub fn to_bytes(&self) -> FieldBytes {
+    pub fn to_bytes(self) -> FieldBytes {
         debug_assert!(self.normalized);
         self.value.to_bytes()
     }

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -252,7 +252,7 @@ fn lincomb_generic<const N: usize>(xs: &[ProjectivePoint; N], ks: &[Scalar; N]) 
 
     let tables1 = static_zip_map(
         |x, r_sign| LookupTable::from(&ProjectivePoint::conditional_select(&x, &-x, r_sign)),
-        &xs,
+        xs,
         &r1_signs,
         LookupTable::default(),
     );

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -252,7 +252,7 @@ impl Scalar {
 
     /// Modulo squares the scalar.
     pub fn square(&self) -> Self {
-        self.mul(&self)
+        self.mul(self)
     }
 
     /// Right shifts the scalar. Note: not constant-time in `shift`.
@@ -468,7 +468,7 @@ impl AddAssign<Scalar> for Scalar {
 
 impl AddAssign<&Scalar> for Scalar {
     fn add_assign(&mut self, rhs: &Scalar) {
-        *self = Scalar::add(self, &rhs);
+        *self = Scalar::add(self, rhs);
     }
 }
 

--- a/k256/src/arithmetic/scalar/scalar_4x64.rs
+++ b/k256/src/arithmetic/scalar/scalar_4x64.rs
@@ -219,7 +219,7 @@ impl Scalar4x64 {
     }
 
     /// Returns the SEC1 encoding of this scalar.
-    pub fn to_bytes(&self) -> FieldBytes {
+    pub fn to_bytes(self) -> FieldBytes {
         let mut ret = FieldBytes::default();
         ret[0..8].copy_from_slice(&self.0[3].to_be_bytes());
         ret[8..16].copy_from_slice(&self.0[2].to_be_bytes());
@@ -312,8 +312,8 @@ impl Scalar4x64 {
     /// in constant time.
     /// In other words, calculates `(high_bit * 2^256 + limbs) % modulus`.
     fn from_overflow(w: &[u64; 4], high_bit: Choice) -> Self {
-        let (r2, underflow) = sbb_array_with_underflow(&w, &MODULUS);
-        Self(conditional_select(&w, &r2, !underflow | high_bit))
+        let (r2, underflow) = sbb_array_with_underflow(w, &MODULUS);
+        Self(conditional_select(w, &r2, !underflow | high_bit))
     }
 
     /// Right shifts a scalar by given number of bits.

--- a/k256/src/arithmetic/scalar/scalar_8x32.rs
+++ b/k256/src/arithmetic/scalar/scalar_8x32.rs
@@ -248,7 +248,7 @@ impl Scalar8x32 {
     }
 
     /// Returns the SEC1 encoding of this scalar.
-    pub fn to_bytes(&self) -> FieldBytes {
+    pub fn to_bytes(self) -> FieldBytes {
         let mut ret = FieldBytes::default();
         ret[0..4].copy_from_slice(&self.0[7].to_be_bytes());
         ret[4..8].copy_from_slice(&self.0[6].to_be_bytes());
@@ -413,8 +413,8 @@ impl Scalar8x32 {
     /// in constant time.
     /// In other words, calculates `(high_bit * 2^256 + limbs) % modulus`.
     fn from_overflow(w: &[u32; 8], high_bit: Choice) -> Self {
-        let (r2, underflow) = sbb_array_with_underflow(&w, &MODULUS);
-        Self(conditional_select(&w, &r2, !underflow | high_bit))
+        let (r2, underflow) = sbb_array_with_underflow(w, &MODULUS);
+        Self(conditional_select(w, &r2, !underflow | high_bit))
     }
 
     /// Right shifts a scalar by given number of bits.

--- a/k256/src/ecdsa/verify.rs
+++ b/k256/src/ecdsa/verify.rs
@@ -118,7 +118,7 @@ impl From<PublicKey> for VerifyingKey {
 
 impl From<&PublicKey> for VerifyingKey {
     fn from(public_key: &PublicKey) -> VerifyingKey {
-        public_key.clone().into()
+        VerifyingKey::from(*public_key)
     }
 }
 
@@ -130,7 +130,7 @@ impl From<VerifyingKey> for PublicKey {
 
 impl From<&VerifyingKey> for PublicKey {
     fn from(verifying_key: &VerifyingKey) -> PublicKey {
-        verifying_key.inner.clone().into()
+        verifying_key.inner.into()
     }
 }
 


### PR DESCRIPTION
Ensures `k256` passes clippy under Rust 1.54