### PR TITLE
Use `PrimeCurve` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.13.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#5961aaa58d44b24fb3dac2665a9b9f3ce9a3f759"
+source = "git+https://github.com/RustCrypto/signatures.git#2d8b5982c0dab25d610787cad55ceeb8bdfe7b0d"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -324,7 +324,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#09d9ea6eedbf317680a07d68667ec40856b08ef2"
+source = "git+https://github.com/RustCrypto/traits.git#405c176ce5e9d4007f6f87ae7fc89348ffdc930b"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/bp256/src/r1.rs
+++ b/bp256/src/r1.rs
@@ -22,9 +22,9 @@ impl elliptic_curve::Curve for BrainpoolP256r1 {
         U256::from_be_hex("a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a7");
 }
 
-impl elliptic_curve::weierstrass::Curve for BrainpoolP256r1 {}
+impl elliptic_curve::PrimeCurve for BrainpoolP256r1 {}
 
-impl elliptic_curve::weierstrass::PointCompression for BrainpoolP256r1 {
+impl elliptic_curve::PointCompression for BrainpoolP256r1 {
     const COMPRESS_POINTS: bool = false;
 }
 

--- a/bp256/src/t1.rs
+++ b/bp256/src/t1.rs
@@ -22,9 +22,9 @@ impl elliptic_curve::Curve for BrainpoolP256t1 {
         U256::from_be_hex("a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a7");
 }
 
-impl elliptic_curve::weierstrass::Curve for BrainpoolP256t1 {}
+impl elliptic_curve::PrimeCurve for BrainpoolP256t1 {}
 
-impl elliptic_curve::weierstrass::PointCompression for BrainpoolP256t1 {
+impl elliptic_curve::PointCompression for BrainpoolP256t1 {
     const COMPRESS_POINTS: bool = false;
 }
 

--- a/bp384/src/r1.rs
+++ b/bp384/src/r1.rs
@@ -22,9 +22,9 @@ impl elliptic_curve::Curve for BrainpoolP384r1 {
         U384::from_be_hex("8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046565");
 }
 
-impl elliptic_curve::weierstrass::Curve for BrainpoolP384r1 {}
+impl elliptic_curve::PrimeCurve for BrainpoolP384r1 {}
 
-impl elliptic_curve::weierstrass::PointCompression for BrainpoolP384r1 {
+impl elliptic_curve::PointCompression for BrainpoolP384r1 {
     const COMPRESS_POINTS: bool = false;
 }
 

--- a/bp384/src/t1.rs
+++ b/bp384/src/t1.rs
@@ -22,9 +22,9 @@ impl elliptic_curve::Curve for BrainpoolP384t1 {
         U384::from_be_hex("8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046565");
 }
 
-impl elliptic_curve::weierstrass::Curve for BrainpoolP384t1 {}
+impl elliptic_curve::PrimeCurve for BrainpoolP384t1 {}
 
-impl elliptic_curve::weierstrass::PointCompression for BrainpoolP384t1 {
+impl elliptic_curve::PointCompression for BrainpoolP384t1 {
     const COMPRESS_POINTS: bool = false;
 }
 

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -8,9 +8,8 @@ use elliptic_curve::{
     group::{prime::PrimeCurveAffine, GroupEncoding},
     sec1::{self, FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
-    weierstrass::DecompressPoint,
     zeroize::DefaultIsZeroes,
-    AffineArithmetic,
+    AffineArithmetic, DecompressPoint,
 };
 
 impl AffineArithmetic for Secp256k1 {

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -47,7 +47,7 @@ use crate::{
         signature::{digest::Digest, DigestVerifier},
         VerifyingKey,
     },
-    elliptic_curve::{consts::U32, ops::Invert, subtle::Choice, weierstrass::DecompressPoint},
+    elliptic_curve::{consts::U32, ops::Invert, subtle::Choice, DecompressPoint},
     lincomb, AffinePoint, FieldBytes, NonZeroScalar, ProjectivePoint, Scalar,
 };
 

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -104,9 +104,9 @@ impl elliptic_curve::Curve for Secp256k1 {
     const ORDER: U256 = ORDER;
 }
 
-impl elliptic_curve::weierstrass::Curve for Secp256k1 {}
+impl elliptic_curve::PrimeCurve for Secp256k1 {}
 
-impl elliptic_curve::weierstrass::PointCompression for Secp256k1 {
+impl elliptic_curve::PointCompression for Secp256k1 {
     /// secp256k1 points are typically compressed.
     const COMPRESS_POINTS: bool = true;
 }

--- a/p256/src/arithmetic/affine.rs
+++ b/p256/src/arithmetic/affine.rs
@@ -10,9 +10,8 @@ use elliptic_curve::{
     sec1::Tag,
     sec1::{self, FromEncodedPoint, ToCompactEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
-    weierstrass::{DecompactPoint, DecompressPoint},
     zeroize::DefaultIsZeroes,
-    AffineArithmetic, Curve,
+    AffineArithmetic, Curve, DecompactPoint, DecompressPoint,
 };
 
 impl AffineArithmetic for NistP256 {

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -126,14 +126,14 @@ impl elliptic_curve::Curve for NistP256 {
         U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
 }
 
-impl elliptic_curve::weierstrass::Curve for NistP256 {}
+impl elliptic_curve::PrimeCurve for NistP256 {}
 
-impl elliptic_curve::weierstrass::PointCompression for NistP256 {
+impl elliptic_curve::PointCompression for NistP256 {
     /// NIST P-256 points are typically uncompressed.
     const COMPRESS_POINTS: bool = false;
 }
 
-impl elliptic_curve::weierstrass::PointCompaction for NistP256 {
+impl elliptic_curve::PointCompaction for NistP256 {
     /// NIST P-256 points are typically uncompressed.
     const COMPACT_POINTS: bool = false;
 }

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -60,9 +60,9 @@ impl elliptic_curve::Curve for NistP384 {
         U384::from_be_hex("ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973");
 }
 
-impl elliptic_curve::weierstrass::Curve for NistP384 {}
+impl elliptic_curve::PrimeCurve for NistP384 {}
 
-impl elliptic_curve::weierstrass::PointCompression for NistP384 {
+impl elliptic_curve::PointCompression for NistP384 {
     const COMPRESS_POINTS: bool = false;
 }
 


### PR DESCRIPTION
Switches from `weierstrass::Curve` to the `PrimeCurve` trait added in RustCrypto/traits#737.