### PR TITLE
k256: implement `FromOkm` for `Scalar`

### DIFF
--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -75,7 +75,7 @@ const FRAC_MODULUS_2: U256 = ORDER.shr_vartime(1);
 /// textual formats, the binary data is encoded as hexadecimal.
 #[derive(Clone, Copy, Debug, Default)]
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-pub struct Scalar(U256);
+pub struct Scalar(pub(crate) U256);
 
 impl Scalar {
     /// Zero scalar.


### PR DESCRIPTION
[FROST uses hash2field in the Scalar field](https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.4-2.2.1). When [adding support for the secp256k1 curve](https://github.com/ZcashFoundation/frost/issues/19), I noticed that k256 does not support the required FromOkm to make that happen, while p256 does support it.

I did the obvious thing and copied the p256 implementation. Let me know if you'd like another approach.