### PR TITLE
k256: add v0.10.4 release notes

### DIFF
--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.4 (2022-03-15)
+### Fixed
+- Normalize before calling `is_odd()` in `sng0()` ([#533])
+
+[#533]: https://github.com/RustCrypto/elliptic-curves/pull/533
+
 ## 0.10.3 (2022-03-14)
 ### Fixed
 - Do not normalize the argument in `FieldElementImpl::is_odd()` ([#530])


### PR DESCRIPTION
This release backports #533.

Since `master` is already v0.11 prereleases, this commit just contains the release notes.

The released code can be found via the `k256/v0.10.4` tag:

https://github.com/RustCrypto/elliptic-curves/tree/k256/v0.10.4