### PR TITLE
CI: fix `cross` MSRV

### DIFF
--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -110,19 +110,19 @@ jobs:
         include:
           # ARM32
           - target: armv7-unknown-linux-gnueabihf
-            rust: 1.57.0 # MSRV
+            rust: 1.58.1 # MSRV (cross)
           - target: armv7-unknown-linux-gnueabihf
             rust: stable
 
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.57.0 # MSRV
+            rust: 1.58.1 # MSRV (cross)
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.57.0 # MSRV
+            rust: 1.58.1 # MSRV (cross)
           - target: powerpc-unknown-linux-gnu
             rust: stable
 

--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -91,19 +91,19 @@ jobs:
         include:
           # ARM32
           - target: armv7-unknown-linux-gnueabihf
-            rust: 1.57.0 # MSRV
+            rust: 1.58.1 # MSRV (cross)
           - target: armv7-unknown-linux-gnueabihf
             rust: stable
 
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.57.0 # MSRV
+            rust: 1.58.1 # MSRV (cross)
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.57.0 # MSRV
+            rust: 1.58.1 # MSRV (cross)
           - target: powerpc-unknown-linux-gnu
             rust: stable
 

--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -87,19 +87,19 @@ jobs:
         include:
           # ARM32
           - target: armv7-unknown-linux-gnueabihf
-            rust: 1.57.0 # MSRV
+            rust: 1.58.1 # MSRV (cross)
           - target: armv7-unknown-linux-gnueabihf
             rust: stable
 
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.57.0 # MSRV
+            rust: 1.58.1 # MSRV (cross)
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.57.0 # MSRV
+            rust: 1.58.1 # MSRV (cross)
           - target: powerpc-unknown-linux-gnu
             rust: stable
 


### PR DESCRIPTION
`cross` v0.2.2 has an MSRV of 1.58.1