### PR TITLE
k256: remove deprecated `SigningKey::verify_key` method

### DIFF
--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -22,7 +22,7 @@
 //!
 //! // Signing
 //! let signing_key = SigningKey::random(&mut OsRng); // Serialize with `::to_bytes()`
-//! let verify_key = signing_key.verify_key();
+//! let verify_key = signing_key.verifying_key();
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //!
 //! // Note: the signature type must be annotated or otherwise inferrable as

--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -63,12 +63,6 @@ impl SigningKey {
         }
     }
 
-    /// Legacy alias for [`SigningKey::verifying_key`].
-    #[deprecated(since = "0.9.3", note = "use `verifying_key()` instead")]
-    pub fn verify_key(&self) -> VerifyingKey {
-        self.verifying_key()
-    }
-
     /// Serialize this [`SigningKey`] as bytes
     pub fn to_bytes(&self) -> FieldBytes {
         self.inner.to_bytes()


### PR DESCRIPTION
It has been renamed to `SigningKey::verifying_key` instead.