### PR TITLE
p384: use canonical form constants

### DIFF
--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -19,15 +19,14 @@ use self::{
     projective::ProjectivePoint,
     scalar::Scalar,
 };
-use crate::U384;
 
 /// a = -3 (0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc)
-///
-/// NOTE: field element has been translated into the Montgomery domain.
-const CURVE_EQUATION_A: FieldElement = FieldElement(U384::from_be_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbfffffffc0000000000000003fffffffc"));
+const CURVE_EQUATION_A: FieldElement = FieldElement::ZERO
+    .sub(&FieldElement::ONE)
+    .sub(&FieldElement::ONE)
+    .sub(&FieldElement::ONE);
 
 /// b = b3312fa7 e23ee7e4 988e056b e3f82d19 181d9c6e fe814112
 ///     0314088f 5013875a c656398d 8a2ed19d 2a85c8ed d3ec2aef
-///
-/// NOTE: field element has been translated into the Montgomery domain.
-const CURVE_EQUATION_B: FieldElement = FieldElement(U384::from_be_hex("cd08114b604fbff9b62b21f41f022094e3374bee94938ae277f2209b1920022ef729add87a4c32ec081188719d412dcc"));
+const CURVE_EQUATION_B: FieldElement =
+    FieldElement::from_be_hex("b3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef");

--- a/p384/src/arithmetic/affine.rs
+++ b/p384/src/arithmetic/affine.rs
@@ -5,7 +5,7 @@
 use core::ops::{Mul, Neg};
 
 use super::{FieldElement, ProjectivePoint, CURVE_EQUATION_A, CURVE_EQUATION_B, MODULUS};
-use crate::{CompressedPoint, EncodedPoint, FieldBytes, NistP384, PublicKey, Scalar, U384};
+use crate::{CompressedPoint, EncodedPoint, FieldBytes, NistP384, PublicKey, Scalar};
 use elliptic_curve::{
     group::{prime::PrimeCurveAffine, GroupEncoding},
     sec1::{self, FromEncodedPoint, ToEncodedPoint},
@@ -66,8 +66,8 @@ impl AffinePoint {
     /// NOTE: coordinate field elements have been translated into the Montgomery
     /// domain.
     pub const GENERATOR: Self = Self {
-        x: FieldElement(U384::from_be_hex("4d3aadc2299e1513812ff723614ede2b6454868459a30eff879c3afc541b4d6e20e378e2a0d6ce383dd0756649c0b528")),
-        y: FieldElement(U384::from_be_hex("2b78abc25a15c5e9dd8002263969a840c6c3521968f4ffd98bade7562e83b050a1bfa8bf7bb4a9ac23043dad4b03a4fe")),
+        x: FieldElement::from_be_hex("aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7"),
+        y: FieldElement::from_be_hex("3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f"),
         infinity: 0,
     };
 

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -40,10 +40,11 @@ pub(crate) const MODULUS: U384 = U384::from_be_hex("ffffffffffffffffffffffffffff
 #[derive(Clone, Copy, Debug)]
 pub struct FieldElement(pub(super) U384);
 
-impl_sec1_field_element!(
+impl_field_element!(
     FieldElement,
-    U384,
     FieldBytes,
+    U384,
+    MODULUS,
     fiat_p384_montgomery_domain_field_element,
     fiat_p384_from_montgomery,
     fiat_p384_to_montgomery,
@@ -55,8 +56,6 @@ impl_sec1_field_element!(
     fiat_p384_divstep_precomp,
     fiat_p384_divstep,
     fiat_p384_msat,
-    MODULUS,
-    "000000000000000000000000000000000000000000000000000000000000000100000000ffffffffffffffff00000001"
 );
 
 impl FieldElement {
@@ -111,14 +110,7 @@ impl FieldElement {
 
 #[cfg(test)]
 mod tests {
-    use super::{fiat_p384_to_montgomery, FieldElement, U384};
-
-    /// Test that the precomputed `FieldElement::ONE` constant is correct.
-    #[test]
-    fn one() {
-        let one_mont = fiat_p384_to_montgomery(U384::ONE.as_ref());
-        assert_eq!(FieldElement(one_mont.into()), FieldElement::ONE);
-    }
+    use super::FieldElement;
 
     /// Basic tests that field inversion works.
     #[test]


### PR DESCRIPTION
Now that conversions to/from the Montgomery domain are `const fn` (#590) it's possible to define constants in their canonical form, rather than converting them into the Montgomery domain first.

This makes the code clearer and easier to audit.