### PR TITLE
k256: make `ecdsa::Signature::normalize_s` non-mutating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.13.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#ec279220173f4a43d870a2f08a593662463eaaaf"
+source = "git+https://github.com/RustCrypto/signatures.git#969e9e7350cd609d534061e6a386ede87002c873"
 dependencies = [
  "der",
  "elliptic-curve",

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -140,13 +140,11 @@ mod tests {
                 let verifying_key =
                     ecdsa_core::VerifyingKey::from_encoded_point(&q_encoded).unwrap();
 
-                let mut sig = match Signature::<Secp256k1>::from_der(sig) {
-                    Ok(s) => s,
+                let sig = match Signature::<Secp256k1>::from_der(sig) {
+                    Ok(s) => s.normalize_s().unwrap_or(s),
                     Err(_) if !pass => return None,
                     Err(_) => return Some("failed to parse signature ASN.1"),
                 };
-
-                sig.normalize_s();
 
                 match verifying_key.verify(msg, &sig) {
                     Ok(_) if pass => None,

--- a/k256/src/ecdsa/normalize.rs
+++ b/k256/src/ecdsa/normalize.rs
@@ -6,11 +6,11 @@ use crate::Scalar;
 use ecdsa_core::NormalizeLow;
 
 impl NormalizeLow for Scalar {
-    fn normalize_low(&self) -> (Self, bool) {
+    fn normalize_low(&self) -> Option<Self> {
         if self.is_high().into() {
-            (-self, true)
+            Some(-self)
         } else {
-            (*self, false)
+            None
         }
     }
 }
@@ -46,8 +46,7 @@ mod tests {
             0xfb, 0x42, 0xef, 0x20, 0xe3, 0xc6, 0xad, 0xb2,
         ]).unwrap();
 
-        let mut sig_normalized = sig_hi;
-        assert!(sig_normalized.normalize_s());
+        let sig_normalized = sig_hi.normalize_s().unwrap();
         assert_eq!(sig_lo, sig_normalized);
     }
 
@@ -61,8 +60,6 @@ mod tests {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ]).unwrap();
 
-        let mut sig_normalized = sig;
-        assert!(!sig_normalized.normalize_s());
-        assert_eq!(sig, sig_normalized);
+        assert_eq!(sig.normalize_s(), None);
     }
 }

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -120,8 +120,7 @@ impl Signature {
     where
         D: Clone + Digest<OutputSize = U32>,
     {
-        let mut signature = *signature;
-        signature.normalize_s();
+        let signature = signature.normalize_s().unwrap_or(*signature);
 
         for recovery_id in 0..=1 {
             if let Ok(recoverable_signature) = Signature::new(&signature, Id(recovery_id)) {

--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -190,10 +190,12 @@ impl RecoverableSignPrimitive<Secp256k1> for Scalar {
             return Err(Error::new());
         }
 
-        let mut signature = Signature::from_scalars(r, s)?;
-        let is_r_odd = bool::from(R.y.normalize().is_odd());
-        let is_s_high = signature.normalize_s();
-        Ok((signature, is_r_odd ^ is_s_high))
+        let signature = Signature::from_scalars(r, s)?;
+        let is_r_odd: bool = R.y.normalize().is_odd().into();
+        let is_s_high: bool = signature.s().is_high().into();
+        let signature_low = signature.normalize_s().unwrap_or(signature);
+
+        Ok((signature_low, is_r_odd ^ is_s_high))
     }
 }
 

--- a/k256/src/ecdsa/verify.rs
+++ b/k256/src/ecdsa/verify.rs
@@ -194,8 +194,8 @@ mod tests {
         let verifying_key = VerifyingKey::from_sec1_bytes(&verifying_key_bytes).unwrap();
 
         let msg = hex!("313233343030");
-        let mut sig = Signature::from_der(&hex!("304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a002207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0")).unwrap();
-        assert!(!sig.normalize_s());
+        let sig = Signature::from_der(&hex!("304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a002207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0")).unwrap();
+        assert!(sig.normalize_s().is_none()); // Ensure signature is already normalized
         assert!(verifying_key.verify(&msg, &sig).is_ok());
     }
 }


### PR DESCRIPTION
Corresponding changes for RustCrypto/signatures#355