### PR TITLE
k256: add impl of `ReduceNonZero<U256>` for `Scalar`

### DIFF
--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -591,8 +591,8 @@ impl Reduce<U512> for Scalar {
 
 impl ReduceNonZero<U256> for Scalar {
     fn from_uint_reduced_nonzero(w: U256) -> Self {
-        let order_minus_one = ORDER.wrapping_sub(&U256::ONE);
-        let (r, underflow) = w.sbb(&order_minus_one, Limb::ZERO);
+        const ORDER_MINUS_ONE: U256 = ORDER.wrapping_sub(&U256::ONE);
+        let (r, underflow) = w.sbb(&ORDER_MINUS_ONE, Limb::ZERO);
         let underflow = Choice::from((underflow.0 >> (Limb::BIT_SIZE - 1)) as u8);
         Self(U256::conditional_select(&w, &r, !underflow).wrapping_add(&U256::ONE))
     }

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -589,6 +589,15 @@ impl Reduce<U512> for Scalar {
     }
 }
 
+impl ReduceNonZero<U256> for Scalar {
+    fn from_uint_reduced_nonzero(w: U256) -> Self {
+        let order_minus_one = ORDER.wrapping_sub(&U256::ONE);
+        let (r, underflow) = w.sbb(&order_minus_one, Limb::ZERO);
+        let underflow = Choice::from((underflow.0 >> (Limb::BIT_SIZE - 1)) as u8);
+        Self(U256::conditional_select(&w, &r, !underflow).wrapping_add(&U256::ONE))
+    }
+}
+
 impl ReduceNonZero<U512> for Scalar {
     fn from_uint_reduced_nonzero(w: U512) -> Self {
         WideScalar(w).reduce_nonzero()

--- a/k256/src/arithmetic/scalar/wide32.rs
+++ b/k256/src/arithmetic/scalar/wide32.rs
@@ -236,6 +236,11 @@ impl WideScalar {
         } else {
             NEG_MODULUS[0]
         };
+        let modulus = if modulus_minus_one {
+            ORDER.wrapping_sub(&U256::ONE)
+        } else {
+            ORDER
+        };
 
         let w = self.0.to_uint_array();
         let n0 = w[8];
@@ -392,7 +397,7 @@ impl WideScalar {
 
         // Final reduction of r.
         let r = U256::from([r0, r1, r2, r3, r4, r5, r6, r7]);
-        let (r2, underflow) = r.sbb(&ORDER, Limb::ZERO);
+        let (r2, underflow) = r.sbb(&modulus, Limb::ZERO);
         let high_bit = Choice::from(c as u8);
         let underflow = Choice::from((underflow.0 >> 31) as u8);
         Scalar(U256::conditional_select(&r, &r2, !underflow | high_bit))

--- a/k256/src/arithmetic/scalar/wide64.rs
+++ b/k256/src/arithmetic/scalar/wide64.rs
@@ -124,6 +124,11 @@ impl WideScalar {
         } else {
             NEG_MODULUS[0]
         };
+        let modulus = if modulus_minus_one {
+            ORDER.wrapping_sub(&U256::ONE)
+        } else {
+            ORDER
+        };
 
         let w = self.0.to_uint_array();
         let n0 = w[4];
@@ -200,7 +205,7 @@ impl WideScalar {
 
         // Final reduction of r.
         let r = U256::from([r0, r1, r2, r3]);
-        let (r2, underflow) = r.sbb(&ORDER, Limb::ZERO);
+        let (r2, underflow) = r.sbb(&modulus, Limb::ZERO);
         let high_bit = Choice::from(c as u8);
         let underflow = Choice::from((underflow.0 >> 63) as u8);
         Scalar(U256::conditional_select(&r, &r2, !underflow | high_bit))


### PR DESCRIPTION
- add impl of `ReduceNonZero<U256>` for `Scalar`
- fix a bug in `WideScalar::reduce_nonzero()` (a zero value returned when reducing `MODULUS-1`)

Very embarrassing for me, but at least chances of someone hitting it were astronomically small, and if they did, it most probably resulted in a panic during inversion or something of the sort.