### PR TITLE
k256: use SHA-256 for computing RFC6979 for `recoverable::Signature`

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -39,12 +39,12 @@ proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
-default = ["arithmetic", "ecdsa", "pkcs8", "sha256", "std"]
+default = ["arithmetic", "ecdsa", "pkcs8", "std"]
 arithmetic = ["elliptic-curve/arithmetic"]
 bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
-ecdsa = ["arithmetic", "digest", "ecdsa-core/sign", "ecdsa-core/verify"]
+ecdsa = ["arithmetic", "ecdsa-core/sign", "ecdsa-core/verify", "sha256"]
 expose-field = ["arithmetic"]
 hash2curve = ["arithmetic", "elliptic-curve/hash2curve"]
 jwk = ["elliptic-curve/jwk"]


### PR DESCRIPTION
For whatever reason when the Ethereum developers decided to use Keccak256 as the digest function for ECDSA itself, they still used SHA-256 as the digest function for RFC6979, possibly because they didn't realize they needed to change the digest function in two places.

Previously the implementation in `k256` would use the same digest function for both (typically Keccak256) but we've had various complaints that doing so doesn't match the test vectors produced by various other libraries (though the signatures will still verify).

This commit uses HMAC-DRBG instantiated with SHA-256 for computing RFC6979 for `ecdsa::recoverable::Signature`, regardless of what digest function is used to hash the message. In theory this should match the Ethereum test vectors.