### PR TITLE
k256+p256: use `UInt::add_mod` for scalar addition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,8 +245,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.5"
-source = "git+https://github.com/RustCrypto/utils.git#b4a5373699aa2ec28304558e525c3dc60065367a"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3e92bef8f9520d23f056674efde37622a5185c4103ca106de82f8f966ece4d"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -324,7 +325,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#30c65cc9cdcd2c16ce724f0b65c98ed30368b771"
+source = "git+https://github.com/RustCrypto/traits.git#b645434a82400400247f4d8e4574ed9ae0dbb79e"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,5 @@ members = [
 ]
 
 [patch.crates-io]
-crypto-bigint = { git = "https://github.com/RustCrypto/utils.git" }
 ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
 elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }


### PR DESCRIPTION
`crypto-bigint` v0.2.7 fixed a bug in `UInt::add_mod` in https://github.com/RustCrypto/utils/pull/619, and the `elliptic-curve` crate has been updated to depend on this version at a minimum.

This means we can now use it to implement scalar addition.