### PR TITLE
Rust 2021 edition upgrade; MSRV 1.56+

### DIFF
--- a/.github/workflows/bp256.yml
+++ b/.github/workflows/bp256.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -31,10 +31,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
+          profile: minimal
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
@@ -47,14 +47,15 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo check --all-features
     - run: cargo test --no-default-features
     - run: cargo test

--- a/.github/workflows/bp384.yml
+++ b/.github/workflows/bp384.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -31,10 +31,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
+          profile: minimal
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
@@ -47,14 +47,15 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo check --all-features
     - run: cargo test --no-default-features
     - run: cargo test

--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -55,14 +55,15 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
+          override: true
+          profile: minimal
       - run: cargo build --all-features --benches
 
   test:
@@ -72,7 +73,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.55.0 # MSRV
+            rust: 1.56.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -80,7 +81,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.55.0 # MSRV
+            rust: 1.56.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 
@@ -105,19 +106,19 @@ jobs:
 #        include:
 #          # ARM32
 #          - target: armv7-unknown-linux-gnueabihf
-#            rust: 1.55.0 # MSRV
+#            rust: 1.56.0 # MSRV
 #          - target: armv7-unknown-linux-gnueabihf
 #            rust: stable
 #
 #          # ARM64
 #          - target: aarch64-unknown-linux-gnu
-#            rust: 1.55.0 # MSRV
+#            rust: 1.56.0 # MSRV
 #          - target: aarch64-unknown-linux-gnu
 #            rust: stable
 #
 #          # PPC32
 #          - target: powerpc-unknown-linux-gnu
-#            rust: 1.55.0 # MSRV
+#            rust: 1.56.0 # MSRV
 #          - target: powerpc-unknown-linux-gnu
 #            rust: stable
 #

--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -54,7 +54,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.55.0 # MSRV
+            rust: 1.56.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -62,7 +62,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.55.0 # MSRV
+            rust: 1.56.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 
@@ -87,19 +87,19 @@ jobs:
 #        include:
 #          # ARM32
 #          - target: armv7-unknown-linux-gnueabihf
-#            rust: 1.55.0 # MSRV
+#            rust: 1.56.0 # MSRV
 #          - target: armv7-unknown-linux-gnueabihf
 #            rust: stable
 #
 #          # ARM64
 #          - target: aarch64-unknown-linux-gnu
-#            rust: 1.55.0 # MSRV
+#            rust: 1.56.0 # MSRV
 #          - target: aarch64-unknown-linux-gnu
 #            rust: stable
 #
 #          # PPC32
 #          - target: powerpc-unknown-linux-gnu
-#            rust: 1.55.0 # MSRV
+#            rust: 1.56.0 # MSRV
 #          - target: powerpc-unknown-linux-gnu
 #            rust: stable
 #

--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -31,10 +31,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
+          profile: minimal
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features jwk
@@ -48,14 +48,15 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo check --all-features
     - run: cargo test --no-default-features
     - run: cargo test

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -14,11 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cache cargo bin
-        uses: actions/cache@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - uses: actions/cache@v1
         with:
           path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-audit-v0.13.1
+          key: ${{ runner.os }}-cargo-audit-v0.15.2
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.55.0
+        toolchain: 1.56.0
         components: clippy
         override: true
         profile: minimal
@@ -29,38 +29,14 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: rustfmt
-          profile: minimal
-          override: true
-
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-  codecov:
-    runs-on: ubuntu-latest
-    steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          profile: minimal
+          components: rustfmt
           override: true
-      - uses: actions-rs/tarpaulin@v0.1
+          profile: minimal
+      - uses: actions-rs/cargo@v1
         with:
-          version: latest
-          args: --all --all-features -- --test-threads 1
-      - uses: codecov/codecov-action@v1
-      - uses: actions/upload-artifact@v1
-        with:
-          name: code-coverage-report
-          path: cobertura.xml
+          command: fmt
+          args: --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,8 +27,8 @@ checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
 
 [[package]]
 name = "base64ct"
