### PR TITLE
feat(ecdsa/secp256r1): Support public key recovery from signature

### DIFF
--- a/p256/src/ecdsa/recoverable.rs
+++ b/p256/src/ecdsa/recoverable.rs
@@ -1,0 +1,382 @@
+//! Ethereum-style "recoverable signatures".
+//!
+//! These signatures include an additional [`Id`] field which allows for
+//! recovery of the [`VerifyingKey`] which can be used to verify them.
+//!
+//! This is helpful in cases where a hash/fingerprint of a [`VerifyingKey`]
+//! for a given signature in known in advance.
+//!
+//! ## Signing/Recovery Example
+//!
+//! NOTE: make sure to enable both the `ecdsa` and `sha256` features of
+//! this crate for the example to work.
+//!
+//! ```
+//! # #[cfg(all(feature = "ecdsa", feature = "sha256"))]
+//! # {
+//! use p256::{
+//!     ecdsa::{SigningKey, recoverable, signature::Signer},
+//!     EncodedPoint
+//! };
+//! use rand_core::OsRng; // requires 'getrandom' feature
+//!
+//! // Signing
+//! let signing_key = SigningKey::random(&mut OsRng); // Serialize with `::to_bytes()`
+//! let verifying_key = signing_key.verifying_key();
+//! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
+//!
+//! // Note: the signature type must be annotated or otherwise inferrable as
+//! // `Signer` has many impls of the `Signer` trait (for both regular and
+//! // recoverable signature types).
+//! let signature: recoverable::Signature = signing_key.sign(message);
+//! let recovered_key = signature.recover_verifying_key(message).expect("couldn't recover pubkey");
+//!
+//! assert_eq!(&verifying_key, &recovered_key);
+//! # }
+//! ```
+
+use core::fmt::{self, Debug};
+use ecdsa_core::{signature::Signature as _, Error, Result};
+use elliptic_curve::subtle::Choice;
+
+#[cfg(feature = "ecdsa")]
+use crate::{
+    ecdsa::{
+        signature::digest::{Digest, FixedOutput},
+        verify::VerifyingKey,
+    },
+    elliptic_curve::{
+        bigint::U256,
+        consts::U32,
+        ops::{Invert, LinearCombination, Reduce},
+        DecompressPoint,
+    },
+    AffinePoint, FieldBytes, NonZeroScalar, ProjectivePoint, Scalar,
+};
+
+#[cfg(feature = "sha256")]
+use sha2::Sha256;
+
+/// Size of an Ethereum-style recoverable signature in bytes
+pub const SIZE: usize = 65;
+
+/// Ethereum-style "recoverable signatures" which allow for the recovery of
+/// the signer's [`VerifyingKey`] from the signature itself.
+///
+/// This format consists of [`Signature`] followed by a 1-byte recovery [`Id`]
+/// (65-bytes total):
+///
+/// - `r`: 32-byte integer, big endian
+/// - `s`: 32-byte integer, big endian
+/// - `v`: 1-byte recovery [`Id`]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct Signature {
+    bytes: [u8; SIZE],
+}
+
+impl Signature {
+    /// Create a new recoverable ECDSA/P-256 signature from a regular
+    /// fixed-size signature and an associated recovery [`Id`].
+    ///
+    /// This is an "unchecked" conversion and assumes the provided [`Id`]
+    /// is valid for this signature.
+    pub fn new(signature: &super::Signature, recovery_id: Id) -> Result<Self> {
+        let mut bytes = [0u8; SIZE];
+        bytes[..64].copy_from_slice(signature.as_ref());
+        bytes[64] = recovery_id.0;
+        Ok(Self { bytes })
+    }
+
+    /// Get the recovery [`Id`] for this signature
+    pub fn recovery_id(self) -> Id {
+        self.bytes[64].try_into().expect("invalid recovery ID")
+    }
+
+    /// Given a public key, message, and signature, use trial recovery
+    /// to determine if a suitable recovery ID exists, or return an error
+    /// otherwise.
+    ///
+    /// Assumes Sha256 as the message digest function. Use
+    /// [`Signature::from_digest_trial_recovery`] to support other
+    ///digest functions.
+    #[cfg(all(feature = "ecdsa", feature = "sha256"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sha256")))]
+    pub fn from_trial_recovery(
+        public_key: &VerifyingKey,
+        msg: &[u8],
+        signature: &super::Signature,
+    ) -> Result<Self> {
+        Self::from_digest_trial_recovery(public_key, Sha256::new_with_prefix(msg), signature)
+    }
+
+    /// Given a public key, message digest, and signature, use trial recovery
+    /// to determine if a suitable recovery ID exists, or return an error
+    /// otherwise.
+    #[cfg(feature = "ecdsa")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+    pub fn from_digest_trial_recovery<D>(
+        public_key: &VerifyingKey,
+        digest: D,
+        signature: &super::Signature,
+    ) -> Result<Self>
+    where
+        D: Clone + Digest + FixedOutput<OutputSize = U32>,
+    {
+        use ecdsa_core::signature::DigestVerifier;
+
+        let signature = signature.normalize_s().unwrap_or(*signature);
+
+        for recovery_id in 0..=1 {
+            if let Ok(recoverable_signature) = Signature::new(&signature, Id(recovery_id)) {
+                if let Ok(recovered_key) =
+                    recoverable_signature.recover_verifying_key_from_digest(digest.clone())
+                {
+                    if public_key == &recovered_key
+                        && public_key.verify_digest(digest.clone(), &signature).is_ok()
+                    {
+                        return Ok(recoverable_signature);
+                    }
+                }
+            }
+        }
+
+        Err(Error::new())
+    }
+
+    /// Recover the public key used to create the given signature as a
+    /// [`VerifyingKey`].
+    #[cfg(all(feature = "ecdsa", feature = "sha256"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sha256")))]
+    pub fn recover_verifying_key(&self, msg: &[u8]) -> Result<VerifyingKey> {
+        self.recover_verifying_key_from_digest(Sha256::new_with_prefix(msg))
+    }
+
+    /// Recover the public key used to create the given signature as a
+    /// [`VerifyingKey`] from the provided precomputed [`Digest`].
+    #[cfg(feature = "ecdsa")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+    pub fn recover_verifying_key_from_digest<D>(&self, msg_digest: D) -> Result<VerifyingKey>
+    where
+        D: Digest<OutputSize = U32>,
+    {
+        self.recover_verifying_key_from_digest_bytes(&msg_digest.finalize())
+    }
+
+    /// Recover the public key used to create the given signature as a
+    /// [`VerifyingKey`] from the raw bytes of a message digest.
+    #[cfg(feature = "ecdsa")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+    #[allow(non_snake_case, clippy::many_single_char_names)]
+    pub fn recover_verifying_key_from_digest_bytes(
+        &self,
+        digest_bytes: &FieldBytes,
+    ) -> Result<VerifyingKey> {
+        let r = self.r();
+        let s = self.s();
+        let z = <Scalar as Reduce<U256>>::from_be_bytes_reduced(*digest_bytes);
+        let R = AffinePoint::decompress(&r.to_bytes(), self.recovery_id().is_y_odd());
+
+        if R.is_none().into() {
+            return Err(Error::new());
+        }
+
+        let R = ProjectivePoint::from(R.unwrap());
+        let r_inv = *r.invert();
+        let u1 = -(r_inv * z);
+        let u2 = r_inv * *s;
+        let pk = ProjectivePoint::lincomb(&ProjectivePoint::GENERATOR, &u1, &R, &u2);
+
+        // TODO(tarcieri): ensure the signature verifies?
+        VerifyingKey::try_from(pk)
+    }
+
+    /// Parse the `r` component of this signature to a [`NonZeroScalar`]
+    #[cfg(feature = "ecdsa")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+    pub fn r(&self) -> NonZeroScalar {
+        NonZeroScalar::try_from(&self.bytes[..32])
+            .expect("r-component ensured valid in constructor")
+    }
+
+    /// Parse the `s` component of this signature to a [`NonZeroScalar`]
+    #[cfg(feature = "ecdsa")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+    pub fn s(&self) -> NonZeroScalar {
+        NonZeroScalar::try_from(&self.bytes[32..64])
+            .expect("s-component ensured valid in constructor")
+    }
+}
+
+impl ecdsa_core::signature::Signature for Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        bytes.try_into()
+    }
+}
+
+impl AsRef<[u8]> for Signature {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes[..]
+    }
+}
+
+impl Debug for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RecoverableSignature {{ bytes: {:?}) }}", self.as_ref())
+    }
+}
+
+impl TryFrom<&[u8]> for Signature {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() != SIZE {
+            return Err(Error::new());
+        }
+
+        let signature = super::Signature::try_from(&bytes[..64])?;
+        let recovery_id = Id::try_from(bytes[64])?;
+        Self::new(&signature, recovery_id)
+    }
+}
+
+impl From<Signature> for super::Signature {
+    fn from(sig: Signature) -> Self {
+        Self::from_bytes(&sig.bytes[..64]).unwrap()
+    }
+}
+
+#[cfg(feature = "sha256")]
+impl ecdsa_core::signature::PrehashSignature for Signature {
+    type Digest = Sha256;
+}
+
+/// Identifier used to compute a [`VerifyingKey`] from a [`Signature`].
+///
+/// In practice these values are always either `0` or `1`, and indicate
+/// whether or not the y-coordinate of the original [`VerifyingKey`] is odd.
+///
+/// While values `2` and `3` are also defined to capture whether `r`
+/// overflowed the curve's order, this crate does *not* support them.
+///
+/// There is a vanishingly small chance of these values occurring outside
+/// of contrived examples, so for simplicity's sake handling these values
+/// is unsupported and will return an `Error` when parsing the `Id`.
+#[derive(Copy, Clone, Debug)]
+pub struct Id(pub(super) u8);
+
+impl Id {
+    /// Create a new [`Id`] from the given byte value
+    pub fn new(byte: u8) -> Result<Self> {
+        match byte {
+            0 | 1 => Ok(Self(byte)),
+            _ => Err(Error::new()),
+        }
+    }
+
+    /// Is `y` odd?
+    fn is_y_odd(self) -> Choice {
+        self.0.into()
+    }
+}
+
+impl TryFrom<u8> for Id {
+    type Error = Error;
+
+    fn try_from(byte: u8) -> Result<Self> {
+        Self::new(byte)
+    }
+}
+
+impl From<Id> for u8 {
+    fn from(recovery_id: Id) -> u8 {
+        recovery_id.0
+    }
+}
+
+impl TryFrom<ecdsa_core::RecoveryId> for Id {
+    type Error = Error;
+
+    fn try_from(id: ecdsa_core::RecoveryId) -> Result<Id> {
+        if id.is_x_reduced() {
+            Err(Error::new())
+        } else if id.is_y_odd() {
+            Ok(Id(1))
+        } else {
+            Ok(Id(0))
+        }
+    }
+}
+
+impl From<Id> for ecdsa_core::RecoveryId {
+    fn from(id: Id) -> ecdsa_core::RecoveryId {
+        ecdsa_core::RecoveryId::new(id.is_y_odd().into(), false)
+    }
+}
+
+#[cfg(all(test, feature = "ecdsa", feature = "sha256"))]
+mod tests {
+    use super::Signature;
+    use crate::{ecdsa::sign::SigningKey, EncodedPoint};
+    use ecdsa_core::signature::Signer;
+    use hex_literal::hex;
+    use sha2::{Digest, Sha256};
+
+    /// Signature recovery test vectors
+    struct RecoveryTestVector {
+        pk: [u8; 33],
+        sig: [u8; 65],
+        msg: &'static [u8],
+    }
+
+    const RECOVERY_TEST_VECTORS: &[RecoveryTestVector] = &[
+        // Recovery ID 0
+        RecoveryTestVector {
+            pk: hex!("02c156afee1ce52ef83a0dd168c1144eb20008697e6664fa132ba23c128cce8055"),
+            sig: hex!(
+                "45fef169243c0163c2e86c864a37973c56733a152303626eafe971b5524e8d4edbd3353771de5a5ef931b53736a12ed6e65fd41a193ca87f165d852f888a03c200"
+            ),
+            msg: b"example message",
+        },
+        // Recovery ID 1
+        RecoveryTestVector {
+            pk: hex!("02c156afee1ce52ef83a0dd168c1144eb20008697e6664fa132ba23c128cce8055"),
+            sig: hex!(
+                "213304ff146105f365feb04ec3aa20f4bb658e4c0c4e11d4820836fa793f173b0479c7332ac3174a5175d9f87df0b28b9f117477288de8f5ece48f9f07827b8601"
+            ),
+            msg: b"example message 2",
+        },
+    ];
+
+    #[test]
+    fn public_key_recovery() {
+        for vector in RECOVERY_TEST_VECTORS {
+            let sig = Signature::try_from(&vector.sig[..]).unwrap();
+            let prehash = Sha256::new_with_prefix(vector.msg);
+            let pk = sig.recover_verifying_key_from_digest(prehash).unwrap();
+            assert_eq!(&vector.pk[..], EncodedPoint::from(&pk).as_bytes());
+        }
+    }
+
+    /// Ensures RFC6979 is implemented in the same way as other Ethereum
+    /// libraries, using HMAC-DRBG-SHA-256 for RFC6979, and Sha256 for
+    /// hashing the message.
+    ///
+    /// Test vectors adapted from:
+    /// <https://github.com/gakonst/ethers-rs/blob/ba00f549/ethers-signers/src/wallet/private_key.rs#L197>
+    #[test]
+    fn signing_rfc6979() {
+        let signing_key = SigningKey::from_bytes(&hex!(
+            "f67b03b2c6e4bf86cce50298dbce351b332c3be65ced9f312b6d9ffc3de6b04f"
+        ))
+        .unwrap();
+
+        let msg = hex!(
+            "e9808504e3b29200831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca0080018080"
+        );
+
+        let sig: Signature = signing_key.sign(&msg);
+        assert_eq!(sig.as_ref(), &hex!("5da79ba879954cc8a25e8e48eae031c856adb2d385cdc6ac75c890fff62df5f33938d7da87e3175d9d00e90671b43a6c7e9327ac5be03ed8f6b195cc44a8089d00"));
+    }
+}

