### PR TITLE
k256: remove `pub(super)` from `WideScalar`'s `.0` field

### DIFF
--- a/k256/src/arithmetic/scalar/wide32.rs
+++ b/k256/src/arithmetic/scalar/wide32.rs
@@ -21,7 +21,7 @@ const NEG_MODULUS: [u32; 8] = [
 ];
 
 #[derive(Clone, Copy, Debug, Default)]
-pub(crate) struct WideScalar(pub(super) [u32; 16]);
+pub(crate) struct WideScalar([u32; 16]);
 
 impl WideScalar {
     pub fn from_bytes(bytes: &[u8; 64]) -> Self {

--- a/k256/src/arithmetic/scalar/wide64.rs
+++ b/k256/src/arithmetic/scalar/wide64.rs
@@ -12,7 +12,7 @@ use elliptic_curve::{
 const NEG_MODULUS: [u64; 4] = [!MODULUS[0] + 1, !MODULUS[1], !MODULUS[2], !MODULUS[3]];
 
 #[derive(Clone, Copy, Debug, Default)]
-pub(crate) struct WideScalar(pub(super) [u64; 8]);
+pub(crate) struct WideScalar([u64; 8]);
 
 impl WideScalar {
     pub fn from_bytes(bytes: &[u8; 64]) -> Self {


### PR DESCRIPTION
This is no longer needed as the function needing access has been moved to the `WideScalar` type.