### PR TITLE
p256: use `impl_field_element!` macro

### DIFF
--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -31,8 +31,9 @@ impl WeierstrassCurve for NistP256 {
         .sub(&FieldElement::ONE)
         .sub(&FieldElement::ONE);
 
-    const EQUATION_B: FieldElement =
-        FieldElement::from_hex("5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b");
+    const EQUATION_B: FieldElement = FieldElement::from_be_hex(
+        "5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b",
+    );
 
     /// Base point of P-256.
     ///
@@ -43,8 +44,12 @@ impl WeierstrassCurve for NistP256 {
     /// Gᵧ = 4fe342e2 fe1a7f9b 8ee7eb4a 7c0f9e16 2bce3357 6b315ece cbb64068 37bf51f5
     /// ```
     const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_hex("6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296"),
-        FieldElement::from_hex("4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5"),
+        FieldElement::from_be_hex(
+            "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
+        ),
+        FieldElement::from_be_hex(
+            "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
+        ),
     );
 }
 

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -2,35 +2,27 @@
 
 #![allow(clippy::assign_op_pattern, clippy::op_ref)]
 
-use super::{u256_to_u64x4, u64x4_to_u256};
-use crate::{
-    arithmetic::util::{adc, mac, sbb},
-    FieldBytes,
-};
-use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+#[cfg_attr(target_pointer_width = "32", path = "field/p256_32.rs")]
+#[cfg_attr(target_pointer_width = "64", path = "field/p256_64.rs")]
+mod field_impl;
+
+use self::field_impl::*;
+use crate::FieldBytes;
+use core::ops::{AddAssign, Mul, MulAssign, Neg, SubAssign};
 use elliptic_curve::{
-    bigint::{ArrayEncoding, U256},
+    bigint::U256,
     ff::{Field, PrimeField},
-    rand_core::RngCore,
-    subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, CtOption},
-    zeroize::DefaultIsZeroes,
+    subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
 /// Constant representing the modulus
 /// p = 2^{224}(2^{32} − 1) + 2^{192} + 2^{96} − 1