--- a/p256/src/ecdsa/sign.rs
+++ b/p256/src/ecdsa/sign.rs
@@ -1,0 +1,317 @@
+//! ECDSA signing support.
+
+use super::{recoverable, verify::VerifyingKey, Error, Signature};
+use crate::{FieldBytes, NistP256, NonZeroScalar, ProjectivePoint, PublicKey, Scalar, SecretKey};
+use core::{
+    borrow::Borrow,
+    fmt::{self, Debug},
+};
+use ecdsa_core::{
+    hazmat::SignPrimitive,
+    signature::{
+        digest::{Digest, FixedOutput},
+        DigestSigner, RandomizedDigestSigner,
+    },
+};
+use elliptic_curve::{
+    bigint::U256,
+    consts::U32,
+    ops::{Invert, Reduce},
+    rand_core::{CryptoRng, RngCore},
+    subtle::{Choice, ConstantTimeEq, CtOption},
+    zeroize::{Zeroize, ZeroizeOnDrop},
+    AffineXCoordinate, Field,
+};
+
+#[cfg(feature = "sha256")]
+use sha2::Sha256;
+
+#[cfg(feature = "sha256")]
+use ecdsa_core::signature::{self, PrehashSignature, RandomizedSigner};
+
+#[cfg(feature = "pkcs8")]
+use crate::pkcs8::{self, DecodePrivateKey};
+
+#[cfg(feature = "pem")]
+use core::str::FromStr;
+
+/// ECDSA/P-256 signing key
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+#[derive(Clone)]
+pub struct SigningKey {
+    /// Inner secret key value
+    inner: NonZeroScalar,
+}
+
+impl SigningKey {
+    /// Generate a cryptographically random [`SigningKey`].
+    pub fn random(rng: impl CryptoRng + RngCore) -> Self {
+        Self {
+            inner: NonZeroScalar::random(rng),
+        }
+    }
+
+    /// Initialize [`SigningKey`] from a raw scalar value (big endian).
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        let inner = SecretKey::from_be_bytes(bytes)
+            .map(|sk| sk.to_nonzero_scalar())
+            .map_err(|_| Error::new())?;
+
+        Ok(Self { inner })
+    }
+
+    /// Get the [`VerifyingKey`] which corresponds to this [`SigningKey`].
+    pub fn verifying_key(&self) -> VerifyingKey {
+        VerifyingKey {
+            inner: PublicKey::from_secret_scalar(&self.inner).into(),
+        }
+    }
+
+    /// Serialize this [`SigningKey`] as bytes
+    pub fn to_bytes(&self) -> FieldBytes {
+        self.inner.to_bytes()
+    }
+}
+
+#[cfg(feature = "sha256")]
+impl<S> signature::Signer<S> for SigningKey
+where
+    S: PrehashSignature,
+    Self: DigestSigner<S::Digest, S>,
+{
+    fn try_sign(&self, msg: &[u8]) -> Result<S, Error> {
+        self.try_sign_digest(S::Digest::new_with_prefix(msg))
+    }
+}
+
+#[cfg(feature = "sha256")]
+impl<S> RandomizedSigner<S> for SigningKey
+where
+    S: PrehashSignature,
+    Self: RandomizedDigestSigner<S::Digest, S>,
+{
+    fn try_sign_with_rng(&self, rng: impl CryptoRng + RngCore, msg: &[u8]) -> Result<S, Error> {
+        self.try_sign_digest_with_rng(rng, S::Digest::new_with_prefix(msg))
+    }
+}
+
+impl<D> DigestSigner<D, Signature> for SigningKey
+where
+    D: Digest + FixedOutput<OutputSize = U32>,
+{
+    fn try_sign_digest(&self, digest: D) -> Result<Signature, Error> {
+        let sig: recoverable::Signature = self.try_sign_digest(digest)?;
+        Ok(sig.into())
+    }
+}
+
+impl<D> DigestSigner<D, recoverable::Signature> for SigningKey
+where
+    D: Digest + FixedOutput<OutputSize = U32>,
+{
+    fn try_sign_digest(&self, msg_digest: D) -> Result<recoverable::Signature, Error> {
+        let digest = msg_digest.finalize_fixed();
+
+        // Ethereum signatures use SHA-256 for RFC6979, even if the message
+        // has been hashed with Sha256
+        let (signature, recid) = self
+            .inner
+            .try_sign_prehashed_rfc6979::<Sha256>(digest, &[])?;
+
+        let recoverable_id = recid.ok_or_else(Error::new)?.try_into()?;
+        recoverable::Signature::new(&signature, recoverable_id)
+    }
+}
+
+impl<D> RandomizedDigestSigner<D, Signature> for SigningKey
+where
+    D: Digest + FixedOutput<OutputSize = U32>,
+{
+    fn try_sign_digest_with_rng(
+        &self,
+        rng: impl CryptoRng + RngCore,
+        digest: D,
+    ) -> Result<Signature, Error> {
+        let sig: recoverable::Signature = self.try_sign_digest_with_rng(rng, digest)?;
+        Ok(sig.into())
+    }
+}
+
+impl<D> RandomizedDigestSigner<D, recoverable::Signature> for SigningKey
+where
+    D: Digest + FixedOutput<OutputSize = U32>,
+{
+    fn try_sign_digest_with_rng(
+        &self,
+        mut rng: impl CryptoRng + RngCore,
+        msg_digest: D,
+    ) -> Result<recoverable::Signature, Error> {
+        let mut ad = FieldBytes::default();
+        rng.fill_bytes(&mut ad);
+
+        let digest = msg_digest.finalize_fixed();
+
+        // Ethereum signatures use SHA-256 for RFC6979, even if the message
+        // has been hashed with Sha256
+        let (signature, recid) = self
+            .inner
+            .try_sign_prehashed_rfc6979::<Sha256>(digest, &ad)?;
+
+        let recoverable_id = recid.ok_or_else(Error::new)?.try_into()?;
+        recoverable::Signature::new(&signature, recoverable_id)
+    }
+}
+
+impl SignPrimitive<NistP256> for Scalar {
+    #[allow(non_snake_case, clippy::many_single_char_names)]
+    fn try_sign_prehashed<K>(
+        &self,
+        ephemeral_scalar: K,
+        z: FieldBytes,
+    ) -> Result<(Signature, Option<ecdsa_core::RecoveryId>), Error>
+    where
+        K: Borrow<Scalar> + Invert<Output = CtOption<Scalar>>,
+    {
+        let z = <Self as Reduce<U256>>::from_be_bytes_reduced(z);
+        let k_inverse = ephemeral_scalar.invert();
+        let k = ephemeral_scalar.borrow();
+
+        if k_inverse.is_none().into() || k.is_zero().into() {
+            return Err(Error::new());
+        }
+
+        let k_inverse = k_inverse.unwrap();
+
+        // Compute 𝐑 = 𝑘×𝑮
+        let R = (ProjectivePoint::GENERATOR * k).to_affine();
+
+        // Lift x-coordinate of 𝐑 (element of base field) into a serialized big
+        // integer, then reduce it into an element of the scalar field
+        let r = <Scalar as Reduce<U256>>::from_be_bytes_reduced(R.x());
+
+        // Compute `s` as a signature over `r` and `z`.
+        let s = k_inverse * (z + (r * self));
+
+        if s.is_zero().into() {
+            return Err(Error::new());
+        }
+
+        let signature = Signature::from_scalars(r, s)?;
+        let is_r_odd: bool = R.is_y_odd();
+        let recovery_id = ecdsa_core::RecoveryId::new(is_r_odd, false);
+
+        Ok((signature, Some(recovery_id)))
+    }
+}
+
+impl ConstantTimeEq for SigningKey {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.inner.ct_eq(&other.inner)
+    }
+}
+
+impl Debug for SigningKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SigningKey").finish_non_exhaustive()
+    }
+}
+
+impl Eq for SigningKey {}
+
+impl PartialEq for SigningKey {
+    fn eq(&self, other: &SigningKey) -> bool {
+        self.ct_eq(other).into()
+    }
+}
+
+impl From<SecretKey> for SigningKey {
+    fn from(secret_key: SecretKey) -> SigningKey {
+        Self::from(&secret_key)
+    }
+}
+
+impl From<&SecretKey> for SigningKey {
+    fn from(secret_key: &SecretKey) -> SigningKey {
+        Self {
+            inner: secret_key.to_nonzero_scalar(),
+        }
+    }
+}
+
+impl From<SigningKey> for SecretKey {
+    fn from(signing_key: SigningKey) -> SecretKey {
+        signing_key.inner.into()
+    }
+}
+
+impl From<&SigningKey> for SecretKey {
+    fn from(signing_key: &SigningKey) -> SecretKey {
+        signing_key.inner.into()
+    }
+}
+
+impl From<SigningKey> for VerifyingKey {
+    fn from(signing_key: SigningKey) -> VerifyingKey {
+        signing_key.verifying_key()
+    }
+}
+
+impl From<&SigningKey> for VerifyingKey {
+    fn from(signing_key: &SigningKey) -> VerifyingKey {
+        signing_key.verifying_key()
+    }
+}
+
+impl From<NonZeroScalar> for SigningKey {
+    fn from(secret_scalar: NonZeroScalar) -> Self {
+        Self {
+            inner: secret_scalar,
+        }
+    }
+}
+
+impl From<&NonZeroScalar> for SigningKey {
+    fn from(secret_scalar: &NonZeroScalar) -> Self {
+        Self {
+            inner: *secret_scalar,
+        }
+    }
+}
+
+impl Drop for SigningKey {
+    fn drop(&mut self) {
+        self.inner.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for SigningKey {}
+
+#[cfg(feature = "pkcs8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
+impl TryFrom<pkcs8::PrivateKeyInfo<'_>> for SigningKey {
+    type Error = pkcs8::Error;
+
+    fn try_from(private_key_info: pkcs8::PrivateKeyInfo<'_>) -> pkcs8::Result<Self> {
+        SecretKey::try_from(private_key_info).map(Into::into)
+    }
+}
+
+#[cfg(feature = "pkcs8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
+impl DecodePrivateKey for SigningKey {}
+
+#[cfg(feature = "pem")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+impl FromStr for SigningKey {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        Self::from_pkcs8_pem(s).map_err(|_| Error::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{test_vectors::ecdsa::ECDSA_TEST_VECTORS, NistP256};
+    ecdsa_core::new_signing_test!(NistP256, ECDSA_TEST_VECTORS);
+}

