### PR TITLE
p384: add `AffinePoint`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ version = "0.9.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "hex-literal",
  "sec1",
  "sha2",
 ]

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,6 +18,9 @@ elliptic-curve = { version = "0.11", default-features = false, features = ["hazm
 sec1 = { version = "0.2", default-features = false }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
+[dev-dependencies]
+hex-literal = "0.3"
+
 [features]
 default = ["arithmetic", "pkcs8", "std"]
 arithmetic = ["elliptic-curve/arithmetic"]

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -1,4 +1,35 @@
 //! Pure Rust implementation of group operations on secp384r1.
+//!
+//! Curve parameters can be found in FIPS 186-4: Digital Signature Standard (DSS):
+//! <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
+//!
+//! See section D.1.2.4: Curve P-384.
 
-pub(crate) mod field;
+#![allow(clippy::unusual_byte_groupings)]
+
+pub(crate) mod affine;
+mod field;
 pub(crate) mod scalar;
+
+use field::{FieldElement, MODULUS};
+
+/// a = -3
+const CURVE_EQUATION_A: FieldElement = FieldElement([
+    MODULUS.0[0] - 3,
+    MODULUS.0[1],
+    MODULUS.0[2],
+    MODULUS.0[3],
+    MODULUS.0[4],
+    MODULUS.0[5],
+]);
+
+/// b = b3312fa7 e23ee7e4 988e056b e3f82d19 181d9c6e fe814112
+///     0314088f 5013875a c656398d 8a2ed19d 2a85c8ed d3ec2aef
+const CURVE_EQUATION_B: FieldElement = FieldElement([
+    0x2a85c8ed_d3ec2aef,
+    0xc656398d_8a2ed19d,
+    0x0314088f_5013875a,
+    0x181d9c6e_fe814112,
+    0x988e056b_e3f82d19,
+    0xb3312fa7_e23ee7e4,
+]);

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -19,10 +19,7 @@ mod arithmetic;
 pub use elliptic_curve::{self, bigint::U384};
 
 #[cfg(feature = "arithmetic")]
-pub use arithmetic::{
-    field::FieldElement, // TODO(tarcieri): make private
-    scalar::Scalar,
-};
+pub use arithmetic::{affine::AffinePoint, scalar::Scalar};
 
 #[cfg(feature = "pkcs8")]
 pub use elliptic_curve::pkcs8;
@@ -30,6 +27,8 @@ pub use elliptic_curve::pkcs8;
 /// Curve order.
 pub const ORDER: U384 =
     U384::from_be_hex("ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973");
+
+use elliptic_curve::generic_array::{typenum::U49, GenericArray};
 
 /// NIST P-384 elliptic curve.
 ///
@@ -79,6 +78,9 @@ impl elliptic_curve::AlgorithmParameters for NistP384 {
     const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::new("1.3.132.0.34");
 }
 
+/// Compressed SEC1-encoded NIST P-384 curve point.
+pub type CompressedPoint = GenericArray<u8, U49>;
+
 /// NIST P-384 field element serialized as bytes.
 ///
 /// Byte array containing a serialized field element value (base field or scalar).
@@ -86,6 +88,14 @@ pub type FieldBytes = elliptic_curve::FieldBytes<NistP384>;
 
 /// NIST P-384 SEC1 encoded point.
 pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP384>;
+
+/// Non-zero NIST P-384 scalar field element.
+#[cfg(feature = "arithmetic")]
+pub type NonZeroScalar = elliptic_curve::NonZeroScalar<NistP384>;
+
+/// NIST P-384 public key.
+#[cfg(feature = "arithmetic")]
+pub type PublicKey = elliptic_curve::PublicKey<NistP384>;
 
 /// NIST P-384 scalar core type.
 ///


### PR DESCRIPTION
Partial implementation of `AffinePoint`, with coordinates internally represented using `FieldElement` type which wraps fiat-crypto's base field arithmetic.

With this in place, `FieldElement` can be removed from the public API without any warnings about dead code.

Note: the implementation is not yet fully correct and some of the tests have been flagged with `#[ignore]`.