### PR TITLE
p384: `FieldElement` cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3e45371ac6a1370324b085acb466f24b07d4d66da6999a42c8ce655bd14e0e"
+checksum = "78a4e0fb04deabeb711eb20bd1179f1524c06f7e6975ebccc495f678a635887b"
 dependencies = [
  "generic-array",
  "rand_core",


### PR DESCRIPTION
Leverages the new `AsRef` and `AsMut` impls on `crypto_bigint::UInt` to simplify passing the limbs array to fiat-crypto functions.

Uses a macro to write the arithmetic ops impls.