### PR TITLE
k256: impl `Reduce<U512>` for `Scalar`

### DIFF
--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -9,7 +9,7 @@ pub(crate) use self::wide::WideScalar;
 use crate::{FieldBytes, Secp256k1, ORDER};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, Sub, SubAssign};
 use elliptic_curve::{
-    bigint::{nlimbs, prelude::*, Limb, LimbUInt, U256},
+    bigint::{nlimbs, prelude::*, Limb, LimbUInt, U256, U512},
     generic_array::arr,
     group::ff::{Field, PrimeField},
     ops::Reduce,
@@ -572,6 +572,12 @@ impl Reduce<U256> for Scalar {
         let (r, underflow) = w.sbb(&ORDER, Limb::ZERO);
         let underflow = Choice::from((underflow.0 >> (Limb::BIT_SIZE - 1)) as u8);
         Self(U256::conditional_select(&w, &r, !underflow))
+    }
+}
+
+impl Reduce<U512> for Scalar {
+    fn from_uint_reduced(w: U512) -> Self {
+        WideScalar(w).reduce()
     }
 }
 

--- a/k256/src/arithmetic/scalar/wide32.rs
+++ b/k256/src/arithmetic/scalar/wide32.rs
@@ -20,7 +20,7 @@ const NEG_MODULUS: [u32; 8] = [
 ];
 
 #[derive(Clone, Copy, Debug, Default)]
-pub(crate) struct WideScalar(U512);
+pub(crate) struct WideScalar(pub(super) U512);
 
 impl WideScalar {
     pub const fn from_bytes(bytes: &[u8; 64]) -> Self {

--- a/k256/src/arithmetic/scalar/wide64.rs
+++ b/k256/src/arithmetic/scalar/wide64.rs
@@ -11,7 +11,7 @@ use elliptic_curve::{
 const NEG_MODULUS: [u64; 4] = [!MODULUS[0] + 1, !MODULUS[1], !MODULUS[2], !MODULUS[3]];
 
 #[derive(Clone, Copy, Debug, Default)]
-pub(crate) struct WideScalar(U512);
+pub(crate) struct WideScalar(pub(super) U512);
 
 impl WideScalar {
     pub const fn from_bytes(bytes: &[u8; 64]) -> Self {

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -46,6 +46,7 @@ use crate::{
         VerifyingKey,
     },
     elliptic_curve::{
+        bigint::U256,
         consts::U32,
         ops::{Invert, Reduce},
         DecompressPoint,
@@ -172,7 +173,7 @@ impl Signature {
     ) -> Result<VerifyingKey> {
         let r = self.r();
         let s = self.s();
-        let z = Scalar::from_be_bytes_reduced(*digest_bytes);
+        let z = <Scalar as Reduce<U256>>::from_be_bytes_reduced(*digest_bytes);
         let R = AffinePoint::decompress(&r.to_bytes(), self.recovery_id().is_y_odd());
 
         if R.is_some().into() {

--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -15,6 +15,7 @@ use ecdsa_core::{
     },
 };
 use elliptic_curve::{
+    bigint::U256,
     consts::U32,
     ops::{Invert, Reduce},
     rand_core::{CryptoRng, RngCore},
@@ -108,7 +109,8 @@ where
 {
     fn try_sign_digest(&self, msg_digest: D) -> Result<recoverable::Signature, Error> {
         let x = Zeroizing::new(ScalarCore::from(self.inner));
-        let msg_scalar = Scalar::from_be_bytes_reduced(msg_digest.finalize_fixed());
+        let msg_scalar =
+            <Scalar as Reduce<U256>>::from_be_bytes_reduced(msg_digest.finalize_fixed());
         let k = Zeroizing::new(
             NonZeroScalar::from_uint(*rfc6979::generate_k::<D, _>(
                 x.as_uint(),
@@ -151,7 +153,8 @@ where
         rng.fill_bytes(&mut added_entropy);
 
         let x = Zeroizing::new(ScalarCore::from(self.inner));
-        let msg_scalar = Scalar::from_be_bytes_reduced(msg_digest.finalize_fixed());
+        let msg_scalar =
+            <Scalar as Reduce<U256>>::from_be_bytes_reduced(msg_digest.finalize_fixed());
         let k = Zeroizing::new(
             NonZeroScalar::from_uint(*rfc6979::generate_k::<D, _>(
                 x.as_uint(),
@@ -191,7 +194,7 @@ impl SignPrimitive<Secp256k1> for Scalar {
 
         // Lift x-coordinate of 𝐑 (element of base field) into a serialized big
         // integer, then reduce it into an element of the scalar field
-        let r = Scalar::from_be_bytes_reduced(R.x.to_bytes());
+        let r = <Scalar as Reduce<U256>>::from_be_bytes_reduced(R.x.to_bytes());
 
         // Compute `s` as a signature over `r` and `z`.
         let s = k_inverse * (z + (r * self));

--- a/k256/src/ecdsa/verify.rs
+++ b/k256/src/ecdsa/verify.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use ecdsa_core::{hazmat::VerifyPrimitive, signature};
 use elliptic_curve::{
+    bigint::U256,
     consts::U32,
     ops::{Invert, Reduce},
     sec1::ToEncodedPoint,
@@ -108,7 +109,7 @@ impl VerifyPrimitive<Secp256k1> for AffinePoint {
         .to_affine()
         .x;
 
-        if Scalar::from_be_bytes_reduced(x.to_bytes()).eq(&r) {
+        if <Scalar as Reduce<U256>>::from_be_bytes_reduced(x.to_bytes()).eq(&r) {
             Ok(())
         } else {
             Err(Error::new())


### PR DESCRIPTION
Adds a second impl of the `Reduce` trait for `Scalar` (where the first was `U256`).

This provides a simple thunk to `WideScalar::reduce`.