### PR TITLE
bp256 v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bp256"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/bp256/CHANGELOG.md
+++ b/bp256/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2021-12-14)
+### Added
+- `serde` feature ([#463])
+
+### Changed
+- Rust 2021 edition upgrade; MSRV 1.56+ ([#453])
+- Bump `elliptic-curve` crate dependency to v0.11 ([#466])
+- Bump `ecdsa` crate dependency to v0.13 ([#467])
+
+[#453]: https://github.com/RustCrypto/elliptic-curves/pull/453
+[#463]: https://github.com/RustCrypto/elliptic-curves/pull/463
+[#466]: https://github.com/RustCrypto/elliptic-curves/pull/466
+[#467]: https://github.com/RustCrypto/elliptic-curves/pull/467
+
 ## 0.2.0 (2021-06-08)
 ### Changed
 - Bump `elliptic-curve` to v0.10; MSRV 1.51+ ([#349])

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp256"
-version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 description = "Brainpool P-256 (brainpoolP256r1 and brainpoolP256t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/bp256/src/lib.rs
+++ b/bp256/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/bp256/0.3.0-pre"
+    html_root_url = "https://docs.rs/bp256/0.3.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `serde` feature ([#463])

### Changed
- Rust 2021 edition upgrade; MSRV 1.56+ ([#453])
- Bump `elliptic-curve` crate dependency to v0.11 ([#466])
- Bump `ecdsa` crate dependency to v0.13 ([#467])

[#453]: https://github.com/RustCrypto/elliptic-curves/pull/453
[#463]: https://github.com/RustCrypto/elliptic-curves/pull/463
[#466]: https://github.com/RustCrypto/elliptic-curves/pull/466
[#467]: https://github.com/RustCrypto/elliptic-curves/pull/467