### PR TITLE
p256 v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "blobby",
  "ecdsa",

--- a/p256/CHANGELOG.md
+++ b/p256/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.1 (2022-01-17)
+### Added
+- Impl `ff::Field` trait for `FieldElement` ([#498])
+- hash2curve support: impl `GroupDigest` trait for `NistP256` ([#503])
+- Impl `VoprfParameters` trait for `NistP256` ([#506])
+- Impl `ReduceNonZero<U256>` trait for `Scalar` ([#507])
+- `IDENTITY` and `GENERATOR` point constants ([#509], [#511])
+
+[#498]: https://github.com/RustCrypto/elliptic-curves/pull/498
+[#503]: https://github.com/RustCrypto/elliptic-curves/pull/503
+[#506]: https://github.com/RustCrypto/elliptic-curves/pull/506
+[#507]: https://github.com/RustCrypto/elliptic-curves/pull/507
+[#509]: https://github.com/RustCrypto/elliptic-curves/pull/509
+[#511]: https://github.com/RustCrypto/elliptic-curves/pull/511
+
 ## 0.10.0 (2021-12-14)
 ### Added
 - Implement point compaction support ([#357])

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256"
-version = "0.10.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve with support for ECDH, ECDSA signing/verification, and general

--- a/p256/LICENSE-MIT
+++ b/p256/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2021 RustCrypto Developers
+Copyright (c) 2020-2022 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -1,3 +1,12 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_root_url = "https://docs.rs/p256/0.10.1"
+)]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc = include_str!("../README.md")]
 
 //! ## `serde` support
@@ -10,16 +19,6 @@
 //! - [`ecdsa::VerifyingKey`]
 //!
 //! Please see type-specific documentation for more information.
-
-#![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/p256/0.10.0"
-)]
-#![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "arithmetic")]
 mod arithmetic;


### PR DESCRIPTION
### Added
- Impl `ff::Field` trait for `FieldElement` ([#498])
- hash2curve support: impl `GroupDigest` trait for `NistP256` ([#503])
- Impl `VoprfParameters` trait for `NistP256` ([#506])
- Impl `ReduceNonZero<U256>` trait for `Scalar` ([#507])
- `IDENTITY` and `GENERATOR` point constants ([#509], [#511])

[#498]: https://github.com/RustCrypto/elliptic-curves/pull/498
[#503]: https://github.com/RustCrypto/elliptic-curves/pull/503
[#506]: https://github.com/RustCrypto/elliptic-curves/pull/506
[#507]: https://github.com/RustCrypto/elliptic-curves/pull/507
[#509]: https://github.com/RustCrypto/elliptic-curves/pull/509
[#511]: https://github.com/RustCrypto/elliptic-curves/pull/511