### PR TITLE
k256: remove `Scalar::conditional_add_bit`

### DIFF
--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -353,16 +353,6 @@ impl Scalar {
         Self(U256::from_be_slice(bytes))
     }
 
-    /// If `flag` evaluates to `true`, adds `(1 << bit)` to `self`.
-    fn conditional_add_bit(&self, bit: usize, flag: Choice) -> Self {
-        debug_assert!(bit < 256);
-
-        // Construct Scalar(1 << bit).
-        // Since the 255-th bit of the modulus is 1, this will always be within range.
-        let w = Scalar(U256::ONE << bit);
-        Self::conditional_select(self, &(self.add(&w)), flag)
-    }
-
     /// Raises the scalar to the power `2^k`.
     fn pow2k(&self, k: usize) -> Self {
         let mut x = *self;

--- a/k256/src/arithmetic/scalar/wide32.rs
+++ b/k256/src/arithmetic/scalar/wide32.rs
@@ -227,7 +227,7 @@ impl WideScalar {
 
         // Check the highmost discarded bit and round up if it is set.
         let c = (l[(shift - 1) >> 5] >> ((shift - 1) & 0x1f)) & 1;
-        res.conditional_add_bit(0, Choice::from(c as u8))
+        Scalar::conditional_select(&res, &res.add(&Scalar::ONE), Choice::from(c as u8))
     }
 
     #[inline(always)] // only used in Scalar::mul(), so won't cause binary bloat

--- a/k256/src/arithmetic/scalar/wide64.rs
+++ b/k256/src/arithmetic/scalar/wide64.rs
@@ -115,7 +115,7 @@ impl WideScalar {
 
         // Check the highmost discarded bit and round up if it is set.
         let c = (l[(shift - 1) >> 6] >> ((shift - 1) & 0x3f)) & 1;
-        res.conditional_add_bit(0, Choice::from(c as u8))
+        Scalar::conditional_select(&res, &res.add(&Scalar::ONE), Choice::from(c as u8))
     }
 
     #[inline(always)] // only used in Scalar::mul(), so won't cause binary bloat


### PR DESCRIPTION
The case it's actually being used for in practice is much simpler and can be easily expressed using the current functionality.