### PR TITLE
p256+p384: add `arithmetic` doc cfg

### DIFF
--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -14,11 +14,14 @@ use elliptic_curve::{
 use primeorder::PrimeOrderCurve;
 
 /// Elliptic curve point in affine coordinates.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type AffinePoint = primeorder::AffinePoint<NistP256>;
 
 /// Elliptic curve point in projective coordinates.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type ProjectivePoint = primeorder::ProjectivePoint<NistP256>;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl PrimeOrderCurve for NistP256 {
     type FieldElement = FieldElement;
 
@@ -53,18 +56,22 @@ impl PrimeOrderCurve for NistP256 {
     );
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl AffineArithmetic for NistP256 {
     type AffinePoint = AffinePoint;
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl ProjectiveArithmetic for NistP256 {
     type ProjectivePoint = ProjectivePoint;
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl PrimeCurveArithmetic for NistP256 {
     type CurveGroup = ProjectivePoint;
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl ScalarArithmetic for NistP256 {
     type Scalar = Scalar;
 }

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -134,10 +134,12 @@ pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP256>;
 
 /// Non-zero NIST P-256 scalar field element.
 #[cfg(feature = "arithmetic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type NonZeroScalar = elliptic_curve::NonZeroScalar<NistP256>;
 
 /// NIST P-256 public key.
 #[cfg(feature = "arithmetic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type PublicKey = elliptic_curve::PublicKey<NistP256>;
 
 /// NIST P-256 secret key.

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -19,9 +19,11 @@ use elliptic_curve::{
 use primeorder::PrimeOrderCurve;
 
 /// Elliptic curve point in affine coordinates.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type AffinePoint = primeorder::AffinePoint<NistP384>;
 
 /// Elliptic curve point in projective coordinates.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type ProjectivePoint = primeorder::ProjectivePoint<NistP384>;
 
 impl PrimeOrderCurve for NistP384 {

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -97,10 +97,12 @@ pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP384>;
 
 /// Non-zero NIST P-384 scalar field element.
 #[cfg(feature = "arithmetic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type NonZeroScalar = elliptic_curve::NonZeroScalar<NistP384>;
 
 /// NIST P-384 public key.
 #[cfg(feature = "arithmetic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type PublicKey = elliptic_curve::PublicKey<NistP384>;
 
 /// NIST P-384 secret key.


### PR DESCRIPTION
Add a rustdoc note that the `arithmetic` feature must be enabled for types like `AffinePoint`, `NonZeroScalar`, and `ProjectivePoint`.