### PR TITLE
k256 v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.11.0-pre.0"
+version = "0.11.0"
 dependencies = [
  "blobby",
  "cfg-if",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.0 (2022-05-09)
+### Changed
+- Make `AffinePoint` to `VerifyingKey` conversion fallible ([#535])
+- Rename `recover_verify_key` => `recover_verifying_key` ([#537])
+- Rename `recover_verify_key_from_digest` => `recover_verifying_key_from_digest` ([#537])
+- Have `pkcs8` feature activate `ecdsa/pkcs8` ([#538])
+- Bump `elliptic-curve` to v0.12 ([#544])
+- Bump `ecdsa` to v0.14 ([#544])
+
+### Fixed
+- `hash2curve` crate feature ([#519])
+
+[#519]: https://github.com/RustCrypto/elliptic-curves/pull/519
+[#535]: https://github.com/RustCrypto/elliptic-curves/pull/535
+[#537]: https://github.com/RustCrypto/elliptic-curves/pull/537
+[#538]: https://github.com/RustCrypto/elliptic-curves/pull/538
+[#544]: https://github.com/RustCrypto/elliptic-curves/pull/544
+
 ## 0.10.4 (2022-03-15)
 ### Fixed
 - Normalize before calling `is_odd()` in `sng0()` ([#533])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.11.0-pre.0"
+version = "0.11.0"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification (including Ethereum-style signatures with public-key

--- a/k256/src/ecdsa/recoverable.rs
+++ b/k256/src/ecdsa/recoverable.rs
@@ -72,7 +72,7 @@ pub const SIZE: usize = 65;
 /// - `r`: 32-byte integer, big endian
 /// - `s`: 32-byte integer, big endian
 /// - `v`: 1-byte recovery [`Id`]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Signature {
     bytes: [u8; SIZE],
 }
@@ -225,16 +225,6 @@ impl AsRef<[u8]> for Signature {
 impl Debug for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "RecoverableSignature {{ bytes: {:?}) }}", self.as_ref())
-    }
-}
-
-// TODO(tarcieri): derive `Eq` after const generics are available
-impl Eq for Signature {}
-
-// TODO(tarcieri): derive `PartialEq` after const generics are available
-impl PartialEq for Signature {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_ref().eq(other.as_ref())
     }
 }
 

--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -240,8 +240,7 @@ impl ConstantTimeEq for SigningKey {
 
 impl Debug for SigningKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO(tarcieri): use `finish_non_exhaustive` when stable
-        f.debug_tuple("SigningKey").field(&"...").finish()
+        f.debug_struct("SigningKey").finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
### Changed
- Bump `digest` to v0.10 ([#515])
- Make `AffinePoint` to `VerifyingKey` conversion fallible ([#535])
- Rename `recover_verify_key` => `recover_verifying_key` ([#537])
- Rename `recover_verify_key_from_digest` => `recover_verifying_key_from_digest` ([#537])
- Have `pkcs8` feature activate `ecdsa/pkcs8` ([#538])
- Bump `elliptic-curve` to v0.12 ([#544])
- Bump `ecdsa` to v0.14 ([#544])

### Fixed
- `hash2curve` crate feature ([#519])

[#515]: https://github.com/RustCrypto/elliptic-curves/pull/515
[#519]: https://github.com/RustCrypto/elliptic-curves/pull/519
[#535]: https://github.com/RustCrypto/elliptic-curves/pull/535
[#537]: https://github.com/RustCrypto/elliptic-curves/pull/537
[#538]: https://github.com/RustCrypto/elliptic-curves/pull/538
[#544]: https://github.com/RustCrypto/elliptic-curves/pull/544