### PR TITLE
p256: Add implementation of Elligator Squared.

### DIFF
--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -48,6 +48,7 @@ sha256 = ["digest", "sha2"]
 std = ["ecdsa-core/std", "elliptic-curve/std"] # TODO: use weak activation for `ecdsa-core/std` when available
 test-vectors = ["hex-literal"]
 voprf = ["elliptic-curve/voprf", "sha2"]
+elligator_squared = ["arithmetic"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -1,6 +1,8 @@
 //! Pure Rust implementation of group operations on secp256r1.
 
 pub(crate) mod affine;
+#[cfg(feature = "elligator_squared")]
+pub mod elligator_squared;
 mod field;
 #[cfg(feature = "hash2curve")]
 mod hash2curve;

--- a/p256/src/arithmetic/elligator_squared.rs
+++ b/p256/src/arithmetic/elligator_squared.rs
@@ -1,0 +1,210 @@
+use elliptic_curve::group::prime::PrimeCurveAffine;
+use elliptic_curve::rand_core::RngCore;
+use elliptic_curve::{Field, Group};
+
+use crate::arithmetic::field::FieldElement;
+use crate::arithmetic::{CURVE_EQUATION_A, CURVE_EQUATION_B};
+use crate::{AffinePoint, ProjectivePoint};
+
+/// Decodes the given pair of field elements into the originally encoded point.
+pub fn elligator_squared_to_point(u: &FieldElement, v: &FieldElement) -> ProjectivePoint {
+    f(u).to_curve() + f(v).to_curve()
+}
+
+/// Encodes the given point as a pair of random, uniformly distributed field elements.
+pub fn point_to_elligator_squared(
+    p: &ProjectivePoint,
+    mut rng: impl RngCore,
+) -> (FieldElement, FieldElement) {
+    for _ in 0..1000 {
+        // Generate a random field element \not\in {-1, 0, 1}.
+        let u = FieldElement::random(&mut rng);
+        if u == -FieldElement::ONE || u == FieldElement::ZERO || u == FieldElement::ONE {
+            continue;
+        }
+
+        // Map the field element to a point and calculate the difference between the random point
+        // and the input point.
+        let q = p - &f(&u);
+
+        // If we managed to randomly generate -p, congratulate ourselves on the improbable and keep
+        // trying.
+        if q.is_identity().into() {
+            continue;
+        }
+
+        // Pick a random biquadratic root.
+        let mut j = [0u8; 1];
+        rng.fill_bytes(&mut j);
+        let j = (j[0] % 4) as usize; // d = 4
+
+        // If the Jth biquadratic root exists for the delta point, return our random field element
+        // and our preimage field element.
+        if let Some(v) = r(&q, j) {
+            return (u, v);
+        }
+    }
+
+    unreachable!()
+}
+
+fn g(x: &FieldElement) -> FieldElement {
+    x.cube() + (CURVE_EQUATION_A * x) + CURVE_EQUATION_B
+}
+
+fn x_0(u: &FieldElement) -> FieldElement {
+    -(CURVE_EQUATION_B * CURVE_EQUATION_A.invert().unwrap())
+        * (FieldElement::ONE + ((u.square() * u.square()) - u.square()).invert().unwrap())
+}
+
+fn x_1(u: &FieldElement) -> FieldElement {
+    -u.square() * x_0(u)
+}
+
+fn f(u: &FieldElement) -> AffinePoint {
+    // Case 1: u \in {-1, 0, 1}
+    // return: infinity
+    if u == &-FieldElement::ONE || u == &FieldElement::ZERO || u == &FieldElement::ONE {
+        return AffinePoint::IDENTITY;
+    }
+
+    // Case 2: u \not\in {-1, 0, 1} and g(X_0(u)) is a square
+    // return: (X_0(u), \sqrt{g(X_0(u))})
+    let x = x_0(u);
+    let y = g(&x);
+    if let Some(y) = y.sqrt().into() {
+        return AffinePoint { x, y, infinity: 0 };
+    }
+
+    // Case 3: u \not\in {-1, 0, 1} and g(X_0(u)) is not a square
+    // return: (X_1(u), -\sqrt{g(X_1(u))})
+    let x = x_1(u);
+    let y = -g(&x).sqrt().unwrap();
+    AffinePoint { x, y, infinity: 0 }
+}
+
+fn r(q: &ProjectivePoint, j: usize) -> Option<FieldElement> {
+    let q = q.to_affine();
+    if q.y.sqrt().is_some().into() {
+        if j == 0 {
+            x0_r0(&q.x)
+        } else if j == 1 {
+            x0_r1(&q.x)
+        } else if j == 2 {
+            x0_r2(&q.x)
+        } else {
+            x0_r3(&q.x)
+        }
+    } else if j == 0 {
+        x1_r0(&q.x)
+    } else if j == 1 {
+        x1_r1(&q.x)
+    } else if j == 2 {
+        x1_r2(&q.x)
+    } else {
+        x1_r3(&q.x)
+    }
+}
+
+fn x0_r0(x: &FieldElement) -> Option<FieldElement> {
+    let omega = ((CURVE_EQUATION_A * CURVE_EQUATION_B.invert().unwrap()) * x) + FieldElement::ONE;
+    let a: Option<FieldElement> = (omega.square() - (FOUR * omega)).sqrt().into();
+    let b: Option<FieldElement> = (TWO * omega).invert().into();
+    let c: Option<FieldElement> = ((omega + a?) * b?).sqrt().into();
+    c
+}
+
+fn x0_r1(x: &FieldElement) -> Option<FieldElement> {
+    let omega = ((CURVE_EQUATION_A * CURVE_EQUATION_B.invert().unwrap()) * x) + FieldElement::ONE;
+    let a: Option<FieldElement> = (omega.square() - (FOUR * omega)).sqrt().into();
+    let b: Option<FieldElement> = (TWO * omega).invert().into();
+    let c: Option<FieldElement> = ((omega + a?) * b?).sqrt().into();
+    Some(-c?)
+}
+
+fn x0_r2(x: &FieldElement) -> Option<FieldElement> {
+    let omega = ((CURVE_EQUATION_A * CURVE_EQUATION_B.invert().unwrap()) * x) + FieldElement::ONE;
+    let a: Option<FieldElement> = (omega.square() - (FOUR * omega)).sqrt().into();
+    let b: Option<FieldElement> = (TWO * omega).invert().into();
+    let c: Option<FieldElement> = ((omega - a?) * b?).sqrt().into();
+    c
+}
+
+fn x0_r3(x: &FieldElement) -> Option<FieldElement> {
+    let omega = ((CURVE_EQUATION_A * CURVE_EQUATION_B.invert().unwrap()) * x) + FieldElement::ONE;
+    let a: Option<FieldElement> = (omega.square() - (FOUR * omega)).sqrt().into();
+    let b: Option<FieldElement> = (TWO * omega).invert().into();
+    let c: Option<FieldElement> = ((omega - a?) * b?).sqrt().into();
+    Some(-c?)
+}
+
+fn x1_r0(x: &FieldElement) -> Option<FieldElement> {
+    let omega = ((CURVE_EQUATION_A * CURVE_EQUATION_B.invert().unwrap()) * x) + FieldElement::ONE;
+    let a: Option<FieldElement> = (omega.square() - (FOUR * omega)).sqrt().into();
+    let b: Option<FieldElement> = TWO.invert().into();
+    let c: Option<FieldElement> = ((omega + a?) * b?).sqrt().into();
+    c
+}
+
+fn x1_r1(x: &FieldElement) -> Option<FieldElement> {
+    let omega = ((CURVE_EQUATION_A * CURVE_EQUATION_B.invert().unwrap()) * x) + FieldElement::ONE;
+    let a: Option<FieldElement> = (omega.square() - (FOUR * omega)).sqrt().into();
+    let b: Option<FieldElement> = TWO.invert().into();
+    let c: Option<FieldElement> = ((omega + a?) * b?).sqrt().into();
+    Some(-c?)
+}
+
+fn x1_r2(x: &FieldElement) -> Option<FieldElement> {
+    let omega = ((CURVE_EQUATION_A * CURVE_EQUATION_B.invert().unwrap()) * x) + FieldElement::ONE;
+    let a: Option<FieldElement> = (omega.square() - (FOUR * omega)).sqrt().into();
+    let b: Option<FieldElement> = TWO.invert().into();
+    let c: Option<FieldElement> = ((omega - a?) * b?).sqrt().into();
+    c
+}
+
+fn x1_r3(x: &FieldElement) -> Option<FieldElement> {
+    let omega = ((CURVE_EQUATION_A * CURVE_EQUATION_B.invert().unwrap()) * x) + FieldElement::ONE;
+    let a: Option<FieldElement> = (omega.square() - (FOUR * omega)).sqrt().into();
+    let b: Option<FieldElement> = TWO.invert().into();
+    let c: Option<FieldElement> = ((omega - a?) * b?).sqrt().into();
+    Some(-c?)
+}
+
+const TWO: FieldElement = FieldElement::add(&FieldElement::ONE, &FieldElement::ONE);
+const FOUR: FieldElement = TWO.square();
+
+#[cfg(test)]
+mod tests {
+    use elliptic_curve::group::GroupEncoding;
+    use elliptic_curve::Group;
+
+    use crate::ProjectivePoint;
+
+    use super::*;
+
+    #[test]
+    fn swu_encoding() {
+        let mut rng = rand_core::OsRng::default();
+        for _ in 0..1_000 {
+            let u = FieldElement::random(&mut rng);
+            let q = f(&u);
+
+            // Check to see if the point is actually on the curve.
+            let b = q.to_bytes();
+            let q_p: Option<AffinePoint> = AffinePoint::from_bytes(&b).into();
+            assert_eq!(Some(q), q_p);
+        }
+    }
+
+    #[test]
+    fn round_trip() {
+        let mut rng = rand_core::OsRng::default();
+        for _ in 0..100 {
+            let p = ProjectivePoint::random(&mut rng);
+            let (u, v) = point_to_elligator_squared(&p, &mut rng);
+            let p2 = elligator_squared_to_point(&u, &v);
+
+            assert_eq!(p, p2);
+        }
+    }
+}

--- a/p256/src/arithmetic/elligator_squared.rs
+++ b/p256/src/arithmetic/elligator_squared.rs
@@ -1,3 +1,6 @@
+//! An implementation of the [Elligator Squared](https://eprint.iacr.org/2014/043.pdf) algorithm
+//! for encoding elliptic curve points as uniformly distributed bitstrings.
+
 use elliptic_curve::group::prime::PrimeCurveAffine;
 use elliptic_curve::rand_core::RngCore;
 use elliptic_curve::{Field, Group};

--- a/p256/src/arithmetic/elligator_squared.rs
+++ b/p256/src/arithmetic/elligator_squared.rs
@@ -20,7 +20,8 @@ pub fn point_to_elligator_squared(
     p: &ProjectivePoint,
     mut rng: impl RngCore,
 ) -> (FieldElement, FieldElement) {
-    for _ in 0..1000 {
+    // Iterate through no more than one thousand candidates. On average, we try N(P) candidates.
+    for _ in 0..1_000 {
         // Generate a random field element \not\in {-1, 0, 1}.
         let u = FieldElement::random(&mut rng);
         if u == -FieldElement::ONE || u == FieldElement::ZERO || u == FieldElement::ONE {
@@ -47,7 +48,9 @@ pub fn point_to_elligator_squared(
         }
     }
 
-    unreachable!()
+    // Statistically, it's more likely the RNG is broken than we found one thousand candidates in a
+    // row with no valid preimage.
+    unreachable!("failed to find candidate, suspect RNG failure")
 }
 
 fn g(x: &FieldElement) -> FieldElement {

--- a/p256/src/arithmetic/elligator_squared.rs
+++ b/p256/src/arithmetic/elligator_squared.rs
@@ -8,20 +8,21 @@ use elliptic_curve::{Field, Group};
 
 use crate::arithmetic::field::FieldElement;
 use crate::arithmetic::{CURVE_EQUATION_A, CURVE_EQUATION_B};
-use crate::{AffinePoint, FieldBytes, ProjectivePoint};
+use crate::{AffinePoint, ProjectivePoint};
 
 /// Decodes the given pair of field elements into the originally encoded point.
-pub fn elligator_squared_to_point(u: &FieldBytes, v: &FieldBytes) -> Option<ProjectivePoint> {
-    FieldElement::from_bytes(u)
-        .and_then(|u| FieldElement::from_bytes(v).map(|v| f(&u).to_curve() + f(&v).to_curve()))
+pub fn elligator_squared_to_point(b: &[u8; 64]) -> Option<ProjectivePoint> {
+    let u: [u8; 32] = b[..32].try_into().ok()?;
+    let v: [u8; 32] = b[32..].try_into().ok()?;
+    FieldElement::from_bytes(&u.into())
+        .and_then(|u| {
+            FieldElement::from_bytes(&v.into()).map(|v| f(&u).to_curve() + f(&v).to_curve())
+        })
         .into()
 }
 
 /// Encodes the given point as a pair of random, uniformly distributed field elements.
-pub fn point_to_elligator_squared(
-    p: &ProjectivePoint,
-    mut rng: impl RngCore,
-) -> (FieldBytes, FieldBytes) {
+pub fn point_to_elligator_squared(p: &ProjectivePoint, mut rng: impl RngCore) -> [u8; 64] {
     // Iterate through no more than one thousand candidates. On average, we try N(P) candidates.
     for _ in 0..1_000 {
         // Generate a random field element \not\in {-1, 0, 1}.
@@ -47,7 +48,10 @@ pub fn point_to_elligator_squared(
         // and our preimage field element.
         let v: Option<FieldElement> = r(&q, j).into();
         if let Some(v) = v {
-            return (u.to_bytes(), v.to_bytes());
+            let mut b = [0u8; 64];
+            b[..32].copy_from_slice(&u.to_bytes());
+            b[32..].copy_from_slice(&v.to_bytes());
+            return b;
         }
     }
 
@@ -153,8 +157,8 @@ mod tests {
         let mut rng = rand_core::OsRng::default();
         for _ in 0..100 {
             let p = ProjectivePoint::random(&mut rng);
-            let (u, v) = point_to_elligator_squared(&p, &mut rng);
-            let p2 = elligator_squared_to_point(&u, &v).expect("should have decoded");
+            let b = point_to_elligator_squared(&p, &mut rng);
+            let p2 = elligator_squared_to_point(&b).expect("should have decoded");
 
             assert_eq!(p, p2);
         }

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -31,6 +31,9 @@ pub mod ecdh;
 #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa-core")))]
 pub mod ecdsa;
 
+#[cfg(feature = "elligator_squared")]
+pub use arithmetic::elligator_squared;
+
 #[cfg(any(feature = "test-vectors", test))]
 #[cfg_attr(docsrs, doc(cfg(feature = "test-vectors")))]
 pub mod test_vectors;


### PR DESCRIPTION
This is in big need of more scrutiny, documenting, and refactoring, but I wanted to push early and allow for input.

[Elligator Squared](https://eprint.iacr.org/2014/043.pdf) is obviously not a standard anything, nor is the simplified Shallue-van de Woestijne-Ulas encoding, so I’m pretty open to this being a bad fit for inclusion in this crate. This is well into “science project” territory and really not something I’d responsibly recommend to anyone.

Buuut it’s neat and I’ve got a hobby project which might could use it and it seems like a decent focal point for conversations about what an EC API looks like which would allow me to ~commit these sorts of crimes~ implement this sort of functionality without having to maintain my own fork. At a minimum, that’d probably be access to `FieldElement`, curve constants, and point construction.

Ostensibly this could also be implemented for [k256](https://github.com/sipa/writeups/tree/main/elligator-square-for-bn), but it’d need a similar degree of specialization.

Absolutely no hurry on this, BTW.