### PR TITLE
Updates for `sec1` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "const-oid"
 version = "0.6.1"
-source = "git+https://github.com/rustcrypto/formats#cc06abfcff56356cee6457162321be21369ab435"
+source = "git+https://github.com/rustcrypto/formats#85322893dc6038d91027599fcf6b19489acd1f7d"
 
 [[package]]
 name = "cpufeatures"
@@ -289,7 +289,7 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.4.3"
-source = "git+https://github.com/rustcrypto/formats#cc06abfcff56356cee6457162321be21369ab435"
+source = "git+https://github.com/rustcrypto/formats#85322893dc6038d91027599fcf6b19489acd1f7d"
 dependencies = [
  "const-oid",
 ]
@@ -306,7 +306,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.13.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#378f3af42d484bf5b15eb38b1f8603ac33a8ae02"
+source = "git+https://github.com/RustCrypto/signatures.git#0eca1f40d9e1142e0ddf40d7bc72504695c0a7b6"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -323,7 +323,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#55a1af7a3ad1088dbfd26c4add473017a05088b5"
+source = "git+https://github.com/RustCrypto/traits.git#301441b62b2563987ae8a76dc71c3d695feaf5e0"
 dependencies = [
  "base64ct",
  "crypto-bigint",
@@ -855,9 +855,11 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "sec1"
 version = "0.0.0"
-source = "git+https://github.com/rustcrypto/formats#cc06abfcff56356cee6457162321be21369ab435"
+source = "git+https://github.com/rustcrypto/formats#85322893dc6038d91027599fcf6b19489acd1f7d"
 dependencies = [
  "der",
+ "generic-array",
+ "subtle",
  "zeroize",
 ]
 

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
 
 [dependencies]
-elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
 ecdsa = { version = "=0.13.0-pre", optional = true, default-features = false, features = ["der"] }

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
 
 [dependencies]
-elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
 ecdsa = { version = "=0.13.0-pre", optional = true, default-features = false, features = ["der"] }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "=0.13.0-pre", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -303,13 +303,6 @@ mod tests {
     }
 
     #[test]
-    fn decompress() {
-        let encoded = EncodedPoint::from_bytes(COMPRESSED_BASEPOINT).unwrap();
-        let decompressed = encoded.decompress().unwrap();
-        assert_eq!(decompressed.as_bytes(), UNCOMPRESSED_BASEPOINT);
-    }
-
-    #[test]
     fn affine_negation() {
         let basepoint = AffinePoint::generator();
         assert_eq!((-(-basepoint)), basepoint);

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -98,8 +98,8 @@ impl ecdsa_core::hazmat::DigestPrimitive for Secp256k1 {
 #[cfg(all(test, feature = "ecdsa", feature = "arithmetic"))]
 mod tests {
     mod wycheproof {
-        use crate::Secp256k1;
-        use ecdsa_core::{elliptic_curve::sec1::EncodedPoint, signature::Verifier, Signature};
+        use crate::{EncodedPoint, Secp256k1};
+        use ecdsa_core::{signature::Verifier, Signature};
 
         #[test]
         fn wycheproof() {
@@ -135,7 +135,7 @@ mod tests {
             ) -> Option<&'static str> {
                 let x = element_from_padded_slice::<Secp256k1>(wx);
                 let y = element_from_padded_slice::<Secp256k1>(wy);
-                let q_encoded: EncodedPoint<Secp256k1> =
+                let q_encoded =
                     EncodedPoint::from_affine_coordinates(&x, &y, /* compress= */ false);
                 let verifying_key =
                     ecdsa_core::VerifyingKey::from_encoded_point(&q_encoded).unwrap();

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
 
 [dependencies]
-elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "=0.13.0-pre", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p256/src/arithmetic/affine.rs
+++ b/p256/src/arithmetic/affine.rs
@@ -349,13 +349,6 @@ mod tests {
     }
 
     #[test]
-    fn decompress() {
-        let encoded = EncodedPoint::from_bytes(COMPRESSED_BASEPOINT).unwrap();
-        let decompressed = encoded.decompress().unwrap();
-        assert_eq!(decompressed.as_bytes(), UNCOMPRESSED_BASEPOINT);
-    }
-
-    #[test]
     fn affine_negation() {
         let basepoint = AffinePoint::generator();
         assert_eq!(-(-basepoint), basepoint);

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "ecc", "nist", "secp384r1"]
 
 [dependencies]
 ecdsa = { version = "=0.13.0-pre", optional = true, default-features = false, features = ["der"] }
-elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat"] }
+elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [features]


### PR DESCRIPTION
These code changes are necessary to support a migration to the `sec1` crate, which extracted types like `EncodedPoint` into a separate reusable crate.

Relevant `elliptic-curve` PR:

https://github.com/RustCrypto/traits/pull/771