### PR TITLE
p256 v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,7 +604,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "p256"
-version = "0.11.0-pre.0"
+version = "0.11.0"
 dependencies = [
  "blobby",
  "ecdsa",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.11.0 (2022-05-09)
 ### Changed
+- Bump `digest` to v0.10 ([#515])
 - Make `AffinePoint` to `VerifyingKey` conversion fallible ([#535])
 - Rename `recover_verify_key` => `recover_verifying_key` ([#537])
 - Rename `recover_verify_key_from_digest` => `recover_verifying_key_from_digest` ([#537])
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `hash2curve` crate feature ([#519])
 
+[#515]: https://github.com/RustCrypto/elliptic-curves/pull/515
 [#519]: https://github.com/RustCrypto/elliptic-curves/pull/519
 [#535]: https://github.com/RustCrypto/elliptic-curves/pull/535
 [#537]: https://github.com/RustCrypto/elliptic-curves/pull/537

--- a/p256/CHANGELOG.md
+++ b/p256/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.0 (2022-05-09)
+### Changed
+- Bump `digest` to v0.10 ([#515])
+- Have `pkcs8` feature activate `ecdsa/pkcs8` ([#538])
+- Bump `elliptic-curve` to v0.12 ([#544])
+- Bump `ecdsa` to v0.14 ([#544])
+
+[#515]: https://github.com/RustCrypto/elliptic-curves/pull/515
+[#538]: https://github.com/RustCrypto/elliptic-curves/pull/538
+[#544]: https://github.com/RustCrypto/elliptic-curves/pull/544
+
 ## 0.10.1 (2022-01-17)
 ### Added
 - Impl `ff::Field` trait for `FieldElement` ([#498])

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256"
-version = "0.11.0-pre.0"
+version = "0.11.0"
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve with support for ECDH, ECDSA signing/verification, and general


### PR DESCRIPTION
### Changed
- Bump `digest` to v0.10 ([#515])
- Have `pkcs8` feature activate `ecdsa/pkcs8` ([#538])
- Bump `elliptic-curve` to v0.12 ([#544])
- Bump `ecdsa` to v0.14 ([#544])

[#515]: https://github.com/RustCrypto/elliptic-curves/pull/515
[#538]: https://github.com/RustCrypto/elliptic-curves/pull/538
[#544]: https://github.com/RustCrypto/elliptic-curves/pull/544
