### PR TITLE
k256: add `basepoint-tables` feature

### DIFF
--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -40,6 +40,7 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features basepoint-tables
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdh
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa-core
@@ -53,7 +54,7 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha256
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,sha256
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,bits,ecdh,ecdsa,hash2curve,jwk,pem,pkcs8,schnorr,serde,sha256
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features basepoint-tables,bits,ecdh,ecdsa,hash2curve,jwk,pem,pkcs8,schnorr,serde,sha256
 
   benches:
     runs-on: ubuntu-latest

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,9 +20,9 @@ rust-version = "1.60"
 [dependencies]
 cfg-if = "1.0"
 elliptic-curve = { version = "0.12.3", default-features = false, features = ["hazmat", "sec1"] }
-once_cell = { version = "1.16", default-features = false, features = ["critical-section"] }
 
 # optional dependencies
+once_cell = { version = "1.16", optional = true, default-features = false, features = ["critical-section"] }
 ecdsa-core = { version = "=0.15.0-rc.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
@@ -41,11 +41,12 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 sha3 = { version = "0.10", default-features = false }
 
 [features]
-default = ["arithmetic", "ecdsa", "pkcs8", "schnorr", "std"]
+default = ["arithmetic", "basepoint-tables", "ecdsa", "pkcs8", "schnorr", "std"]
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std"]
 
 arithmetic = ["elliptic-curve/arithmetic"]
+basepoint-tables = ["arithmetic", "once_cell"]
 bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]


### PR DESCRIPTION
This allows developers concerned with the resident size of the program to avoid the large `GEN_LOOKUP_TABLE` static.