-version = "1.1.1"
-source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
+version = "1.2.0-pre"
+source = "git+https://github.com/RustCrypto/formats.git#82f60d9b8367de6e1244dbbcd96b378b87efd02d"
 
 [[package]]
 name = "bit-set"
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byteorder"
@@ -155,8 +155,8 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.6.2"
-source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/formats.git#82f60d9b8367de6e1244dbbcd96b378b87efd02d"
 
 [[package]]
 name = "cpufeatures"
@@ -294,10 +294,10 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.5.0-pre.1"
-source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
+source = "git+https://github.com/RustCrypto/formats.git#82f60d9b8367de6e1244dbbcd96b378b87efd02d"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
+ "pem-rfc7468 0.3.0-pre",
 ]
 
 [[package]]
@@ -312,7 +312,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.13.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#23947daef3ab97587f774765f95227455bc82323"
+source = "git+https://github.com/RustCrypto/signatures.git#ddd6fadd9ee6c5df108f435fd30a1c5c57f7471a"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -329,16 +329,16 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#d2639c11cbaa49db6186f99f1a0d90a44be146ad"
+source = "git+https://github.com/RustCrypto/traits.git#b168e8c348ce358c6d9bfca66aa142b81d1380d2"
 dependencies = [
- "base64ct 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64ct 1.1.1",
  "crypto-bigint",
  "der",
  "ff",
  "generic-array",
  "group",
  "hex-literal",
- "pem-rfc7468",
+ "pem-rfc7468 0.2.3",
  "pkcs8",
  "rand_core",
  "sec1",
@@ -594,16 +594,25 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.2.2"
-source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f22eb0e3c593294a99e9ff4b24cf6b752d43f193aa4415fe5077c159996d497"
 dependencies = [
- "base64ct 1.1.1 (git+https://github.com/RustCrypto/formats.git)",
+ "base64ct 1.1.1",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.3.0-pre"
+source = "git+https://github.com/RustCrypto/formats.git#82f60d9b8367de6e1244dbbcd96b378b87efd02d"
+dependencies = [
+ "base64ct 1.2.0-pre",
 ]
 
 [[package]]
 name = "pkcs8"
 version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
+source = "git+https://github.com/RustCrypto/formats.git#82f60d9b8367de6e1244dbbcd96b378b87efd02d"
 dependencies = [
  "der",
  "spki",
@@ -858,7 +867,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "sec1"
 version = "0.2.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
+source = "git+https://github.com/RustCrypto/formats.git#82f60d9b8367de6e1244dbbcd96b378b87efd02d"
 dependencies = [
  "der",
  "generic-array",
@@ -937,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
 dependencies = [
  "digest",
  "rand_core",
@@ -948,9 +957,9 @@ dependencies = [
 [[package]]
 name = "spki"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
+source = "git+https://github.com/RustCrypto/formats.git#82f60d9b8367de6e1244dbbcd96b378b87efd02d"
 dependencies = [
- "base64ct 1.1.1 (git+https://github.com/RustCrypto/formats.git)",
+ "base64ct 1.2.0-pre",
  "der",
 ]
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ if you are interested in curves beyond the ones listed here.
 
 ## Minimum Supported Rust Version
 
-All crates in this repository support Rust **1.55** or higher.
+All crates in this repository support Rust **1.56** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -50,7 +50,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [deps-image]: https://deps.rs/repo/github/RustCrypto/elliptic-curves/status.svg

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "bp256"
-description = "Brainpool P-256 (brainpoolP256r1 and brainpoolP256t1) elliptic curves"
 version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
+description = "Brainpool P-256 (brainpoolP256r1 and brainpoolP256t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"
 repository = "https://github.com/RustCrypto/elliptic-curves/tree/master/bp256"
 readme = "README.md"
-edition = "2018"
 categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }

--- a/bp256/README.md
+++ b/bp256/README.md
@@ -14,7 +14,7 @@ implemented in terms of traits from the [`elliptic-curve`] crate.
 
 ## Minimum Supported Rust Version
 
-Rust **1.55** or higher.
+Rust **1.56** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -46,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/bp256/badge.svg
 [docs-link]: https://docs.rs/bp256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/bp256/badge.svg?branch=master&event=push

--- a/bp256/src/lib.rs
+++ b/bp256/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.55** or higher.
+//! Rust **1.56** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "bp384"
-description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
 version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
+description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"
 repository = "https://github.com/RustCrypto/elliptic-curves/tree/master/bp384"
 readme = "README.md"
-edition = "2018"
 categories = ["cryptography", "no-std"]
 keywords = ["brainpool", "crypto", "ecc"]
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }

--- a/bp384/README.md
+++ b/bp384/README.md
@@ -14,7 +14,7 @@ implemented in terms of traits from the [`elliptic-curve`] crate.
 
 ## Minimum Supported Rust Version
 
-Rust **1.55** or higher.
+Rust **1.56** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -46,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/bp384/badge.svg
 [docs-link]: https://docs.rs/bp384/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/bp384/badge.svg?branch=master&event=push

--- a/bp384/src/lib.rs
+++ b/bp384/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.55** or higher.
+//! Rust **1.56** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,20 +1,21 @@
 [package]
 name = "k256"
+version = "0.10.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification (including Ethereum-style signatures with public-key
 recovery), Elliptic Curve Diffie-Hellman (ECDH), and general purpose secp256k1
 curve arithmetic useful for implementing arbitrary group-based protocols.
 """
-version = "0.10.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"
 repository = "https://github.com/RustCrypto/elliptic-curves/tree/master/k256"
 readme = "README.md"
-edition = "2018"
 categories = ["cryptography", "cryptography::cryptocurrencies", "no-std"]
 keywords = ["bitcoin", "crypto", "ecc", "ethereum", "secp256k1"]
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 cfg-if = "1.0"

--- a/k256/README.md
+++ b/k256/README.md
@@ -63,7 +63,7 @@ most popular and commonly used elliptic curves.
 
 ## Minimum Supported Rust Version
 
-Rust **1.55** or higher.
+Rust **1.56** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -95,7 +95,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/k256/badge.svg
 [docs-link]: https://docs.rs/k256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/k256/badge.svg?branch=master&event=push

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.55** or higher.
+//! Rust **1.56** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "p256"
+version = "0.10.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve with support for ECDH, ECDSA signing/verification, and general
 purpose curve arithmetic
 """
-version = "0.10.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"
 repository = "https://github.com/RustCrypto/elliptic-curves/tree/master/p256"
 readme = "README.md"
-edition = "2018"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "prime256v1", "secp256r1"]
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }

--- a/p256/README.md
+++ b/p256/README.md
@@ -47,7 +47,7 @@ like TLS and the associated X.509 PKI.
 
 ## Minimum Supported Rust Version
 
-Rust **1.55** or higher.
+Rust **1.56** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -79,7 +79,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/p256/badge.svg
 [docs-link]: https://docs.rs/p256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/p256/badge.svg?branch=master&event=push

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.55** or higher.
+//! Rust **1.56** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "p384"
-description = "NIST P-384 (secp384r1) elliptic curve"
 version = "0.9.0-pre" # Also update html_root_url in lib.rs when bumping this
+description = "NIST P-384 (secp384r1) elliptic curve"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"
 repository = "https://github.com/RustCrypto/elliptic-curves/tree/master/p384"
 readme = "README.md"
-edition = "2018"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "secp384r1"]
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 ecdsa = { version = "=0.13.0-pre", optional = true, default-features = false, features = ["der"] }

--- a/p384/README.md
+++ b/p384/README.md
@@ -25,7 +25,7 @@ X.509 PKI.
 
 ## Minimum Supported Rust Version
 
-Rust **1.55** or higher.
+Rust **1.56** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -57,7 +57,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/p384/badge.svg
 [docs-link]: https://docs.rs/p384/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/p384/badge.svg?branch=master&event=push

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.55** or higher.
+//! Rust **1.56** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.


### PR DESCRIPTION
The `elliptic-curve` and `ecdsa` crates as well as format parsers including `der`, `sec1`, and `pkcs8` have all been bumped to Rust 2021 edition:

- https://github.com/RustCrypto/traits/pull/795
- https://github.com/RustCrypto/signatures/pull/384

This commit updates the crates in this repo accordingly.