### PR TITLE
p384: field cleanups

### DIFF
--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -11,14 +11,11 @@ pub(crate) mod field;
 pub(crate) mod projective;
 pub(crate) mod scalar;
 
-use affine::AffinePoint;
-use elliptic_curve::bigint::nlimbs;
-use field::{FieldElement, MODULUS};
-use projective::ProjectivePoint;
-use scalar::Scalar;
+use self::{affine::AffinePoint, field::FieldElement, projective::ProjectivePoint, scalar::Scalar};
+use elliptic_curve::bigint;
 
 /// Number of limbs used to represent a field element.
-const LIMBS: usize = nlimbs!(384);
+const LIMBS: usize = bigint::nlimbs!(384);
 
 /// a = -3 (0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc)
 /// NOTE: field element has been translated into the Montgomery domain.

--- a/p384/src/arithmetic/affine.rs
+++ b/p384/src/arithmetic/affine.rs
@@ -4,6 +4,8 @@
 
 use core::ops::{Mul, Neg};
 
+use super::{FieldElement, ProjectivePoint, CURVE_EQUATION_A, CURVE_EQUATION_B};
+use crate::{CompressedPoint, EncodedPoint, FieldBytes, NistP384, PublicKey, Scalar};
 use elliptic_curve::{
     bigint::Encoding,
     group::{prime::PrimeCurveAffine, GroupEncoding},
@@ -12,11 +14,9 @@ use elliptic_curve::{
     zeroize::DefaultIsZeroes,
     AffineArithmetic, AffineXCoordinate, Curve, DecompactPoint, DecompressPoint, Error, Result,
 };
+
 #[cfg(feature = "serde")]
 use serdect::serde::{de, ser, Deserialize, Serialize};
-
-use super::{FieldElement, ProjectivePoint, CURVE_EQUATION_A, CURVE_EQUATION_B, MODULUS};
-use crate::{CompressedPoint, EncodedPoint, FieldBytes, NistP384, PublicKey, Scalar};
 
 impl AffineArithmetic for NistP384 {
     type AffinePoint = AffinePoint;
@@ -210,7 +210,7 @@ impl DecompressPoint<NistP384> for AffinePoint {
 
             beta.map(|beta| {
                 let y = FieldElement::conditional_select(
-                    &(MODULUS - &beta),
+                    &(FieldElement::MODULUS - &beta),
                     &beta,
                     beta.is_odd().ct_eq(&y_is_odd),
                 );
@@ -257,8 +257,8 @@ impl DecompactPoint<NistP384> for AffinePoint {
             montgomery_y.map(|montgomery_y| {
                 // Convert to canonical form for comparisons
                 let y = montgomery_y.to_canonical();
-                let p_y = MODULUS - &y;
-                //                let (_, borrow) = p_y.informed_subtract(&y);
+                let p_y = FieldElement::MODULUS - &y;
+                // let (_, borrow) = p_y.informed_subtract(&y);
                 let borrow = 0;
                 let recovered_y = if borrow == 0 { y } else { p_y };
                 AffinePoint {
@@ -318,7 +318,7 @@ impl ToCompactEncodedPoint<NistP384> for AffinePoint {
     fn to_compact_encoded_point(&self) -> CtOption<EncodedPoint> {
         // Convert to canonical form for comparisons
         let y = self.y.to_canonical();
-        let (p_y, borrow) = MODULUS.informed_subtract(&y);
+        let (p_y, borrow) = FieldElement::MODULUS.informed_subtract(&y);
         assert_eq!(borrow, 0);
         let (_, borrow) = p_y.informed_subtract(&y);
 

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -90,8 +90,8 @@ impl Scalar {
         let mut mont = Default::default();
         fiat_p384_scalar_to_montgomery(&mut mont, &non_mont);
         let out = Scalar(mont);
-        let overflow = U384::from_be_bytes(bytes.into()).ct_lt(&NistP384::ORDER);
-        CtOption::new(out, overflow)
+        let is_some = U384::from_le_bytes(bytes.into()).ct_lt(&NistP384::ORDER);
+        CtOption::new(out, is_some)
     }
 
     /// Decode scalar from a little endian byte slice.


### PR DESCRIPTION
- Make `FieldElement::MODULUS` an inherent constant
- Replace some bespoke logic with U384