### PR TITLE
p521: initial `NistP521` type definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40997c4145fd5570180f579db9fcea452c91a2b72411da899efb1fb041136eae"
+checksum = "ac961631d66e80ac7ac2ac01320628ce214ad2b5ef0a88ceb86eae459069e2b4"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.0.0"
+version = "0.11.1"
 dependencies = [
  "elliptic-curve",
 ]

--- a/p521/CHANGELOG.md
+++ b/p521/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -1,21 +1,23 @@
 [package]
 name = "p521"
-description = "NIST P-521 (secp521r1) elliptic curve"
-version = "0.0.0"
+version = "0.11.1"
+description = "Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
-documentation = "https://docs.rs/elliptic-curve"
+documentation = "https://docs.rs/p521"
 repository = "https://github.com/RustCrypto/elliptic-curves/tree/master/p521"
 readme = "README.md"
-edition = "2018"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "secp521r1"]
+edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 elliptic-curve = { version = "0.12.1", default-features = false, features = ["hazmat", "sec1"] }
 
 [features]
+default = ["pem", "std"]
+jwk = ["elliptic-curve/jwk"]
+pem = ["elliptic-curve/pem", "pkcs8"]
+pkcs8 = ["elliptic-curve/pkcs8"]
 std = ["elliptic-curve/std"]
-
-[package.metadata.docs.rs]
-all-features = true

--- a/p521/LICENSE-MIT
+++ b/p521/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020 RustCrypto Developers
+Copyright (c) 2020-2022 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/p521/README.md
+++ b/p521/README.md
@@ -2,24 +2,25 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
-[![Build Status][build-image]][build-link]
+[![Project Chat][chat-image]][chat-link]
 
-NIST P-521 elliptic curve (a.k.a. secp521r1) types.
+Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve.
 
 [Documentation][docs-link]
 
-## Stub!
+## About P-521
 
-This crate is a placeholder for implementing NIST P-521 in terms of traits
-from the [`elliptic-curve`] crate, however no actual implementation work has
-been done yet. If you are actually interested in P-521 support, please open
-an issue about it.
+NIST P-521 is a Weierstrass curve specified in FIPS 186-4: Digital Signature
+Standard (DSS):
+
+<https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.57** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -46,15 +47,17 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/p521.svg
+[crate-image]: https://buildstats.info/crate/p521
 [crate-link]: https://crates.io/crates/p521
 [docs-image]: https://docs.rs/p521/badge.svg
 [docs-link]: https://docs.rs/p521/
+[build-image]: https://github.com/RustCrypto/elliptic-curves/actions/workflows/p521.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/elliptic-curves/actions/workflows/p521.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
-[build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/p521/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/elliptic-curves/actions?query=workflow%3Ap521
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 
-[//]: # (general links)
+[//]: # (links)
 
 [`elliptic-curve`]: https://github.com/RustCrypto/traits/tree/master/elliptic-curve

--- a/p521/src/lib.rs
+++ b/p521/src/lib.rs
@@ -1,17 +1,67 @@
-//! NIST P-521 elliptic curve
-//!
-//! ## Minimum Supported Rust Version
-//!
-//! Rust **1.41** or higher.
-//!
-//! Minimum supported Rust version can be changed in the future, but it will be
-//! done with a minor version bump.
-
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
+)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc = include_str!("../README.md")]
 
-pub use elliptic_curve;
+pub use elliptic_curve::{self, bigint::U576};
 
-// TODO(tarcieri): curve definition
+#[cfg(feature = "pkcs8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
+pub use elliptic_curve::pkcs8;
+
+use elliptic_curve::{consts::U66, generic_array::GenericArray};
+
+/// NIST P-521 elliptic curve.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
+pub struct NistP521;
+
+impl elliptic_curve::Curve for NistP521 {
+    /// 521-bit integer type used for internally representing field elements.
+    type UInt = U576;
+
+    /// Order of NIST P-521's elliptic curve group (i.e. scalar modulus).
+    const ORDER: U576 = U576::from_be_hex("00000000000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409");
+}
+
+impl elliptic_curve::PrimeCurve for NistP521 {}
+
+impl elliptic_curve::PointCompression for NistP521 {
+    /// NIST P-521 points are typically uncompressed.
+    const COMPRESS_POINTS: bool = false;
+}
+
+impl elliptic_curve::PointCompaction for NistP521 {
+    /// NIST P-521 points are typically uncompressed.
+    const COMPACT_POINTS: bool = false;
+}
+
+#[cfg(feature = "jwk")]
+#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
+impl elliptic_curve::JwkParameters for NistP521 {
+    const CRV: &'static str = "P-521";
+}
+
+#[cfg(feature = "pkcs8")]
+impl pkcs8::AssociatedOid for NistP521 {
+    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::new_unwrap("1.3.132.0.35");
+}
+
+/// Compressed SEC1-encoded NIST P-521 curve point.
+pub type CompressedPoint = GenericArray<u8, U66>;
+
+/// NIST P-521 field element serialized as bytes.
+///
+/// Byte array containing a serialized field element value (base field or
+/// scalar).
+pub type FieldBytes = elliptic_curve::FieldBytes<NistP521>;
+
+/// NIST P-521 SEC1 encoded point.
+pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP521>;
+
+/// NIST P-521 secret key.
+pub type SecretKey = elliptic_curve::SecretKey<NistP521>;


### PR DESCRIPTION
Adds an initial type which impls the `elliptic_curve::Curve` trait and defines the order, JWK identifier, and PKCS#8 OID for secp521r1.