### PR TITLE
Implement `VoprfParameters` for `NistP256` and `NistP384`

### DIFF
--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -46,7 +46,8 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha256
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,bits,ecdh,ecdsa,jwk,pem,pkcs8,serde,sha256
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features voprf
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,bits,ecdh,ecdsa,jwk,pem,pkcs8,serde,sha256,voprf
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -45,7 +45,8 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha384
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,jwk,pem,pkcs8,serde,sha384
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features voprf
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,jwk,pem,pkcs8,serde,sha384,voprf
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,13 +328,14 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "decb3a27ea454a5f23f96eb182af0671c12694d64ecc33dada74edd1301f6cfc"
+checksum = "5fcbfdf46fd1157b49be0c2170bab2784ca19233b35c2dc772d60247b72f2071"
 dependencies = [
  "base64ct",
  "crypto-bigint",
  "der",
+ "digest",
  "ff",
  "generic-array",
  "group",

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-elliptic-curve = { version = "0.11.6", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "0.11.7", default-features = false, features = ["hazmat", "sec1"] }
 sec1 = { version = "0.2", default-features = false }
 
 # optional dependencies
@@ -46,6 +46,7 @@ serde = ["ecdsa-core/serde", "elliptic-curve/serde", "sec1/serde"]
 sha256 = ["digest", "sha2"]
 std = ["ecdsa-core/std", "elliptic-curve/std"] # TODO: use weak activation for `ecdsa-core/std` when available
 test-vectors = ["hex-literal"]
+voprf = ["elliptic-curve/voprf", "sha2"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -150,3 +150,13 @@ impl elliptic_curve::sec1::ValidatePublicKey for NistP256 {}
 #[cfg(feature = "bits")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
 pub type ScalarBits = elliptic_curve::ScalarBits<NistP256>;
+
+#[cfg(feature = "voprf")]
+#[cfg_attr(docsrs, doc(cfg(feature = "voprf")))]
+impl elliptic_curve::VoprfParameters for NistP256 {
+    /// See <https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-08.html#section-4.3-1.3>.
+    const ID: u16 = 0x0003;
+
+    /// See <https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-08.html#section-4.3-1.2>.
+    type Hash = sha2::Sha256;
+}

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.56"
 
 [dependencies]
 ecdsa = { version = "0.13", optional = true, default-features = false, features = ["der"] }
-elliptic-curve = { version = "0.11", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "0.11.7", default-features = false, features = ["hazmat", "sec1"] }
 sec1 = { version = "0.2", default-features = false }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
@@ -30,6 +30,7 @@ pkcs8 = ["elliptic-curve/pkcs8"]
 serde = ["ecdsa/serde", "elliptic-curve/serde", "sec1/serde"]
 sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
 std = ["elliptic-curve/std"]
+voprf = ["elliptic-curve/voprf", "sha2"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -106,3 +106,13 @@ pub type ScalarCore = elliptic_curve::ScalarCore<NistP384>;
 pub type SecretKey = elliptic_curve::SecretKey<NistP384>;
 
 impl elliptic_curve::sec1::ValidatePublicKey for NistP384 {}
+
+#[cfg(feature = "voprf")]
+#[cfg_attr(docsrs, doc(cfg(feature = "voprf")))]
+impl elliptic_curve::VoprfParameters for NistP384 {
+    /// See <https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-08.html#section-4.4-1.3>.
+    const ID: u16 = 0x0004;
+
+    /// See <https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-08.html#section-4.4-1.2>.
+    type Hash = sha2::Sha384;
+}


### PR DESCRIPTION
See RustCrypto/traits#878.
Reference: https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-08.html#section-4.