### PR TITLE
Remove mention of `None` in `to_affine` docs

### DIFF
--- a/p256/src/arithmetic/projective.rs
+++ b/p256/src/arithmetic/projective.rs
@@ -68,7 +68,7 @@ impl ProjectivePoint {
         Self::GENERATOR
     }
 
-    /// Returns the affine representation of this point, or `None` if it is the identity.
+    /// Returns the affine representation of this point.
     pub fn to_affine(&self) -> AffinePoint {
         self.z
             .invert()


### PR DESCRIPTION
Since `to_affine` doesn't return an `Option`, the mention of `None` in the documentation doesn't seem to make sense anymore.