### PR TITLE
k256: implement `ZeroizeOnDrop` for `ecdsa::SigningKey` and `schnor::SigningKey`

### DIFF
--- a/k256/src/ecdsa/sign.rs
+++ b/k256/src/ecdsa/sign.rs
@@ -19,7 +19,7 @@ use elliptic_curve::{
     ops::{Invert, Reduce},
     rand_core::{CryptoRng, RngCore},
     subtle::{Choice, ConstantTimeEq, CtOption},
-    zeroize::Zeroize,
+    zeroize::{Zeroize, ZeroizeOnDrop},
     IsHigh,
 };
 use sha2::Sha256;
@@ -283,6 +283,8 @@ impl Drop for SigningKey {
         self.inner.zeroize();
     }
 }
+
+impl ZeroizeOnDrop for SigningKey {}
 
 #[cfg(feature = "pkcs8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]

--- a/k256/src/schnorr/sign.rs
+++ b/k256/src/schnorr/sign.rs
@@ -11,6 +11,7 @@ use elliptic_curve::{
     ops::Reduce,
     rand_core::{CryptoRng, RngCore},
     subtle::ConditionallySelectable,
+    zeroize::{Zeroize, ZeroizeOnDrop},
 };
 use sha2::{Digest, Sha256};
 
@@ -160,3 +161,11 @@ impl Signer<Signature> for SigningKey {
         self.try_sign_digest(Sha256::new_with_prefix(msg))
     }
 }
+
+impl Drop for SigningKey {
+    fn drop(&mut self) {
+        self.secret_key.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for SigningKey {}


### PR DESCRIPTION
- `ecdsa::SigningKey` already has a `Drop` implemented, so just added the `ZeroizeOnDrop` marker
- For `schnor::SigningKey` implemented a zeroizing `Drop`, and added the `ZeroizeOnDrop` marker

`k256` 0.11 depends on `elliptic-curve` 0.12, which depends on `zeroize` 1.5, so this trait should be safe to use. 