### PR TITLE
p256,p384: test larger and smaller prehash operation

### DIFF
--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -80,13 +80,21 @@ impl VerifyPrimitive<NistP256> for AffinePoint {}
 #[cfg(all(test, feature = "ecdsa"))]
 mod tests {
     use crate::{
-        ecdsa::{signature::Signer, SigningKey},
+        ecdsa::{
+            signature::hazmat::{PrehashSigner, PrehashVerifier},
+            signature::Signer,
+            Signature, SigningKey, VerifyingKey,
+        },
         test_vectors::ecdsa::ECDSA_TEST_VECTORS,
-        BlindedScalar, Scalar,
+        AffinePoint, BlindedScalar, EncodedPoint, Scalar,
     };
     use ecdsa_core::hazmat::SignPrimitive;
-    use elliptic_curve::{generic_array::GenericArray, group::ff::PrimeField, rand_core::OsRng};
+    use elliptic_curve::{
+        generic_array::GenericArray, group::ff::PrimeField, rand_core::OsRng,
+        sec1::FromEncodedPoint,
+    };
     use hex_literal::hex;
+    use sha2::Digest;
 
     // Test vector from RFC 6979 Appendix 2.5 (NIST P-256 + SHA-256)
     // <https://tools.ietf.org/html/rfc6979#appendix-A.2.5>
@@ -110,6 +118,57 @@ mod tests {
                 019f4113742a2b14bd25926b49c649155f267e60d3814b4c0cc84250e46f0083"
             )[..]
         );
+    }
+
+    // Test signing with PrehashSigner using SHA-384 which output is larger than P-256 field size.
+    #[test]
+    fn prehash_signer_signing_with_sha384() {
+        let x = &hex!("c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721");
+        let signer = SigningKey::from_bytes(x).unwrap();
+        let digest = sha2::Sha384::digest(b"test");
+        let signature = signer.sign_prehash(&digest).unwrap();
+        assert_eq!(
+            signature.as_ref(),
+            &hex!(
+                "ebde85f1539af67e70dd7a8a6afeeb332aa7f08f01ebb6ab6e04e2a62d2fef75
+                871af45800daddf55619b005a601a7a84f544260f1d2625b2ef5aa7a4f4dd76f"
+            )[..]
+        );
+    }
+
+    // Test verifying with PrehashVerifier using SHA-256 which output is larger than P-256 field size.
+    #[test]
+    fn prehash_signer_verification_with_sha384() {
+        // The following test vector adapted from the FIPS 186-4 ECDSA test vectors
+        // (P-256, SHA-384, from `SigGen.txt` in `186-4ecdsatestvectors.zip`)
+        // <https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/digital-signatures>
+        let verifier = VerifyingKey::from_affine(
+            AffinePoint::from_encoded_point(&EncodedPoint::from_affine_coordinates(
+                GenericArray::from_slice(&hex!(
+                    "e0e7b99bc62d8dd67883e39ed9fa0657789c5ff556cc1fd8dd1e2a55e9e3f243"
+                )),
+                GenericArray::from_slice(&hex!(
+                    "63fbfd0232b95578075c903a4dbf85ad58f8350516e1ec89b0ee1f5e1362da69"
+                )),
+                false,
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        let signature = Signature::from_scalars(
+            GenericArray::clone_from_slice(&hex!(
+                "f5087878e212b703578f5c66f434883f3ef414dc23e2e8d8ab6a8d159ed5ad83"
+            )),
+            GenericArray::clone_from_slice(&hex!(
+                "306b4c6c20213707982dffbb30fba99b96e792163dd59dbe606e734328dd7c8a"
+            )),
+        )
+        .unwrap();
+        let result = verifier.verify_prehash(
+            &hex!("d9c83b92fa0979f4a5ddbd8dd22ab9377801c3c31bf50f932ace0d2146e2574da0d5552dbed4b18836280e9f94558ea6"),
+            &signature,
+        );
+        assert!(result.is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Add integration tests to verify the following scenarios:

- P-256 ECDSA signing/verification with SHA-384 (longer than field size)
- P-384 ECDSA signing/verification with SHA-256 (smaller than field size)

Verification scenarios use a test vector adopted from FIPS 186-4.

Signing scenarios use a key from RFC6979 test vector but the test signature is pre-calculated using ecdsa crate (with the following fix applied) and cross-verified using OpenSSL. Unfortunately there are no suitable test vector to test `DigestPrimitive::prehash_to_field_bytes` through `PrehashSigner`.

The tests added in p384 currently fails and a fix has been submitted separately at https://github.com/RustCrypto/signatures/pull/547

@tarcieri PTAL cc/ @aumetra 