### PR TITLE
p384: add `FieldElement::{to_canonical, to_montgomery}`

### DIFF
--- a/p256/src/arithmetic/affine.rs
+++ b/p256/src/arithmetic/affine.rs
@@ -184,13 +184,13 @@ impl DecompactPoint<NistP256> for AffinePoint {
             let montgomery_y = (x * &x * &x + &(CURVE_EQUATION_A * &x) + &CURVE_EQUATION_B).sqrt();
             montgomery_y.map(|montgomery_y| {
                 // Convert to canonical form for comparisons
-                let y = montgomery_y.as_canonical();
+                let y = montgomery_y.to_canonical();
                 let p_y = MODULUS.subtract(&y);
                 let (_, borrow) = p_y.informed_subtract(&y);
                 let recovered_y = if borrow == 0 { y } else { p_y };
                 AffinePoint {
                     x,
-                    y: recovered_y.as_montgomery(),
+                    y: recovered_y.to_montgomery(),
                     infinity: Choice::from(0),
                 }
             })
@@ -251,7 +251,7 @@ impl ToCompactEncodedPoint<NistP256> for AffinePoint {
     /// Serialize this value as a  SEC1 compact [`EncodedPoint`]
     fn to_compact_encoded_point(&self) -> Option<EncodedPoint> {
         // Convert to canonical form for comparisons
-        let y = self.y.as_canonical();
+        let y = self.y.to_canonical();
         let (p_y, borrow) = MODULUS.informed_subtract(&y);
         assert_eq!(borrow, 0);
         let (_, borrow) = p_y.informed_subtract(&y);

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -25,11 +25,13 @@ const CURVE_EQUATION_A: FieldElement = FieldElement([
 
 /// b = b3312fa7 e23ee7e4 988e056b e3f82d19 181d9c6e fe814112
 ///     0314088f 5013875a c656398d 8a2ed19d 2a85c8ed d3ec2aef
+///
+/// NOTE: field element has been translated into the Montgomery domain.
 const CURVE_EQUATION_B: FieldElement = FieldElement([
-    0x2a85c8ed_d3ec2aef,
-    0xc656398d_8a2ed19d,
-    0x0314088f_5013875a,
-    0x181d9c6e_fe814112,
-    0x988e056b_e3f82d19,
-    0xb3312fa7_e23ee7e4,
+    0x81188719_d412dcc,
+    0xf729add8_7a4c32ec,
+    0x77f2209b_1920022e,
+    0xe3374bee_94938ae2,
+    0xb62b21f4_1f022094,
+    0xcd08114b_604fbff9,
 ]);


### PR DESCRIPTION
Adds wrappers for fiat-crypto's `fiat_p384_from_montgomery` and `fiat_p384_to_montgomery`, using them to translate field elements into and out of the Montgomery domain when decoding or encoding them from big endian-serialized canonical form.

Also ensures field element constants are already in Montgomery form.