### PR TITLE
p384 v0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "blobby",
  "criterion",

--- a/p384/CHANGELOG.md
+++ b/p384/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.1 (2022-06-12)
+### Added
+- RFC6979 test vectors ([#591])
+- Impl `serde::{Serialize, Deserialize}` for `Scalar` ([#604])
+
+### Changed
+- Use generic prime order formulas ([#601])
+
+[#591]: https://github.com/RustCrypto/elliptic-curves/pull/591
+[#601]: https://github.com/RustCrypto/elliptic-curves/pull/601
+[#604]: https://github.com/RustCrypto/elliptic-curves/pull/604
+
 ## 0.11.0 (2022-06-03)
 ### Added
 - Arithmetic implementation ([#565], [#573])

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p384"
-version = "0.11.0"
+version = "0.11.1"
 description = """
 Pure Rust implementation of the NIST P-384 (a.k.a. secp384r1) elliptic curve
 with support for ECDH, ECDSA signing/verification, and general purpose curve


### PR DESCRIPTION
### Added
- RFC6979 test vectors ([#591])
- Impl `serde::{Serialize, Deserialize}` for `Scalar` ([#604])

### Changed
- Use generic prime order formulas ([#601])

[#591]: https://github.com/RustCrypto/elliptic-curves/pull/591
[#601]: https://github.com/RustCrypto/elliptic-curves/pull/601
[#604]: https://github.com/RustCrypto/elliptic-curves/pull/604