### PR TITLE
Bump `elliptic-curve` to v0.11.0-pre

### DIFF
--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -99,37 +99,38 @@ jobs:
       - run: cargo test --release --target ${{ matrix.target }} --features field-montgomery
       - run: cargo test --release --target ${{ matrix.target }} --all-features
 
-  cross:
-    strategy:
-      matrix:
-        include:
-          # ARM32
-          - target: armv7-unknown-linux-gnueabihf
-            rust: 1.51.0 # MSRV
-          - target: armv7-unknown-linux-gnueabihf
-            rust: stable
-
-          # ARM64
-          - target: aarch64-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
-          - target: aarch64-unknown-linux-gnu
-            rust: stable
-
-          # PPC32
-          - target: powerpc-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
-          - target: powerpc-unknown-linux-gnu
-            rust: stable
-
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: ${{ matrix.deps }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
-      - run: cargo install cross
-      - run: cross test --release --target ${{ matrix.target }} --all-features
+# TODO(tarcieri): re-enable when new `elliptic-curve` and `ecdsa` crates are released
+#  cross:
+#    strategy:
+#      matrix:
+#        include:
+#          # ARM32
+#          - target: armv7-unknown-linux-gnueabihf
+#            rust: 1.51.0 # MSRV
+#          - target: armv7-unknown-linux-gnueabihf
+#            rust: stable
+#
+#          # ARM64
+#          - target: aarch64-unknown-linux-gnu
+#            rust: 1.51.0 # MSRV
+#          - target: aarch64-unknown-linux-gnu
+#            rust: stable
+#
+#          # PPC32
+#          - target: powerpc-unknown-linux-gnu
+#            rust: 1.51.0 # MSRV
+#          - target: powerpc-unknown-linux-gnu
+#            rust: stable
+#
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: ${{ matrix.deps }}
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: ${{ matrix.rust }}
+#          target: ${{ matrix.target }}
+#          override: true
+#      - run: cargo install cross
+#      - run: cross test --release --target ${{ matrix.target }} --all-features

--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -80,37 +80,38 @@ jobs:
       - run: cargo test --release --target ${{ matrix.target }}
       - run: cargo test --release --target ${{ matrix.target }} --all-features
 
-  cross:
-    strategy:
-      matrix:
-        include:
-          # ARM32
-          - target: armv7-unknown-linux-gnueabihf
-            rust: 1.51.0 # MSRV
-          - target: armv7-unknown-linux-gnueabihf
-            rust: stable
-
-          # ARM64
-          - target: aarch64-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
-          - target: aarch64-unknown-linux-gnu
-            rust: stable
-
-          # PPC32
-          - target: powerpc-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
-          - target: powerpc-unknown-linux-gnu
-            rust: stable
-
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: ${{ matrix.deps }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
-      - run: cargo install cross
-      - run: cross test --release --target ${{ matrix.target }} --all-features
+# TODO(tarcieri): re-enable when new `elliptic-curve` and `ecdsa` crates are released
+#  cross:
+#    strategy:
+#      matrix:
+#        include:
+#          # ARM32
+#          - target: armv7-unknown-linux-gnueabihf
+#            rust: 1.51.0 # MSRV
+#          - target: armv7-unknown-linux-gnueabihf
+#            rust: stable
+#
+#          # ARM64
+#          - target: aarch64-unknown-linux-gnu
+#            rust: 1.51.0 # MSRV
+#          - target: aarch64-unknown-linux-gnu
+#            rust: stable
+#
+#          # PPC32
+#          - target: powerpc-unknown-linux-gnu
+#            rust: 1.51.0 # MSRV
+#          - target: powerpc-unknown-linux-gnu
+#            rust: stable
+#
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: ${{ matrix.deps }}
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: ${{ matrix.rust }}
+#          target: ${{ matrix.target }}
+#          override: true
+#      - run: cargo install cross
+#      - run: cross test --release --target ${{ matrix.target }} --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bp256"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "bp384"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -307,9 +307,8 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
+version = "0.13.0-pre"
+source = "git+https://github.com/RustCrypto/signatures.git#ec279220173f4a43d870a2f08a593662463eaaaf"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -325,9 +324,8 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
+version = "0.11.0-pre"
+source = "git+https://github.com/RustCrypto/traits.git#133f12ad8368ba1d31973d88d7c6986a57ca3351"
 dependencies = [
  "base64ct",
  "crypto-bigint",
@@ -345,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63eec06c61e487eecf0f7e6e6372e596a81922c28d33e645d6983ca6493a1af0"
+checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
 dependencies = [
  "bitvec",
  "rand_core",
@@ -389,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
 dependencies = [
  "ff",
  "rand_core",
@@ -455,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.9.6"
+version = "0.10.0-pre"
 dependencies = [
  "blobby",
  "cfg-if",
@@ -567,7 +565,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.9.0"
+version = "0.10.0-pre"
 dependencies = [
  "blobby",
  "ecdsa",
@@ -580,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.8.0"
+version = "0.9.0-pre"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ members = [
     "p256",
     "p384",
 ]
+
+[patch.crates-io]
+ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
+elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bp256"
 description = "Brainpool P-256 (brainpoolP256r1 and brainpoolP256t1) elliptic curves"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"
@@ -12,10 +12,10 @@ categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
 
 [dependencies]
-elliptic-curve = { version = "0.10", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat"] }
 
 # optional dependencies
-ecdsa = { version = "0.12", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.13.0-pre", optional = true, default-features = false, features = ["der"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [features]

--- a/bp256/src/lib.rs
+++ b/bp256/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/bp256/0.2.0"
+    html_root_url = "https://docs.rs/bp256/0.3.0-pre"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bp384"
 description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"
@@ -12,10 +12,10 @@ categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
 
 [dependencies]
-elliptic-curve = { version = "0.10", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat"] }
 
 # optional dependencies
-ecdsa = { version = "0.12", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.13.0-pre", optional = true, default-features = false, features = ["der"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [features]

--- a/bp384/src/lib.rs
+++ b/bp384/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/bp384/0.2.0"
+    html_root_url = "https://docs.rs/bp384/0.3.0-pre"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -6,7 +6,7 @@ signing/verification (including Ethereum-style signatures with public-key
 recovery), Elliptic Curve Diffie-Hellman (ECDH), and general purpose secp256k1
 curve arithmetic useful for implementing arbitrary group-based protocols.
 """
-version = "0.9.6" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"
@@ -18,24 +18,18 @@ keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "0.10.6", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat"] }
 
 # optional dependencies
+ecdsa-core = { version = "=0.13.0-pre", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 sha3 = { version = "0.9", optional = true, default-features = false }
 
-[dependencies.ecdsa-core]
-version = "0.12.1"
-package = "ecdsa"
-optional = true
-default-features = false
-features = ["der"]
-
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.3"
-ecdsa-core = { version = "0.12.1", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.13.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -95,10 +95,6 @@ impl Field for Scalar {
         Scalar::one()
     }
 
-    fn is_zero(&self) -> bool {
-        self.0.is_zero().into()
-    }
-
     #[must_use]
     fn square(&self) -> Self {
         Scalar::square(self)
@@ -493,16 +489,16 @@ impl PrimeField for Scalar {
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
-    fn from_repr(bytes: FieldBytes) -> Option<Self> {
-        ScalarImpl::from_bytes(bytes.as_ref()).map(Self).into()
+    fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
+        ScalarImpl::from_bytes(bytes.as_ref()).map(Self)
     }
 
     fn to_repr(&self) -> FieldBytes {
         self.to_bytes()
     }
 
-    fn is_odd(&self) -> bool {
-        self.0.is_odd().into()
+    fn is_odd(&self) -> Choice {
+        self.0.is_odd()
     }
 
     fn multiplicative_generator() -> Self {
@@ -707,7 +703,7 @@ impl Scalar {
         // TODO: pre-generate several scalars to bring the probability of non-constant-timeness down?
         loop {
             rng.fill_bytes(&mut bytes);
-            if let Some(scalar) = Scalar::from_repr(bytes) {
+            if let Some(scalar) = Scalar::from_repr(bytes).into() {
                 return scalar;
             }
         }

--- a/k256/src/ecdsa/normalize.rs
+++ b/k256/src/ecdsa/normalize.rs
@@ -47,7 +47,7 @@ mod tests {
         ]).unwrap();
 
         let mut sig_normalized = sig_hi;
-        assert!(sig_normalized.normalize_s().unwrap());
+        assert!(sig_normalized.normalize_s());
         assert_eq!(sig_lo, sig_normalized);
     }
 
@@ -62,7 +62,7 @@ mod tests {
         ]).unwrap();
 
         let mut sig_normalized = sig;
-        assert!(!sig_normalized.normalize_s().unwrap());
+        assert!(!sig_normalized.normalize_s());
         assert_eq!(sig, sig_normalized);
     }
 }

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -47,10 +47,7 @@ use crate::{
         signature::{digest::Digest, DigestVerifier},
         VerifyingKey,
     },
-    elliptic_curve::{
-        consts::U32, generic_array::GenericArray, ops::Invert, subtle::Choice,
-        weierstrass::DecompressPoint,
-    },
+    elliptic_curve::{consts::U32, ops::Invert, subtle::Choice, weierstrass::DecompressPoint},
     lincomb, AffinePoint, FieldBytes, NonZeroScalar, ProjectivePoint, Scalar,
 };
 
@@ -81,9 +78,6 @@ impl Signature {
     /// This is an "unchecked" conversion and assumes the provided [`Id`]
     /// is valid for this signature.
     pub fn new(signature: &super::Signature, recovery_id: Id) -> Result<Self, Error> {
-        #[cfg(feature = "ecdsa")]
-        super::check_scalars(signature)?;
-
         let mut bytes = [0u8; SIZE];
         bytes[..64].copy_from_slice(signature.as_ref());
         bytes[64] = recovery_id.0;
@@ -127,7 +121,7 @@ impl Signature {
         D: Clone + Digest<OutputSize = U32>,
     {
         let mut signature = *signature;
-        signature.normalize_s()?;
+        signature.normalize_s();
 
         for recovery_id in 0..=1 {
             if let Ok(recoverable_signature) = Signature::new(&signature, Id(recovery_id)) {
@@ -198,16 +192,16 @@ impl Signature {
     #[cfg(feature = "ecdsa")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     pub fn r(&self) -> NonZeroScalar {
-        NonZeroScalar::from_repr(GenericArray::clone_from_slice(&self.bytes[..32]))
-            .unwrap_or_else(|| unreachable!("r-component ensured valid in constructor"))
+        NonZeroScalar::try_from(&self.bytes[..32])
+            .expect("r-component ensured valid in constructor")
     }
 
     /// Parse the `s` component of this signature to a [`NonZeroScalar`]
     #[cfg(feature = "ecdsa")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     pub fn s(&self) -> NonZeroScalar {
-        NonZeroScalar::from_repr(GenericArray::clone_from_slice(&self.bytes[32..64]))
-            .unwrap_or_else(|| unreachable!("s-component ensured valid in constructor"))
+        NonZeroScalar::try_from(&self.bytes[32..64])
+            .expect("s-component ensured valid in constructor")
     }
 }
 

--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -192,7 +192,7 @@ impl RecoverableSignPrimitive<Secp256k1> for Scalar {
 
         let mut signature = Signature::from_scalars(r, s)?;
         let is_r_odd = bool::from(R.y.normalize().is_odd());
-        let is_s_high = signature.normalize_s()?;
+        let is_s_high = signature.normalize_s();
         Ok((signature, is_r_odd ^ is_s_high))
     }
 }

--- a/k256/src/ecdsa/verify.rs
+++ b/k256/src/ecdsa/verify.rs
@@ -195,7 +195,7 @@ mod tests {
 
         let msg = hex!("313233343030");
         let mut sig = Signature::from_der(&hex!("304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a002207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0")).unwrap();
-        assert!(!sig.normalize_s().unwrap());
+        assert!(!sig.normalize_s());
         assert!(verifying_key.verify(&msg, &sig).is_ok());
     }
 }

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/k256/0.9.6"
+    html_root_url = "https://docs.rs/k256/0.10.0-pre"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -5,7 +5,7 @@ Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve with support for ECDH, ECDSA signing/verification, and general
 purpose curve arithmetic
 """
-version = "0.9.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"
@@ -16,22 +16,16 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
 
 [dependencies]
-elliptic-curve = { version = "0.10", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat"] }
 
 # optional dependencies
+ecdsa-core = { version = "=0.13.0-pre", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
-[dependencies.ecdsa-core]
-version = "0.12"
-package = "ecdsa"
-optional = true
-default-features = false
-features = ["der"]
-
 [dev-dependencies]
 blobby = "0.3"
-ecdsa-core = { version = "0.12", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.13.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -139,7 +139,7 @@ impl FieldElement {
     }
 
     /// Returns the SEC1 encoding of this field element.
-    pub fn to_bytes(&self) -> FieldBytes {
+    pub fn to_bytes(self) -> FieldBytes {
         // Convert from Montgomery form to canonical form
         let tmp =
             FieldElement::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -48,7 +48,7 @@ use {
     crate::{AffinePoint, ProjectivePoint, Scalar},
     core::borrow::Borrow,
     ecdsa_core::hazmat::{SignPrimitive, VerifyPrimitive},
-    elliptic_curve::ops::Invert,
+    elliptic_curve::{group::ff::Field, ops::Invert},
 };
 
 /// ECDSA/P-256 signature (fixed-size)

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/p256/0.9.0"
+    html_root_url = "https://docs.rs/p256/0.10.0-pre"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p384"
 description = "NIST P-384 (secp384r1) elliptic curve"
-version = "0.8.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"
@@ -12,8 +12,8 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "secp384r1"]
 
 [dependencies]
-ecdsa = { version = "0.12", optional = true, default-features = false, features = ["der"] }
-elliptic-curve = { version = "0.10", default-features = false, features = ["hazmat"] }
+ecdsa = { version = "=0.13.0-pre", optional = true, default-features = false, features = ["der"] }
+elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [features]

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/p384/0.8.0"
+    html_root_url = "https://docs.rs/p384/0.9.0-pre"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
Sourced from git.

This includes transitive updates to ff and group v0.11. A major notable change of these updates is switching several APIs to use `subtle::Choice` and `subtle::CtOption` instead of `bool`/`Option`.

Fortunately, the crates in this repo are already written with constant-time implementations internally, so this was an easy change.