### PR TITLE
k256: normalize before calling is_odd() in sng0()

### DIFF
--- a/k256/src/arithmetic/hash2curve.rs
+++ b/k256/src/arithmetic/hash2curve.rs
@@ -42,7 +42,7 @@ impl FromOkm for FieldElement {
 
 impl Sgn0 for FieldElement {
     fn sgn0(&self) -> Choice {
-        self.is_odd()
+        self.normalize().is_odd()
     }
 }
 


### PR DESCRIPTION
An `is_odd()` call I forgot to address in #530

While this fixes the problem at hand, there are a couple of considerations:
- To prevent future problems like this, we do need either #531, or just auto-normalizing in `FieldElement::is_odd()` (but not in `FieldElementImpl`!). Originally I didn't do that because I wanted to leave a possibility for a slightly more efficient code (where the caller would know whether the value has been previously normalized or not), but perhaps it is not worth it, and it's better to prevent errors instead.
- This was not caught in tests in #530 because in CI we run tests with `--release`, and apparently this bug does not affect `hash2curve` test, which is the only one touching `sgn0()`. @tarcieri , why was that decision made originally?