### PR TITLE
k256+p256: impl `LinearCombination` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,9 +328,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4c31bb557a73d165c838b614521f888112f9d4fcff7421d35646376dd17caf"
+checksum = "d9be7b065e66163fd97787a4cadc56625f948e22e914a0deab1d22b1f48fde25"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.56"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "0.11.3", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "0.11.4", default-features = false, features = ["hazmat", "sec1"] }
 sec1 = { version = "0.2", default-features = false }
 
 # optional dependencies

--- a/k256/bench/scalar.rs
+++ b/k256/bench/scalar.rs
@@ -5,8 +5,8 @@ use criterion::{
 };
 use hex_literal::hex;
 use k256::{
-    elliptic_curve::{generic_array::arr, group::ff::PrimeField},
-    lincomb, ProjectivePoint, Scalar,
+    elliptic_curve::{generic_array::arr, group::ff::PrimeField, ops::LinearCombination},
+    ProjectivePoint, Scalar, Secp256k1,
 };
 
 fn test_scalar_x() -> Scalar {
@@ -39,7 +39,9 @@ fn bench_point_lincomb<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let m = hex!("AA5E28D6A97A2479A65527F7290311A3624D4CC0FA1578598EE3C2613BF99522");
     let s = Scalar::from_repr(m.into()).unwrap();
     group.bench_function("lincomb via mul+add", |b| b.iter(|| &p * &s + &p * &s));
-    group.bench_function("lincomb()", |b| b.iter(|| lincomb(&p, &s, &p, &s)));
+    group.bench_function("lincomb()", |b| {
+        b.iter(|| Secp256k1::lincomb(&p, &s, &p, &s))
+    });
 }
 
 fn bench_high_level(c: &mut Criterion) {

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -10,7 +10,6 @@ pub(crate) mod scalar;
 mod dev;
 
 pub use field::FieldElement;
-pub use mul::lincomb;
 
 use affine::AffinePoint;
 use projective::ProjectivePoint;

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -48,10 +48,10 @@ use crate::{
     elliptic_curve::{
         bigint::U256,
         consts::U32,
-        ops::{Invert, Reduce},
+        ops::{Invert, LinearCombination, Reduce},
         DecompressPoint,
     },
-    lincomb, AffinePoint, FieldBytes, NonZeroScalar, ProjectivePoint, Scalar,
+    AffinePoint, FieldBytes, NonZeroScalar, ProjectivePoint, Scalar, Secp256k1,
 };
 
 #[cfg(feature = "keccak256")]
@@ -181,7 +181,7 @@ impl Signature {
             let r_inv = r.invert().unwrap();
             let u1 = -(r_inv * z);
             let u2 = r_inv * *s;
-            let pk = lincomb(&ProjectivePoint::generator(), &u1, &R, &u2).to_affine();
+            let pk = Secp256k1::lincomb(&ProjectivePoint::generator(), &u1, &R, &u2).to_affine();
 
             // TODO(tarcieri): ensure the signature verifies?
             Ok(VerifyingKey::from(&pk))

--- a/k256/src/ecdsa/verify.rs
+++ b/k256/src/ecdsa/verify.rs
@@ -2,14 +2,13 @@
 
 use super::{recoverable, Error, Signature};
 use crate::{
-    lincomb, AffinePoint, CompressedPoint, EncodedPoint, ProjectivePoint, PublicKey, Scalar,
-    Secp256k1,
+    AffinePoint, CompressedPoint, EncodedPoint, ProjectivePoint, PublicKey, Scalar, Secp256k1,
 };
 use ecdsa_core::{hazmat::VerifyPrimitive, signature};
 use elliptic_curve::{
     bigint::U256,
     consts::U32,
-    ops::{Invert, Reduce},
+    ops::{Invert, LinearCombination, Reduce},
     sec1::ToEncodedPoint,
     IsHigh,
 };
@@ -111,7 +110,7 @@ impl VerifyPrimitive<Secp256k1> for AffinePoint {
         let u1 = z * s_inv;
         let u2 = *r * s_inv;
 
-        let x = lincomb(
+        let x = Secp256k1::lincomb(
             &ProjectivePoint::generator(),
             &u1,
             &ProjectivePoint::from(*self),

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -39,7 +39,7 @@ pub mod test_vectors;
 pub use elliptic_curve::{self, bigint::U256};
 
 #[cfg(feature = "arithmetic")]
-pub use arithmetic::{affine::AffinePoint, lincomb, projective::ProjectivePoint, scalar::Scalar};
+pub use arithmetic::{affine::AffinePoint, projective::ProjectivePoint, scalar::Scalar};
 
 #[cfg(feature = "expose-field")]
 pub use arithmetic::FieldElement;

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -1,4 +1,4 @@
-//! A pure-Rust implementation of group operations on secp256r1.
+//! Pure Rust implementation of group operations on secp256r1.
 
 pub(crate) mod affine;
 mod field;
@@ -6,7 +6,9 @@ pub(crate) mod projective;
 pub(crate) mod scalar;
 pub(crate) mod util;
 
+use crate::NistP256;
 use affine::AffinePoint;
+use elliptic_curve::ops::LinearCombination;
 use field::{FieldElement, MODULUS};
 use projective::ProjectivePoint;
 use scalar::Scalar;
@@ -24,6 +26,8 @@ const CURVE_EQUATION_B: FieldElement = FieldElement([
     0xe5a2_20ab_f721_2ed6,
     0xdc30_061d_0487_4834,
 ]);
+
+impl LinearCombination for NistP256 {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Adds impls of traits for linear combinations added in RustCrypto/traits#833:

- `k256` uses an optimized implementation.
- `p256` uses the default unoptimized implementation.