### PR TITLE
k256 v0.11.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "blobby",
  "cfg-if",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.6 (2022-09-27)
+### Added
+- `ecdsa::recoverable::Signature::from_digest_bytes_trial_recovery` ([#660])
+
+### Changed
+- Make `ProjectivePoint` equality and `is_identity` faster ([#650])
+
+[#650]: https://github.com/RustCrypto/elliptic-curves/pull/650
+[#660]: https://github.com/RustCrypto/elliptic-curves/pull/660
+
 ## 0.11.5 (2022-09-14)
 ### Added
 - Impl `PrehashSigner` and `PrehashVerifier` traits for ECDSA keys ([#653])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.11.5"
+version = "0.11.6"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification (including Ethereum-style signatures with public-key


### PR DESCRIPTION
### Added
- `ecdsa::recoverable::Signature::from_digest_bytes_trial_recovery` ([#660])

### Changed
- Make `ProjectivePoint` equality and `is_identity` faster ([#650])

[#650]: https://github.com/RustCrypto/elliptic-curves/pull/650
[#660]: https://github.com/RustCrypto/elliptic-curves/pull/660