### PR TITLE
k256 v0.11.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "blobby",
  "cfg-if",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.5 (2022-09-14)
+### Added
+- Impl `PrehashSigner` and `PrehashVerifier` traits for ECDSA keys ([#653])
+- Impl `Keypair` for `SigningKey` ([#654])
+
+[#653]: https://github.com/RustCrypto/elliptic-curves/pull/653
+[#654]: https://github.com/RustCrypto/elliptic-curves/pull/654
+
 ## 0.11.4 (2022-08-13)
 ### Added
 - Impl `ZeroizeOnDrop` for `ecdsa::SigningKey` and `schnorr::SigningKey` ([#630])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.11.4"
+version = "0.11.5"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification (including Ethereum-style signatures with public-key
@@ -22,7 +22,7 @@ cfg-if = "1.0"
 elliptic-curve = { version = "0.12.3", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.14.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }


### PR DESCRIPTION
### Added
- Impl `PrehashSigner` and `PrehashVerifier` traits for ECDSA keys ([#653])
- Impl `Keypair` for `SigningKey` ([#654])

[#653]: https://github.com/RustCrypto/elliptic-curves/pull/653
[#654]: https://github.com/RustCrypto/elliptic-curves/pull/654