### PR TITLE
Add RFC 6979 test vectors to `p256` and `p384` ECDSA

### DIFF
--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -102,6 +102,14 @@ mod tests {
                      f7cb1c942d657c41d436c7a1b6e29f65f3e900dbb9aff4064dc4ab2f843acda8"
             )[..]
         );
+        let signature = signer.sign(b"test");
+        assert_eq!(
+            signature.as_ref(),
+            &hex!(
+                "f1abb023518351cd71d881567b1ea663ed3efcf6c5132b354f28d3b0b7d38367
+                019f4113742a2b14bd25926b49c649155f267e60d3814b4c0cc84250e46f0083"
+            )[..]
+        );
     }
 
     #[test]

--- a/p384/src/ecdsa.rs
+++ b/p384/src/ecdsa.rs
@@ -76,7 +76,35 @@ impl VerifyPrimitive<NistP384> for AffinePoint {}
 
 #[cfg(all(test, feature = "ecdsa"))]
 mod tests {
-    use crate::{ecdsa::SigningKey, SecretKey};
+    use crate::{
+        ecdsa::{signature::Signer, SigningKey},
+        SecretKey,
+    };
+    use hex_literal::hex;
+
+    // Test vector from RFC 6979 Appendix 2.6 (NIST P-384 + SHA-384)
+    // <https://tools.ietf.org/html/rfc6979#appendix-A.2.6>
+    #[test]
+    fn rfc6979() {
+        let x = &hex!("6b9d3dad2e1b8c1c05b19875b6659f4de23c3b667bf297ba9aa47740787137d896d5724e4c70a825f872c9ea60d2edf5");
+        let signer = SigningKey::from_bytes(x).unwrap();
+        let signature = signer.sign(b"sample");
+        assert_eq!(
+            signature.as_ref(),
+            &hex!(
+                "94edbb92a5ecb8aad4736e56c691916b3f88140666ce9fa73d64c4ea95ad133c81a648152e44acf96e36dd1e80fabe46
+                99ef4aeb15f178cea1fe40db2603138f130e740a19624526203b6351d0a3a94fa329c145786e679e7b82c71a38628ac8"
+            )[..]
+        );
+        let signature = signer.sign(b"test");
+        assert_eq!(
+            signature.as_ref(),
+            &hex!(
+                "8203b63d3c853e8d77227fb377bcf7b7b772e97892a80f36ab775d509d7a5feb0542a7f0812998da8f1dd3ca3cf023db
+                ddd0760448d42d8a43af45af836fce4de8be06b485e9b61b827c2f13173923e06a739f040649a667bf3b828246baa5a5"
+            )[..]
+        );
+    }
 
     #[test]
     fn signing_secret_key_equivalent() {


### PR DESCRIPTION
One additional test for `p256` and added matching to `p384`.