### PR TITLE
Bump `pkcs8` crate; update encoding traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
 [[package]]
 name = "base64ct"
 version = "1.1.1"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 
 [[package]]
 name = "bit-set"
@@ -156,7 +156,7 @@ dependencies = [
 [[package]]
 name = "const-oid"
 version = "0.6.2"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 
 [[package]]
 name = "cpufeatures"
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12477e115c0d570c12a2dfd859f80b55b60ddb5075df210d3af06d133a69f45"
+checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -294,9 +294,10 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.5.0-pre.1"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
 ]
 
 [[package]]
@@ -311,7 +312,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.13.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#54925be85d4eeb0540bf7c687ab08152a858871a"
+source = "git+https://github.com/RustCrypto/signatures.git#23947daef3ab97587f774765f95227455bc82323"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -328,7 +329,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#80ee951080a3544e6550a86923ed49258f8b91ce"
+source = "git+https://github.com/RustCrypto/traits.git#d2639c11cbaa49db6186f99f1a0d90a44be146ad"
 dependencies = [
  "base64ct 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-bigint",
@@ -489,9 +490,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
 
 [[package]]
 name = "log"
@@ -594,7 +595,7 @@ dependencies = [
 [[package]]
 name = "pem-rfc7468"
 version = "0.2.2"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
  "base64ct 1.1.1 (git+https://github.com/RustCrypto/formats.git)",
 ]
@@ -602,10 +603,9 @@ dependencies = [
 [[package]]
 name = "pkcs8"
 version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
  "der",
- "pem-rfc7468",
  "spki",
  "zeroize",
 ]
@@ -857,8 +857,8 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sec1"
-version = "0.2.0"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+version = "0.2.0-pre"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
  "der",
  "generic-array",
@@ -948,8 +948,9 @@ dependencies = [
 [[package]]
 name = "spki"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
+ "base64ct 1.1.1 (git+https://github.com/RustCrypto/formats.git)",
  "der",
 ]
 

--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -1,4 +1,4 @@
-//! ECDSA signer
+//! ECDSA signing support.
 
 use super::{recoverable, Error, Signature, VerifyingKey};
 use crate::{FieldBytes, NonZeroScalar, ProjectivePoint, PublicKey, Scalar, Secp256k1, SecretKey};
@@ -26,7 +26,7 @@ use elliptic_curve::{
 use ecdsa_core::signature::{self, digest::Digest, PrehashSignature, RandomizedSigner};
 
 #[cfg(feature = "pkcs8")]
-use crate::pkcs8::{self, FromPrivateKey};
+use crate::pkcs8::{self, DecodePrivateKey};
 
 #[cfg(feature = "pem")]
 use core::str::FromStr;
@@ -283,7 +283,7 @@ impl Drop for SigningKey {
 
 #[cfg(feature = "pkcs8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
-impl FromPrivateKey for SigningKey {
+impl DecodePrivateKey for SigningKey {
     fn from_pkcs8_private_key_info(
         private_key_info: pkcs8::PrivateKeyInfo<'_>,
     ) -> pkcs8::Result<Self> {

--- a/k256/src/ecdsa/verify.rs
+++ b/k256/src/ecdsa/verify.rs
@@ -1,4 +1,4 @@
-//! ECDSA verifier
+//! ECDSA verification support.
 
 use super::{recoverable, Error, Signature};
 use crate::{
@@ -18,7 +18,7 @@ use signature::{digest::Digest, DigestVerifier};
 use signature::PrehashSignature;
 
 #[cfg(feature = "pkcs8")]
-use crate::pkcs8::{self, FromPublicKey};
+use crate::pkcs8::{self, DecodePublicKey};
 
 #[cfg(feature = "pem")]
 use core::str::FromStr;
@@ -166,8 +166,8 @@ impl TryFrom<&EncodedPoint> for VerifyingKey {
 
 #[cfg(feature = "pkcs8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
-impl FromPublicKey for VerifyingKey {
-    fn from_spki(spki: pkcs8::SubjectPublicKeyInfo<'_>) -> pkcs8::Result<Self> {
+impl DecodePublicKey for VerifyingKey {
+    fn from_spki(spki: pkcs8::SubjectPublicKeyInfo<'_>) -> pkcs8::der::Result<Self> {
         PublicKey::from_spki(spki).map(|pk| Self { inner: pk.into() })
     }
 }

--- a/p256/tests/pkcs8.rs
+++ b/p256/tests/pkcs8.rs
@@ -5,11 +5,11 @@
 use hex_literal::hex;
 use p256::{
     elliptic_curve::sec1::ToEncodedPoint,
-    pkcs8::{FromPrivateKey, FromPublicKey},
+    pkcs8::{DecodePrivateKey, DecodePublicKey},
 };
 
 #[cfg(feature = "pem")]
-use p256::elliptic_curve::pkcs8::{ToPrivateKey, ToPublicKey};
+use p256::elliptic_curve::pkcs8::{EncodePrivateKey, EncodePublicKey};
 
 /// DER-encoded PKCS#8 private key
 const PKCS8_PRIVATE_KEY_DER: &[u8; 138] = include_bytes!("examples/pkcs8-private-key.der");
@@ -83,7 +83,9 @@ fn encode_pkcs8_public_key_to_der() {
 #[cfg(feature = "pem")]
 fn encode_pkcs8_private_key_to_pem() {
     let original_secret_key = p256::SecretKey::from_pkcs8_der(&PKCS8_PRIVATE_KEY_DER[..]).unwrap();
-    let reencoded_secret_key = original_secret_key.to_pkcs8_pem().unwrap();
+    let reencoded_secret_key = original_secret_key
+        .to_pkcs8_pem(Default::default())
+        .unwrap();
     assert_eq!(reencoded_secret_key.as_str(), PKCS8_PRIVATE_KEY_PEM);
 }
 


### PR DESCRIPTION
Updates `pkcs8` and related crates to use the new trait names after they were renamed in RustCrypto/formats#121.