### PR TITLE
Add `serde` feature

### DIFF
--- a/.github/workflows/bp256.yml
+++ b/.github/workflows/bp256.yml
@@ -39,8 +39,9 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha256
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,pem,pkcs8,sha256
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,pem,pkcs8,serde,sha256
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/bp384.yml
+++ b/.github/workflows/bp384.yml
@@ -39,8 +39,9 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha384
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,pem,pkcs8,sha384
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,pem,pkcs8,serde,sha384
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -45,10 +45,11 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features keccak256
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha256
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,keccak256
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,sha256
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,bits,ecdh,ecdsa,jwk,keccak256,pem,pkcs8,sha256
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,bits,ecdh,ecdsa,jwk,keccak256,pem,pkcs8,serde,sha256
 
   benches:
     runs-on: ubuntu-latest

--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -44,8 +44,9 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features jwk
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha256
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,bits,ecdh,ecdsa,jwk,pem,pkcs8,sha256
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,bits,ecdh,ecdsa,jwk,pem,pkcs8,serde,sha256
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -40,8 +40,9 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features jwk
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha384
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,jwk,pem,pkcs8,sha384
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,jwk,pem,pkcs8,serde,sha384
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ version = "0.3.0-pre"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "sec1",
  "sha2",
 ]
 
@@ -95,6 +96,7 @@ version = "0.3.0-pre"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "sec1",
  "sha2",
 ]
 
@@ -309,7 +311,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.13.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#97ebdb8dbe94e94825d4ab620142b52a0c7651b3"
+source = "git+https://github.com/RustCrypto/signatures.git#62a3f860f800f7c17ff3f868827e0780c838abba"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -326,7 +328,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#7d813023da0ce6e418e4f7bf3b0dda9914a891cb"
+source = "git+https://github.com/RustCrypto/traits.git#88d5ea3ad633d13c9ac3b064c084f645830d7713"
 dependencies = [
  "base64ct",
  "crypto-bigint",
@@ -468,6 +470,7 @@ dependencies = [
  "num-traits",
  "proptest",
  "rand_core",
+ "sec1",
  "sha2",
  "sha3",
 ]
@@ -576,6 +579,7 @@ dependencies = [
  "hex-literal",
  "proptest",
  "rand_core",
+ "sec1",
  "sha2",
 ]
 
@@ -585,6 +589,7 @@ version = "0.9.0-pre"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "sec1",
  "sha2",
 ]
 
@@ -864,13 +869,14 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sec1"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2503adcd8c83e7081b3f9a3173f328f4d6cd50e116aaa324389b46f2d771d595"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
 dependencies = [
  "der",
  "generic-array",
  "pkcs8",
+ "serde",
  "subtle",
  "zeroize",
 ]

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.56"
 
 [dependencies]
 elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
+sec1 = { version = "0.2", default-features = false }
 
 # optional dependencies
 ecdsa = { version = "=0.13.0-pre", optional = true, default-features = false, features = ["der"] }
@@ -23,6 +24,7 @@ sha2 = { version = "0.9", optional = true, default-features = false }
 default = ["pkcs8", "std"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8"]
+serde = ["ecdsa/serde", "elliptic-curve/serde", "sec1/serde"]
 sha256 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
 std = ["elliptic-curve/std"]
 

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.56"
 
 [dependencies]
 elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
+sec1 = { version = "0.2", default-features = false }
 
 # optional dependencies
 ecdsa = { version = "=0.13.0-pre", optional = true, default-features = false, features = ["der"] }
@@ -23,6 +24,7 @@ sha2 = { version = "0.9", optional = true, default-features = false }
 default = ["pkcs8", "std"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8"]
+serde = ["ecdsa/serde", "elliptic-curve/serde", "sec1/serde"]
 sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
 std = ["elliptic-curve/std"]
 

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,6 +20,7 @@ rust-version = "1.56"
 [dependencies]
 cfg-if = "1.0"
 elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
+sec1 = { version = "0.2", default-features = false }
 
 # optional dependencies
 ecdsa-core = { version = "=0.13.0-pre", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
@@ -49,6 +50,7 @@ jwk = ["elliptic-curve/jwk"]
 keccak256 = ["digest", "sha3"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8"]
+serde = ["ecdsa-core/serde", "elliptic-curve/serde", "sec1/serde"]
 sha256 = ["digest", "sha2"]
 std = ["ecdsa-core/std", "elliptic-curve/std"] # TODO: use weak activation for `ecdsa-core/std` when available
 test-vectors = ["hex-literal"]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.56"
 
 [dependencies]
 elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
+sec1 = { version = "0.2", default-features = false }
 
 # optional dependencies
 ecdsa-core = { version = "=0.13.0-pre", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
@@ -41,6 +42,7 @@ ecdsa = ["arithmetic", "ecdsa-core/sign", "ecdsa-core/verify", "sha256"]
 jwk = ["elliptic-curve/jwk"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8"]
+serde = ["ecdsa-core/serde", "elliptic-curve/serde", "sec1/serde"]
 sha256 = ["digest", "sha2"]
 std = ["ecdsa-core/std", "elliptic-curve/std"] # TODO: use weak activation for `ecdsa-core/std` when available
 test-vectors = ["hex-literal"]

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.56"
 [dependencies]
 ecdsa = { version = "=0.13.0-pre", optional = true, default-features = false, features = ["der"] }
 elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
+sec1 = { version = "0.2", default-features = false }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [features]
@@ -22,6 +23,7 @@ default = ["pkcs8", "std"]
 jwk = ["elliptic-curve/jwk"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8"]
+serde = ["ecdsa/serde", "elliptic-curve/serde", "sec1/serde"]
 sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
 std = ["elliptic-curve/std"]
 


### PR DESCRIPTION
Adds a `serde` feature to all crates which activates the corresponding `serde` feature in the `ecdsa`, `elliptic-curve`, and `sec1` crates.