### PR TITLE
k256: factor `mul_by_generator` into `ProjectivePoint`

### DIFF
--- a/k256/benches/scalar.rs
+++ b/k256/benches/scalar.rs
@@ -6,7 +6,7 @@ use criterion::{
 use hex_literal::hex;
 use k256::{
     elliptic_curve::{generic_array::arr, group::ff::PrimeField, ops::LinearCombination},
-    mul_by_generator, ProjectivePoint, Scalar,
+    ProjectivePoint, Scalar,
 };
 
 fn test_scalar_x() -> Scalar {
@@ -51,7 +51,7 @@ fn bench_point_mul_by_generator<'a, M: Measurement>(group: &mut BenchmarkGroup<'
     group.bench_function("mul_by_generator naive", |b| b.iter(|| &p * &x));
 
     group.bench_function("mul_by_generator precomputed", |b| {
-        b.iter(|| mul_by_generator(&x))
+        b.iter(|| ProjectivePoint::mul_by_generator(&x))
     });
 }
 

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -12,7 +12,6 @@ pub(crate) mod scalar;
 mod dev;
 
 pub use field::FieldElement;
-pub use mul::mul_by_generator;
 
 use affine::AffinePoint;
 use projective::ProjectivePoint;

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -157,7 +157,7 @@ use crate::Secp256k1;
 
 #[cfg(feature = "ecdsa")]
 use {
-    crate::{arithmetic::mul_by_generator, AffinePoint, FieldBytes, Scalar, U256},
+    crate::{AffinePoint, FieldBytes, ProjectivePoint, Scalar, U256},
     core::borrow::Borrow,
     ecdsa_core::hazmat::{SignPrimitive, VerifyPrimitive},
     elliptic_curve::{
@@ -212,7 +212,7 @@ impl SignPrimitive<Secp256k1> for Scalar {
         let k_inverse = k_inverse.unwrap();
 
         // Compute 𝐑 = 𝑘×𝑮
-        let R = mul_by_generator(k).to_affine();
+        let R = ProjectivePoint::mul_by_generator(k).to_affine();
 
         // Lift x-coordinate of 𝐑 (element of base field) into a serialized big
         // integer, then reduce it into an element of the scalar field

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -48,9 +48,7 @@ pub mod test_vectors;
 pub use elliptic_curve::{self, bigint::U256};
 
 #[cfg(feature = "arithmetic")]
-pub use arithmetic::{
-    affine::AffinePoint, mul_by_generator, projective::ProjectivePoint, scalar::Scalar,
-};
+pub use arithmetic::{affine::AffinePoint, projective::ProjectivePoint, scalar::Scalar};
 
 #[cfg(feature = "expose-field")]
 pub use arithmetic::FieldElement;


### PR DESCRIPTION
Makes `ProjectivePoint::mul_by_generator` an inherent static method instead of a free function.

This avoids the need to import it separately from `ProjectivePoint`.