### PR TITLE
Add `alloc` feature

### DIFF
--- a/.github/workflows/bp256.yml
+++ b/.github/workflows/bp256.yml
@@ -38,6 +38,7 @@ jobs:
           override: true
           profile: minimal
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8

--- a/.github/workflows/bp384.yml
+++ b/.github/workflows/bp384.yml
@@ -38,6 +38,7 @@ jobs:
           override: true
           profile: minimal
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8

--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -38,6 +38,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdh

--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -38,6 +38,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdh

--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -38,6 +38,7 @@ jobs:
           override: true
           profile: minimal
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa-core
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features jwk

--- a/.github/workflows/p521.yml
+++ b/.github/workflows/p521.yml
@@ -38,6 +38,7 @@ jobs:
           override: true
           profile: minimal
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
 
   test:
     runs-on: ubuntu-latest

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -21,11 +21,13 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 
 [features]
 default = ["pkcs8", "std"]
+alloc = ["elliptic-curve/alloc"]
+std = ["alloc", "elliptic-curve/std"]
+
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa/serde", "elliptic-curve/serde"]
 sha256 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
-std = ["elliptic-curve/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -21,11 +21,13 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 
 [features]
 default = ["pkcs8", "std"]
+alloc = ["elliptic-curve/alloc"]
+std = ["alloc", "elliptic-curve/std"]
+
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa/serde", "elliptic-curve/serde"]
 sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
-std = ["elliptic-curve/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -40,6 +40,9 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pkcs8", "schnorr", "std"]
+alloc = ["elliptic-curve/alloc"]
+std = ["alloc", "ecdsa-core/std", "elliptic-curve/std"] # TODO: use weak activation for `ecdsa-core/std` when available
+
 arithmetic = ["elliptic-curve/arithmetic"]
 bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
@@ -54,7 +57,6 @@ pkcs8 = ["ecdsa-core/pkcs8", "elliptic-curve/pkcs8"]
 schnorr = ["arithmetic", "sha256"]
 serde = ["ecdsa-core/serde", "elliptic-curve/serde", "serdect"]
 sha256 = ["digest", "sha2"]
-std = ["ecdsa-core/std", "elliptic-curve/std"] # TODO: use weak activation for `ecdsa-core/std` when available
 test-vectors = ["hex-literal"]
 
 [package.metadata.docs.rs]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -36,6 +36,9 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pkcs8", "std"]
+alloc = ["elliptic-curve/alloc"]
+std = ["alloc", "ecdsa-core/std", "elliptic-curve/std"] # TODO: use weak activation for `ecdsa-core/std` when available
+
 arithmetic = ["elliptic-curve/arithmetic"]
 bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
@@ -48,7 +51,6 @@ pem = ["elliptic-curve/pem", "ecdsa-core/pem", "pkcs8"]
 pkcs8 = ["ecdsa-core/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa-core/serde", "elliptic-curve/serde", "serdect"]
 sha256 = ["digest", "sha2"]
-std = ["ecdsa-core/std", "elliptic-curve/std"] # TODO: use weak activation for `ecdsa-core/std` when available
 test-vectors = ["hex-literal"]
 voprf = ["elliptic-curve/voprf", "sha2"]
 

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -36,6 +36,9 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
 default = ["arithmetic", "ecdh", "ecdsa", "pem", "std"]
+alloc = ["elliptic-curve/alloc"]
+std = ["alloc", "ecdsa-core/std", "elliptic-curve/std"] # TODO: use weak activation for `ecdsa-core/std` when available
+
 arithmetic = ["elliptic-curve/arithmetic", "elliptic-curve/digest"]
 bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
@@ -48,7 +51,6 @@ pem = ["elliptic-curve/pem", "ecdsa-core/pem", "pkcs8"]
 pkcs8 = ["ecdsa-core/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa-core/serde", "elliptic-curve/serde", "serdect"]
 sha384 = ["digest", "sha2"]
-std = ["ecdsa-core/std", "elliptic-curve/std"]
 test-vectors = ["hex-literal"]
 voprf = ["elliptic-curve/voprf", "sha2"]
 

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -17,7 +17,9 @@ elliptic-curve = { version = "0.12.3", default-features = false, features = ["ha
 
 [features]
 default = ["pem", "std"]
+alloc = ["elliptic-curve/alloc"]
+std = ["alloc", "elliptic-curve/std"] # TODO: use weak activation for `ecdsa-core/std` when available
+
 jwk = ["elliptic-curve/jwk"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8"]
-std = ["elliptic-curve/std"]


### PR DESCRIPTION
Adds an `alloc` feature to all crates which enables `elliptic-curve/alloc`.

When weak feature activation is MSRV-compatible, we can use it to enable the alloc feature of all dependencies.