### PR TITLE
k256: enable `schnorr` feature by default

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -39,7 +39,7 @@ proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
-default = ["arithmetic", "ecdsa", "pkcs8", "std"]
+default = ["arithmetic", "ecdsa", "pkcs8", "schnorr", "std"]
 arithmetic = ["elliptic-curve/arithmetic"]
 bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
@@ -58,7 +58,7 @@ std = ["ecdsa-core/std", "elliptic-curve/std"] # TODO: use weak activation for `
 test-vectors = ["hex-literal"]
 
 [package.metadata.docs.rs]
-features = ["ecdh", "ecdsa", "sha256", "keccak256"]
+features = ["ecdh", "ecdsa", "schnorr", "sha256", "keccak256"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [[bench]]


### PR DESCRIPTION
And also enable it on docs.rs when generating rustdoc

It has no additional dependencies beyond what is required by default, so there's little reason to leave it off-by-default.