### PR TITLE
k256+p256: impl `PrimeCurveArithmetic`; MSRV 1.52

### DIFF
--- a/.github/workflows/bp256.yml
+++ b/.github/workflows/bp256.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.52.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.52.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/bp384.yml
+++ b/.github/workflows/bp384.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.52.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.52.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.52.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.52.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v2
@@ -72,7 +72,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
+            rust: 1.52.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -80,7 +80,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
+            rust: 1.52.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 
@@ -105,19 +105,19 @@ jobs:
 #        include:
 #          # ARM32
 #          - target: armv7-unknown-linux-gnueabihf
-#            rust: 1.51.0 # MSRV
+#            rust: 1.52.0 # MSRV
 #          - target: armv7-unknown-linux-gnueabihf
 #            rust: stable
 #
 #          # ARM64
 #          - target: aarch64-unknown-linux-gnu
-#            rust: 1.51.0 # MSRV
+#            rust: 1.52.0 # MSRV
 #          - target: aarch64-unknown-linux-gnu
 #            rust: stable
 #
 #          # PPC32
 #          - target: powerpc-unknown-linux-gnu
-#            rust: 1.51.0 # MSRV
+#            rust: 1.52.0 # MSRV
 #          - target: powerpc-unknown-linux-gnu
 #            rust: stable
 #

--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.52.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -54,7 +54,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
+            rust: 1.52.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -62,7 +62,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
+            rust: 1.52.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 
@@ -87,19 +87,19 @@ jobs:
 #        include:
 #          # ARM32
 #          - target: armv7-unknown-linux-gnueabihf
-#            rust: 1.51.0 # MSRV
+#            rust: 1.52.0 # MSRV
 #          - target: armv7-unknown-linux-gnueabihf
 #            rust: stable
 #
 #          # ARM64
 #          - target: aarch64-unknown-linux-gnu
-#            rust: 1.51.0 # MSRV
+#            rust: 1.52.0 # MSRV
 #          - target: aarch64-unknown-linux-gnu
 #            rust: stable
 #
 #          # PPC32
 #          - target: powerpc-unknown-linux-gnu
-#            rust: 1.51.0 # MSRV
+#            rust: 1.52.0 # MSRV
 #          - target: powerpc-unknown-linux-gnu
 #            rust: stable
 #

--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.52.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.52.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.51.0
+        toolchain: 1.52.0
         components: clippy
         override: true
         profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.13.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#e795f91d11cf373018a7066628c4f19f9eb94b0a"
+source = "git+https://github.com/RustCrypto/signatures.git#afdf1938cc25c4b91aa3ae4952d2d84852a2bc47"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -324,7 +324,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#9d916903fa715b52f8fe80e72f621bf9632a9e8a"
+source = "git+https://github.com/RustCrypto/traits.git#50564e5d59dceab04909a71e2aec43af12b8bc90"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ if you are interested in curves beyond the ones listed here.
 
 ## Minimum Supported Rust Version
 
-All crates in this repository support Rust **1.51** or higher.
+All crates in this repository support Rust **1.52** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -50,7 +50,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.52+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [deps-image]: https://deps.rs/repo/github/RustCrypto/elliptic-curves/status.svg

--- a/bp256/README.md
+++ b/bp256/README.md
@@ -14,7 +14,7 @@ implemented in terms of traits from the [`elliptic-curve`] crate.
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or higher.
+Rust **1.52** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -46,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/bp256/badge.svg
 [docs-link]: https://docs.rs/bp256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.52+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/bp256/badge.svg?branch=master&event=push

--- a/bp256/src/lib.rs
+++ b/bp256/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.51** or higher.
+//! Rust **1.52** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/bp384/README.md
+++ b/bp384/README.md
@@ -14,7 +14,7 @@ implemented in terms of traits from the [`elliptic-curve`] crate.
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or higher.
+Rust **1.52** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -46,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/bp384/badge.svg
 [docs-link]: https://docs.rs/bp384/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.52+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/bp384/badge.svg?branch=master&event=push

--- a/bp384/src/lib.rs
+++ b/bp384/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.51** or higher.
+//! Rust **1.52** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/k256/LICENSE-MIT
+++ b/k256/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020 RustCrypto Developers
+Copyright (c) 2020-2021 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/k256/README.md
+++ b/k256/README.md
@@ -63,7 +63,7 @@ most popular and commonly used elliptic curves.
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or higher.
+Rust **1.52** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -95,7 +95,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/k256/badge.svg
 [docs-link]: https://docs.rs/k256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.52+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/k256/badge.svg?branch=master&event=push

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -16,7 +16,7 @@ use elliptic_curve::{
     sec1::{FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
-    ProjectiveArithmetic,
+    PrimeCurveArithmetic, ProjectiveArithmetic,
 };
 
 #[rustfmt::skip]
@@ -29,6 +29,10 @@ const ENDOMORPHISM_BETA: FieldElement = FieldElement::from_bytes_unchecked(&[
 
 impl ProjectiveArithmetic for Secp256k1 {
     type ProjectivePoint = ProjectivePoint;
+}
+
+impl PrimeCurveArithmetic for Secp256k1 {
+    type CurveGroup = ProjectivePoint;
 }
 
 /// A point on the secp256k1 curve in projective coordinates.

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.51** or higher.
+//! Rust **1.52** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/p256/LICENSE-MIT
+++ b/p256/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020 RustCrypto Developers
+Copyright (c) 2020-2021 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/p256/README.md
+++ b/p256/README.md
@@ -47,7 +47,7 @@ like TLS and the associated X.509 PKI.
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or higher.
+Rust **1.52** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -79,7 +79,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/p256/badge.svg
 [docs-link]: https://docs.rs/p256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.52+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/p256/badge.svg?branch=master&event=push

--- a/p256/src/arithmetic/projective.rs
+++ b/p256/src/arithmetic/projective.rs
@@ -17,11 +17,15 @@ use elliptic_curve::{
     sec1::{FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
-    ProjectiveArithmetic,
+    PrimeCurveArithmetic, ProjectiveArithmetic,
 };
 
 impl ProjectiveArithmetic for NistP256 {
     type ProjectivePoint = ProjectivePoint;
+}
+
+impl PrimeCurveArithmetic for NistP256 {
+    type CurveGroup = ProjectivePoint;
 }
 
 /// A point on the secp256r1 curve in projective coordinates.

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.51** or higher.
+//! Rust **1.52** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/p384/LICENSE-MIT
+++ b/p384/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020 RustCrypto Developers
+Copyright (c) 2020-2021 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.51** or higher.
+//! Rust **1.52** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.


### PR DESCRIPTION
Implements the `PrimeCurveArithmetic` trait introduced in RustCrypto/traits#739