### PR TITLE
p256: Allow converting affine points to coordinates and back

### DIFF
--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -14,13 +14,13 @@ use projective::ProjectivePoint;
 use scalar::Scalar;
 
 /// a = -3
-const CURVE_EQUATION_A: FieldElement = FieldElement::ZERO
+pub const CURVE_EQUATION_A: FieldElement = FieldElement::ZERO
     .subtract(&FieldElement::ONE)
     .subtract(&FieldElement::ONE)
     .subtract(&FieldElement::ONE);
 
 /// b = 0x5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B
-const CURVE_EQUATION_B: FieldElement = FieldElement([
+pub const CURVE_EQUATION_B: FieldElement = FieldElement([
     0xd89c_df62_29c4_bddf,
     0xacf0_05cd_7884_3090,
     0xe5a2_20ab_f721_2ed6,

--- a/p256/src/arithmetic/affine.rs
+++ b/p256/src/arithmetic/affine.rs
@@ -84,6 +84,22 @@ impl AffinePoint {
         .to_montgomery(),
         infinity: 0,
     };
+
+    #[cfg(feature = "expose-field")]
+    /// Construct a point directly from affine coordinates.
+    pub fn from_coordinates_unchecked(x: &FieldElement, y: &FieldElement) -> AffinePoint {
+        AffinePoint {
+            x: *x,
+            y: *y,
+            infinity: 0,
+        }
+    }
+
+    #[cfg(feature = "expose-field")]
+    /// Decompose a point into X and Y coordinates.
+    pub fn to_coordinates(&self) -> (FieldElement, FieldElement) {
+        (self.x, self.y)
+    }
 }
 
 impl PrimeCurveAffine for AffinePoint {

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -46,6 +46,9 @@ pub use arithmetic::{
 #[cfg(feature = "expose-field")]
 pub use arithmetic::field::FieldElement;
 
+#[cfg(feature = "expose-field")]
+pub use arithmetic::{CURVE_EQUATION_A, CURVE_EQUATION_B};
+
 #[cfg(feature = "pkcs8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub use elliptic_curve::pkcs8;

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -47,6 +47,9 @@ pub use arithmetic::{
 pub use arithmetic::field::FieldElement;
 
 #[cfg(feature = "expose-field")]
+pub use arithmetic::affine::AffineCoordinates;
+
+#[cfg(feature = "expose-field")]
 pub use arithmetic::{CURVE_EQUATION_A, CURVE_EQUATION_B};
 
 #[cfg(feature = "pkcs8")]


### PR DESCRIPTION
This adds a trait `AffineCoordinates` with two methods (`from_coordinates` and `to_coordinates`) to convert field element coordinates to points and back, checking that the coordinates are on the curve. Internal conversions now use this trait, and the trait is exposed publicly if the `expose-field` flag is set.

Also re-exports the two curve constants if the `expose-field` flag is set.

These two changes would allow for a full Elligator Squared implementation (#540) entirely outside of the `p256` crate.