### PR TITLE
k256: `IDENTITY` and `GENERATOR` point constants

### DIFF
--- a/k256/bench/scalar.rs
+++ b/k256/bench/scalar.rs
@@ -28,14 +28,14 @@ fn test_scalar_y() -> Scalar {
 }
 
 fn bench_point_mul<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
-    let p = ProjectivePoint::generator();
+    let p = ProjectivePoint::GENERATOR;
     let m = hex!("AA5E28D6A97A2479A65527F7290311A3624D4CC0FA1578598EE3C2613BF99522");
     let s = Scalar::from_repr(m.into()).unwrap();
     group.bench_function("point-scalar mul", |b| b.iter(|| &p * &s));
 }
 
 fn bench_point_lincomb<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
-    let p = ProjectivePoint::generator();
+    let p = ProjectivePoint::GENERATOR;
     let m = hex!("AA5E28D6A97A2479A65527F7290311A3624D4CC0FA1578598EE3C2613BF99522");
     let s = Scalar::from_repr(m.into()).unwrap();
     group.bench_function("lincomb via mul+add", |b| b.iter(|| &p * &s + &p * &s));

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -101,7 +101,7 @@ impl LookupTable {
         let xabs = (x + xmask) ^ xmask;
 
         // Get an array element in constant time
-        let mut t = ProjectivePoint::identity();
+        let mut t = ProjectivePoint::IDENTITY;
         for j in 1..9 {
             let c = (xabs as u8).ct_eq(&(j as u8));
             t.conditional_assign(&self.0[j - 1], c);
@@ -278,7 +278,7 @@ fn lincomb_generic<const N: usize>(xs: &[ProjectivePoint; N], ks: &[Scalar; N]) 
         Radix16Decomposition::default(),
     );
 
-    let mut acc = ProjectivePoint::identity();
+    let mut acc = ProjectivePoint::IDENTITY;
     for component in 0..N {
         acc += &tables1[component].select(digits1[component].0[32]);
         acc += &tables2[component].select(digits2[component].0[32]);

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -184,7 +184,7 @@ impl Signature {
         let r_inv = r.invert().unwrap();
         let u1 = -(r_inv * z);
         let u2 = r_inv * *s;
-        let pk = ProjectivePoint::lincomb(&ProjectivePoint::generator(), &u1, &R, &u2).to_affine();
+        let pk = ProjectivePoint::lincomb(&ProjectivePoint::GENERATOR, &u1, &R, &u2).to_affine();
 
         // TODO(tarcieri): ensure the signature verifies?
         Ok(VerifyingKey::from(&pk))

--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -169,7 +169,7 @@ impl SignPrimitive<Secp256k1> for Scalar {
         let k_inverse = k_inverse.unwrap();
 
         // Compute 𝐑 = 𝑘×𝑮
-        let R = (ProjectivePoint::generator() * k).to_affine();
+        let R = (ProjectivePoint::GENERATOR * k).to_affine();
 
         // Lift x-coordinate of 𝐑 (element of base field) into a serialized big
         // integer, then reduce it into an element of the scalar field

--- a/k256/src/ecdsa/verify.rs
+++ b/k256/src/ecdsa/verify.rs
@@ -111,9 +111,9 @@ impl VerifyPrimitive<Secp256k1> for AffinePoint {
         let u2 = *r * s_inv;
 
         let x = ProjectivePoint::lincomb(
-            &ProjectivePoint::generator(),
+            &ProjectivePoint::GENERATOR,
             &u1,
-            &ProjectivePoint::from(*self),
+            &ProjectivePoint::from(self),
             &u2,
         )
         .to_affine()


### PR DESCRIPTION
Adds inherent constants to `AffinePoint` and `ProjectivePoint` representing the identity and generator points.

This should make it possible to write `const fn`s that produce things like precomputed basepoint tables (see #508).

Deprecates the previous inherent methods on `ProjectivePoint` for returning these constants.