### PR TITLE
Handle identity point in `GroupEncoding`

### DIFF
--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -171,6 +171,12 @@ impl GroupEncoding for AffinePoint {
         let is_compressed_point = y_is_odd | tag.ct_eq(&sec1::Tag::CompressedEvenY.into());
         Self::decompress(FieldBytes::from_slice(&bytes[1..]), y_is_odd)
             .and_then(|point| CtOption::new(point, is_compressed_point))
+            .or_else(|| {
+                CtOption::new(
+                    AffinePoint::identity(),
+                    tag.ct_eq(&sec1::Tag::Identity.into()),
+                )
+            })
     }
 
     fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
@@ -179,7 +185,11 @@ impl GroupEncoding for AffinePoint {
     }
 
     fn to_bytes(&self) -> Self::Repr {
-        CompressedPoint::clone_from_slice(self.to_encoded_point(true).as_bytes())
+        let bytes = self.to_encoded_point(true);
+        let bytes = bytes.as_bytes();
+        let mut result = CompressedPoint::default();
+        result[..bytes.len()].copy_from_slice(bytes);
+        result
     }
 }
 
@@ -248,7 +258,7 @@ mod tests {
     use super::AffinePoint;
     use crate::EncodedPoint;
     use elliptic_curve::{
-        group::prime::PrimeCurveAffine,
+        group::{prime::PrimeCurveAffine, GroupEncoding},
         sec1::{FromEncodedPoint, ToEncodedPoint},
     };
     use hex_literal::hex;
@@ -306,5 +316,16 @@ mod tests {
     fn affine_negation() {
         let basepoint = AffinePoint::generator();
         assert_eq!((-(-basepoint)), basepoint);
+    }
+
+    #[test]
+    fn identity_encoding() {
+        // This is technically an invalid SEC1 encoding, but is preferable to panicking.
+        assert_eq!([0; 33], AffinePoint::identity().to_bytes().as_slice());
+        assert!(bool::from(
+            AffinePoint::from_bytes(&AffinePoint::identity().to_bytes())
+                .unwrap()
+                .is_identity()
+        ))
     }
 }

--- a/p256/src/arithmetic/projective.rs
+++ b/p256/src/arithmetic/projective.rs
@@ -525,7 +525,7 @@ impl<'a> Neg for &'a ProjectivePoint {
 mod tests {
     use super::{AffinePoint, ProjectivePoint, Scalar};
     use crate::test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS};
-    use elliptic_curve::group::{ff::PrimeField, prime::PrimeCurveAffine, GroupEncoding};
+    use elliptic_curve::group::{ff::PrimeField, prime::PrimeCurveAffine, Group, GroupEncoding};
 
     #[test]
     fn affine_to_projective() {
@@ -671,8 +671,13 @@ mod tests {
     }
 
     #[test]
-    fn projective_identity_to_bytes() {
+    fn identity_encoding() {
         // This is technically an invalid SEC1 encoding, but is preferable to panicking.
         assert_eq!([0; 33], ProjectivePoint::identity().to_bytes().as_slice());
+        assert!(bool::from(
+            ProjectivePoint::from_bytes(&ProjectivePoint::identity().to_bytes())
+                .unwrap()
+                .is_identity()
+        ))
     }
 }


### PR DESCRIPTION
This enabled `GroupEncoding::to_bytes()` and `GroupEncoding::from_bytes()` for `AffinePoint` and `ProjectivePoint` for p256 and k256 to handle the identity point.

See #443.