### PR TITLE
k256+p256: impl `Reduce` trait on `Scalar` types

### DIFF
--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -47,7 +47,12 @@ use crate::{
         signature::{digest::Digest, DigestVerifier},
         VerifyingKey,
     },
-    elliptic_curve::{consts::U32, ops::Invert, subtle::Choice, DecompressPoint},
+    elliptic_curve::{
+        consts::U32,
+        ops::{Invert, Reduce},
+        subtle::Choice,
+        DecompressPoint,
+    },
     lincomb, AffinePoint, FieldBytes, NonZeroScalar, ProjectivePoint, Scalar,
 };
 
@@ -170,7 +175,7 @@ impl Signature {
     ) -> Result<VerifyingKey, Error> {
         let r = self.r();
         let s = self.s();
-        let z = Scalar::from_bytes_reduced(digest_bytes);
+        let z = Scalar::from_be_bytes_reduced(*digest_bytes);
         let R = AffinePoint::decompress(&r.to_bytes(), self.recovery_id().is_y_odd());
 
         if R.is_some().into() {

--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -16,7 +16,7 @@ use ecdsa_core::{
 };
 use elliptic_curve::{
     consts::U32,
-    ops::Invert,
+    ops::{Invert, Reduce},
     rand_core::{CryptoRng, RngCore},
     subtle::{Choice, ConstantTimeEq},
 };
@@ -181,7 +181,7 @@ impl RecoverableSignPrimitive<Secp256k1> for Scalar {
 
         // Lift x-coordinate of 𝐑 (element of base field) into a serialized big
         // integer, then reduce it into an element of the scalar field
-        let r = Scalar::from_bytes_reduced(&R.x.to_bytes());
+        let r = Scalar::from_be_bytes_reduced(R.x.to_bytes());
 
         // Compute `s` as a signature over `r` and `z`.
         let s = k_inverse * (z + (r * self));

--- a/k256/src/ecdsa/verify.rs
+++ b/k256/src/ecdsa/verify.rs
@@ -7,7 +7,11 @@ use crate::{
 };
 use core::convert::TryFrom;
 use ecdsa_core::{hazmat::VerifyPrimitive, signature};
-use elliptic_curve::{consts::U32, ops::Invert, sec1::ToEncodedPoint};
+use elliptic_curve::{
+    consts::U32,
+    ops::{Invert, Reduce},
+    sec1::ToEncodedPoint,
+};
 use signature::{digest::Digest, DigestVerifier};
 
 #[cfg(feature = "sha256")]
@@ -100,7 +104,7 @@ impl VerifyPrimitive<Secp256k1> for AffinePoint {
         .to_affine()
         .x;
 
-        if Scalar::from_bytes_reduced(&x.to_bytes()).eq(&r) {
+        if Scalar::from_be_bytes_reduced(x.to_bytes()).eq(&r) {
             Ok(())
         } else {
             Err(Error::new())

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -48,7 +48,10 @@ use {
     crate::{AffinePoint, ProjectivePoint, Scalar},
     core::borrow::Borrow,
     ecdsa_core::hazmat::{SignPrimitive, VerifyPrimitive},
-    elliptic_curve::{group::ff::Field, ops::Invert},
+    elliptic_curve::{
+        group::ff::Field,
+        ops::{Invert, Reduce},
+    },
 };
 
 /// ECDSA/P-256 signature (fixed-size)
@@ -94,7 +97,7 @@ impl SignPrimitive<NistP256> for Scalar {
 
         // Lift `x` (element of base field) to serialized big endian integer,
         // then reduce it to an element of the scalar field
-        let r = Scalar::from_bytes_reduced(&x.to_bytes());
+        let r = Scalar::from_be_bytes_reduced(x.to_bytes());
 
         // Compute `s` as a signature over `r` and `z`.
         let s = k_inverse * (z + &(r * self));
@@ -120,7 +123,7 @@ impl VerifyPrimitive<NistP256> for AffinePoint {
             .to_affine()
             .x;
 
-        if Scalar::from_bytes_reduced(&x.to_bytes()) == *r {
+        if Scalar::from_be_bytes_reduced(x.to_bytes()) == *r {
             Ok(())
         } else {
             Err(Error::new())


### PR DESCRIPTION
Adds trait impls to `k256::Scalar` and `p256::Scalar` for the newly introduced `Reduce` trait, replacing the previous inherent methods:

https://github.com/RustCrypto/traits/pull/768