### PR TITLE
p384: refactor `MODULUS` and macros

### DIFF
--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -5,12 +5,20 @@
 //!
 //! See section D.1.2.4: Curve P-384.
 
+#[macro_use]
+mod macros;
+
 pub(crate) mod affine;
 pub(crate) mod field;
 pub(crate) mod projective;
 pub(crate) mod scalar;
 
-use self::{affine::AffinePoint, field::FieldElement, projective::ProjectivePoint, scalar::Scalar};
+use self::{
+    affine::AffinePoint,
+    field::{FieldElement, MODULUS},
+    projective::ProjectivePoint,
+    scalar::Scalar,
+};
 use crate::U384;
 use elliptic_curve::bigint;
 

--- a/p384/src/arithmetic/affine.rs
+++ b/p384/src/arithmetic/affine.rs
@@ -4,7 +4,7 @@
 
 use core::ops::{Mul, Neg};
 
-use super::{FieldElement, ProjectivePoint, CURVE_EQUATION_A, CURVE_EQUATION_B};
+use super::{FieldElement, ProjectivePoint, CURVE_EQUATION_A, CURVE_EQUATION_B, MODULUS};
 use crate::{CompressedPoint, EncodedPoint, FieldBytes, NistP384, PublicKey, Scalar, U384};
 use elliptic_curve::{
     bigint::Encoding,
@@ -175,7 +175,7 @@ impl DecompressPoint<NistP384> for AffinePoint {
 
             beta.map(|beta| {
                 let y = FieldElement::conditional_select(
-                    &(FieldElement::MODULUS - &beta),
+                    &(FieldElement(MODULUS) - &beta),
                     &beta,
                     beta.is_odd().ct_eq(&y_is_odd),
                 );
@@ -222,7 +222,7 @@ impl DecompactPoint<NistP384> for AffinePoint {
             montgomery_y.map(|montgomery_y| {
                 // Convert to canonical form for comparisons
                 let y = montgomery_y.to_canonical();
-                let p_y = FieldElement::MODULUS - &y;
+                let p_y = FieldElement(MODULUS) - &y;
                 // let (_, borrow) = p_y.informed_subtract(&y);
                 let borrow = 0;
                 let recovered_y = if borrow == 0 { y } else { p_y };
@@ -283,7 +283,7 @@ impl ToCompactEncodedPoint<NistP384> for AffinePoint {
     fn to_compact_encoded_point(&self) -> CtOption<EncodedPoint> {
         // Convert to canonical form for comparisons
         let y = self.y.to_canonical();
-        let (p_y, borrow) = FieldElement::MODULUS.informed_subtract(&y);
+        let (p_y, borrow) = FieldElement(MODULUS).informed_subtract(&y);
         assert_eq!(borrow, 0);
         let (_, borrow) = p_y.informed_subtract(&y);
 

--- a/p384/src/arithmetic/macros.rs
+++ b/p384/src/arithmetic/macros.rs
@@ -1,0 +1,42 @@
+//! Field arithmetic macros
+
+// TODO(tarcieri): extract this into the `elliptic-curve` crate when stable
+
+/// Emit impls for a `core::ops` trait for all combinations of reference types,
+/// which thunk to the given function.
+macro_rules! impl_field_op {
+    ($name:tt, $inner:ty, $op:tt, $op_fn:ident, $func:ident) => {
+        impl $op for $name {
+            type Output = $name;
+
+            #[inline]
+            fn $op_fn(self, rhs: $name) -> $name {
+                let mut out = <$inner>::default();
+                $func(out.as_mut(), self.as_ref(), rhs.as_ref());
+                $name(out)
+            }
+        }
+
+        impl $op<&$name> for $name {
+            type Output = $name;
+
+            #[inline]
+            fn $op_fn(self, rhs: &$name) -> $name {
+                let mut out = <$inner>::default();
+                $func(out.as_mut(), self.as_ref(), rhs.as_ref());
+                $name(out)
+            }
+        }
+
+        impl $op<&$name> for &$name {
+            type Output = $name;
+
+            #[inline]
+            fn $op_fn(self, rhs: &$name) -> $name {
+                let mut out = <$inner>::default();
+                $func(out.as_mut(), self.as_ref(), rhs.as_ref());
+                $name(out)
+            }
+        }
+    };
+}


### PR DESCRIPTION
- Makes `MODULUS` a toplevel constant instead of an inherent one, and also makes it a `U384` instead of a `FieldElement`, since it isn't technically a valid field element.
- Factors arithmetic macros into their own module in preparation for using them to impl `Scalar`.