### PR TITLE
k256: rename `precomputed-tables` feature

### DIFF
--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -40,7 +40,6 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features basepoint-tables
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdh
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa-core
@@ -49,12 +48,13 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features jwk
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features precomputed-tables
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features schnorr
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha256
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,sha256
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features basepoint-tables,bits,ecdh,ecdsa,hash2curve,jwk,pem,pkcs8,schnorr,serde,sha256
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits,ecdh,ecdsa,hash2curve,jwk,pem,pkcs8,precomputed-tables,schnorr,serde,sha256
 
   benches:
     runs-on: ubuntu-latest

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -41,12 +41,11 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 sha3 = { version = "0.10", default-features = false }
 
 [features]
-default = ["arithmetic", "basepoint-tables", "ecdsa", "pkcs8", "schnorr", "std"]
+default = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "schnorr", "std"]
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std"]
 
 arithmetic = ["elliptic-curve/arithmetic"]
-basepoint-tables = ["arithmetic", "once_cell"]
 bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
@@ -56,6 +55,7 @@ hash2curve = ["arithmetic", "elliptic-curve/hash2curve"]
 jwk = ["elliptic-curve/jwk"]
 pem = ["ecdsa-core/pem", "elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa-core/pkcs8", "elliptic-curve/pkcs8"]
+precomputed-tables = ["arithmetic", "once_cell"]
 schnorr = ["arithmetic", "sha256", "signature"]
 serde = ["ecdsa-core/serde", "elliptic-curve/serde", "serdect"]
 sha256 = ["digest", "sha2"]

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -45,7 +45,7 @@ use elliptic_curve::{
     IsHigh,
 };
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 use once_cell::sync::Lazy;
 
 /// Lookup table containing precomputed values `[p, 2p, 3p, ..., 8p]`
@@ -375,10 +375,10 @@ fn lincomb_generic<const N: usize>(xs: &[ProjectivePoint; N], ks: &[Scalar; N]) 
 }
 
 /// Lazily computed basepoint table.
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 static GEN_LOOKUP_TABLE: Lazy<[LookupTable; 33]> = Lazy::new(precompute_gen_lookup_table);
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 fn precompute_gen_lookup_table() -> [LookupTable; 33] {
     let mut gen = ProjectivePoint::GENERATOR;
     let mut res = [LookupTable::default(); 33];
@@ -396,13 +396,13 @@ fn precompute_gen_lookup_table() -> [LookupTable; 33] {
 
 impl ProjectivePoint {
     /// Calculates `k * G`, where `G` is the generator.
-    #[cfg(not(feature = "basepoint-tables"))]
+    #[cfg(not(feature = "precomputed-tables"))]
     pub fn mul_by_generator(k: &Scalar) -> ProjectivePoint {
         ProjectivePoint::GENERATOR * k
     }
 
     /// Calculates `k * G`, where `G` is the generator.
-    #[cfg(feature = "basepoint-tables")]
+    #[cfg(feature = "precomputed-tables")]
     pub fn mul_by_generator(k: &Scalar) -> ProjectivePoint {
         let digits = Radix16Decomposition::<65>::new(k);
         let table = *GEN_LOOKUP_TABLE;


### PR DESCRIPTION
Originally introduced as `basepoint-tables` in #705