### PR TITLE
Lint improvements

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.60.0
+        toolchain: 1.66.0
         components: clippy
         override: true
         profile: minimal

--- a/bp256/src/lib.rs
+++ b/bp256/src/lib.rs
@@ -6,7 +6,14 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 pub mod r1;
 pub mod t1;

--- a/bp384/src/lib.rs
+++ b/bp384/src/lib.rs
@@ -6,7 +6,14 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 pub mod r1;
 pub mod t1;

--- a/k256/src/arithmetic/hash2curve.rs
+++ b/k256/src/arithmetic/hash2curve.rs
@@ -106,7 +106,7 @@ impl OsswuMap for FieldElement {
         tv2 = gx1 * gxd; // gx1 * gxd
         tv4 *= tv2;
 
-        let y1 = tv4.pow_vartime(&Self::PARAMS.c1) * tv2; // tv4^C1 * tv2
+        let y1 = tv4.pow_vartime(Self::PARAMS.c1) * tv2; // tv4^C1 * tv2
         let x2n = tv3 * x1n; // tv3 * x1n
 
         let y2 = y1 * Self::PARAMS.c2 * tv1 * self; // y1 * c2 * tv1 * u

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -263,7 +263,7 @@ impl Field for Scalar {
     #[allow(clippy::many_single_char_names)]
     fn sqrt(&self) -> CtOption<Self> {
         // Note: `pow_vartime` is constant-time with respect to `self`
-        let w = self.pow_vartime(&[
+        let w = self.pow_vartime([
             0x777fa4bd19a06c82,
             0xfd755db9cd5e9140,
             0xffffffffffffffff,

--- a/k256/src/arithmetic/scalar/wide64.rs
+++ b/k256/src/arithmetic/scalar/wide64.rs
@@ -253,7 +253,7 @@ fn muladd(a: u64, b: u64, c0: u64, c1: u64, c2: u64) -> (u64, u64, u64) {
     let tl = t as u64;
 
     let new_c0 = c0.wrapping_add(tl); // overflow is handled on the next line
-    let new_th = th + if new_c0 < tl { 1 } else { 0 }; // at most 0xFFFFFFFFFFFFFFFF
+    let new_th = th + u64::from(new_c0 < tl); // at most 0xFFFFFFFFFFFFFFFF
     let new_c1 = c1.wrapping_add(new_th); // overflow is handled on the next line
     let new_c2 = c2 + ct_less(new_c1, new_th); // never overflows by contract (verified in the next line)
     debug_assert!((new_c1 >= new_th) || (new_c2 != 0));

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -6,7 +6,14 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 //! ## `serde` support
 //!

--- a/k256/src/schnorr.rs
+++ b/k256/src/schnorr.rs
@@ -180,8 +180,8 @@ impl signature::PrehashSignature for Signature {
 fn tagged_hash(tag: &[u8]) -> Sha256 {
     let tag_hash = Sha256::digest(tag);
     let mut digest = Sha256::new();
-    digest.update(&tag_hash);
-    digest.update(&tag_hash);
+    digest.update(tag_hash);
+    digest.update(tag_hash);
     digest
 }
 

--- a/k256/src/schnorr/signing.rs
+++ b/k256/src/schnorr/signing.rs
@@ -31,6 +31,8 @@ pub struct SigningKey {
 
 impl SigningKey {
     /// Generate a cryptographically random [`SigningKey`].
+    // TODO(tarcieri): eliminate usage of unwrap
+    #[allow(clippy::unwrap_used)]
     pub fn random(rng: &mut impl CryptoRngCore) -> Self {
         let bytes = NonZeroScalar::random(rng).to_bytes();
         Self::from_bytes(&bytes).unwrap()
@@ -106,8 +108,8 @@ impl SigningKey {
         }
 
         let rand = tagged_hash(NONCE_TAG)
-            .chain_update(&t)
-            .chain_update(&self.verifying_key.as_affine().x.to_bytes())
+            .chain_update(t)
+            .chain_update(self.verifying_key.as_affine().x.to_bytes())
             .chain_update(msg_digest)
             .finalize();
 
@@ -118,8 +120,8 @@ impl SigningKey {
 
         let e = <Scalar as Reduce<U256>>::from_be_bytes_reduced(
             tagged_hash(CHALLENGE_TAG)
-                .chain_update(&r.to_bytes())
-                .chain_update(&self.verifying_key.to_bytes())
+                .chain_update(r.to_bytes())
+                .chain_update(self.verifying_key.to_bytes())
                 .chain_update(msg_digest)
                 .finalize(),
         );

--- a/k256/src/schnorr/verifying.rs
+++ b/k256/src/schnorr/verifying.rs
@@ -73,7 +73,7 @@ impl PrehashVerifier<Signature> for VerifyingKey {
 
         let R = ProjectivePoint::lincomb(
             &ProjectivePoint::GENERATOR,
-            &*s,
+            s,
             &self.inner.to_projective(),
             &-e,
         )

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -133,7 +133,7 @@ impl Scalar {
         // Thus inversion can be implemented with a single exponentiation.
         //
         // This is `n - 2`, so the top right two digits are `4f` instead of `51`.
-        let inverse = self.pow_vartime(&[
+        let inverse = self.pow_vartime([
             0xf3b9_cac2_fc63_254f,
             0xbce6_faad_a717_9e84,
             0xffff_ffff_ffff_ffff,
@@ -258,7 +258,7 @@ impl Field for Scalar {
     #[allow(clippy::many_single_char_names)]
     fn sqrt(&self) -> CtOption<Self> {
         // Note: `pow_vartime` is constant-time with respect to `self`
-        let w = self.pow_vartime(&[
+        let w = self.pow_vartime([
             0x279dce5617e3192a,
             0xfde737d56d38bcf4,
             0x07ffffffffffffff,

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -1,12 +1,19 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-#![doc = include_str!("../README.md")]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 //! ## `serde` support
 //!

--- a/p521/src/lib.rs
+++ b/p521/src/lib.rs
@@ -1,12 +1,19 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-#![doc = include_str!("../README.md")]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 pub use elliptic_curve::{self, bigint::U576};
 

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -195,7 +195,7 @@ where
         let mut pos = C::UInt::BIT_SIZE - 4;
 
         loop {
-            let slot = (k[(pos >> 3) as usize] >> (pos & 7)) & 0xf;
+            let slot = (k[pos >> 3] >> (pos & 7)) & 0xf;
 
             let mut t = ProjectivePoint::IDENTITY;
 


### PR DESCRIPTION
Adopts the following lints across all crates:

    #![warn(
        clippy::mod_module_files,
        clippy::unwrap_used,
        missing_docs,
        rust_2018_idioms,
        unused_lifetimes,
        unused_qualifications
    )]

Also bumps the rustc version used for clippy to 1.66 and fixes all clippy errors under the new configuration.