### PR TITLE
p384 v0.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "blobby",
  "criterion",

--- a/p384/CHANGELOG.md
+++ b/p384/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.2 (2022-08-03)
+### Added
+- Re-export low-level `diffie_hellman` function ([#627])
+
+[#627]: https://github.com/RustCrypto/elliptic-curves/pull/627
+
 ## 0.11.1 (2022-06-12)
 ### Added
 - RFC6979 test vectors ([#591])

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p384"
-version = "0.11.1"
+version = "0.11.2"
 description = """
 Pure Rust implementation of the NIST P-384 (a.k.a. secp384r1) elliptic curve
 with support for ECDH, ECDSA signing/verification, and general purpose curve


### PR DESCRIPTION
### Added
- Re-export low-level `diffie_hellman` function ([#627])

[#627]: https://github.com/RustCrypto/elliptic-curves/pull/627