### PR TITLE
Update `ecdsa` crate and leverage generic ECDSA implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476ecdba12db8402a1664482de8c37fff7dc96241258bd0de1f0d70e760a45fd"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.13.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#1cd36321b7d59a570996d01538bc4b0d73eb73d3"
+source = "git+https://github.com/RustCrypto/signatures.git#97ebdb8dbe94e94825d4ab620142b52a0c7651b3"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -326,7 +326,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#31436a2eaf8bd3fb5292e11e9a0b1f93056a7817"
+source = "git+https://github.com/RustCrypto/traits.git#7d813023da0ce6e418e4f7bf3b0dda9914a891cb"
 dependencies = [
  "base64ct",
  "crypto-bigint",
@@ -910,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
+checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
 dependencies = [
  "itoa",
  "ryu",

--- a/k256/bench/ecdsa.rs
+++ b/k256/bench/ecdsa.rs
@@ -3,7 +3,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use ecdsa_core::{
     elliptic_curve::group::prime::PrimeCurveAffine,
-    hazmat::{RecoverableSignPrimitive, VerifyPrimitive},
+    hazmat::{SignPrimitive, VerifyPrimitive},
 };
 use k256::{
     elliptic_curve::{generic_array::arr, group::ff::PrimeField},
@@ -44,15 +44,15 @@ fn bench_ecdsa(c: &mut Criterion) {
     let k = test_scalar_k();
     let z = test_scalar_z();
 
-    group.bench_function("try_sign_recoverable_prehashed", |b| {
-        b.iter(|| d.try_sign_recoverable_prehashed(&k, &z).unwrap())
+    group.bench_function("try_sign_prehashed", |b| {
+        b.iter(|| d.try_sign_prehashed(k, z).unwrap())
     });
 
     let q = (AffinePoint::generator() * d).to_affine();
-    let s = d.try_sign_recoverable_prehashed(&k, &z).unwrap().0;
+    let s = d.try_sign_prehashed(k, z).unwrap().0;
 
     group.bench_function("verify_prehashed", |b| {
-        b.iter(|| q.verify_prehashed(&z, &s).unwrap())
+        b.iter(|| q.verify_prehashed(z, &s).unwrap())
     });
 
     group.finish();

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -9,7 +9,7 @@ use elliptic_curve::{
     sec1::{self, FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
-    AffineArithmetic, DecompressPoint,
+    AffineArithmetic, AffineXCoordinate, DecompressPoint,
 };
 
 impl AffineArithmetic for Secp256k1 {
@@ -68,6 +68,12 @@ impl PrimeCurveAffine for AffinePoint {
     /// Convert to curve representation.
     fn to_curve(&self) -> ProjectivePoint {
         ProjectivePoint::from(*self)
+    }
+}
+
+impl AffineXCoordinate<Secp256k1> for AffinePoint {
+    fn x(&self) -> FieldBytes {
+        self.x.to_bytes()
     }
 }
 

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -70,7 +70,10 @@ use crate::arithmetic::{
     ProjectivePoint,
 };
 use core::ops::{Mul, MulAssign};
-use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+use elliptic_curve::{
+    subtle::{Choice, ConditionallySelectable, ConstantTimeEq},
+    IsHigh,
+};
 
 /// Lookup table containing precomputed values `[p, 2p, 3p, ..., 8p]`
 #[derive(Copy, Clone, Default)]

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -19,7 +19,7 @@ use elliptic_curve::{
         CtOption,
     },
     zeroize::DefaultIsZeroes,
-    Curve, ScalarArithmetic, ScalarCore,
+    Curve, IsHigh, ScalarArithmetic, ScalarCore,
 };
 
 #[cfg(feature = "bits")]
@@ -208,11 +208,6 @@ impl Scalar {
     /// Multiplicative identity.
     pub const ONE: Self = Self(U256::ONE);
 
-    /// Is this scalar greater than or equal to n / 2?
-    pub fn is_high(&self) -> Choice {
-        self.0.ct_gt(&FRAC_MODULUS_2)
-    }
-
     /// Checks if the scalar is zero.
     pub fn is_zero(&self) -> Choice {
         self.0.is_zero()
@@ -368,6 +363,12 @@ impl From<u64> for Scalar {
 impl From<ScalarCore<Secp256k1>> for Scalar {
     fn from(scalar: ScalarCore<Secp256k1>) -> Scalar {
         Scalar(*scalar.as_uint())
+    }
+}
+
+impl IsHigh for Scalar {
+    fn is_high(&self) -> Choice {
+        self.0.ct_gt(&FRAC_MODULUS_2)
     }
 }
 
@@ -577,7 +578,10 @@ impl From<&Scalar> for FieldBytes {
 mod tests {
     use super::Scalar;
     use crate::arithmetic::dev::{biguint_to_bytes, bytes_to_biguint};
-    use elliptic_curve::group::ff::{Field, PrimeField};
+    use elliptic_curve::{
+        ff::{Field, PrimeField},
+        IsHigh,
+    };
     use num_bigint::{BigUint, ToBigUint};
     use proptest::prelude::*;
 

--- a/k256/src/ecdsa/normalize.rs
+++ b/k256/src/ecdsa/normalize.rs
@@ -2,19 +2,6 @@
 //!
 //! [1]: https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki
 
-use crate::Scalar;
-use ecdsa_core::NormalizeLow;
-
-impl NormalizeLow for Scalar {
-    fn normalize_low(&self) -> Option<Self> {
-        if self.is_high().into() {
-            Some(-self)
-        } else {
-            None
-        }
-    }
-}
-
 #[cfg(all(test, feature = "ecdsa"))]
 mod tests {
     use crate::ecdsa::Signature;

--- a/k256/src/ecdsa/verify.rs
+++ b/k256/src/ecdsa/verify.rs
@@ -10,6 +10,7 @@ use elliptic_curve::{
     consts::U32,
     ops::{Invert, Reduce},
     sec1::ToEncodedPoint,
+    IsHigh,
 };
 use signature::{digest::Digest, DigestVerifier};
 
@@ -81,7 +82,7 @@ where
 }
 
 impl VerifyPrimitive<Secp256k1> for AffinePoint {
-    fn verify_prehashed(&self, z: &Scalar, signature: &Signature) -> Result<(), Error> {
+    fn verify_prehashed(&self, z: Scalar, signature: &Signature) -> Result<(), Error> {
         let r = signature.r();
         let s = signature.s();
 
@@ -91,7 +92,7 @@ impl VerifyPrimitive<Secp256k1> for AffinePoint {
         }
 
         let s_inv = s.invert().unwrap();
-        let u1 = z * &s_inv;
+        let u1 = z * s_inv;
         let u2 = *r * s_inv;
 
         let x = lincomb(

--- a/p256/src/arithmetic/affine.rs
+++ b/p256/src/arithmetic/affine.rs
@@ -11,7 +11,7 @@ use elliptic_curve::{
     sec1::{self, FromEncodedPoint, ToCompactEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
-    AffineArithmetic, Curve, DecompactPoint, DecompressPoint,
+    AffineArithmetic, AffineXCoordinate, Curve, DecompactPoint, DecompressPoint,
 };
 
 impl AffineArithmetic for NistP256 {
@@ -70,6 +70,12 @@ impl PrimeCurveAffine for AffinePoint {
     /// Convert to curve representation.
     fn to_curve(&self) -> ProjectivePoint {
         ProjectivePoint::from(*self)
+    }
+}
+
+impl AffineXCoordinate<NistP256> for AffinePoint {
+    fn x(&self) -> FieldBytes {
+        self.x.to_bytes()
     }
 }
 


### PR DESCRIPTION
This updates the crates in this repo to leverage the following generic implementations recently added to the `ecdsa` crate:

- Sign: RustCrypto/signatures#396
- Verify: RustCrypto/signatures#397

The `p256` crate is able to directly utilize the generic implementation from the `ecdsa` crate.

The `k256` crate retains its previous custom implementation, which provides a secp256k1-specific take on public key recovery, but can also directly leverage optimizations for computing linear combinations, which there are not presently traits in `elliptic-curve` or `group` to express.