-pub const MODULUS: FieldElement = FieldElement(U256::from_be_hex(
-    "ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-));
-
-/// R = 2^256 mod p
-const R: FieldElement = FieldElement(U256::from_be_hex(
-    "00000000fffffffeffffffffffffffffffffffff000000000000000000000001",
-));
+pub const MODULUS: U256 =
+    U256::from_be_hex("ffffffff00000001000000000000000000000000ffffffffffffffffffffffff");
 
 /// R^2 = 2^512 mod p
-const R2: FieldElement = FieldElement(U256::from_be_hex(
-    "00000004fffffffdfffffffffffffffefffffffbffffffff0000000000000003",
-));
+const R_2: U256 =
+    U256::from_be_hex("00000004fffffffdfffffffffffffffefffffffbffffffff0000000000000003");
 
 /// An element in the finite field modulo p = 2^{224}(2^{32} − 1) + 2^{192} + 2^{96} − 1.
 ///
@@ -39,284 +31,33 @@ const R2: FieldElement = FieldElement(U256::from_be_hex(
 #[derive(Clone, Copy, Debug)]
 pub struct FieldElement(pub(crate) U256);
 
+elliptic_curve::impl_field_element!(
+    FieldElement,
+    FieldBytes,
+    U256,
+    MODULUS,
+    Fe,
+    p256_from_montgomery,
+    p256_to_montgomery,
+    p256_add,
+    p256_sub,
+    p256_mul,
+    p256_neg,
+    p256_square
+);
+
 impl FieldElement {
-    /// Zero element.
-    pub const ZERO: Self = FieldElement(U256::ZERO);
-
-    /// Multiplicative identity.
-    pub const ONE: Self = R;
-
     /// Attempts to parse the given byte array as an SEC1-encoded field element.
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
     pub fn from_sec1(bytes: FieldBytes) -> CtOption<Self> {
-        Self::from_uint(U256::from_be_byte_array(bytes))
+        Self::from_be_bytes(bytes)
     }
 
     /// Returns the SEC1 encoding of this field element.
     pub fn to_sec1(self) -> FieldBytes {
-        self.to_canonical().0.to_be_byte_array()
-    }
-
-    /// Decode [`FieldElement`] from [`U256`], converting it into Montgomery form:
-    ///
-    /// ```text
-    /// w * R^2 * R^-1 mod p = wR mod p
-    /// ```
-    pub fn from_uint(uint: U256) -> CtOption<Self> {
-        let is_some = uint.ct_lt(&MODULUS.0);
-        CtOption::new(Self::from_uint_unchecked(uint), is_some)
-    }
-
-    /// Parse a [`FieldElement`] from big endian hex-encoded bytes.
-    ///
-    /// Does *not* perform a check that the field element does not overflow the order.
-    ///
-    /// This method is primarily intended for defining internal constants.
-    pub(crate) const fn from_hex(hex: &str) -> Self {
-        Self::from_uint_unchecked(U256::from_be_hex(hex))
-    }
-
-    /// Decode [`FieldElement`] from [`U256`] converting it into Montgomery form.
-    ///
-    /// Does *not* perform a check that the field element does not overflow the order.
-    ///
-    /// Used incorrectly this can lead to invalid results!
-    pub(crate) const fn from_uint_unchecked(w: U256) -> Self {
-        Self(w).to_montgomery()
-    }
-
-    /// Determine if this `FieldElement` is zero.
-    ///
-    /// # Returns
-    ///
-    /// If zero, return `Choice(1)`.  Otherwise, return `Choice(0)`.
-    pub fn is_zero(&self) -> Choice {
-        self.ct_eq(&FieldElement::zero())
-    }
-
-    /// Determine if this `FieldElement` is odd in the SEC1 sense: `self mod 2 == 1`.
-    ///
-    /// # Returns
-    ///
-    /// If odd, return `Choice(1)`.  Otherwise, return `Choice(0)`.
-    pub fn is_odd(&self) -> Choice {
-        let bytes = self.to_sec1();
-        (bytes[31] & 1).into()
-    }
-
-    /// Returns self + rhs mod p
-    pub const fn add(&self, rhs: &Self) -> Self {
-        let a = u256_to_u64x4(self.0);
-        let b = u256_to_u64x4(rhs.0);
-
-        // Bit 256 of p is set, so addition can result in five words.
-        let (w0, carry) = adc(a[0], b[0], 0);
-        let (w1, carry) = adc(a[1], b[1], carry);
-        let (w2, carry) = adc(a[2], b[2], carry);
-        let (w3, w4) = adc(a[3], b[3], carry);
-
-        // Attempt to subtract the modulus, to ensure the result is in the field.
-        let modulus = u256_to_u64x4(MODULUS.0);
-        let (result, _) = Self::sub_inner(
-            w0, w1, w2, w3, w4, modulus[0], modulus[1], modulus[2], modulus[3], 0,
-        );
-        result
-    }
-
-    /// Returns 2*self.
-    pub const fn double(&self) -> Self {
-        self.add(self)
-    }
-
-    /// Returns self - rhs mod p
-    pub const fn sub(&self, rhs: &Self) -> Self {
-        let a = u256_to_u64x4(self.0);
-        let b = u256_to_u64x4(rhs.0);
-        Self::sub_inner(a[0], a[1], a[2], a[3], 0, b[0], b[1], b[2], b[3], 0).0
-    }
-
-    fn from_bytes_wide(bytes: [u8; 64]) -> Self {
-        FieldElement::montgomery_reduce(
-            u64::from_be_bytes(bytes[0..8].try_into().unwrap()),
-            u64::from_be_bytes(bytes[8..16].try_into().unwrap()),
-            u64::from_be_bytes(bytes[16..24].try_into().unwrap()),
-            u64::from_be_bytes(bytes[24..32].try_into().unwrap()),
-            u64::from_be_bytes(bytes[32..40].try_into().unwrap()),
-            u64::from_be_bytes(bytes[40..48].try_into().unwrap()),
-            u64::from_be_bytes(bytes[48..56].try_into().unwrap()),
-            u64::from_be_bytes(bytes[56..64].try_into().unwrap()),
-        )
-    }
-
-    #[inline]
-    #[allow(clippy::too_many_arguments)]
-    const fn sub_inner(
-        l0: u64,
-        l1: u64,
-        l2: u64,
-        l3: u64,
-        l4: u64,
-        r0: u64,
-        r1: u64,
-        r2: u64,
-        r3: u64,
-        r4: u64,
-    ) -> (Self, u64) {
-        let (w0, borrow) = sbb(l0, r0, 0);
-        let (w1, borrow) = sbb(l1, r1, borrow);
-        let (w2, borrow) = sbb(l2, r2, borrow);
-        let (w3, borrow) = sbb(l3, r3, borrow);
-        let (_, borrow) = sbb(l4, r4, borrow);
-
-        // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
-        // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
-        // modulus.
-        let modulus = u256_to_u64x4(MODULUS.0);
-        let (w0, carry) = adc(w0, modulus[0] & borrow, 0);
-        let (w1, carry) = adc(w1, modulus[1] & borrow, carry);
-        let (w2, carry) = adc(w2, modulus[2] & borrow, carry);
-        let (w3, _) = adc(w3, modulus[3] & borrow, carry);
-
-        (Self(u64x4_to_u256([w0, w1, w2, w3])), borrow)
-    }
-
-    /// Montgomery Reduction
-    ///
-    /// The general algorithm is:
-    /// ```text
-    /// A <- input (2n b-limbs)
-    /// for i in 0..n {
-    ///     k <- A[i] p' mod b
-    ///     A <- A + k p b^i
-    /// }
-    /// A <- A / b^n
-    /// if A >= p {
-    ///     A <- A - p
-    /// }
-    /// ```
-    ///
-    /// For secp256r1, we have the following simplifications:
-    ///
-    /// - `p'` is 1, so our multiplicand is simply the first limb of the intermediate A.
-    ///
-    /// - The first limb of p is 2^64 - 1; multiplications by this limb can be simplified
-    ///   to a shift and subtraction:
-    ///   ```text
-    ///       a_i * (2^64 - 1) = a_i * 2^64 - a_i = (a_i << 64) - a_i
-    ///   ```
-    ///   However, because `p' = 1`, the first limb of p is multiplied by limb i of the
-    ///   intermediate A and then immediately added to that same limb, so we simply
-    ///   initialize the carry to limb i of the intermediate.
-    ///
-    /// - The third limb of p is zero, so we can ignore any multiplications by it and just
-    ///   add the carry.
-    ///
-    /// References:
-    /// - Handbook of Applied Cryptography, Chapter 14
-    ///   Algorithm 14.32
-    ///   http://cacr.uwaterloo.ca/hac/about/chap14.pdf
-    ///
-    /// - Efficient and Secure Elliptic Curve Cryptography Implementation of Curve P-256
-    ///   Algorithm 7) Montgomery Word-by-Word Reduction
-    ///   https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf
-    #[inline]
-    #[allow(clippy::too_many_arguments)]
-    const fn montgomery_reduce(
-        r0: u64,
-        r1: u64,
-        r2: u64,
-        r3: u64,
-        r4: u64,
-        r5: u64,
-        r6: u64,
-        r7: u64,
-    ) -> Self {
-        let modulus = u256_to_u64x4(MODULUS.0);
-
-        let (r1, carry) = mac(r1, r0, modulus[1], r0);
-        let (r2, carry) = adc(r2, 0, carry);
-        let (r3, carry) = mac(r3, r0, modulus[3], carry);
-        let (r4, carry2) = adc(r4, 0, carry);
-
-        let (r2, carry) = mac(r2, r1, modulus[1], r1);
-        let (r3, carry) = adc(r3, 0, carry);
-        let (r4, carry) = mac(r4, r1, modulus[3], carry);
-        let (r5, carry2) = adc(r5, carry2, carry);
-
-        let (r3, carry) = mac(r3, r2, modulus[1], r2);
-        let (r4, carry) = adc(r4, 0, carry);
-        let (r5, carry) = mac(r5, r2, modulus[3], carry);
-        let (r6, carry2) = adc(r6, carry2, carry);
-
-        let (r4, carry) = mac(r4, r3, modulus[1], r3);
-        let (r5, carry) = adc(r5, 0, carry);
-        let (r6, carry) = mac(r6, r3, modulus[3], carry);
-        let (r7, r8) = adc(r7, carry2, carry);
-
-        // Result may be within MODULUS of the correct value
-        let (result, _) = Self::sub_inner(
-            r4, r5, r6, r7, r8, modulus[0], modulus[1], modulus[2], modulus[3], 0,
-        );
-        result
-    }
-
-    /// Translate a field element out of the Montgomery domain.
-    #[inline]
-    pub(crate) const fn to_canonical(self) -> Self {
-        let w = u256_to_u64x4(self.0);
-        FieldElement::montgomery_reduce(w[0], w[1], w[2], w[3], 0, 0, 0, 0)
-    }
-
-    /// Translate a field element into the Montgomery domain.
-    #[inline]
-    pub(crate) const fn to_montgomery(self) -> Self {
-        Self::mul(&self, &R2)
-    }
-
-    /// Returns self * rhs mod p
-    pub const fn mul(&self, rhs: &Self) -> Self {
-        // Schoolbook multiplication.
-        let a = u256_to_u64x4(self.0);
-        let b = u256_to_u64x4(rhs.0);
-
-        let (w0, carry) = mac(0, a[0], b[0], 0);
-        let (w1, carry) = mac(0, a[0], b[1], carry);
-        let (w2, carry) = mac(0, a[0], b[2], carry);
-        let (w3, w4) = mac(0, a[0], b[3], carry);
-
-        let (w1, carry) = mac(w1, a[1], b[0], 0);
-        let (w2, carry) = mac(w2, a[1], b[1], carry);
-        let (w3, carry) = mac(w3, a[1], b[2], carry);
-        let (w4, w5) = mac(w4, a[1], b[3], carry);
-
-        let (w2, carry) = mac(w2, a[2], b[0], 0);
-        let (w3, carry) = mac(w3, a[2], b[1], carry);
-        let (w4, carry) = mac(w4, a[2], b[2], carry);
-        let (w5, w6) = mac(w5, a[2], b[3], carry);
-
-        let (w3, carry) = mac(w3, a[3], b[0], 0);
-        let (w4, carry) = mac(w4, a[3], b[1], carry);
-        let (w5, carry) = mac(w5, a[3], b[2], carry);
-        let (w6, w7) = mac(w6, a[3], b[3], carry);
-
-        FieldElement::montgomery_reduce(w0, w1, w2, w3, w4, w5, w6, w7)
-    }
-
-    /// Returns self * self mod p
-    pub const fn square(&self) -> Self {
-        // Schoolbook multiplication.
-        self.mul(self)
-    }
-
-    /// Returns self^(2^n) mod p
-    fn sqn(&self, n: usize) -> Self {
-        let mut x = *self;
-        for _ in 0..n {
-            x = x.square();
-        }
-        x
+        self.to_be_bytes()
     }
 
     /// Returns `self^by`, where `by` is a little-endian integer exponent.
@@ -390,41 +131,20 @@ impl FieldElement {
             (&sqrt * &sqrt).ct_eq(self), // Only return Some if it's the square root.
         )
     }
+
+    /// Returns self^(2^n) mod p
+    fn sqn(&self, n: usize) -> Self {
+        let mut x = *self;
+        for _ in 0..n {
+            x = x.square();
+        }
+        x
+    }
 }
 
-impl Field for FieldElement {
-    fn random(mut rng: impl RngCore) -> Self {
-        // We reduce a random 512-bit value into a 256-bit field, which results in a
-        // negligible bias from the uniform distribution.
-        let mut buf = [0; 64];
-        rng.fill_bytes(&mut buf);
-        FieldElement::from_bytes_wide(buf)
-    }
-
-    fn zero() -> Self {
-        Self::ZERO
-    }
-
-    fn one() -> Self {
-        Self::ONE
-    }
-
-    #[must_use]
-    fn square(&self) -> Self {
-        self.square()
-    }
-
-    #[must_use]
-    fn double(&self) -> Self {
-        self.double()
-    }
-
-    fn invert(&self) -> CtOption<Self> {
-        self.invert()
-    }
-
-    fn sqrt(&self) -> CtOption<Self> {
-        self.sqrt()
+impl From<u64> for FieldElement {
+    fn from(n: u64) -> FieldElement {
+        Self::from_uint_unchecked(U256::from(n))
     }
 }
 
@@ -464,168 +184,13 @@ impl PrimeField for FieldElement {
     }
 }
 
-impl ConditionallySelectable for FieldElement {
-    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        Self(U256::conditional_select(&a.0, &b.0, choice))
-    }
-}
-
-impl ConstantTimeEq for FieldElement {
-    fn ct_eq(&self, other: &Self) -> Choice {
-        self.0.ct_eq(&other.0)
-    }
-}
-
-impl Default for FieldElement {
-    fn default() -> Self {
-        FieldElement::zero()
-    }
-}
-
-impl DefaultIsZeroes for FieldElement {}
-
-impl Eq for FieldElement {}
-
-impl From<u64> for FieldElement {
-    fn from(n: u64) -> FieldElement {
-        Self::from_uint_unchecked(U256::from(n))
-    }
-}
-
-impl PartialEq for FieldElement {
-    fn eq(&self, other: &Self) -> bool {
-        self.ct_eq(other).into()
-    }
-}
-
-impl Add<FieldElement> for FieldElement {
-    type Output = FieldElement;
-
-    fn add(self, other: FieldElement) -> FieldElement {
-        FieldElement::add(&self, &other)
-    }
-}
-
-impl Add<&FieldElement> for FieldElement {
-    type Output = FieldElement;
-
-    fn add(self, other: &FieldElement) -> FieldElement {
-        FieldElement::add(&self, other)
-    }
-}
-
-impl Add<&FieldElement> for &FieldElement {
-    type Output = FieldElement;
-
-    fn add(self, other: &FieldElement) -> FieldElement {
-        FieldElement::add(self, other)
-    }
-}
-
-impl AddAssign<FieldElement> for FieldElement {
-    fn add_assign(&mut self, other: FieldElement) {
-        *self = FieldElement::add(self, &other);
-    }
-}
-
-impl AddAssign<&FieldElement> for FieldElement {
-    fn add_assign(&mut self, other: &FieldElement) {
-        *self = FieldElement::add(self, other);
-    }
-}
-
-impl Sub<FieldElement> for FieldElement {
-    type Output = FieldElement;
-
-    fn sub(self, other: FieldElement) -> FieldElement {
-        FieldElement::sub(&self, &other)
-    }
-}
-
-impl Sub<&FieldElement> for FieldElement {
-    type Output = FieldElement;
-
-    fn sub(self, other: &FieldElement) -> FieldElement {
-        FieldElement::sub(&self, other)
-    }
-}
-
-impl Sub<&FieldElement> for &FieldElement {
-    type Output = FieldElement;
-
-    fn sub(self, other: &FieldElement) -> FieldElement {
-        FieldElement::sub(self, other)
-    }
-}
-
-impl SubAssign<FieldElement> for FieldElement {
-    fn sub_assign(&mut self, other: FieldElement) {
-        *self = FieldElement::sub(self, &other);
-    }
-}
-
-impl SubAssign<&FieldElement> for FieldElement {
-    fn sub_assign(&mut self, other: &FieldElement) {
-        *self = FieldElement::sub(self, other);
-    }
-}
-
-impl Mul<FieldElement> for FieldElement {
-    type Output = FieldElement;
-
-    fn mul(self, other: FieldElement) -> FieldElement {
-        FieldElement::mul(&self, &other)
-    }
-}
-
-impl Mul<&FieldElement> for FieldElement {
-    type Output = FieldElement;
-
-    fn mul(self, other: &FieldElement) -> FieldElement {
-        FieldElement::mul(&self, other)
-    }
-}
-
-impl Mul<&FieldElement> for &FieldElement {
-    type Output = FieldElement;
-
-    fn mul(self, other: &FieldElement) -> FieldElement {
-        FieldElement::mul(self, other)
-    }
-}
-
-impl MulAssign<FieldElement> for FieldElement {
-    fn mul_assign(&mut self, other: FieldElement) {
-        *self = FieldElement::mul(self, &other);
-    }
-}
-
-impl MulAssign<&FieldElement> for FieldElement {
-    fn mul_assign(&mut self, other: &FieldElement) {
-        *self = FieldElement::mul(self, other);
-    }
-}
-
-impl Neg for FieldElement {
-    type Output = FieldElement;
-
-    fn neg(self) -> FieldElement {
-        FieldElement::zero() - &self
-    }
-}
-
-impl Neg for &FieldElement {
-    type Output = FieldElement;
-
-    fn neg(self) -> FieldElement {
-        FieldElement::zero() - self
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{u64x4_to_u256, FieldElement};
-    use crate::{test_vectors::field::DBL_TEST_VECTORS, FieldBytes};
+    use crate::{
+        arithmetic::{u64x4_to_u256, FieldElement},
+        test_vectors::field::DBL_TEST_VECTORS,
+        FieldBytes,
+    };
     use elliptic_curve::ff::Field;
     use proptest::{num::u64::ANY, prelude::*};
 

--- a/p256/src/arithmetic/field/p256_32.rs
+++ b/p256/src/arithmetic/field/p256_32.rs
@@ -1,0 +1,206 @@
+//! 32-bit secp256r1 base field implementation
+
+// TODO(tarcieri): adapt 64-bit arithmetic to proper 32-bit arithmetic
+
+use super::{MODULUS, R_2};
+use crate::arithmetic::util::{adc, mac, sbb};
+
+/// Raw field element.
+pub type Fe = [u32; 8];
+
+/// Translate a field element out of the Montgomery domain.
+#[inline]
+pub const fn p256_from_montgomery(w: &Fe) -> Fe {
+    let w = fe32_to_fe64(w);
+    montgomery_reduce(&[w[0], w[1], w[2], w[3], 0, 0, 0, 0])
+}
+
+/// Translate a field element into the Montgomery domain.
+#[inline]
+pub const fn p256_to_montgomery(w: &Fe) -> Fe {
+    p256_mul(w, R_2.as_words())
+}
+
+/// Returns `self + rhs mod p`.
+pub const fn p256_add(a: &Fe, b: &Fe) -> Fe {
+    let a = fe32_to_fe64(a);
+    let b = fe32_to_fe64(b);
+
+    // Bit 256 of p is set, so addition can result in five words.
+    let (w0, carry) = adc(a[0], b[0], 0);
+    let (w1, carry) = adc(a[1], b[1], carry);
+    let (w2, carry) = adc(a[2], b[2], carry);
+    let (w3, w4) = adc(a[3], b[3], carry);
+
+    // Attempt to subtract the modulus, to ensure the result is in the field.
+    let modulus = fe32_to_fe64(MODULUS.as_words());
+    sub_inner(
+        &[w0, w1, w2, w3, w4],
+        &[modulus[0], modulus[1], modulus[2], modulus[3], 0],
+    )
+}
+
+/// Returns `a - b mod p`.
+pub const fn p256_sub(a: &Fe, b: &Fe) -> Fe {
+    let a = fe32_to_fe64(a);
+    let b = fe32_to_fe64(b);
+    sub_inner(&[a[0], a[1], a[2], a[3], 0], &[b[0], b[1], b[2], b[3], 0])
+}
+
+/// Returns `a * b mod p`.
+pub const fn p256_mul(a: &Fe, b: &Fe) -> Fe {
+    let a = fe32_to_fe64(a);
+    let b = fe32_to_fe64(b);
+
+    let (w0, carry) = mac(0, a[0], b[0], 0);
+    let (w1, carry) = mac(0, a[0], b[1], carry);
+    let (w2, carry) = mac(0, a[0], b[2], carry);
+    let (w3, w4) = mac(0, a[0], b[3], carry);
+
+    let (w1, carry) = mac(w1, a[1], b[0], 0);
+    let (w2, carry) = mac(w2, a[1], b[1], carry);
+    let (w3, carry) = mac(w3, a[1], b[2], carry);
+    let (w4, w5) = mac(w4, a[1], b[3], carry);
+
+    let (w2, carry) = mac(w2, a[2], b[0], 0);
+    let (w3, carry) = mac(w3, a[2], b[1], carry);
+    let (w4, carry) = mac(w4, a[2], b[2], carry);
+    let (w5, w6) = mac(w5, a[2], b[3], carry);
+
+    let (w3, carry) = mac(w3, a[3], b[0], 0);
+    let (w4, carry) = mac(w4, a[3], b[1], carry);
+    let (w5, carry) = mac(w5, a[3], b[2], carry);
+    let (w6, w7) = mac(w6, a[3], b[3], carry);
+
+    montgomery_reduce(&[w0, w1, w2, w3, w4, w5, w6, w7])
+}
+
+/// Returns `-w mod p`.
+pub const fn p256_neg(w: &Fe) -> Fe {
+    p256_sub(&[0; 8], w)
+}
+
+/// Returns `w * w mod p`.
+pub const fn p256_square(w: &Fe) -> Fe {
+    p256_mul(w, w)
+}
+
+/// Montgomery Reduction
+///
+/// The general algorithm is:
+/// ```text
+/// A <- input (2n b-limbs)
+/// for i in 0..n {
+///     k <- A[i] p' mod b
+///     A <- A + k p b^i
+/// }
+/// A <- A / b^n
+/// if A >= p {
+///     A <- A - p
+/// }
+/// ```
+///
+/// For secp256r1, we have the following simplifications:
+///
+/// - `p'` is 1, so our multiplicand is simply the first limb of the intermediate A.
+///
+/// - The first limb of p is 2^64 - 1; multiplications by this limb can be simplified
+///   to a shift and subtraction:
+///   ```text
+///       a_i * (2^64 - 1) = a_i * 2^64 - a_i = (a_i << 64) - a_i
+///   ```
+///   However, because `p' = 1`, the first limb of p is multiplied by limb i of the
+///   intermediate A and then immediately added to that same limb, so we simply
+///   initialize the carry to limb i of the intermediate.
+///
+/// - The third limb of p is zero, so we can ignore any multiplications by it and just
+///   add the carry.
+///
+/// References:
+/// - Handbook of Applied Cryptography, Chapter 14
+///   Algorithm 14.32
+///   http://cacr.uwaterloo.ca/hac/about/chap14.pdf
+///
+/// - Efficient and Secure Elliptic Curve Cryptography Implementation of Curve P-256
+///   Algorithm 7) Montgomery Word-by-Word Reduction
+///   https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf
+#[inline]
+#[allow(clippy::too_many_arguments)]
+const fn montgomery_reduce(r: &[u64; 8]) -> Fe {
+    let r0 = r[0];
+    let r1 = r[1];
+    let r2 = r[2];
+    let r3 = r[3];
+    let r4 = r[4];
+    let r5 = r[5];
+    let r6 = r[6];
+    let r7 = r[7];
+    let modulus = fe32_to_fe64(MODULUS.as_words());
+
+    let (r1, carry) = mac(r1, r0, modulus[1], r0);
+    let (r2, carry) = adc(r2, 0, carry);
+    let (r3, carry) = mac(r3, r0, modulus[3], carry);
+    let (r4, carry2) = adc(r4, 0, carry);
+
+    let (r2, carry) = mac(r2, r1, modulus[1], r1);
+    let (r3, carry) = adc(r3, 0, carry);
+    let (r4, carry) = mac(r4, r1, modulus[3], carry);
+    let (r5, carry2) = adc(r5, carry2, carry);
+
+    let (r3, carry) = mac(r3, r2, modulus[1], r2);
+    let (r4, carry) = adc(r4, 0, carry);
+    let (r5, carry) = mac(r5, r2, modulus[3], carry);
+    let (r6, carry2) = adc(r6, carry2, carry);
+
+    let (r4, carry) = mac(r4, r3, modulus[1], r3);
+    let (r5, carry) = adc(r5, 0, carry);
+    let (r6, carry) = mac(r6, r3, modulus[3], carry);
+    let (r7, r8) = adc(r7, carry2, carry);
+
+    // Result may be within MODULUS of the correct value
+    sub_inner(
+        &[r4, r5, r6, r7, r8],
+        &[modulus[0], modulus[1], modulus[2], modulus[3], 0],
+    )
+}
+
+#[inline]
+#[allow(clippy::too_many_arguments)]
+const fn sub_inner(l: &[u64; 5], r: &[u64; 5]) -> Fe {
+    let (w0, borrow) = sbb(l[0], r[0], 0);
+    let (w1, borrow) = sbb(l[1], r[1], borrow);
+    let (w2, borrow) = sbb(l[2], r[2], borrow);
+    let (w3, borrow) = sbb(l[3], r[3], borrow);
+    let (_, borrow) = sbb(l[4], r[4], borrow);
+
+    // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
+    // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
+    // modulus.
+    let modulus = fe32_to_fe64(MODULUS.as_words());
+    let (w0, carry) = adc(w0, modulus[0] & borrow, 0);
+    let (w1, carry) = adc(w1, modulus[1] & borrow, carry);
+    let (w2, carry) = adc(w2, modulus[2] & borrow, carry);
+    let (w3, _) = adc(w3, modulus[3] & borrow, carry);
+
+    [
+        (w0 & 0xFFFFFFFF) as u32,
+        (w0 >> 32) as u32,
+        (w1 & 0xFFFFFFFF) as u32,
+        (w1 >> 32) as u32,
+        (w2 & 0xFFFFFFFF) as u32,
+        (w2 >> 32) as u32,
+        (w3 & 0xFFFFFFFF) as u32,
+        (w3 >> 32) as u32,
+    ]
+}
+
+// TODO(tarcieri): replace this with proper 32-bit arithmetic
+#[inline]
+const fn fe32_to_fe64(fe32: &Fe) -> [u64; 4] {
+    [
+        (fe32[0] as u64) | ((fe32[1] as u64) << 32),
+        (fe32[2] as u64) | ((fe32[3] as u64) << 32),
+        (fe32[4] as u64) | ((fe32[5] as u64) << 32),
+        (fe32[6] as u64) | ((fe32[7] as u64) << 32),
+    ]
+}

--- a/p256/src/arithmetic/field/p256_64.rs
+++ b/p256/src/arithmetic/field/p256_64.rs
@@ -1,0 +1,175 @@
+//! 64-bit secp256r1 base field implementation
+
+use super::{MODULUS, R_2};
+use crate::arithmetic::util::{adc, mac, sbb};
+
+/// Raw field element.
+pub type Fe = [u64; 4];
+
+/// Translate a field element out of the Montgomery domain.
+#[inline]
+pub const fn p256_from_montgomery(w: &Fe) -> Fe {
+    montgomery_reduce(&[w[0], w[1], w[2], w[3], 0, 0, 0, 0])
+}
+
+/// Translate a field element into the Montgomery domain.
+#[inline]
+pub const fn p256_to_montgomery(w: &Fe) -> Fe {
+    p256_mul(w, R_2.as_words())
+}
+
+/// Returns `self + rhs mod p`.
+pub const fn p256_add(a: &Fe, b: &Fe) -> Fe {
+    // Bit 256 of p is set, so addition can result in five words.
+    let (w0, carry) = adc(a[0], b[0], 0);
+    let (w1, carry) = adc(a[1], b[1], carry);
+    let (w2, carry) = adc(a[2], b[2], carry);
+    let (w3, w4) = adc(a[3], b[3], carry);
+
+    // Attempt to subtract the modulus, to ensure the result is in the field.
+    let modulus = MODULUS.as_words();
+    sub_inner(
+        &[w0, w1, w2, w3, w4],
+        &[modulus[0], modulus[1], modulus[2], modulus[3], 0],
+    )
+}
+
+/// Returns `a - b mod p`.
+pub const fn p256_sub(a: &Fe, b: &Fe) -> Fe {
+    sub_inner(&[a[0], a[1], a[2], a[3], 0], &[b[0], b[1], b[2], b[3], 0])
+}
+
+/// Returns `a * b mod p`.
+pub const fn p256_mul(a: &Fe, b: &Fe) -> Fe {
+    let (w0, carry) = mac(0, a[0], b[0], 0);
+    let (w1, carry) = mac(0, a[0], b[1], carry);
+    let (w2, carry) = mac(0, a[0], b[2], carry);
+    let (w3, w4) = mac(0, a[0], b[3], carry);
+
+    let (w1, carry) = mac(w1, a[1], b[0], 0);
+    let (w2, carry) = mac(w2, a[1], b[1], carry);
+    let (w3, carry) = mac(w3, a[1], b[2], carry);
+    let (w4, w5) = mac(w4, a[1], b[3], carry);
+
+    let (w2, carry) = mac(w2, a[2], b[0], 0);
+    let (w3, carry) = mac(w3, a[2], b[1], carry);
+    let (w4, carry) = mac(w4, a[2], b[2], carry);
+    let (w5, w6) = mac(w5, a[2], b[3], carry);
+
+    let (w3, carry) = mac(w3, a[3], b[0], 0);
+    let (w4, carry) = mac(w4, a[3], b[1], carry);
+    let (w5, carry) = mac(w5, a[3], b[2], carry);
+    let (w6, w7) = mac(w6, a[3], b[3], carry);
+
+    montgomery_reduce(&[w0, w1, w2, w3, w4, w5, w6, w7])
+}
+
+/// Returns `-w mod p`.
+pub const fn p256_neg(w: &Fe) -> Fe {
+    p256_sub(&[0, 0, 0, 0], w)
+}
+
+/// Returns `w * w mod p`.
+pub const fn p256_square(w: &Fe) -> Fe {
+    p256_mul(w, w)
+}
+
+/// Montgomery Reduction
+///
+/// The general algorithm is:
+/// ```text
+/// A <- input (2n b-limbs)
+/// for i in 0..n {
+///     k <- A[i] p' mod b
+///     A <- A + k p b^i
+/// }
+/// A <- A / b^n
+/// if A >= p {
+///     A <- A - p
+/// }
+/// ```
+///
+/// For secp256r1, we have the following simplifications:
+///
+/// - `p'` is 1, so our multiplicand is simply the first limb of the intermediate A.
+///
+/// - The first limb of p is 2^64 - 1; multiplications by this limb can be simplified
+///   to a shift and subtraction:
+///   ```text
+///       a_i * (2^64 - 1) = a_i * 2^64 - a_i = (a_i << 64) - a_i
+///   ```
+///   However, because `p' = 1`, the first limb of p is multiplied by limb i of the
+///   intermediate A and then immediately added to that same limb, so we simply
+///   initialize the carry to limb i of the intermediate.
+///
+/// - The third limb of p is zero, so we can ignore any multiplications by it and just
+///   add the carry.
+///
+/// References:
+/// - Handbook of Applied Cryptography, Chapter 14
+///   Algorithm 14.32
+///   http://cacr.uwaterloo.ca/hac/about/chap14.pdf
+///
+/// - Efficient and Secure Elliptic Curve Cryptography Implementation of Curve P-256
+///   Algorithm 7) Montgomery Word-by-Word Reduction
+///   https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf
+#[inline]
+#[allow(clippy::too_many_arguments)]
+const fn montgomery_reduce(r: &[u64; 8]) -> Fe {
+    let r0 = r[0];
+    let r1 = r[1];
+    let r2 = r[2];
+    let r3 = r[3];
+    let r4 = r[4];
+    let r5 = r[5];
+    let r6 = r[6];
+    let r7 = r[7];
+    let modulus = MODULUS.as_words();
+
+    let (r1, carry) = mac(r1, r0, modulus[1], r0);
+    let (r2, carry) = adc(r2, 0, carry);
+    let (r3, carry) = mac(r3, r0, modulus[3], carry);
+    let (r4, carry2) = adc(r4, 0, carry);
+
+    let (r2, carry) = mac(r2, r1, modulus[1], r1);
+    let (r3, carry) = adc(r3, 0, carry);
+    let (r4, carry) = mac(r4, r1, modulus[3], carry);
+    let (r5, carry2) = adc(r5, carry2, carry);
+
+    let (r3, carry) = mac(r3, r2, modulus[1], r2);
+    let (r4, carry) = adc(r4, 0, carry);
+    let (r5, carry) = mac(r5, r2, modulus[3], carry);
+    let (r6, carry2) = adc(r6, carry2, carry);
+
+    let (r4, carry) = mac(r4, r3, modulus[1], r3);
+    let (r5, carry) = adc(r5, 0, carry);
+    let (r6, carry) = mac(r6, r3, modulus[3], carry);
+    let (r7, r8) = adc(r7, carry2, carry);
+
+    // Result may be within MODULUS of the correct value
+    sub_inner(
+        &[r4, r5, r6, r7, r8],
+        &[modulus[0], modulus[1], modulus[2], modulus[3], 0],
+    )
+}
+
+#[inline]
+#[allow(clippy::too_many_arguments)]
+const fn sub_inner(l: &[u64; 5], r: &[u64; 5]) -> Fe {
+    let (w0, borrow) = sbb(l[0], r[0], 0);
+    let (w1, borrow) = sbb(l[1], r[1], borrow);
+    let (w2, borrow) = sbb(l[2], r[2], borrow);
+    let (w3, borrow) = sbb(l[3], r[3], borrow);
+    let (_, borrow) = sbb(l[4], r[4], borrow);
+
+    // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
+    // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
+    // modulus.
+    let modulus = MODULUS.as_words();
+    let (w0, carry) = adc(w0, modulus[0] & borrow, 0);
+    let (w1, carry) = adc(w1, modulus[1] & borrow, carry);
+    let (w2, carry) = adc(w2, modulus[2] & borrow, carry);
+    let (w3, _) = adc(w3, modulus[3] & borrow, carry);
+
+    [w0, w1, w2, w3]
+}


### PR DESCRIPTION
Uses the same macro as `p384` to define the `FieldElement` type.

Isolates core arithmetic functionality in a `p256_64.rs` module, with the goal of eventually producing a 32-bit implementation as well.

Also adds a `p256_32.rs` module which provides a skeleton of a 32-bit implementation, although most of the functionality is currently implemented in terms of 64-bit integers, with the goal of facilitating an incremental conversion to a 32-bit backend.