### PR TITLE
k256+p256: scalar conversion bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#50564e5d59dceab04909a71e2aec43af12b8bc90"
+source = "git+https://github.com/RustCrypto/traits.git#e433b13bab2f96279fa7bd630bed1f6dc239ef02"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -22,7 +22,7 @@ use elliptic_curve::{
         CtOption,
     },
     zeroize::DefaultIsZeroes,
-    Curve, ScalarArithmetic,
+    Curve, ScalarArithmetic, ScalarCore,
 };
 use wide::WideScalar;
 
@@ -644,6 +644,18 @@ impl From<u32> for Scalar {
 impl From<u64> for Scalar {
     fn from(k: u64) -> Self {
         Self(k.into())
+    }
+}
+
+impl From<ScalarCore<Secp256k1>> for Scalar {
+    fn from(scalar: ScalarCore<Secp256k1>) -> Scalar {
+        Scalar(*scalar.as_uint())
+    }
+}
+
+impl From<Scalar> for U256 {
+    fn from(scalar: Scalar) -> U256 {
+        scalar.0
     }
 }
 

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -14,7 +14,7 @@ use elliptic_curve::{
     rand_core::RngCore,
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, CtOption},
     zeroize::DefaultIsZeroes,
-    Curve, ScalarArithmetic,
+    Curve, ScalarArithmetic, ScalarCore,
 };
 
 #[cfg(feature = "bits")]
@@ -635,6 +635,18 @@ impl Ord for Scalar {
 impl From<u64> for Scalar {
     fn from(k: u64) -> Self {
         Scalar(k.into())
+    }
+}
+
+impl From<ScalarCore<NistP256>> for Scalar {
+    fn from(scalar: ScalarCore<NistP256>) -> Scalar {
+        Scalar(*scalar.as_uint())
+    }
+}
+
+impl From<Scalar> for U256 {
+    fn from(scalar: Scalar) -> U256 {
+        scalar.0
     }
 }
 


### PR DESCRIPTION
Adds the scalar conversion bounds from RustCrypto/traits#740