### PR TITLE
p256 v0.10.0-pre.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.10.0-pre"
+version = "0.10.0-pre.1"
 dependencies = [
  "blobby",
  "ecdsa",

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256"
-version = "0.10.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.0-pre.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve with support for ECDH, ECDSA signing/verification, and general

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/p256/0.10.0-pre"
+    html_root_url = "https://docs.rs/p256/0.10.0-pre.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
This pre-release includes upgrades to the following:

- `ecdsa` v0.13
- `elliptic-curve` v0.11
  - `ff` v0.11
  - `group` v0.11