### PR TITLE
Scalar multiplication by the generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d299f547288d6db8d5c3a2916f7b2f66134b15b8c1ac1c4357dd3b8752af7bb2"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +234,12 @@ dependencies = [
  "cast",
  "itertools",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crossbeam-channel"
@@ -524,6 +539,7 @@ dependencies = [
  "hex-literal",
  "num-bigint",
  "num-traits",
+ "once_cell",
  "proptest",
  "rand_core",
  "serdect",
@@ -610,9 +626,13 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+dependencies = [
+ "atomic-polyfill",
+ "critical-section",
+]
 
 [[package]]
 name = "oorandom"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,6 +20,7 @@ rust-version = "1.60"
 [dependencies]
 cfg-if = "1.0"
 elliptic-curve = { version = "0.12.3", default-features = false, features = ["hazmat", "sec1"] }
+once_cell = { version = "1.16", default-features = false, features = ["critical-section"] }
 
 # optional dependencies
 ecdsa-core = { version = "=0.15.0-rc.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/k256/benches/scalar.rs
+++ b/k256/benches/scalar.rs
@@ -6,7 +6,7 @@ use criterion::{
 use hex_literal::hex;
 use k256::{
     elliptic_curve::{generic_array::arr, group::ff::PrimeField, ops::LinearCombination},
-    ProjectivePoint, Scalar,
+    mul_by_generator, ProjectivePoint, Scalar,
 };
 
 fn test_scalar_x() -> Scalar {
@@ -44,9 +44,21 @@ fn bench_point_lincomb<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     });
 }
 
+fn bench_point_mul_by_generator<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
+    let p = ProjectivePoint::GENERATOR;
+    let x = test_scalar_x();
+
+    group.bench_function("mul_by_generator naive", |b| b.iter(|| &p * &x));
+
+    group.bench_function("mul_by_generator precomputed", |b| {
+        b.iter(|| mul_by_generator(&x))
+    });
+}
+
 fn bench_high_level(c: &mut Criterion) {
     let mut group = c.benchmark_group("high-level operations");
     bench_point_mul(&mut group);
+    bench_point_mul_by_generator(&mut group);
     bench_point_lincomb(&mut group);
     group.finish();
 }

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -12,6 +12,7 @@ pub(crate) mod scalar;
 mod dev;
 
 pub use field::FieldElement;
+pub use mul::mul_by_generator;
 
 use affine::AffinePoint;
 use projective::ProjectivePoint;

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -157,7 +157,7 @@ use crate::Secp256k1;
 
 #[cfg(feature = "ecdsa")]
 use {
-    crate::{AffinePoint, FieldBytes, ProjectivePoint, Scalar, U256},
+    crate::{arithmetic::mul_by_generator, AffinePoint, FieldBytes, Scalar, U256},
     core::borrow::Borrow,
     ecdsa_core::hazmat::{SignPrimitive, VerifyPrimitive},
     elliptic_curve::{
@@ -212,7 +212,7 @@ impl SignPrimitive<Secp256k1> for Scalar {
         let k_inverse = k_inverse.unwrap();
 
         // Compute 𝐑 = 𝑘×𝑮
-        let R = (ProjectivePoint::GENERATOR * k).to_affine();
+        let R = mul_by_generator(k).to_affine();
 
         // Lift x-coordinate of 𝐑 (element of base field) into a serialized big
         // integer, then reduce it into an element of the scalar field

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -48,7 +48,9 @@ pub mod test_vectors;
 pub use elliptic_curve::{self, bigint::U256};
 
 #[cfg(feature = "arithmetic")]
-pub use arithmetic::{affine::AffinePoint, projective::ProjectivePoint, scalar::Scalar};
+pub use arithmetic::{
+    affine::AffinePoint, mul_by_generator, projective::ProjectivePoint, scalar::Scalar,
+};
 
 #[cfg(feature = "expose-field")]
 pub use arithmetic::FieldElement;


### PR DESCRIPTION
This PR introduces a way to multiply a scalar by the generator by keeping precomputed lookup tables. It is exported as `mul_by_generator()` (and used in the signing code). It takes 40us compared to 86us for regular multiplication; signing takes 70us compared to 116us.

The precomputed table contains values for every second radix and takes ~30kb; if we calculated it for every radix it would take 60kb with the performance improvement of only ~3%, so I don't think it is worth it (the same choice was taken by https://github.com/dalek-cryptography/curve25519-dalek).

I am not sure how to speed up the verification, which relies on calculating `k1 * G + k2 * x`. Pre-calculating lookup tables for `G` in `lincomb` only speeds it up from 129us to 122us on my machine. Calculating `k1 * G` via `mul_by_generator()` results in the timing of 126us. Not great, any ideas are welcome.

The precomputed tables use `once_cell`. Note that the feature `critical-section` of `once_cell` (which we need to use to support `no_std`) has the MSRV of 1.63. Proper gating is up to @tarcieri 