### PR TITLE
k256+p256: replace `ecdsa::hazmat::FromDigest` with `Reduce`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.13.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#c730a0fe33c0ab65974e76f70991466e8d862ed2"
+source = "git+https://github.com/RustCrypto/signatures.git#010da678be92aa557a26154b6a5d5345dcc0dd92"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -325,7 +325,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#fcafb48f1fc9786a784644d6e4b8946d991510ae"
+source = "git+https://github.com/RustCrypto/traits.git#fea0010f3356186804b42e57a8cb3612b96dab9f"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -25,9 +25,6 @@ use elliptic_curve::{
 #[cfg(feature = "bits")]
 use {crate::ScalarBits, elliptic_curve::group::ff::PrimeFieldBits};
 
-#[cfg(feature = "digest")]
-use ecdsa_core::{elliptic_curve::consts::U32, hazmat::FromDigest, signature::digest::Digest};
-
 #[cfg(test)]
 use num_bigint::{BigUint, ToBigUint};
 
@@ -377,19 +374,6 @@ impl From<ScalarCore<Secp256k1>> for Scalar {
 impl From<Scalar> for U256 {
     fn from(scalar: Scalar) -> U256 {
         scalar.0
-    }
-}
-
-#[cfg(feature = "digest")]
-#[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
-impl FromDigest<Secp256k1> for Scalar {
-    /// Convert the output of a digest algorithm into a [`Scalar`] reduced
-    /// modulo n.
-    fn from_digest<D>(digest: D) -> Self
-    where
-        D: Digest<OutputSize = U32>,
-    {
-        Self::from_be_bytes_reduced(digest.finalize())
     }
 }
 

--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -7,7 +7,7 @@ use core::{
     fmt::{self, Debug},
 };
 use ecdsa_core::{
-    hazmat::{FromDigest, RecoverableSignPrimitive},
+    hazmat::RecoverableSignPrimitive,
     rfc6979,
     signature::{
         digest::{BlockInput, FixedOutput, Reset, Update},
@@ -110,9 +110,9 @@ impl<D> DigestSigner<D, recoverable::Signature> for SigningKey
 where
     D: BlockInput + FixedOutput<OutputSize = U32> + Clone + Default + Reset + Update,
 {
-    fn try_sign_digest(&self, digest: D) -> Result<recoverable::Signature, Error> {
-        let ephemeral_scalar = rfc6979::generate_k(&self.inner, digest.clone(), &[]);
-        let msg_scalar = Scalar::from_digest(digest);
+    fn try_sign_digest(&self, msg_digest: D) -> Result<recoverable::Signature, Error> {
+        let ephemeral_scalar = rfc6979::generate_k(&self.inner, msg_digest.clone(), &[]);
+        let msg_scalar = Scalar::from_be_bytes_reduced(msg_digest.finalize_fixed());
         let (signature, recovery_id) = self
             .inner
             .try_sign_recoverable_prehashed(ephemeral_scalar.as_ref(), &msg_scalar)?;
@@ -142,13 +142,13 @@ where
     fn try_sign_digest_with_rng(
         &self,
         mut rng: impl CryptoRng + RngCore,
-        digest: D,
+        msg_digest: D,
     ) -> Result<recoverable::Signature, Error> {
         let mut added_entropy = FieldBytes::default();
         rng.fill_bytes(&mut added_entropy);
 
-        let ephemeral_scalar = rfc6979::generate_k(&self.inner, digest.clone(), &added_entropy);
-        let msg_scalar = Scalar::from_digest(digest);
+        let ephemeral_scalar = rfc6979::generate_k(&self.inner, msg_digest.clone(), &added_entropy);
+        let msg_scalar = Scalar::from_be_bytes_reduced(msg_digest.finalize_fixed());
         let (signature, is_r_odd) = self
             .inner
             .try_sign_recoverable_prehashed(ephemeral_scalar.as_ref(), &msg_scalar)?;

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -21,9 +21,6 @@ use elliptic_curve::{
 #[cfg(feature = "bits")]
 use {crate::ScalarBits, elliptic_curve::group::ff::PrimeFieldBits};
 
-#[cfg(feature = "digest")]
-use ecdsa_core::{elliptic_curve::consts::U32, hazmat::FromDigest, signature::digest::Digest};
-
 /// Array containing 4 x 64-bit unsigned integers.
 // TODO(tarcieri): replace this entirely with `U256`
 type U64x4 = [u64; 4];
@@ -571,19 +568,6 @@ impl From<ScalarCore<NistP256>> for Scalar {
 impl From<Scalar> for U256 {
     fn from(scalar: Scalar) -> U256 {
         scalar.0
-    }
-}
-
-#[cfg(feature = "digest")]
-#[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
-impl FromDigest<NistP256> for Scalar {
-    /// Convert the output of a digest algorithm into a [`Scalar`] reduced
-    /// modulo n.
-    fn from_digest<D>(digest: D) -> Self
-    where
-        D: Digest<OutputSize = U32>,
-    {
-        Self::from_be_bytes_reduced(digest.finalize())
     }
 }
 


### PR DESCRIPTION
The `FromDigest` trait has been removed from the `ecdsa` crate, in favor of using the `Reduce` trait:

https://github.com/RustCrypto/signatures/pull/372

This is the corresponding set of changes to the above upstream PR to the `ecdsa` crate which implements this change.