### PR TITLE
Constructors for scalars from u128

### DIFF
--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -361,12 +361,18 @@ impl DefaultIsZeroes for Scalar {}
 
 impl From<u32> for Scalar {
     fn from(k: u32) -> Self {
-        Self::from(k as u64)
+        Self(k.into())
     }
 }
 
 impl From<u64> for Scalar {
     fn from(k: u64) -> Self {
+        Self(k.into())
+    }
+}
+
+impl From<u128> for Scalar {
+    fn from(k: u128) -> Self {
         Self(k.into())
     }
 }

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -142,8 +142,20 @@ impl FieldElement {
     }
 }
 
+impl From<u32> for FieldElement {
+    fn from(n: u32) -> FieldElement {
+        Self::from_uint_unchecked(U256::from(n))
+    }
+}
+
 impl From<u64> for FieldElement {
     fn from(n: u64) -> FieldElement {
+        Self::from_uint_unchecked(U256::from(n))
+    }
+}
+
+impl From<u128> for FieldElement {
+    fn from(n: u128) -> FieldElement {
         Self::from_uint_unchecked(U256::from(n))
     }
 }
@@ -168,7 +180,7 @@ impl PrimeField for FieldElement {
     }
 
     fn multiplicative_generator() -> Self {
-        6.into()
+        6u32.into()
     }
 
     fn root_of_unity() -> Self {

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -380,8 +380,20 @@ impl Ord for Scalar {
     }
 }
 
+impl From<u32> for Scalar {
+    fn from(k: u32) -> Self {
+        Scalar(k.into())
+    }
+}
+
 impl From<u64> for Scalar {
     fn from(k: u64) -> Self {
+        Scalar(k.into())
+    }
+}
+
+impl From<u128> for Scalar {
+    fn from(k: u128) -> Self {
         Scalar(k.into())
     }
 }
@@ -708,7 +720,7 @@ mod tests {
             0xffff_ffff,
         ]);
 
-        let scalar_bits = ScalarBits::from(&-Scalar::from(1));
+        let scalar_bits = ScalarBits::from(&-Scalar::from(1u32));
         assert_eq!(minus_one, scalar_bits);
     }
 }

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -123,8 +123,20 @@ impl FieldElement {
     }
 }
 
+impl From<u32> for FieldElement {
+    fn from(n: u32) -> FieldElement {
+        Self::from_uint(U384::from(n)).unwrap()
+    }
+}
+
 impl From<u64> for FieldElement {
     fn from(n: u64) -> FieldElement {
+        Self::from_uint(U384::from(n)).unwrap()
+    }
+}
+
+impl From<u128> for FieldElement {
+    fn from(n: u128) -> FieldElement {
         Self::from_uint(U384::from(n)).unwrap()
     }
 }
@@ -149,7 +161,7 @@ impl PrimeField for FieldElement {
     }
 
     fn multiplicative_generator() -> Self {
-        19.into()
+        19u32.into()
     }
 
     fn root_of_unity() -> Self {

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -217,8 +217,20 @@ impl Reduce<U384> for Scalar {
     }
 }
 
+impl From<u32> for Scalar {
+    fn from(n: u32) -> Scalar {
+        Self::from_uint_unchecked(U384::from(n))
+    }
+}
+
 impl From<u64> for Scalar {
     fn from(n: u64) -> Scalar {
+        Self::from_uint_unchecked(U384::from(n))
+    }
+}
+
+impl From<u128> for Scalar {
+    fn from(n: u128) -> Scalar {
         Self::from_uint_unchecked(U384::from(n))
     }
 }


### PR DESCRIPTION
These are helpful when using the scalars in Shamir secret sharing with random (128 bit) participants.

I didn't touch the field.rs files, as then automatic method selection in the `multiplicative_generator` implementations fails - so there is potentially a danger of backwards incompat in p256+p384 which don't have `From<u32>`.

Personally, I'm only interested in `From<u128>` for `k256`.