### PR TITLE
.cargo/audit.toml: initial config with RUSTSEC-2021-0127

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,4 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2021-0127", # serde_cbor is unmaintained
+]


### PR DESCRIPTION
Ignores `RUSTSEC-2021-0127`: `serde_cbor` is unmaintained

This is a transitive dependency of `criterion`