### PR TITLE
k256 v0.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "blobby",
  "cfg-if",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.2 (2022-01-17)
+### Added
+- hash2curve support: impl `GroupDigest` for `Secp256k1` ([#503])
+- `IDENTITY` and `GENERATOR` point constants ([#511])
+
+[#503]: https://github.com/RustCrypto/elliptic-curves/pull/503
+[#511]: https://github.com/RustCrypto/elliptic-curves/pull/511
+
 ## 0.10.1 (2022-01-04)
 ### Added
 - Impl `ff::Field` trait for `FieldElement` ([#498])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.10.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification (including Ethereum-style signatures with public-key

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/k256/0.10.1"
+    html_root_url = "https://docs.rs/k256/0.10.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- hash2curve support: impl `GroupDigest` for `Secp256k1` ([#503])
- `IDENTITY` and `GENERATOR` point constants ([#511])

[#503]: https://github.com/RustCrypto/elliptic-curves/pull/503
[#511]: https://github.com/RustCrypto/elliptic-curves/pull/511