### PR TITLE
k256: Add non-biased/non-zero constructors to Scalar

### DIFF
--- a/k256/src/arithmetic/scalar/wide32.rs
+++ b/k256/src/arithmetic/scalar/wide32.rs
@@ -1,9 +1,10 @@
 //! Wide scalar (32-bit limbs)
 
 use super::{Scalar, MODULUS};
-use crate::ORDER;
+use crate::{NonZeroScalar, ORDER};
 use elliptic_curve::{
     bigint::{Limb, U256, U512},
+    group::ff::Field,
     subtle::{Choice, ConditionallySelectable},
 };
 
@@ -230,8 +231,13 @@ impl WideScalar {
         Scalar::conditional_select(&res, &res.add(&Scalar::ONE), Choice::from(c as u8))
     }
 
-    #[inline(always)] // only used in Scalar::mul(), so won't cause binary bloat
-    pub(super) fn reduce(&self) -> Scalar {
+    pub(super) fn reduce_impl(&self, modulus_minus_one: bool) -> Scalar {
+        let neg_modulus0 = if modulus_minus_one {
+            NEG_MODULUS[0] + 1
+        } else {
+            NEG_MODULUS[0]
+        };
+
         let w = self.0.to_uint_array();
         let n0 = w[8];
         let n1 = w[9];
@@ -249,46 +255,46 @@ impl WideScalar {
         let c0 = w[0];
         let c1 = 0;
         let c2 = 0;
-        let (c0, c1) = muladd_fast(n0, NEG_MODULUS[0], c0, c1);
+        let (c0, c1) = muladd_fast(n0, neg_modulus0, c0, c1);
         let (m0, c0, c1) = (c0, c1, 0);
         let (c0, c1) = sumadd_fast(w[1], c0, c1);
-        let (c0, c1, c2) = muladd(n1, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(n1, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(n0, NEG_MODULUS[1], c0, c1, c2);
         let (m1, c0, c1, c2) = (c0, c1, c2, 0);
         let (c0, c1, c2) = sumadd(w[2], c0, c1, c2);
-        let (c0, c1, c2) = muladd(n2, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(n2, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(n1, NEG_MODULUS[1], c0, c1, c2);
         let (c0, c1, c2) = muladd(n0, NEG_MODULUS[2], c0, c1, c2);
         let (m2, c0, c1, c2) = (c0, c1, c2, 0);
         let (c0, c1, c2) = sumadd(w[3], c0, c1, c2);
-        let (c0, c1, c2) = muladd(n3, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(n3, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(n2, NEG_MODULUS[1], c0, c1, c2);
         let (c0, c1, c2) = muladd(n1, NEG_MODULUS[2], c0, c1, c2);
         let (c0, c1, c2) = muladd(n0, NEG_MODULUS[3], c0, c1, c2);
         let (m3, c0, c1, c2) = (c0, c1, c2, 0);
         let (c0, c1, c2) = sumadd(w[4], c0, c1, c2);
-        let (c0, c1, c2) = muladd(n4, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(n4, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(n3, NEG_MODULUS[1], c0, c1, c2);
         let (c0, c1, c2) = muladd(n2, NEG_MODULUS[2], c0, c1, c2);
         let (c0, c1, c2) = muladd(n1, NEG_MODULUS[3], c0, c1, c2);
         let (c0, c1, c2) = sumadd(n0, c0, c1, c2);
         let (m4, c0, c1, c2) = (c0, c1, c2, 0);
         let (c0, c1, c2) = sumadd(w[5], c0, c1, c2);
-        let (c0, c1, c2) = muladd(n5, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(n5, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(n4, NEG_MODULUS[1], c0, c1, c2);
         let (c0, c1, c2) = muladd(n3, NEG_MODULUS[2], c0, c1, c2);
         let (c0, c1, c2) = muladd(n2, NEG_MODULUS[3], c0, c1, c2);
         let (c0, c1, c2) = sumadd(n1, c0, c1, c2);
         let (m5, c0, c1, c2) = (c0, c1, c2, 0);
         let (c0, c1, c2) = sumadd(w[6], c0, c1, c2);
-        let (c0, c1, c2) = muladd(n6, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(n6, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(n5, NEG_MODULUS[1], c0, c1, c2);
         let (c0, c1, c2) = muladd(n4, NEG_MODULUS[2], c0, c1, c2);
         let (c0, c1, c2) = muladd(n3, NEG_MODULUS[3], c0, c1, c2);
         let (c0, c1, c2) = sumadd(n2, c0, c1, c2);
         let (m6, c0, c1, c2) = (c0, c1, c2, 0);
         let (c0, c1, c2) = sumadd(w[7], c0, c1, c2);
-        let (c0, c1, c2) = muladd(n7, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(n7, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(n6, NEG_MODULUS[1], c0, c1, c2);
         let (c0, c1, c2) = muladd(n5, NEG_MODULUS[2], c0, c1, c2);
         let (c0, c1, c2) = muladd(n4, NEG_MODULUS[3], c0, c1, c2);
@@ -316,25 +322,25 @@ impl WideScalar {
         let c0 = m0;
         let c1 = 0;
         let c2 = 0;
-        let (c0, c1) = muladd_fast(m8, NEG_MODULUS[0], c0, c1);
+        let (c0, c1) = muladd_fast(m8, neg_modulus0, c0, c1);
         let (p0, c0, c1) = (c0, c1, 0);
         let (c0, c1) = sumadd_fast(m1, c0, c1);
-        let (c0, c1, c2) = muladd(m9, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(m9, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(m8, NEG_MODULUS[1], c0, c1, c2);
         let (p1, c0, c1, c2) = (c0, c1, c2, 0);
         let (c0, c1, c2) = sumadd(m2, c0, c1, c2);
-        let (c0, c1, c2) = muladd(m10, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(m10, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(m9, NEG_MODULUS[1], c0, c1, c2);
         let (c0, c1, c2) = muladd(m8, NEG_MODULUS[2], c0, c1, c2);
         let (p2, c0, c1, c2) = (c0, c1, c2, 0);
         let (c0, c1, c2) = sumadd(m3, c0, c1, c2);
-        let (c0, c1, c2) = muladd(m11, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(m11, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(m10, NEG_MODULUS[1], c0, c1, c2);
         let (c0, c1, c2) = muladd(m9, NEG_MODULUS[2], c0, c1, c2);
         let (c0, c1, c2) = muladd(m8, NEG_MODULUS[3], c0, c1, c2);
         let (p3, c0, c1, c2) = (c0, c1, c2, 0);
         let (c0, c1, c2) = sumadd(m4, c0, c1, c2);
-        let (c0, c1, c2) = muladd(m12, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(m12, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(m11, NEG_MODULUS[1], c0, c1, c2);
         let (c0, c1, c2) = muladd(m10, NEG_MODULUS[2], c0, c1, c2);
         let (c0, c1, c2) = muladd(m9, NEG_MODULUS[3], c0, c1, c2);
@@ -360,7 +366,7 @@ impl WideScalar {
 
         // Reduce 258 bits into 256.
         // r[0..7] = p[0..7] + p[8] * NEG_MODULUS.
-        let mut c = p0 as u64 + (NEG_MODULUS[0] as u64) * (p8 as u64);
+        let mut c = p0 as u64 + (neg_modulus0 as u64) * (p8 as u64);
         let r0 = (c & 0xFFFFFFFFu64) as u32;
         c >>= 32;
         c += p1 as u64 + (NEG_MODULUS[1] as u64) * (p8 as u64);
@@ -391,6 +397,16 @@ impl WideScalar {
         let high_bit = Choice::from(c as u8);
         let underflow = Choice::from((underflow.0 >> 31) as u8);
         Scalar(U256::conditional_select(&r, &r2, !underflow | high_bit))
+    }
+
+    #[inline(always)] // only used in Scalar::mul(), so won't cause binary bloat
+    pub(super) fn reduce(&self) -> Scalar {
+        self.reduce_impl(false)
+    }
+
+    pub(super) fn reduce_nonzero(&self) -> NonZeroScalar {
+        let s = self.reduce_impl(true);
+        NonZeroScalar::new(s + Scalar::one()).unwrap()
     }
 }
 

--- a/k256/src/arithmetic/scalar/wide64.rs
+++ b/k256/src/arithmetic/scalar/wide64.rs
@@ -1,9 +1,10 @@
 //! Wide scalar (64-bit limbs)
 
 use super::{Scalar, MODULUS};
-use crate::ORDER;
+use crate::{NonZeroScalar, ORDER};
 use elliptic_curve::{
     bigint::{Limb, U256, U512},
+    group::ff::Field,
     subtle::{Choice, ConditionallySelectable},
 };
 
@@ -118,8 +119,13 @@ impl WideScalar {
         Scalar::conditional_select(&res, &res.add(&Scalar::ONE), Choice::from(c as u8))
     }
 
-    #[inline(always)] // only used in Scalar::mul(), so won't cause binary bloat
-    pub(super) fn reduce(&self) -> Scalar {
+    fn reduce_impl(&self, modulus_minus_one: bool) -> Scalar {
+        let neg_modulus0 = if modulus_minus_one {
+            NEG_MODULUS[0] + 1
+        } else {
+            NEG_MODULUS[0]
+        };
+
         let w = self.0.to_uint_array();
         let n0 = w[4];
         let n1 = w[5];
@@ -127,23 +133,23 @@ impl WideScalar {
         let n3 = w[7];
 
         // Reduce 512 bits into 385.
-        // m[0..6] = self[0..3] + n[0..3] * NEG_MODULUS.
+        // m[0..6] = self[0..3] + n[0..3] * neg_modulus.
         let c0 = w[0];
         let c1 = 0;
         let c2 = 0;
-        let (c0, c1) = muladd_fast(n0, NEG_MODULUS[0], c0, c1);
+        let (c0, c1) = muladd_fast(n0, neg_modulus0, c0, c1);
         let (m0, c0, c1) = (c0, c1, 0);
         let (c0, c1) = sumadd_fast(w[1], c0, c1);
-        let (c0, c1, c2) = muladd(n1, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(n1, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(n0, NEG_MODULUS[1], c0, c1, c2);
         let (m1, c0, c1, c2) = (c0, c1, c2, 0);
         let (c0, c1, c2) = sumadd(w[2], c0, c1, c2);
-        let (c0, c1, c2) = muladd(n2, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(n2, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(n1, NEG_MODULUS[1], c0, c1, c2);
         let (c0, c1, c2) = sumadd(n0, c0, c1, c2);
         let (m2, c0, c1, c2) = (c0, c1, c2, 0);
         let (c0, c1, c2) = sumadd(w[3], c0, c1, c2);
-        let (c0, c1, c2) = muladd(n3, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(n3, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(n2, NEG_MODULUS[1], c0, c1, c2);
         let (c0, c1, c2) = sumadd(n1, c0, c1, c2);
         let (m3, c0, c1, c2) = (c0, c1, c2, 0);
@@ -156,18 +162,18 @@ impl WideScalar {
         let m6 = c0;
 
         // Reduce 385 bits into 258.
-        // p[0..4] = m[0..3] + m[4..6] * NEG_MODULUS.
+        // p[0..4] = m[0..3] + m[4..6] * neg_modulus.
         let c0 = m0;
         let c1 = 0;
         let c2 = 0;
-        let (c0, c1) = muladd_fast(m4, NEG_MODULUS[0], c0, c1);
+        let (c0, c1) = muladd_fast(m4, neg_modulus0, c0, c1);
         let (p0, c0, c1) = (c0, c1, 0);
         let (c0, c1) = sumadd_fast(m1, c0, c1);
-        let (c0, c1, c2) = muladd(m5, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(m5, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(m4, NEG_MODULUS[1], c0, c1, c2);
         let (p1, c0, c1) = (c0, c1, 0);
         let (c0, c1, c2) = sumadd(m2, c0, c1, c2);
-        let (c0, c1, c2) = muladd(m6, NEG_MODULUS[0], c0, c1, c2);
+        let (c0, c1, c2) = muladd(m6, neg_modulus0, c0, c1, c2);
         let (c0, c1, c2) = muladd(m5, NEG_MODULUS[1], c0, c1, c2);
         let (c0, c1, c2) = sumadd(m4, c0, c1, c2);
         let (p2, c0, c1, _c2) = (c0, c1, c2, 0);
@@ -179,8 +185,8 @@ impl WideScalar {
         debug_assert!(p4 <= 2);
 
         // Reduce 258 bits into 256.
-        // r[0..3] = p[0..3] + p[4] * NEG_MODULUS.
-        let mut c = (p0 as u128) + (NEG_MODULUS[0] as u128) * (p4 as u128);
+        // r[0..3] = p[0..3] + p[4] * neg_modulus.
+        let mut c = (p0 as u128) + (neg_modulus0 as u128) * (p4 as u128);
         let r0 = (c & 0xFFFFFFFFFFFFFFFFu128) as u64;
         c >>= 64;
         c += (p1 as u128) + (NEG_MODULUS[1] as u128) * (p4 as u128);
@@ -199,6 +205,16 @@ impl WideScalar {
         let high_bit = Choice::from(c as u8);
         let underflow = Choice::from((underflow.0 >> 63) as u8);
         Scalar(U256::conditional_select(&r, &r2, !underflow | high_bit))
+    }
+
+    #[inline(always)] // only used in Scalar::mul(), so won't cause binary bloat
+    pub(super) fn reduce(&self) -> Scalar {
+        self.reduce_impl(false)
+    }
+
+    pub(super) fn reduce_nonzero(&self) -> NonZeroScalar {
+        let s = self.reduce_impl(true);
+        NonZeroScalar::new(s + Scalar::one()).unwrap()
     }
 }
 


### PR DESCRIPTION
This is a "spitballing" PR, intended primarily for illustration of required API and discussion.

There are two things I'm missing from the current `Scalar` API:
- an ability to generate random `NonZeroScalar`s (without unwrapping)
- an ability to generate a `Scalar`/`NonZeroScalar` from a digest safely according to [hash-to-curve standard](https://tools.ietf.org/pdf/draft-irtf-cfrg-hash-to-curve-11.pdf)

The latter needs the scalar to be reduced from `L = ceil((ceil(log2(p)) + k) / 8)` bytes (Section 5.3), where `p` is the order, and `k` is the security parameter. For `k = 256` this gives 64 bytes, for `k = 128` it's 48 bytes. I went with 64 for simplicity.

The public methods added to `Scalar`:
- `pub fn random_nonzero(rng: impl RngCore) -> NonZeroScalar`
- `pub fn from_digest_safe<D>(digest: D) -> Self where D: Digest<OutputSize = U64>`
- `pub fn from_digest_safe_nonzero<D>(digest: D) -> NonZeroScalar where D: Digest<OutputSize = U64>`

Now for the problems:
- `random()` is a part of the `Field` trait. If `NonZeroScalar` implemented `Field`, the code from `random_nonzero()` could go there.
- `FromDigest` requires `OutputSize = FieldSize`, so it can't be changed to 64 bytes output. The ways to deal with it include:
  - adding a `SafeExpansionSize` (or whatever) type and locking `FromDigest` to it
  - adding a `FromDigestSafe` trait
- `from_digest_safe_nonzero()` can be an impl of `FromDigest` for `NonZeroScalar` (but again there's the size problem)
- The added internal function `Scalar::from_wide_bytes_reduced()` assumes that `WideScalar::reduce()` can reduce any 512 bit, and not just anything below `order^2`. I'm 99.9% certain that's true, but I can't present a formal proof right now. I did test it for `0xfff...fff`, and it works.
- `WideScalar::reduce_nonzero()` assumes that `reduce()` works just as well for the modulus decreased by one. See the comment above about being 99.9% sure.
- `WideScalar::reduce_nonzero()` contains an `unwrap()`. Ideally I'd prefer to have something like `NonZeroScalar::from_bytes_unchecked()` to avoid it.

