### PR TITLE
k256+p256: re-export low-level `diffie_hellman` function

### DIFF
--- a/k256/src/ecdh.rs
+++ b/k256/src/ecdh.rs
@@ -36,6 +36,8 @@
 //! assert_eq!(alice_shared.raw_secret_bytes(), bob_shared.raw_secret_bytes());
 //! ```
 
+pub use elliptic_curve::ecdh::diffie_hellman;
+
 use crate::{AffinePoint, Secp256k1};
 
 /// NIST P-256 Ephemeral Diffie-Hellman Secret.

--- a/p256/src/ecdh.rs
+++ b/p256/src/ecdh.rs
@@ -36,6 +36,8 @@
 //! assert_eq!(alice_shared.raw_secret_bytes(), bob_shared.raw_secret_bytes());
 //! ```
 
+pub use elliptic_curve::ecdh::diffie_hellman;
+
 use crate::{AffinePoint, NistP256};
 
 /// NIST P-256 Ephemeral Diffie-Hellman Secret.


### PR DESCRIPTION
Exports `diffie_hellman` within the `ecdh` module.

This is a low-level Diffie-Hellman function which can be used for static D-H where necessary.

Closes #555.