--- a/p256/src/ecdsa/verify.rs
+++ b/p256/src/ecdsa/verify.rs
@@ -1,0 +1,296 @@
+//! ECDSA verification support.
+
+use super::{recoverable, Error, Signature};
+use crate::{
+    AffinePoint, CompressedPoint, EncodedPoint, FieldBytes, NistP256, ProjectivePoint, PublicKey,
+    Scalar,
+};
+use ecdsa_core::{hazmat::VerifyPrimitive, signature};
+use elliptic_curve::{
+    bigint::U256,
+    consts::U32,
+    ops::{Invert, LinearCombination, Reduce},
+    sec1::ToEncodedPoint,
+    AffineXCoordinate,
+};
+use signature::digest::{Digest, FixedOutput};
+use signature::DigestVerifier;
+
+#[cfg(feature = "sha256")]
+use signature::PrehashSignature;
+
+#[cfg(feature = "pkcs8")]
+use crate::pkcs8::{self, DecodePublicKey};
+
+#[cfg(feature = "pem")]
+use core::str::FromStr;
+
+#[cfg(all(feature = "pem", feature = "serde"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "serde"))))]
+use serdect::serde::{de, ser, Deserialize, Serialize};
+
+/// ECDSA/P-256 verification key (i.e. public key)
+///
+/// # `serde` support
+///
+/// When the `serde` feature of this crate is enabled, the `Serialize` and
+/// `Deserialize` traits are impl'd for this type.
+///
+/// The serialization is binary-oriented and supports ASN.1 DER-encoded
+/// X.509 Subject Public Key Info (SPKI) as the encoding format.
+///
+/// For a more text-friendly encoding of public keys, use
+/// [`elliptic_curve::JwkEcKey`] instead.
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct VerifyingKey {
+    /// Core ECDSA verify key
+    pub(super) inner: ecdsa_core::VerifyingKey<NistP256>,
+}
+
+impl VerifyingKey {
+    /// Initialize [`VerifyingKey`] from a SEC1-encoded public key.
+    pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        ecdsa_core::VerifyingKey::from_sec1_bytes(bytes).map(|key| VerifyingKey { inner: key })
+    }
+
+    /// Initialize [`VerifyingKey`] from a SEC1 [`EncodedPoint`].
+    // TODO(tarcieri): switch to using `FromEncodedPoint` trait?
+    pub fn from_encoded_point(public_key: &EncodedPoint) -> Result<Self, Error> {
+        ecdsa_core::VerifyingKey::from_encoded_point(public_key)
+            .map(|key| VerifyingKey { inner: key })
+    }
+
+    /// Serialize this [`VerifyingKey`] as a SEC1-encoded bytestring
+    /// (with point compression applied)
+    pub fn to_bytes(&self) -> CompressedPoint {
+        CompressedPoint::clone_from_slice(EncodedPoint::from(self).as_bytes())
+    }
+}
+
+#[cfg(feature = "sha256")]
+impl<S> signature::Verifier<S> for VerifyingKey
+where
+    S: PrehashSignature,
+    Self: DigestVerifier<S::Digest, S>,
+{
+    fn verify(&self, msg: &[u8], signature: &S) -> Result<(), Error> {
+        self.verify_digest(S::Digest::new_with_prefix(msg), signature)
+    }
+}
+
+impl<D> DigestVerifier<D, Signature> for VerifyingKey
+where
+    D: Digest + FixedOutput<OutputSize = U32>,
+{
+    fn verify_digest(&self, digest: D, signature: &Signature) -> Result<(), Error> {
+        self.inner.verify_digest(digest, signature)
+    }
+}
+
+impl<D> DigestVerifier<D, recoverable::Signature> for VerifyingKey
+where
+    D: Digest + FixedOutput<OutputSize = U32>,
+{
+    fn verify_digest(&self, digest: D, signature: &recoverable::Signature) -> Result<(), Error> {
+        self.inner
+            .verify_digest(digest, &Signature::from(*signature))
+    }
+}
+
+impl VerifyPrimitive<NistP256> for AffinePoint {
+    fn verify_prehashed(&self, z: FieldBytes, signature: &Signature) -> Result<(), Error> {
+        let (r, s) = signature.split_scalars();
+        let z = <Scalar as Reduce<U256>>::from_be_bytes_reduced(z);
+
+        let s_inv = *s.invert();
+        let u1 = z * s_inv;
+        let u2 = *r * s_inv;
+
+        let x = ProjectivePoint::lincomb(
+            &ProjectivePoint::GENERATOR,
+            &u1,
+            &ProjectivePoint::from(self),
+            &u2,
+        )
+        .to_affine()
+        .x();
+
+        if <Scalar as Reduce<U256>>::from_be_bytes_reduced(x).eq(&r) {
+            Ok(())
+        } else {
+            Err(Error::new())
+        }
+    }
+}
+
+impl From<PublicKey> for VerifyingKey {
+    fn from(public_key: PublicKey) -> VerifyingKey {
+        Self {
+            inner: public_key.into(),
+        }
+    }
+}
+
+impl From<&PublicKey> for VerifyingKey {
+    fn from(public_key: &PublicKey) -> VerifyingKey {
+        VerifyingKey::from(*public_key)
+    }
+}
+
+impl From<VerifyingKey> for PublicKey {
+    fn from(verifying_key: VerifyingKey) -> PublicKey {
+        verifying_key.inner.into()
+    }
+}
+
+impl From<&VerifyingKey> for PublicKey {
+    fn from(verifying_key: &VerifyingKey) -> PublicKey {
+        verifying_key.inner.into()
+    }
+}
+
+impl From<ecdsa_core::VerifyingKey<NistP256>> for VerifyingKey {
+    fn from(verifying_key: ecdsa_core::VerifyingKey<NistP256>) -> VerifyingKey {
+        VerifyingKey {
+            inner: verifying_key,
+        }
+    }
+}
+
+impl From<&VerifyingKey> for EncodedPoint {
+    fn from(verifying_key: &VerifyingKey) -> EncodedPoint {
+        verifying_key.to_encoded_point(true)
+    }
+}
+
+impl ToEncodedPoint<NistP256> for VerifyingKey {
+    fn to_encoded_point(&self, compress: bool) -> EncodedPoint {
+        self.inner.to_encoded_point(compress)
+    }
+}
+
+impl TryFrom<AffinePoint> for VerifyingKey {
+    type Error = Error;
+
+    fn try_from(affine_point: AffinePoint) -> Result<VerifyingKey, Error> {
+        let inner = PublicKey::try_from(affine_point)
+            .map_err(|_| Error::new())?
+            .into();
+
+        Ok(VerifyingKey { inner })
+    }
+}
+
+impl TryFrom<&AffinePoint> for VerifyingKey {
+    type Error = Error;
+
+    fn try_from(affine_point: &AffinePoint) -> Result<VerifyingKey, Error> {
+        VerifyingKey::try_from(*affine_point)
+    }
+}
+
+impl TryFrom<&EncodedPoint> for VerifyingKey {
+    type Error = Error;
+
+    fn try_from(encoded_point: &EncodedPoint) -> Result<Self, Error> {
+        Self::from_encoded_point(encoded_point)
+    }
+}
+
+impl From<VerifyingKey> for ProjectivePoint {
+    fn from(verifying_key: VerifyingKey) -> ProjectivePoint {
+        PublicKey::from(verifying_key.inner).into()
+    }
+}
+
+impl From<&VerifyingKey> for ProjectivePoint {
+    fn from(verifying_key: &VerifyingKey) -> ProjectivePoint {
+        PublicKey::from(verifying_key.inner).into()
+    }
+}
+
+impl TryFrom<ProjectivePoint> for VerifyingKey {
+    type Error = Error;
+
+    fn try_from(point: ProjectivePoint) -> Result<VerifyingKey, Error> {
+        AffinePoint::from(point).try_into()
+    }
+}
+
+impl TryFrom<&ProjectivePoint> for VerifyingKey {
+    type Error = Error;
+
+    fn try_from(point: &ProjectivePoint) -> Result<VerifyingKey, Error> {
+        AffinePoint::from(point).try_into()
+    }
+}
+
+#[cfg(feature = "pkcs8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
+impl TryFrom<pkcs8::SubjectPublicKeyInfo<'_>> for VerifyingKey {
+    type Error = pkcs8::spki::Error;
+
+    fn try_from(spki: pkcs8::SubjectPublicKeyInfo<'_>) -> pkcs8::spki::Result<Self> {
+        PublicKey::try_from(spki).map(|pk| Self { inner: pk.into() })
+    }
+}
+
+#[cfg(feature = "pkcs8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
+impl DecodePublicKey for VerifyingKey {}
+
+#[cfg(feature = "pem")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+impl FromStr for VerifyingKey {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        Self::from_public_key_pem(s).map_err(|_| Error::new())
+    }
+}
+
+#[cfg(all(feature = "pem", feature = "serde"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "serde"))))]
+impl Serialize for VerifyingKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        self.inner.serialize(serializer)
+    }
+}
+
+#[cfg(all(feature = "pem", feature = "serde"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "serde"))))]
+impl<'de> Deserialize<'de> for VerifyingKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        ecdsa_core::VerifyingKey::<NistP256>::deserialize(deserializer).map(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // use super::VerifyingKey;
+    use crate::{ecdsa::verify::VerifyingKey, test_vectors::ecdsa::ECDSA_TEST_VECTORS, NistP256};
+    use ecdsa_core::signature::Verifier;
+    use hex_literal::hex;
+
+    ecdsa_core::new_verification_test!(NistP256, ECDSA_TEST_VECTORS);
+
+    /// Wycheproof tcId: 304
+    #[test]
+    fn malleability_edge_case_valid() {
+        let verifying_key_bytes =
+            hex!("02c156afee1ce52ef83a0dd168c1144eb20008697e6664fa132ba23c128cce8055");
+        let verifying_key = VerifyingKey::from_sec1_bytes(&verifying_key_bytes).unwrap();
+
+        let msg = hex!("313233343030");
+        let sig = Signature::from_der(&hex!("30440220784eea04d4a9e68260ba55b39277b2221db3793e47ec5c9301e43b45c7285792022016c4c411c20aa62c314ad383d00aa1e6c145641d7ce10e52075fb10e7d8bec2b")).unwrap();
+        assert!(sig.normalize_s().is_none()); // Ensure signature is already normalized
+        assert!(verifying_key.verify(&msg, &sig).is_ok());
+    }
+}

--- a/weierstrass/src/affine.rs
+++ b/weierstrass/src/affine.rs
@@ -64,6 +64,11 @@ where
         Choice::from(self.infinity)
     }
 
+    /// Indicates the parity of coordinate Y.
+    pub fn is_y_odd(self) -> bool {
+        self.y.is_odd().into()
+    }
+
     /// Conditionally negate [`AffinePoint`] for use with point compaction.
     fn to_compact(self) -> Self {
         let neg_self = -self;


### PR DESCRIPTION
This merge request adds support for recovering the public key from a signature. Most of the new code is identical to the `secp256k1` implementation. Only the `try_sign_prehashed` method of `SignPrimitive<NistP256>` trait was slightly modified to produce valid Nist P-256 (`s`, `v`) values.

Also, it adds a public method `is_y_odd` to AffinePoint type in `weierstrass` crate to avoid making the `y` coordinate public.

Issue: #642