### PR TITLE
Bump `ecdsa` crate to v0.15.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,9 +317,8 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+version = "0.15.0-pre"
+source = "git+https://github.com/RustCrypto/signatures.git#1578fe31b96cad80afdc1be47e5f0d088bd5bc2b"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -514,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.11.6"
+version = "0.12.0-pre"
 dependencies = [
  "blobby",
  "cfg-if",
@@ -871,9 +870,8 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c86280f057430a52f4861551b092a01b419b8eacefc7c995eacb9dc132fe32"
+version = "0.3.1"
+source = "git+https://github.com/RustCrypto/signatures.git#1578fe31b96cad80afdc1be47e5f0d088bd5bc2b"
 dependencies = [
  "crypto-bigint",
  "hmac",
@@ -992,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.2"
+version = "2.0.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a622c5fc69cf2a070d3217981bded5071cdd1b1ac17ae906646debae83579b54"
+checksum = "3b7d7471fcfa786b75b657061bd5bf1d51179b3aac54db33bba7e44f5a4b5b75"
 dependencies = [
  "digest",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.57"
 elliptic-curve = { version = "0.12", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.14", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.15.0-pre", optional = true, default-features = false, features = ["der"] }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [features]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.57"
 elliptic-curve = { version = "0.12", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.14", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.15.0-pre", optional = true, default-features = false, features = ["der"] }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [features]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.11.6"
+version = "0.12.0-pre"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification (including Ethereum-style signatures with public-key
@@ -22,7 +22,7 @@ cfg-if = "1.0"
 elliptic-curve = { version = "0.12.3", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.14.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.15.0-pre", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
@@ -31,7 +31,7 @@ sha3 = { version = "0.10", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.4"
-ecdsa-core = { version = "0.14", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.15.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -13,7 +13,7 @@ use elliptic_curve::{
     generic_array::arr,
     group::ff::{Field, PrimeField},
     ops::{Reduce, ReduceNonZero},
-    rand_core::{CryptoRng, RngCore},
+    rand_core::{CryptoRngCore, RngCore},
     subtle::{
         Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
         CtOption,
@@ -184,7 +184,7 @@ impl Scalar {
     }
 
     /// Returns a (nearly) uniformly-random scalar, generated in constant time.
-    pub fn generate_biased(mut rng: impl CryptoRng + RngCore) -> Self {
+    pub fn generate_biased(rng: &mut impl CryptoRngCore) -> Self {
         // We reduce a random 512-bit value into a 256-bit field, which results in a
         // negligible bias from the uniform distribution, but the process is constant-time.
         let mut buf = [0u8; 64];
@@ -194,7 +194,7 @@ impl Scalar {
 
     /// Returns a uniformly-random scalar, generated using rejection sampling.
     // TODO(tarcieri): make this a `CryptoRng` when `ff` allows it
-    pub fn generate_vartime(mut rng: impl RngCore) -> Self {
+    pub fn generate_vartime(rng: &mut impl RngCore) -> Self {
         let mut bytes = FieldBytes::default();
 
         // TODO: pre-generate several scalars to bring the probability of non-constant-timeness down?
@@ -223,7 +223,7 @@ impl Scalar {
 }
 
 impl Field for Scalar {
-    fn random(rng: impl RngCore) -> Self {
+    fn random(mut rng: impl RngCore) -> Self {
         // Uses rejection sampling as the default random generation method,
         // which produces a uniformly random distribution of scalars.
         //
@@ -233,7 +233,7 @@ impl Field for Scalar {
         //
         // With an unbiased RNG, the probability of failing to complete after 4
         // iterations is vanishingly small.
-        Self::generate_vartime(rng)
+        Self::generate_vartime(&mut rng)
     }
 
     fn zero() -> Self {

--- a/k256/src/ecdsa/normalize.rs
+++ b/k256/src/ecdsa/normalize.rs
@@ -5,13 +5,12 @@
 #[cfg(all(test, feature = "ecdsa"))]
 mod tests {
     use crate::ecdsa::Signature;
-    use ecdsa_core::signature::Signature as _;
 
     // Test vectors generated using rust-secp256k1
     #[test]
     #[rustfmt::skip]
     fn normalize_s_high() {
-        let sig_hi = Signature::from_bytes(&[
+        let sig_hi = Signature::try_from([
             0x20, 0xc0, 0x1a, 0x91, 0x0e, 0xbb, 0x26, 0x10,
             0xaf, 0x2d, 0x76, 0x3f, 0xa0, 0x9b, 0x3b, 0x30,
             0x92, 0x3c, 0x8e, 0x40, 0x8b, 0x11, 0xdf, 0x2c,
@@ -20,9 +19,9 @@ mod tests {
             0x61, 0x7d, 0x13, 0x57, 0xf4, 0xd5, 0x56, 0x41,
             0x09, 0x0a, 0x48, 0xf2, 0x01, 0xe9, 0xb9, 0x59,
             0xc4, 0x8f, 0x6f, 0x6b, 0xec, 0x6f, 0x93, 0x8f,
-        ]).unwrap();
+        ].as_slice()).unwrap();
 
-        let sig_lo = Signature::from_bytes(&[
+        let sig_lo = Signature::try_from([
             0x20, 0xc0, 0x1a, 0x91, 0x0e, 0xbb, 0x26, 0x10,
             0xaf, 0x2d, 0x76, 0x3f, 0xa0, 0x9b, 0x3b, 0x30,
             0x92, 0x3c, 0x8e, 0x40, 0x8b, 0x11, 0xdf, 0x2c,
@@ -31,7 +30,7 @@ mod tests {
             0x9e, 0x82, 0xec, 0xa8, 0x0b, 0x2a, 0xa9, 0xbd,
             0xb1, 0xa4, 0x93, 0xf4, 0xad, 0x5e, 0xe6, 0xe1,
             0xfb, 0x42, 0xef, 0x20, 0xe3, 0xc6, 0xad, 0xb2,
-        ]).unwrap();
+        ].as_slice()).unwrap();
 
         let sig_normalized = sig_hi.normalize_s().unwrap();
         assert_eq!(sig_lo, sig_normalized);
@@ -40,12 +39,12 @@ mod tests {
     #[test]
     fn normalize_s_low() {
         #[rustfmt::skip]
-            let sig = Signature::from_bytes(&[
+        let sig = Signature::try_from([
             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ]).unwrap();
+        ].as_slice()).unwrap();
 
         assert_eq!(sig.normalize_s(), None);
     }

--- a/k256/src/schnorr/verify.rs
+++ b/k256/src/schnorr/verify.rs
@@ -34,7 +34,7 @@ impl VerifyingKey {
 
         let e = <Scalar as Reduce<U256>>::from_be_bytes_reduced(
             tagged_hash(CHALLENGE_TAG)
-                .chain_update(&sig.bytes[..32])
+                .chain_update(sig.r.to_bytes())
                 .chain_update(self.to_bytes())
                 .chain_update(msg_digest)
                 .finalize(),

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -21,7 +21,7 @@ elliptic-curve = { version = "0.12", default-features = false, features = ["hazm
 weierstrass = { version = "0", path = "../weierstrass" }
 
 # optional dependencies
-ecdsa-core = { version = "0.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.15.0-pre", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
@@ -29,7 +29,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.4"
-ecdsa-core = { version = "0.14", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.15.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p256/src/arithmetic/scalar/blinded.rs
+++ b/p256/src/arithmetic/scalar/blinded.rs
@@ -6,11 +6,7 @@
 use super::Scalar;
 use core::borrow::Borrow;
 use elliptic_curve::{
-    group::ff::Field,
-    ops::Invert,
-    rand_core::{CryptoRng, RngCore},
-    subtle::CtOption,
-    zeroize::Zeroize,
+    group::ff::Field, ops::Invert, rand_core::CryptoRngCore, subtle::CtOption, zeroize::Zeroize,
 };
 
 /// Scalar blinded with a randomly generated masking value.
@@ -28,8 +24,8 @@ pub struct BlindedScalar {
 }
 
 impl BlindedScalar {
-    /// Create a new [`BlindedScalar`] from a scalar and a [`CryptoRng`]
-    pub fn new(scalar: Scalar, rng: impl CryptoRng + RngCore) -> Self {
+    /// Create a new [`BlindedScalar`] from a scalar and a [`CryptoRngCore`]
+    pub fn new(scalar: Scalar, rng: &mut impl CryptoRngCore) -> Self {
         Self {
             scalar,
             mask: Scalar::random(rng),

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -29,7 +29,7 @@
 //! // Signing
 //! let signing_key = SigningKey::random(&mut OsRng); // Serialize with `::to_bytes()`
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
-//! let signature = signing_key.sign(message);
+//! let signature: Signature = signing_key.sign(message);
 //!
 //! // Verification
 //! use p256::ecdsa::{VerifyingKey, signature::Verifier};
@@ -102,21 +102,21 @@ mod tests {
     fn rfc6979() {
         let x = &hex!("c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721");
         let signer = SigningKey::from_bytes(x).unwrap();
-        let signature = signer.sign(b"sample");
+        let signature: Signature = signer.sign(b"sample");
         assert_eq!(
-            signature.as_ref(),
+            signature.to_bytes().as_slice(),
             &hex!(
                 "efd48b2aacb6a8fd1140dd9cd45e81d69d2c877b56aaf991c34d0ea84eaf3716
-                     f7cb1c942d657c41d436c7a1b6e29f65f3e900dbb9aff4064dc4ab2f843acda8"
-            )[..]
+                 f7cb1c942d657c41d436c7a1b6e29f65f3e900dbb9aff4064dc4ab2f843acda8"
+            )
         );
-        let signature = signer.sign(b"test");
+        let signature: Signature = signer.sign(b"test");
         assert_eq!(
-            signature.as_ref(),
+            signature.to_bytes().as_slice(),
             &hex!(
                 "f1abb023518351cd71d881567b1ea663ed3efcf6c5132b354f28d3b0b7d38367
-                019f4113742a2b14bd25926b49c649155f267e60d3814b4c0cc84250e46f0083"
-            )[..]
+                 019f4113742a2b14bd25926b49c649155f267e60d3814b4c0cc84250e46f0083"
+            )
         );
     }
 
@@ -126,13 +126,13 @@ mod tests {
         let x = &hex!("c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721");
         let signer = SigningKey::from_bytes(x).unwrap();
         let digest = sha2::Sha384::digest(b"test");
-        let signature = signer.sign_prehash(&digest).unwrap();
+        let signature: Signature = signer.sign_prehash(&digest).unwrap();
         assert_eq!(
-            signature.as_ref(),
+            signature.to_bytes().as_slice(),
             &hex!(
                 "ebde85f1539af67e70dd7a8a6afeeb332aa7f08f01ebb6ab6e04e2a62d2fef75
-                871af45800daddf55619b005a601a7a84f544260f1d2625b2ef5aa7a4f4dd76f"
-            )[..]
+                 871af45800daddf55619b005a601a7a84f544260f1d2625b2ef5aa7a4f4dd76f"
+            )
         );
     }
 

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -21,7 +21,7 @@ elliptic-curve = { version = "0.12", default-features = false, features = ["hazm
 weierstrass = { version = "0", path = "../weierstrass" }
 
 # optional dependencies
-ecdsa-core = { version = "0.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.15.0-pre", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
@@ -29,7 +29,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.4"
-ecdsa-core = { version = "0.14", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.15.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p384/src/ecdsa.rs
+++ b/p384/src/ecdsa.rs
@@ -27,7 +27,7 @@
 //! // Signing
 //! let signing_key = SigningKey::random(&mut OsRng); // Serialize with `::to_bytes()`
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
-//! let signature = signing_key.sign(message);
+//! let signature: Signature = signing_key.sign(message);
 //!
 //! // Verification
 //! use p384::ecdsa::{signature::Verifier, VerifyingKey};
@@ -95,21 +95,22 @@ mod tests {
     fn rfc6979() {
         let x = &hex!("6b9d3dad2e1b8c1c05b19875b6659f4de23c3b667bf297ba9aa47740787137d896d5724e4c70a825f872c9ea60d2edf5");
         let signer = SigningKey::from_bytes(x).unwrap();
-        let signature = signer.sign(b"sample");
+        let signature: Signature = signer.sign(b"sample");
         assert_eq!(
-            signature.as_ref(),
+            signature.to_bytes().as_slice(),
             &hex!(
                 "94edbb92a5ecb8aad4736e56c691916b3f88140666ce9fa73d64c4ea95ad133c81a648152e44acf96e36dd1e80fabe46
                 99ef4aeb15f178cea1fe40db2603138f130e740a19624526203b6351d0a3a94fa329c145786e679e7b82c71a38628ac8"
-            )[..]
+            )
         );
-        let signature = signer.sign(b"test");
+
+        let signature: Signature = signer.sign(b"test");
         assert_eq!(
-            signature.as_ref(),
+            signature.to_bytes().as_slice(),
             &hex!(
                 "8203b63d3c853e8d77227fb377bcf7b7b772e97892a80f36ab775d509d7a5feb0542a7f0812998da8f1dd3ca3cf023db
                 ddd0760448d42d8a43af45af836fce4de8be06b485e9b61b827c2f13173923e06a739f040649a667bf3b828246baa5a5"
-            )[..]
+            )
         );
     }
 
@@ -119,13 +120,13 @@ mod tests {
         let x = &hex!("6b9d3dad2e1b8c1c05b19875b6659f4de23c3b667bf297ba9aa47740787137d896d5724e4c70a825f872c9ea60d2edf5");
         let signer = SigningKey::from_bytes(x).unwrap();
         let digest = sha2::Sha256::digest(b"test");
-        let signature = signer.sign_prehash(&digest).unwrap();
+        let signature: Signature = signer.sign_prehash(&digest).unwrap();
         assert_eq!(
-            signature.as_ref(),
+            signature.to_bytes().as_slice(),
             &hex!(
                 "010c3ab1a300f8c9d63eafa9a41813f0c5416c08814bdfc0236458d6c2603d71c4941f4696e60aff5717476170bb6ab4
                 03c4ad6274c61691346b2178def879424726909af308596ffb6355a042f48a114e2eb28eaa6918592b4727961057c0c1"
-            )[..]
+            )
         );
     }
 


### PR DESCRIPTION
This (unpublished) prerelease of the `ecdsa` crate impl's the prospective `signature` v2 API from: RustCrypto/traits#1141