### PR TITLE
k256+p256: handle identity point in `GroupEncoding`

### DIFF
--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -132,11 +132,15 @@ impl GroupEncoding for AffinePoint {
     type Repr = CompressedPoint;
 
     fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
-        let tag = bytes[0];
-        let y_is_odd = tag.ct_eq(&sec1::Tag::CompressedOddY.into());
-        let is_compressed_point = y_is_odd | tag.ct_eq(&sec1::Tag::CompressedEvenY.into());
-        Self::decompress(FieldBytes::from_slice(&bytes[1..]), y_is_odd)
-            .and_then(|point| CtOption::new(point, is_compressed_point))
+        EncodedPoint::from_bytes(bytes)
+            .map(|point| CtOption::new(point, Choice::from(1)))
+            .unwrap_or_else(|_| {
+                // SEC1 identity encoding is technically 1-byte 0x00, but the
+                // `GroupEncoding` API requires a fixed-width `Repr`
+                let is_identity = bytes.ct_eq(&Self::Repr::default());
+                CtOption::new(EncodedPoint::identity(), is_identity)
+            })
+            .and_then(|point| Self::from_encoded_point(&point))
     }
 
     fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
@@ -145,7 +149,10 @@ impl GroupEncoding for AffinePoint {
     }
 
     fn to_bytes(&self) -> Self::Repr {
-        CompressedPoint::clone_from_slice(self.to_encoded_point(true).as_bytes())
+        let encoded = self.to_encoded_point(true);
+        let mut result = CompressedPoint::default();
+        result[..encoded.len()].copy_from_slice(encoded.as_bytes());
+        result
     }
 }
 
@@ -241,7 +248,7 @@ mod tests {
     use super::AffinePoint;
     use crate::EncodedPoint;
     use elliptic_curve::{
-        group::prime::PrimeCurveAffine,
+        group::{prime::PrimeCurveAffine, GroupEncoding},
         sec1::{FromEncodedPoint, ToEncodedPoint},
     };
     use hex_literal::hex;
@@ -299,5 +306,16 @@ mod tests {
     fn affine_negation() {
         let basepoint = AffinePoint::generator();
         assert_eq!((-(-basepoint)), basepoint);
+    }
+
+    #[test]
+    fn identity_encoding() {
+        // This is technically an invalid SEC1 encoding, but is preferable to panicking.
+        assert_eq!([0; 33], AffinePoint::identity().to_bytes().as_slice());
+        assert!(bool::from(
+            AffinePoint::from_bytes(&AffinePoint::identity().to_bytes())
+                .unwrap()
+                .is_identity()
+        ))
     }
 }

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -298,7 +298,7 @@ impl GroupEncoding for ProjectivePoint {
     type Repr = CompressedPoint;
 
     fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
-        <AffinePoint as GroupEncoding>::from_bytes(bytes).map(|point| point.into())
+        <AffinePoint as GroupEncoding>::from_bytes(bytes).map(Into::into)
     }
 
     fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
@@ -307,7 +307,7 @@ impl GroupEncoding for ProjectivePoint {
     }
 
     fn to_bytes(&self) -> Self::Repr {
-        CompressedPoint::clone_from_slice(self.to_affine().to_encoded_point(true).as_bytes())
+        self.to_affine().to_bytes()
     }
 }
 

--- a/p256/src/arithmetic/projective.rs
+++ b/p256/src/arithmetic/projective.rs
@@ -66,7 +66,7 @@ impl GroupEncoding for ProjectivePoint {
     type Repr = CompressedPoint;
 
     fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
-        <AffinePoint as GroupEncoding>::from_bytes(bytes).map(|point| point.into())
+        <AffinePoint as GroupEncoding>::from_bytes(bytes).map(Into::into)
     }
 
     fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
@@ -75,11 +75,7 @@ impl GroupEncoding for ProjectivePoint {
     }
 
     fn to_bytes(&self) -> Self::Repr {
-        let bytes = self.to_affine().to_encoded_point(true);
-        let bytes = bytes.as_bytes();
-        let mut result = CompressedPoint::default();
-        result[..bytes.len()].copy_from_slice(bytes);
-        result
+        self.to_affine().to_bytes()
     }
 }
 


### PR DESCRIPTION
`GroupEncoding` uses a fixed-width `Repr` whereas SEC1 is variable-width with respect to compressed points versus the identity.

This change allows 33-bytes of zeroes to be used as the identity. Technically that's not a valid SEC1 encoding: the SEC1 encoding for the identity is 1-byte: 0x00. However, this is the best we can do with a fixed-width encoding.

See also: #443 and #444