### PR TITLE
bp384 v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "bp384"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/bp384/CHANGELOG.md
+++ b/bp384/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2022-05-09)
+### Changed
+- Have `pkcs8` feature activate `ecdsa/pkcs8` ([#538])
+- Bump `elliptic-curve` to v0.12 ([#544])
+- Bump `ecdsa` to v0.14 ([#544])
+
+[#538]: https://github.com/RustCrypto/elliptic-curves/pull/538
+[#544]: https://github.com/RustCrypto/elliptic-curves/pull/544
+
 ## 0.3.0 (2021-12-14)
 ### Added
 - `serde` feature ([#463])

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp384"
-version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
### Changed
- Have `pkcs8` feature activate `ecdsa/pkcs8` ([#538])
- Bump `elliptic-curve` to v0.12 ([#544])
- Bump `ecdsa` to v0.14 ([#544])

[#538]: https://github.com/RustCrypto/elliptic-curves/pull/538
[#544]: https://github.com/RustCrypto/elliptic-curves/pull/544