### PR TITLE
k256: impl `From<NonZeroScalar>` for `schnorr::SigningKey`

### DIFF
--- a/k256/src/schnorr/verifying.rs
+++ b/k256/src/schnorr/verifying.rs
@@ -17,7 +17,7 @@ use signature::{hazmat::PrehashVerifier, DigestVerifier, Error, Result, Verifier
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct VerifyingKey {
     /// Inner public key
-    inner: PublicKey,
+    pub(super) inner: PublicKey,
 }
 
 impl VerifyingKey {


### PR DESCRIPTION
Leverage various infallible conversions to eliminate the use of `unwrap()` and allow infallible conversions from `NonZeroScalar` to `SigningKey`.