### PR TITLE
k256: fallible `AffinePoint` to `VerifyingKey` conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.0-pre.1"
+version = "0.14.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734abc41546cac3773230c5719ac16a3bbdff020e8f22393372537334f46d699"
+checksum = "28c2de318745e96b4c6679669a4283c345977dc6b5683e4e713661bbb5b33637"
 dependencies = [
  "der",
  "elliptic-curve",

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -17,7 +17,7 @@ elliptic-curve = { version = "0.12.0-pre.1", default-features = false, features 
 sec1 = { version = "0.2", default-features = false }
 
 # optional dependencies
-ecdsa = { version = "0.14.0-pre.1", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.14.0-pre.2", optional = true, default-features = false, features = ["der"] }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [features]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -17,7 +17,7 @@ elliptic-curve = { version = "0.12.0-pre.1", default-features = false, features 
 sec1 = { version = "0.2", default-features = false }
 
 # optional dependencies
-ecdsa = { version = "0.14.0-pre.1", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.14.0-pre.2", optional = true, default-features = false, features = ["der"] }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [features]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -23,7 +23,7 @@ elliptic-curve = { version = "0.12.0-pre.1", default-features = false, features 
 sec1 = { version = "0.2", default-features = false }
 
 # optional dependencies
-ecdsa-core = { version = "0.14.0-pre.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.14.0-pre.2", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.10", optional = true, default-features = false }
 sha3 = { version = "0.10", optional = true, default-features = false }
@@ -31,7 +31,7 @@ sha3 = { version = "0.10", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.3"
-ecdsa-core = { version = "0.14.0-pre.1", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.14.0-pre.2", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::op_ref)]
 
 use super::{AffinePoint, FieldElement, Scalar, CURVE_EQUATION_B_SINGLE};
-use crate::{CompressedPoint, EncodedPoint, Secp256k1};
+use crate::{CompressedPoint, EncodedPoint, PublicKey, Secp256k1};
 use core::{
     iter::Sum,
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
@@ -18,7 +18,7 @@ use elliptic_curve::{
     sec1::{FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
-    PrimeCurveArithmetic, ProjectiveArithmetic,
+    Error, PrimeCurveArithmetic, ProjectiveArithmetic, Result,
 };
 
 #[rustfmt::skip]
@@ -528,6 +528,34 @@ impl<'a> Neg for &'a ProjectivePoint {
 
     fn neg(self) -> ProjectivePoint {
         ProjectivePoint::neg(self)
+    }
+}
+
+impl From<PublicKey> for ProjectivePoint {
+    fn from(public_key: PublicKey) -> ProjectivePoint {
+        AffinePoint::from(public_key).into()
+    }
+}
+
+impl From<&PublicKey> for ProjectivePoint {
+    fn from(public_key: &PublicKey) -> ProjectivePoint {
+        AffinePoint::from(public_key).into()
+    }
+}
+
+impl TryFrom<ProjectivePoint> for PublicKey {
+    type Error = Error;
+
+    fn try_from(point: ProjectivePoint) -> Result<PublicKey> {
+        AffinePoint::from(point).try_into()
+    }
+}
+
+impl TryFrom<&ProjectivePoint> for PublicKey {
+    type Error = Error;
+
+    fn try_from(point: &ProjectivePoint) -> Result<PublicKey> {
+        AffinePoint::from(point).try_into()
     }
 }
 

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -187,10 +187,10 @@ impl Signature {
         let r_inv = *r.invert();
         let u1 = -(r_inv * z);
         let u2 = r_inv * *s;
-        let pk = ProjectivePoint::lincomb(&ProjectivePoint::GENERATOR, &u1, &R, &u2).to_affine();
+        let pk = ProjectivePoint::lincomb(&ProjectivePoint::GENERATOR, &u1, &R, &u2);
 
         // TODO(tarcieri): ensure the signature verifies?
-        Ok(VerifyingKey::from(&pk))
+        VerifyingKey::try_from(pk)
     }
 
     /// Parse the `r` component of this signature to a [`NonZeroScalar`]

--- a/k256/src/ecdsa/verify.rs
+++ b/k256/src/ecdsa/verify.rs
@@ -154,12 +154,6 @@ impl From<&VerifyingKey> for PublicKey {
     }
 }
 
-impl From<&AffinePoint> for VerifyingKey {
-    fn from(affine_point: &AffinePoint) -> VerifyingKey {
-        VerifyingKey::from_encoded_point(&affine_point.to_encoded_point(false)).unwrap()
-    }
-}
-
 impl From<ecdsa_core::VerifyingKey<Secp256k1>> for VerifyingKey {
     fn from(verifying_key: ecdsa_core::VerifyingKey<Secp256k1>) -> VerifyingKey {
         VerifyingKey {
@@ -180,11 +174,59 @@ impl ToEncodedPoint<Secp256k1> for VerifyingKey {
     }
 }
 
+impl TryFrom<AffinePoint> for VerifyingKey {
+    type Error = Error;
+
+    fn try_from(affine_point: AffinePoint) -> Result<VerifyingKey, Error> {
+        let inner = PublicKey::try_from(affine_point)
+            .map_err(|_| Error::new())?
+            .into();
+
+        Ok(VerifyingKey { inner })
+    }
+}
+
+impl TryFrom<&AffinePoint> for VerifyingKey {
+    type Error = Error;
+
+    fn try_from(affine_point: &AffinePoint) -> Result<VerifyingKey, Error> {
+        VerifyingKey::try_from(*affine_point)
+    }
+}
+
 impl TryFrom<&EncodedPoint> for VerifyingKey {
     type Error = Error;
 
     fn try_from(encoded_point: &EncodedPoint) -> Result<Self, Error> {
         Self::from_encoded_point(encoded_point)
+    }
+}
+
+impl From<VerifyingKey> for ProjectivePoint {
+    fn from(verifying_key: VerifyingKey) -> ProjectivePoint {
+        PublicKey::from(verifying_key.inner).into()
+    }
+}
+
+impl From<&VerifyingKey> for ProjectivePoint {
+    fn from(verifying_key: &VerifyingKey) -> ProjectivePoint {
+        PublicKey::from(verifying_key.inner).into()
+    }
+}
+
+impl TryFrom<ProjectivePoint> for VerifyingKey {
+    type Error = Error;
+
+    fn try_from(point: ProjectivePoint) -> Result<VerifyingKey, Error> {
+        AffinePoint::from(point).try_into()
+    }
+}
+
+impl TryFrom<&ProjectivePoint> for VerifyingKey {
+    type Error = Error;
+
+    fn try_from(point: &ProjectivePoint) -> Result<VerifyingKey, Error> {
+        AffinePoint::from(point).try_into()
     }
 }
 

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -21,13 +21,13 @@ elliptic-curve = { version = "0.12.0-pre.1", default-features = false, features 
 sec1 = { version = "0.2", default-features = false }
 
 # optional dependencies
-ecdsa-core = { version = "0.14.0-pre.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.14.0-pre.2", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
-ecdsa-core = { version = "0.14.0-pre.1", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.14.0-pre.2", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p256/src/arithmetic/projective.rs
+++ b/p256/src/arithmetic/projective.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::op_ref)]
 
 use super::{AffinePoint, FieldElement, Scalar, CURVE_EQUATION_B};
-use crate::{CompressedPoint, EncodedPoint, NistP256};
+use crate::{CompressedPoint, EncodedPoint, NistP256, PublicKey};
 use core::{
     iter::Sum,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
@@ -20,7 +20,7 @@ use elliptic_curve::{
     sec1::{FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
-    PrimeCurveArithmetic, ProjectiveArithmetic,
+    Error, PrimeCurveArithmetic, ProjectiveArithmetic, Result,
 };
 
 impl ProjectiveArithmetic for NistP256 {
@@ -543,6 +543,34 @@ impl<'a> Neg for &'a ProjectivePoint {
 
     fn neg(self) -> ProjectivePoint {
         ProjectivePoint::neg(self)
+    }
+}
+
+impl From<PublicKey> for ProjectivePoint {
+    fn from(public_key: PublicKey) -> ProjectivePoint {
+        AffinePoint::from(public_key).into()
+    }
+}
+
+impl From<&PublicKey> for ProjectivePoint {
+    fn from(public_key: &PublicKey) -> ProjectivePoint {
+        AffinePoint::from(public_key).into()
+    }
+}
+
+impl TryFrom<ProjectivePoint> for PublicKey {
+    type Error = Error;
+
+    fn try_from(point: ProjectivePoint) -> Result<PublicKey> {
+        AffinePoint::from(point).try_into()
+    }
+}
+
+impl TryFrom<&ProjectivePoint> for PublicKey {
+    type Error = Error;
+
+    fn try_from(point: &ProjectivePoint) -> Result<PublicKey> {
+        AffinePoint::from(point).try_into()
     }
 }
 

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-ecdsa = { version = "0.14.0-pre.1", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.14.0-pre.2", optional = true, default-features = false, features = ["der"] }
 elliptic-curve = { version = "0.12.0-pre.1", default-features = false, features = ["hazmat", "sec1"] }
 sec1 = { version = "0.2", default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }


### PR DESCRIPTION
The inner type of `VerifyingKey` is a `PublicKey`, which is itself a wrapper for an inner curve-specific `AffinePoint` which ensures that the inner point is *NOT* the additive identity / point at infinity.

Therefore, any conversion from an `AffinePoint` is potentially fallible, so the existing `From` conversions need to be changed to `TryFrom`.

This commit also adds some additional type conversions between `AffinePoint`/`ProjectivePoint` and `PublicKey`/`VerifyingKey`, and also includes them in `p256` for consistency.