### PR TITLE
k256: add `schnorr::SigningKey::as_nonzero_scalar`

### DIFF
--- a/k256/src/schnorr/sign.rs
+++ b/k256/src/schnorr/sign.rs
@@ -75,6 +75,17 @@ impl SigningKey {
         &self.verifying_key
     }
 
+    /// Borrow the secret [`NonZeroScalar`] value for this key.
+    ///
+    /// # ⚠️ Warning
+    ///
+    /// This value is key material.
+    ///
+    /// Please treat it with the care it deserves!
+    pub fn as_nonzero_scalar(&self) -> &NonZeroScalar {
+        &self.secret_key
+    }
+
     /// Compute Schnorr signature.
     ///
     /// # ⚠️ Warning


### PR DESCRIPTION
Adds an accessor for the inner `NonZeroScalar` value that represents a Schnorr secret key.