### PR TITLE
p256: use `U256` as the internal representation of `Scalar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.2.5"
-source = "git+https://github.com/RustCrypto/utils.git#8fa1b4fb22789fb5afd51bc1fad08ebf95789965"
+source = "git+https://github.com/RustCrypto/utils.git#b4a5373699aa2ec28304558e525c3dc60065367a"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -324,7 +324,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#c7c63d39dbd9c9d5fc0dfd32e3ac0d58535dc500"
+source = "git+https://github.com/RustCrypto/traits.git#09d9ea6eedbf317680a07d68667ec40856b08ef2"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,3 @@ members = [
 crypto-bigint = { git = "https://github.com/RustCrypto/utils.git" }
 ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
 elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
-

--- a/p256/src/arithmetic/projective.rs
+++ b/p256/src/arithmetic/projective.rs
@@ -284,7 +284,7 @@ impl ProjectivePoint {
     fn mul(&self, k: &Scalar) -> ProjectivePoint {
         let mut ret = ProjectivePoint::identity();
 
-        for limb in k.0.iter().rev() {
+        for limb in k.to_u64x4().iter().rev() {
             for i in (0..64).rev() {
                 ret = ret.double();
                 ret.conditional_assign(&(ret + self), Choice::from(((limb >> i) & 1u64) as u8));


### PR DESCRIPTION
This is a minimally invasive change to use `crypto_bigint::U256` as the internal representation of `p256::Scalar`.

There are several places that various functions are still using a `U64x4` type which could be made to work over 8 x 32-bit limbs instead on 32-bit platforms, which is what `U256` uses internally.

This commit doesn't attempt to implement those changes, but rather just switch out the type used for the internal representation. This should hopefully avoid any regressions in this particular change.