### PR TITLE
Bump `elliptic-curve` crate dependency to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.13.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#62a3f860f800f7c17ff3f868827e0780c838abba"
+source = "git+https://github.com/RustCrypto/signatures.git#7e6295ace4cbc48cae458c337d18f71d655d4a00"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -327,8 +327,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#bd1f7122d668a866037886462c380bdc89b5f412"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5ff748dcb04505ce82b6447d4bad4ef9cf653a1d811bed2b04083127a44c3f"
 dependencies = [
  "base64ct",
  "crypto-bigint",
@@ -489,9 +490,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.107"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
+checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "log"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,3 @@ members = [
 
 [patch.crates-io]
 ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
-elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "0.11", default-features = false, features = ["hazmat", "sec1"] }
 sec1 = { version = "0.2", default-features = false }
 
 # optional dependencies

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "0.11", default-features = false, features = ["hazmat", "sec1"] }
 sec1 = { version = "0.2", default-features = false }
 
 # optional dependencies

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.56"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "0.11", default-features = false, features = ["hazmat", "sec1"] }
 sec1 = { version = "0.2", default-features = false }
 
 # optional dependencies

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "0.11", default-features = false, features = ["hazmat", "sec1"] }
 sec1 = { version = "0.2", default-features = false }
 
 # optional dependencies

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.56"
 
 [dependencies]
 ecdsa = { version = "=0.13.0-pre", optional = true, default-features = false, features = ["der"] }
-elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "0.11", default-features = false, features = ["hazmat", "sec1"] }
 sec1 = { version = "0.2", default-features = false }
 sha2 = { version = "0.9", optional = true, default-features = false }
 


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/traits/pull/821