### PR TITLE
k256+p256: impl `ff::Field` trait for `FieldElement` types

### DIFF
--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -1,9 +1,12 @@
 //! Affine points
 
+#![allow(clippy::op_ref)]
+
 use super::{FieldElement, ProjectivePoint, CURVE_EQUATION_B};
 use crate::{CompressedPoint, EncodedPoint, FieldBytes, Scalar, Secp256k1};
 use core::ops::{Mul, Neg};
 use elliptic_curve::{
+    ff::Field,
     generic_array::arr,
     group::{prime::PrimeCurveAffine, GroupEncoding},
     sec1::{self, FromEncodedPoint, ToEncodedPoint},

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -1,5 +1,7 @@
 //! Projective points
 
+#![allow(clippy::op_ref)]
+
 use super::{AffinePoint, FieldElement, Scalar, CURVE_EQUATION_B_SINGLE};
 use crate::{CompressedPoint, EncodedPoint, Secp256k1};
 use core::{
@@ -102,9 +104,9 @@ impl ProjectivePoint {
     /// "point at infinity".
     pub const fn identity() -> ProjectivePoint {
         ProjectivePoint {
-            x: FieldElement::zero(),
-            y: FieldElement::one(),
-            z: FieldElement::zero(),
+            x: FieldElement::ZERO,
+            y: FieldElement::ONE,
+            z: FieldElement::ZERO,
         }
     }
 

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -12,10 +12,10 @@ use projective::ProjectivePoint;
 use scalar::Scalar;
 
 /// a = -3
-const CURVE_EQUATION_A: FieldElement = FieldElement::zero()
-    .subtract(&FieldElement::one())
-    .subtract(&FieldElement::one())
-    .subtract(&FieldElement::one());
+const CURVE_EQUATION_A: FieldElement = FieldElement::ZERO
+    .subtract(&FieldElement::ONE)
+    .subtract(&FieldElement::ONE)
+    .subtract(&FieldElement::ONE);
 
 /// b = 0x5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B
 const CURVE_EQUATION_B: FieldElement = FieldElement([

--- a/p256/src/arithmetic/affine.rs
+++ b/p256/src/arithmetic/affine.rs
@@ -1,5 +1,7 @@
 //! Affine points
 
+#![allow(clippy::op_ref)]
+
 use super::{FieldElement, ProjectivePoint, CURVE_EQUATION_A, CURVE_EQUATION_B, MODULUS};
 use crate::{CompressedPoint, EncodedPoint, FieldBytes, NistP256, Scalar};
 use core::ops::{Mul, Neg};
@@ -49,8 +51,8 @@ impl PrimeCurveAffine for AffinePoint {
     /// Returns the identity of the group: the point at infinity.
     fn identity() -> AffinePoint {
         Self {
-            x: FieldElement::zero(),
-            y: FieldElement::zero(),
+            x: FieldElement::ZERO,
+            y: FieldElement::ZERO,
             infinity: Choice::from(1),
         }
     }

--- a/p256/src/arithmetic/projective.rs
+++ b/p256/src/arithmetic/projective.rs
@@ -1,5 +1,7 @@
 //! Projective points
 
+#![allow(clippy::op_ref)]
+
 use super::{AffinePoint, FieldElement, Scalar, CURVE_EQUATION_B};
 use crate::{CompressedPoint, EncodedPoint, NistP256};
 use core::{
@@ -156,9 +158,9 @@ impl ProjectivePoint {
     /// "point at infinity".
     pub const fn identity() -> ProjectivePoint {
         ProjectivePoint {
-            x: FieldElement::zero(),
-            y: FieldElement::one(),
-            z: FieldElement::zero(),
+            x: FieldElement::ZERO,
+            y: FieldElement::ONE,
+            z: FieldElement::ZERO,
         }
     }
 


### PR DESCRIPTION
Allows for writing code which is generic over field elements, such as the optimized SWU implementation added in RustCrypto/traits#854