### PR TITLE
p256: initial 32-bit scalar backend

### DIFF
--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -9,7 +9,7 @@ pub(crate) mod util;
 use self::{field::FieldElement, scalar::Scalar};
 use crate::NistP256;
 use elliptic_curve::{
-    bigint::U256, AffineArithmetic, PrimeCurveArithmetic, ProjectiveArithmetic, ScalarArithmetic,
+    AffineArithmetic, PrimeCurveArithmetic, ProjectiveArithmetic, ScalarArithmetic,
 };
 use weierstrass::WeierstrassCurve;
 
@@ -67,51 +67,4 @@ impl PrimeCurveArithmetic for NistP256 {
 
 impl ScalarArithmetic for NistP256 {
     type Scalar = Scalar;
-}
-
-/// Array containing 4 x 64-bit unsigned integers.
-// TODO(tarcieri): replace this entirely with `U256`
-type U64x4 = [u64; 4];
-
-/// Convert to a [`U64x4`] array.
-// TODO(tarcieri): implement all algorithms in terms of `U256`?
-#[cfg(target_pointer_width = "32")]
-const fn u256_to_u64x4(u256: U256) -> U64x4 {
-    let limbs = u256.to_words();
-
-    [
-        (limbs[0] as u64) | ((limbs[1] as u64) << 32),
-        (limbs[2] as u64) | ((limbs[3] as u64) << 32),
-        (limbs[4] as u64) | ((limbs[5] as u64) << 32),
-        (limbs[6] as u64) | ((limbs[7] as u64) << 32),
-    ]
-}
-
-/// Convert to a [`U64x4`] array.
-// TODO(tarcieri): implement all algorithms in terms of `U256`?
-#[cfg(target_pointer_width = "64")]
-const fn u256_to_u64x4(u256: U256) -> U64x4 {
-    u256.to_words()
-}
-
-/// Convert from a [`U64x4`] array.
-#[cfg(target_pointer_width = "32")]
-pub(crate) const fn u64x4_to_u256(limbs: U64x4) -> U256 {
-    U256::from_words([
-        (limbs[0] & 0xFFFFFFFF) as u32,
-        (limbs[0] >> 32) as u32,
-        (limbs[1] & 0xFFFFFFFF) as u32,
-        (limbs[1] >> 32) as u32,
-        (limbs[2] & 0xFFFFFFFF) as u32,
-        (limbs[2] >> 32) as u32,
-        (limbs[3] & 0xFFFFFFFF) as u32,
-        (limbs[3] >> 32) as u32,
-    ])
-}
-
-/// Convert from a [`U64x4`] array.
-// TODO(tarcieri): implement all algorithms in terms of `U256`?
-#[cfg(target_pointer_width = "64")]
-pub(crate) const fn u64x4_to_u256(limbs: U64x4) -> U256 {
-    U256::from_words(limbs)
 }

--- a/p256/src/arithmetic/field/field64.rs
+++ b/p256/src/arithmetic/field/field64.rs
@@ -1,31 +1,25 @@
-//! 32-bit secp256r1 base field implementation
-
-// TODO(tarcieri): adapt 64-bit arithmetic to proper 32-bit arithmetic
+//! 64-bit secp256r1 base field implementation
 
 use super::{MODULUS, R_2};
 use crate::arithmetic::util::{adc, mac, sbb};
 
 /// Raw field element.
-pub type Fe = [u32; 8];
+pub type Fe = [u64; 4];
 
 /// Translate a field element out of the Montgomery domain.
 #[inline]
-pub const fn p256_from_montgomery(w: &Fe) -> Fe {
-    let w = fe32_to_fe64(w);
+pub const fn fe_from_montgomery(w: &Fe) -> Fe {
     montgomery_reduce(&[w[0], w[1], w[2], w[3], 0, 0, 0, 0])
 }
 
 /// Translate a field element into the Montgomery domain.
 #[inline]
-pub const fn p256_to_montgomery(w: &Fe) -> Fe {
-    p256_mul(w, R_2.as_words())
+pub const fn fe_to_montgomery(w: &Fe) -> Fe {
+    fe_mul(w, R_2.as_words())
 }
 
-/// Returns `self + rhs mod p`.
-pub const fn p256_add(a: &Fe, b: &Fe) -> Fe {
-    let a = fe32_to_fe64(a);
-    let b = fe32_to_fe64(b);
-
+/// Returns `a + b mod p`.
+pub const fn fe_add(a: &Fe, b: &Fe) -> Fe {
     // Bit 256 of p is set, so addition can result in five words.
     let (w0, carry) = adc(a[0], b[0], 0);
     let (w1, carry) = adc(a[1], b[1], carry);
@@ -33,7 +27,7 @@ pub const fn p256_add(a: &Fe, b: &Fe) -> Fe {
     let (w3, w4) = adc(a[3], b[3], carry);
 
     // Attempt to subtract the modulus, to ensure the result is in the field.
-    let modulus = fe32_to_fe64(MODULUS.as_words());
+    let modulus = MODULUS.as_words();
     sub_inner(
         &[w0, w1, w2, w3, w4],
         &[modulus[0], modulus[1], modulus[2], modulus[3], 0],
@@ -41,17 +35,12 @@ pub const fn p256_add(a: &Fe, b: &Fe) -> Fe {
 }
 
 /// Returns `a - b mod p`.
-pub const fn p256_sub(a: &Fe, b: &Fe) -> Fe {
-    let a = fe32_to_fe64(a);
-    let b = fe32_to_fe64(b);
+pub const fn fe_sub(a: &Fe, b: &Fe) -> Fe {
     sub_inner(&[a[0], a[1], a[2], a[3], 0], &[b[0], b[1], b[2], b[3], 0])
 }
 
 /// Returns `a * b mod p`.
-pub const fn p256_mul(a: &Fe, b: &Fe) -> Fe {
-    let a = fe32_to_fe64(a);
-    let b = fe32_to_fe64(b);
-
+pub const fn fe_mul(a: &Fe, b: &Fe) -> Fe {
     let (w0, carry) = mac(0, a[0], b[0], 0);
     let (w1, carry) = mac(0, a[0], b[1], carry);
     let (w2, carry) = mac(0, a[0], b[2], carry);
@@ -76,13 +65,13 @@ pub const fn p256_mul(a: &Fe, b: &Fe) -> Fe {
 }
 
 /// Returns `-w mod p`.
-pub const fn p256_neg(w: &Fe) -> Fe {
-    p256_sub(&[0; 8], w)
+pub const fn fe_neg(w: &Fe) -> Fe {
+    fe_sub(&[0, 0, 0, 0], w)
 }
 
 /// Returns `w * w mod p`.
-pub const fn p256_square(w: &Fe) -> Fe {
-    p256_mul(w, w)
+pub const fn fe_square(w: &Fe) -> Fe {
+    fe_mul(w, w)
 }
 
 /// Montgomery Reduction
@@ -135,7 +124,7 @@ const fn montgomery_reduce(r: &[u64; 8]) -> Fe {
     let r5 = r[5];
     let r6 = r[6];
     let r7 = r[7];
-    let modulus = fe32_to_fe64(MODULUS.as_words());
+    let modulus = MODULUS.as_words();
 
     let (r1, carry) = mac(r1, r0, modulus[1], r0);
     let (r2, carry) = adc(r2, 0, carry);
@@ -176,31 +165,11 @@ const fn sub_inner(l: &[u64; 5], r: &[u64; 5]) -> Fe {
     // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
     // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
     // modulus.
-    let modulus = fe32_to_fe64(MODULUS.as_words());
+    let modulus = MODULUS.as_words();
     let (w0, carry) = adc(w0, modulus[0] & borrow, 0);
     let (w1, carry) = adc(w1, modulus[1] & borrow, carry);
     let (w2, carry) = adc(w2, modulus[2] & borrow, carry);
     let (w3, _) = adc(w3, modulus[3] & borrow, carry);
 
-    [
-        (w0 & 0xFFFFFFFF) as u32,
-        (w0 >> 32) as u32,
-        (w1 & 0xFFFFFFFF) as u32,
-        (w1 >> 32) as u32,
-        (w2 & 0xFFFFFFFF) as u32,
-        (w2 >> 32) as u32,
-        (w3 & 0xFFFFFFFF) as u32,
-        (w3 >> 32) as u32,
-    ]
-}
-
-// TODO(tarcieri): replace this with proper 32-bit arithmetic
-#[inline]
-const fn fe32_to_fe64(fe32: &Fe) -> [u64; 4] {
-    [
-        (fe32[0] as u64) | ((fe32[1] as u64) << 32),
-        (fe32[2] as u64) | ((fe32[3] as u64) << 32),
-        (fe32[4] as u64) | ((fe32[5] as u64) << 32),
-        (fe32[6] as u64) | ((fe32[7] as u64) << 32),
-    ]
+    [w0, w1, w2, w3]
 }

--- a/p256/src/arithmetic/hash2curve.rs
+++ b/p256/src/arithmetic/hash2curve.rs
@@ -1,5 +1,5 @@
 use super::FieldElement;
-use crate::{arithmetic::u64x4_to_u256, AffinePoint, NistP256, ProjectivePoint, Scalar};
+use crate::{AffinePoint, FieldBytes, NistP256, ProjectivePoint, Scalar};
 use elliptic_curve::{
     bigint::{ArrayEncoding, U256},
     consts::U48,
@@ -21,19 +21,13 @@ impl FromOkm for FieldElement {
             "00000000000000030000000200000000fffffffffffffffefffffffeffffffff",
         ));
 
-        let d0 = FieldElement::from_uint_unchecked(u64x4_to_u256([
-            u64::from_be_bytes(data[16..24].try_into().unwrap()),
-            u64::from_be_bytes(data[8..16].try_into().unwrap()),
-            u64::from_be_bytes(data[0..8].try_into().unwrap()),
-            0,
-        ]));
+        let mut d0_bytes = FieldBytes::default();
+        d0_bytes[8..].copy_from_slice(&data[..24]);
+        let d0 = FieldElement::from_uint_unchecked(U256::from_be_byte_array(d0_bytes));
 
-        let d1 = FieldElement::from_uint_unchecked(u64x4_to_u256([
-            u64::from_be_bytes(data[40..48].try_into().unwrap()),
-            u64::from_be_bytes(data[32..40].try_into().unwrap()),
-            u64::from_be_bytes(data[24..32].try_into().unwrap()),
-            0,
-        ]));
+        let mut d1_bytes = FieldBytes::default();
+        d1_bytes[8..].copy_from_slice(&data[24..]);
+        let d1 = FieldElement::from_uint_unchecked(U256::from_be_byte_array(d1_bytes));
 
         d0 * F_2_192 + d1
     }

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -2,11 +2,12 @@
 
 pub mod blinded;
 
-use super::{u256_to_u64x4, u64x4_to_u256, U64x4};
-use crate::{
-    arithmetic::util::{adc, mac, sbb},
-    FieldBytes, NistP256, SecretKey,
-};
+#[cfg_attr(target_pointer_width = "32", path = "scalar/scalar32.rs")]
+#[cfg_attr(target_pointer_width = "64", path = "scalar/scalar64.rs")]
+mod scalar_impl;
+
+use self::scalar_impl::barrett_reduce;
+use crate::{FieldBytes, NistP256, SecretKey};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use elliptic_curve::{
     bigint::{prelude::*, Limb, U256},
@@ -30,9 +31,10 @@ use serdect::serde::{de, ser, Deserialize, Serialize};
 
 /// Constant representing the modulus
 /// n = FFFFFFFF 00000000 FFFFFFFF FFFFFFFF BCE6FAAD A7179E84 F3B9CAC2 FC632551
-const MODULUS: U64x4 = u256_to_u64x4(NistP256::ORDER);
+pub(crate) const MODULUS: U256 = NistP256::ORDER;
 
-const FRAC_MODULUS_2: Scalar = Scalar(NistP256::ORDER.shr_vartime(1));
+/// `MODULUS / 2`
+const FRAC_MODULUS_2: Scalar = Scalar(MODULUS.shr_vartime(1));
 
 /// MU = floor(2^512 / n)
 ///    = 115792089264276142090721624801893421302707618245269942344307673200490803338238
@@ -110,7 +112,7 @@ impl Scalar {
     /// Returns self * rhs mod n
     pub const fn mul(&self, rhs: &Self) -> Self {
         let (lo, hi) = self.0.mul_wide(&rhs.0);
-        Self::barrett_reduce(lo, hi)
+        Self(barrett_reduce(lo, hi))
     }
 
     /// Returns self * self mod p
@@ -200,169 +202,6 @@ impl Scalar {
     /// Is integer representing equivalence class even?
     pub fn is_even(&self) -> Choice {
         !self.is_odd()
-    }
-
-    /// Barrett Reduction
-    ///
-    /// The general algorithm is:
-    /// ```text
-    /// p = n = order of group
-    /// b = 2^64 = 64bit machine word
-    /// k = 4
-    /// a \in [0, 2^512]
-    /// mu := floor(b^{2k} / p)
-    /// q1 := floor(a / b^{k - 1})
-    /// q2 := q1 * mu
-    /// q3 := <- floor(a / b^{k - 1})
-    /// r1 := a mod b^{k + 1}
-    /// r2 := q3 * m mod b^{k + 1}
-    /// r := r1 - r2
-    ///
-    /// if r < 0: r := r + b^{k + 1}
-    /// while r >= p: do r := r - p (at most twice)
-    /// ```
-    ///
-    /// References:
-    /// - Handbook of Applied Cryptography, Chapter 14
-    ///   Algorithm 14.42
-    ///   http://cacr.uwaterloo.ca/hac/about/chap14.pdf
-    ///
-    /// - Efficient and Secure Elliptic Curve Cryptography Implementation of Curve P-256
-    ///   Algorithm 6) Barrett Reduction modulo p
-    ///   https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf
-    #[inline]
-    #[allow(clippy::too_many_arguments)]
-    const fn barrett_reduce(lo: U256, hi: U256) -> Self {
-        let lo = u256_to_u64x4(lo);
-        let hi = u256_to_u64x4(hi);
-        let a0 = lo[0];
-        let a1 = lo[1];
-        let a2 = lo[2];
-        let a3 = lo[3];
-        let a4 = hi[0];
-        let a5 = hi[1];
-        let a6 = hi[2];
-        let a7 = hi[3];
-        let q1: [u64; 5] = [a3, a4, a5, a6, a7];
-
-        const fn q1_times_mu_shift_five(q1: &[u64; 5]) -> [u64; 5] {
-            // Schoolbook multiplication.
-
-            let (_w0, carry) = mac(0, q1[0], MU[0], 0);
-            let (w1, carry) = mac(0, q1[0], MU[1], carry);
-            let (w2, carry) = mac(0, q1[0], MU[2], carry);
-            let (w3, carry) = mac(0, q1[0], MU[3], carry);
-            let (w4, w5) = mac(0, q1[0], MU[4], carry);
-
-            let (_w1, carry) = mac(w1, q1[1], MU[0], 0);
-            let (w2, carry) = mac(w2, q1[1], MU[1], carry);
-            let (w3, carry) = mac(w3, q1[1], MU[2], carry);
-            let (w4, carry) = mac(w4, q1[1], MU[3], carry);
-            let (w5, w6) = mac(w5, q1[1], MU[4], carry);
-
-            let (_w2, carry) = mac(w2, q1[2], MU[0], 0);
-            let (w3, carry) = mac(w3, q1[2], MU[1], carry);
-            let (w4, carry) = mac(w4, q1[2], MU[2], carry);
-            let (w5, carry) = mac(w5, q1[2], MU[3], carry);
-            let (w6, w7) = mac(w6, q1[2], MU[4], carry);
-
-            let (_w3, carry) = mac(w3, q1[3], MU[0], 0);
-            let (w4, carry) = mac(w4, q1[3], MU[1], carry);
-            let (w5, carry) = mac(w5, q1[3], MU[2], carry);
-            let (w6, carry) = mac(w6, q1[3], MU[3], carry);
-            let (w7, w8) = mac(w7, q1[3], MU[4], carry);
-
-            let (_w4, carry) = mac(w4, q1[4], MU[0], 0);
-            let (w5, carry) = mac(w5, q1[4], MU[1], carry);
-            let (w6, carry) = mac(w6, q1[4], MU[2], carry);
-            let (w7, carry) = mac(w7, q1[4], MU[3], carry);
-            let (w8, w9) = mac(w8, q1[4], MU[4], carry);
-
-            // let q2 = [_w0, _w1, _w2, _w3, _w4, w5, w6, w7, w8, w9];
-            [w5, w6, w7, w8, w9]
-        }
-
-        let q3 = q1_times_mu_shift_five(&q1);
-
-        let r1: [u64; 5] = [a0, a1, a2, a3, a4];
-
-        const fn q3_times_n_keep_five(q3: &[u64; 5]) -> [u64; 5] {
-            // Schoolbook multiplication.
-
-            let (w0, carry) = mac(0, q3[0], MODULUS[0], 0);
-            let (w1, carry) = mac(0, q3[0], MODULUS[1], carry);
-            let (w2, carry) = mac(0, q3[0], MODULUS[2], carry);
-            let (w3, carry) = mac(0, q3[0], MODULUS[3], carry);
-            let (w4, _) = mac(0, q3[0], 0, carry);
-
-            let (w1, carry) = mac(w1, q3[1], MODULUS[0], 0);
-            let (w2, carry) = mac(w2, q3[1], MODULUS[1], carry);
-            let (w3, carry) = mac(w3, q3[1], MODULUS[2], carry);
-            let (w4, _) = mac(w4, q3[1], MODULUS[3], carry);
-
-            let (w2, carry) = mac(w2, q3[2], MODULUS[0], 0);
-            let (w3, carry) = mac(w3, q3[2], MODULUS[1], carry);
-            let (w4, _) = mac(w4, q3[2], MODULUS[2], carry);
-
-            let (w3, carry) = mac(w3, q3[3], MODULUS[0], 0);
-            let (w4, _) = mac(w4, q3[3], MODULUS[1], carry);
-
-            let (w4, _) = mac(w4, q3[4], MODULUS[0], 0);
-
-            [w0, w1, w2, w3, w4]
-        }
-
-        let r2: [u64; 5] = q3_times_n_keep_five(&q3);
-
-        #[inline]
-        #[allow(clippy::too_many_arguments)]
-        const fn sub_inner_five(l: [u64; 5], r: [u64; 5]) -> [u64; 5] {
-            let (w0, borrow) = sbb(l[0], r[0], 0);
-            let (w1, borrow) = sbb(l[1], r[1], borrow);
-            let (w2, borrow) = sbb(l[2], r[2], borrow);
-            let (w3, borrow) = sbb(l[3], r[3], borrow);
-            let (w4, _borrow) = sbb(l[4], r[4], borrow);
-
-            // If underflow occurred on the final limb - don't care (= add b^{k+1}).
-            [w0, w1, w2, w3, w4]
-        }
-
-        let r: [u64; 5] = sub_inner_five(r1, r2);
-
-        #[inline]
-        #[allow(clippy::too_many_arguments)]
-        const fn subtract_n_if_necessary(r0: u64, r1: u64, r2: u64, r3: u64, r4: u64) -> [u64; 5] {
-            let (w0, borrow) = sbb(r0, MODULUS[0], 0);
-            let (w1, borrow) = sbb(r1, MODULUS[1], borrow);
-            let (w2, borrow) = sbb(r2, MODULUS[2], borrow);
-            let (w3, borrow) = sbb(r3, MODULUS[3], borrow);
-            let (w4, borrow) = sbb(r4, 0, borrow);
-
-            // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
-            // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
-            // modulus.
-            let (w0, carry) = adc(w0, MODULUS[0] & borrow, 0);
-            let (w1, carry) = adc(w1, MODULUS[1] & borrow, carry);
-            let (w2, carry) = adc(w2, MODULUS[2] & borrow, carry);
-            let (w3, carry) = adc(w3, MODULUS[3] & borrow, carry);
-            let (w4, _carry) = adc(w4, 0, carry);
-
-            [w0, w1, w2, w3, w4]
-        }
-
-        // Result is in range (0, 3*n - 1),
-        // and 90% of the time, no subtraction will be needed.
-        let r = subtract_n_if_necessary(r[0], r[1], r[2], r[3], r[4]);
-        let r = subtract_n_if_necessary(r[0], r[1], r[2], r[3], r[4]);
-        Scalar::from_u64x4_unchecked([r[0], r[1], r[2], r[3]])
-    }
-
-    /// Perform unchecked conversion from a U64x4 to a Scalar.
-    ///
-    /// Note: this does *NOT* ensure that the provided value is less than `MODULUS`.
-    // TODO(tarcieri): implement all algorithms in terms of `U256`?
-    const fn from_u64x4_unchecked(limbs: U64x4) -> Self {
-        Self(u64x4_to_u256(limbs))
     }
 
     /// Shift right by one bit

--- a/p256/src/arithmetic/scalar/scalar32.rs
+++ b/p256/src/arithmetic/scalar/scalar32.rs
@@ -1,0 +1,188 @@
+//! 32-bit secp256r1 scalar field algorithms.
+
+// TODO(tarcieri): adapt 64-bit arithmetic to proper 32-bit arithmetic
+
+use super::{MODULUS, MU};
+use crate::{
+    arithmetic::util::{adc, mac, sbb},
+    U256,
+};
+
+/// Barrett Reduction
+///
+/// The general algorithm is:
+/// ```text
+/// p = n = order of group
+/// b = 2^64 = 64bit machine word
+/// k = 4
+/// a \in [0, 2^512]
+/// mu := floor(b^{2k} / p)
+/// q1 := floor(a / b^{k - 1})
+/// q2 := q1 * mu
+/// q3 := <- floor(a / b^{k - 1})
+/// r1 := a mod b^{k + 1}
+/// r2 := q3 * m mod b^{k + 1}
+/// r := r1 - r2
+///
+/// if r < 0: r := r + b^{k + 1}
+/// while r >= p: do r := r - p (at most twice)
+/// ```
+///
+/// References:
+/// - Handbook of Applied Cryptography, Chapter 14
+///   Algorithm 14.42
+///   http://cacr.uwaterloo.ca/hac/about/chap14.pdf
+///
+/// - Efficient and Secure Elliptic Curve Cryptography Implementation of Curve P-256
+///   Algorithm 6) Barrett Reduction modulo p
+///   https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf
+#[inline]
+#[allow(clippy::too_many_arguments)]
+pub(super) const fn barrett_reduce(lo: U256, hi: U256) -> U256 {
+    let lo = u256_to_u64x4(lo);
+    let hi = u256_to_u64x4(hi);
+    let a0 = lo[0];
+    let a1 = lo[1];
+    let a2 = lo[2];
+    let a3 = lo[3];
+    let a4 = hi[0];
+    let a5 = hi[1];
+    let a6 = hi[2];
+    let a7 = hi[3];
+    let q1: [u64; 5] = [a3, a4, a5, a6, a7];
+    let q3 = q1_times_mu_shift_five(&q1);
+
+    let r1: [u64; 5] = [a0, a1, a2, a3, a4];
+    let r2: [u64; 5] = q3_times_n_keep_five(&q3);
+    let r: [u64; 5] = sub_inner_five(r1, r2);
+
+    // Result is in range (0, 3*n - 1),
+    // and 90% of the time, no subtraction will be needed.
+    let r = subtract_n_if_necessary(r[0], r[1], r[2], r[3], r[4]);
+    let r = subtract_n_if_necessary(r[0], r[1], r[2], r[3], r[4]);
+
+    U256::from_words([
+        (r[0] & 0xFFFFFFFF) as u32,
+        (r[0] >> 32) as u32,
+        (r[1] & 0xFFFFFFFF) as u32,
+        (r[1] >> 32) as u32,
+        (r[2] & 0xFFFFFFFF) as u32,
+        (r[2] >> 32) as u32,
+        (r[3] & 0xFFFFFFFF) as u32,
+        (r[3] >> 32) as u32,
+    ])
+}
+
+const fn q1_times_mu_shift_five(q1: &[u64; 5]) -> [u64; 5] {
+    // Schoolbook multiplication.
+
+    let (_w0, carry) = mac(0, q1[0], MU[0], 0);
+    let (w1, carry) = mac(0, q1[0], MU[1], carry);
+    let (w2, carry) = mac(0, q1[0], MU[2], carry);
+    let (w3, carry) = mac(0, q1[0], MU[3], carry);
+    let (w4, w5) = mac(0, q1[0], MU[4], carry);
+
+    let (_w1, carry) = mac(w1, q1[1], MU[0], 0);
+    let (w2, carry) = mac(w2, q1[1], MU[1], carry);
+    let (w3, carry) = mac(w3, q1[1], MU[2], carry);
+    let (w4, carry) = mac(w4, q1[1], MU[3], carry);
+    let (w5, w6) = mac(w5, q1[1], MU[4], carry);
+
+    let (_w2, carry) = mac(w2, q1[2], MU[0], 0);
+    let (w3, carry) = mac(w3, q1[2], MU[1], carry);
+    let (w4, carry) = mac(w4, q1[2], MU[2], carry);
+    let (w5, carry) = mac(w5, q1[2], MU[3], carry);
+    let (w6, w7) = mac(w6, q1[2], MU[4], carry);
+
+    let (_w3, carry) = mac(w3, q1[3], MU[0], 0);
+    let (w4, carry) = mac(w4, q1[3], MU[1], carry);
+    let (w5, carry) = mac(w5, q1[3], MU[2], carry);
+    let (w6, carry) = mac(w6, q1[3], MU[3], carry);
+    let (w7, w8) = mac(w7, q1[3], MU[4], carry);
+
+    let (_w4, carry) = mac(w4, q1[4], MU[0], 0);
+    let (w5, carry) = mac(w5, q1[4], MU[1], carry);
+    let (w6, carry) = mac(w6, q1[4], MU[2], carry);
+    let (w7, carry) = mac(w7, q1[4], MU[3], carry);
+    let (w8, w9) = mac(w8, q1[4], MU[4], carry);
+
+    // let q2 = [_w0, _w1, _w2, _w3, _w4, w5, w6, w7, w8, w9];
+    [w5, w6, w7, w8, w9]
+}
+
+const fn q3_times_n_keep_five(q3: &[u64; 5]) -> [u64; 5] {
+    // Schoolbook multiplication.
+
+    let modulus = u256_to_u64x4(MODULUS);
+
+    let (w0, carry) = mac(0, q3[0], modulus[0], 0);
+    let (w1, carry) = mac(0, q3[0], modulus[1], carry);
+    let (w2, carry) = mac(0, q3[0], modulus[2], carry);
+    let (w3, carry) = mac(0, q3[0], modulus[3], carry);
+    let (w4, _) = mac(0, q3[0], 0, carry);
+
+    let (w1, carry) = mac(w1, q3[1], modulus[0], 0);
+    let (w2, carry) = mac(w2, q3[1], modulus[1], carry);
+    let (w3, carry) = mac(w3, q3[1], modulus[2], carry);
+    let (w4, _) = mac(w4, q3[1], modulus[3], carry);
+
+    let (w2, carry) = mac(w2, q3[2], modulus[0], 0);
+    let (w3, carry) = mac(w3, q3[2], modulus[1], carry);
+    let (w4, _) = mac(w4, q3[2], modulus[2], carry);
+
+    let (w3, carry) = mac(w3, q3[3], modulus[0], 0);
+    let (w4, _) = mac(w4, q3[3], modulus[1], carry);
+
+    let (w4, _) = mac(w4, q3[4], modulus[0], 0);
+
+    [w0, w1, w2, w3, w4]
+}
+
+#[inline]
+#[allow(clippy::too_many_arguments)]
+const fn sub_inner_five(l: [u64; 5], r: [u64; 5]) -> [u64; 5] {
+    let (w0, borrow) = sbb(l[0], r[0], 0);
+    let (w1, borrow) = sbb(l[1], r[1], borrow);
+    let (w2, borrow) = sbb(l[2], r[2], borrow);
+    let (w3, borrow) = sbb(l[3], r[3], borrow);
+    let (w4, _borrow) = sbb(l[4], r[4], borrow);
+
+    // If underflow occurred on the final limb - don't care (= add b^{k+1}).
+    [w0, w1, w2, w3, w4]
+}
+
+#[inline]
+#[allow(clippy::too_many_arguments)]
+const fn subtract_n_if_necessary(r0: u64, r1: u64, r2: u64, r3: u64, r4: u64) -> [u64; 5] {
+    let modulus = u256_to_u64x4(MODULUS);
+
+    let (w0, borrow) = sbb(r0, modulus[0], 0);
+    let (w1, borrow) = sbb(r1, modulus[1], borrow);
+    let (w2, borrow) = sbb(r2, modulus[2], borrow);
+    let (w3, borrow) = sbb(r3, modulus[3], borrow);
+    let (w4, borrow) = sbb(r4, 0, borrow);
+
+    // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
+    // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
+    // modulus.
+    let (w0, carry) = adc(w0, modulus[0] & borrow, 0);
+    let (w1, carry) = adc(w1, modulus[1] & borrow, carry);
+    let (w2, carry) = adc(w2, modulus[2] & borrow, carry);
+    let (w3, carry) = adc(w3, modulus[3] & borrow, carry);
+    let (w4, _carry) = adc(w4, 0, carry);
+
+    [w0, w1, w2, w3, w4]
+}
+
+// TODO(tarcieri): replace this with proper 32-bit arithmetic
+#[inline]
+const fn u256_to_u64x4(u256: U256) -> [u64; 4] {
+    let words = u256.as_words();
+
+    [
+        (words[0] as u64) | ((words[1] as u64) << 32),
+        (words[2] as u64) | ((words[3] as u64) << 32),
+        (words[4] as u64) | ((words[5] as u64) << 32),
+        (words[6] as u64) | ((words[7] as u64) << 32),
+    ]
+}

--- a/p256/src/arithmetic/scalar/scalar64.rs
+++ b/p256/src/arithmetic/scalar/scalar64.rs
@@ -1,0 +1,163 @@
+//! 64-bit secp256r1 scalar field algorithms.
+
+use super::{MODULUS, MU};
+use crate::{
+    arithmetic::util::{adc, mac, sbb},
+    U256,
+};
+
+/// Barrett Reduction
+///
+/// The general algorithm is:
+/// ```text
+/// p = n = order of group
+/// b = 2^64 = 64bit machine word
+/// k = 4
+/// a \in [0, 2^512]
+/// mu := floor(b^{2k} / p)
+/// q1 := floor(a / b^{k - 1})
+/// q2 := q1 * mu
+/// q3 := <- floor(a / b^{k - 1})
+/// r1 := a mod b^{k + 1}
+/// r2 := q3 * m mod b^{k + 1}
+/// r := r1 - r2
+///
+/// if r < 0: r := r + b^{k + 1}
+/// while r >= p: do r := r - p (at most twice)
+/// ```
+///
+/// References:
+/// - Handbook of Applied Cryptography, Chapter 14
+///   Algorithm 14.42
+///   http://cacr.uwaterloo.ca/hac/about/chap14.pdf
+///
+/// - Efficient and Secure Elliptic Curve Cryptography Implementation of Curve P-256
+///   Algorithm 6) Barrett Reduction modulo p
+///   https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf
+#[inline]
+#[allow(clippy::too_many_arguments)]
+pub(super) const fn barrett_reduce(lo: U256, hi: U256) -> U256 {
+    let lo = lo.as_words();
+    let hi = hi.as_words();
+    let a0 = lo[0];
+    let a1 = lo[1];
+    let a2 = lo[2];
+    let a3 = lo[3];
+    let a4 = hi[0];
+    let a5 = hi[1];
+    let a6 = hi[2];
+    let a7 = hi[3];
+    let q1: [u64; 5] = [a3, a4, a5, a6, a7];
+    let q3 = q1_times_mu_shift_five(&q1);
+
+    let r1: [u64; 5] = [a0, a1, a2, a3, a4];
+    let r2: [u64; 5] = q3_times_n_keep_five(&q3);
+    let r: [u64; 5] = sub_inner_five(r1, r2);
+
+    // Result is in range (0, 3*n - 1),
+    // and 90% of the time, no subtraction will be needed.
+    let r = subtract_n_if_necessary(r[0], r[1], r[2], r[3], r[4]);
+    let r = subtract_n_if_necessary(r[0], r[1], r[2], r[3], r[4]);
+    U256::from_words([r[0], r[1], r[2], r[3]])
+}
+
+const fn q1_times_mu_shift_five(q1: &[u64; 5]) -> [u64; 5] {
+    // Schoolbook multiplication.
+
+    let (_w0, carry) = mac(0, q1[0], MU[0], 0);
+    let (w1, carry) = mac(0, q1[0], MU[1], carry);
+    let (w2, carry) = mac(0, q1[0], MU[2], carry);
+    let (w3, carry) = mac(0, q1[0], MU[3], carry);
+    let (w4, w5) = mac(0, q1[0], MU[4], carry);
+
+    let (_w1, carry) = mac(w1, q1[1], MU[0], 0);
+    let (w2, carry) = mac(w2, q1[1], MU[1], carry);
+    let (w3, carry) = mac(w3, q1[1], MU[2], carry);
+    let (w4, carry) = mac(w4, q1[1], MU[3], carry);
+    let (w5, w6) = mac(w5, q1[1], MU[4], carry);
+
+    let (_w2, carry) = mac(w2, q1[2], MU[0], 0);
+    let (w3, carry) = mac(w3, q1[2], MU[1], carry);
+    let (w4, carry) = mac(w4, q1[2], MU[2], carry);
+    let (w5, carry) = mac(w5, q1[2], MU[3], carry);
+    let (w6, w7) = mac(w6, q1[2], MU[4], carry);
+
+    let (_w3, carry) = mac(w3, q1[3], MU[0], 0);
+    let (w4, carry) = mac(w4, q1[3], MU[1], carry);
+    let (w5, carry) = mac(w5, q1[3], MU[2], carry);
+    let (w6, carry) = mac(w6, q1[3], MU[3], carry);
+    let (w7, w8) = mac(w7, q1[3], MU[4], carry);
+
+    let (_w4, carry) = mac(w4, q1[4], MU[0], 0);
+    let (w5, carry) = mac(w5, q1[4], MU[1], carry);
+    let (w6, carry) = mac(w6, q1[4], MU[2], carry);
+    let (w7, carry) = mac(w7, q1[4], MU[3], carry);
+    let (w8, w9) = mac(w8, q1[4], MU[4], carry);
+
+    // let q2 = [_w0, _w1, _w2, _w3, _w4, w5, w6, w7, w8, w9];
+    [w5, w6, w7, w8, w9]
+}
+
+const fn q3_times_n_keep_five(q3: &[u64; 5]) -> [u64; 5] {
+    // Schoolbook multiplication.
+
+    let modulus = MODULUS.as_words();
+
+    let (w0, carry) = mac(0, q3[0], modulus[0], 0);
+    let (w1, carry) = mac(0, q3[0], modulus[1], carry);
+    let (w2, carry) = mac(0, q3[0], modulus[2], carry);
+    let (w3, carry) = mac(0, q3[0], modulus[3], carry);
+    let (w4, _) = mac(0, q3[0], 0, carry);
+
+    let (w1, carry) = mac(w1, q3[1], modulus[0], 0);
+    let (w2, carry) = mac(w2, q3[1], modulus[1], carry);
+    let (w3, carry) = mac(w3, q3[1], modulus[2], carry);
+    let (w4, _) = mac(w4, q3[1], modulus[3], carry);
+
+    let (w2, carry) = mac(w2, q3[2], modulus[0], 0);
+    let (w3, carry) = mac(w3, q3[2], modulus[1], carry);
+    let (w4, _) = mac(w4, q3[2], modulus[2], carry);
+
+    let (w3, carry) = mac(w3, q3[3], modulus[0], 0);
+    let (w4, _) = mac(w4, q3[3], modulus[1], carry);
+
+    let (w4, _) = mac(w4, q3[4], modulus[0], 0);
+
+    [w0, w1, w2, w3, w4]
+}
+
+#[inline]
+#[allow(clippy::too_many_arguments)]
+const fn sub_inner_five(l: [u64; 5], r: [u64; 5]) -> [u64; 5] {
+    let (w0, borrow) = sbb(l[0], r[0], 0);
+    let (w1, borrow) = sbb(l[1], r[1], borrow);
+    let (w2, borrow) = sbb(l[2], r[2], borrow);
+    let (w3, borrow) = sbb(l[3], r[3], borrow);
+    let (w4, _borrow) = sbb(l[4], r[4], borrow);
+
+    // If underflow occurred on the final limb - don't care (= add b^{k+1}).
+    [w0, w1, w2, w3, w4]
+}
+
+#[inline]
+#[allow(clippy::too_many_arguments)]
+const fn subtract_n_if_necessary(r0: u64, r1: u64, r2: u64, r3: u64, r4: u64) -> [u64; 5] {
+    let modulus = MODULUS.as_words();
+
+    let (w0, borrow) = sbb(r0, modulus[0], 0);
+    let (w1, borrow) = sbb(r1, modulus[1], borrow);
+    let (w2, borrow) = sbb(r2, modulus[2], borrow);
+    let (w3, borrow) = sbb(r3, modulus[3], borrow);
+    let (w4, borrow) = sbb(r4, 0, borrow);
+
+    // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
+    // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
+    // modulus.
+    let (w0, carry) = adc(w0, modulus[0] & borrow, 0);
+    let (w1, carry) = adc(w1, modulus[1] & borrow, carry);
+    let (w2, carry) = adc(w2, modulus[2] & borrow, carry);
+    let (w3, carry) = adc(w3, modulus[3] & borrow, carry);
+    let (w4, _carry) = adc(w4, 0, carry);
+
+    [w0, w1, w2, w3, w4]
+}


### PR DESCRIPTION
This applies a similar treatment from #635 to the scalar backend, clearing the way to implement a proper 32-bit backend for both the base and scalar fields.