### PR TITLE
p384: `FieldElement::invert()` should check if self was non-zero

### DIFF
--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -303,7 +303,7 @@ impl FieldElement {
         fiat_p384_selectznz(&mut v_, s, &v, &v_opp);
         let mut fe: Fe = Default::default();
         fiat_p384_mul(&mut fe, &v_, &precomp);
-        CtOption::new(FieldElement::from(fe), 1.into())
+        CtOption::new(FieldElement::from(fe), !self.is_zero())
     }
 }
 

--- a/p384/src/arithmetic/projective.rs
+++ b/p384/src/arithmetic/projective.rs
@@ -612,11 +612,9 @@ mod tests {
         );
         assert_eq!(basepoint_projective.to_affine(), basepoint_affine);
         assert!(!bool::from(basepoint_projective.to_affine().is_identity()));
-
-        // TODO(tarcieri): BROKEN!
-        // assert!(bool::from(
-        //     ProjectivePoint::IDENTITY.to_affine().is_identity()
-        // ));
+        assert!(bool::from(
+            ProjectivePoint::IDENTITY.to_affine().is_identity()
+        ));
     }
 
     #[test]

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -235,7 +235,7 @@ impl Field for Scalar {
         fiat_p384_scalar_selectznz(&mut v_, s, &v, &v_opp);
         let mut fe: Fe = Default::default();
         fiat_p384_scalar_mul(&mut fe, &v_, &precomp);
-        CtOption::new(fe.into(), 1.into())
+        CtOption::new(fe.into(), !self.is_zero())
     }
 
     fn sqrt(&self) -> CtOption<Self> {


### PR DESCRIPTION
Fix for broken test https://github.com/RustCrypto/elliptic-curves/pull/567#discussion_r883209549

Edit: The same check has been changed in `Scalar::invert()` but there was no existing test to detect this.