### PR TITLE
k256 v0.11.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "blobby",
  "cfg-if",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.3 (2022-07-02)
+### Changed
+- Relax `DigestSigner` trait bounds ([#613])
+- Bump `elliptic-curve` to v0.12.2 ([#616])
+
+[#613]: https://github.com/RustCrypto/elliptic-curves/pull/613
+[#616]: https://github.com/RustCrypto/elliptic-curves/pull/616
+
 ## 0.11.2 (2022-05-24)
 ### Changed
 - Enable `schnorr` feature by default ([#561])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.11.2"
+version = "0.11.3"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification (including Ethereum-style signatures with public-key


### PR DESCRIPTION
### Changed
- Relax `DigestSigner` trait bounds ([#613])
- Bump `elliptic-curve` to v0.12.2 ([#616])

[#613]: https://github.com/RustCrypto/elliptic-curves/pull/613
[#616]: https://github.com/RustCrypto/elliptic-curves/pull/616