### PR TITLE
k256: don't eagerly enable `once_cell`'s `critical-section` feature

### DIFF
--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -41,6 +41,7 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features critical-section
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdh
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa-core
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
@@ -48,13 +49,12 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features jwk
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features precomputed-tables
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features schnorr
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha256
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,sha256
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits,ecdh,ecdsa,hash2curve,jwk,pem,pkcs8,precomputed-tables,schnorr,serde,sha256
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits,critical-section,ecdh,ecdsa,hash2curve,jwk,pem,pkcs8,schnorr,serde,sha256
 
   benches:
     runs-on: ubuntu-latest

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1.0"
 elliptic-curve = { version = "0.12.3", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-once_cell = { version = "1.16", optional = true, default-features = false, features = ["critical-section"] }
+once_cell = { version = "1.16", optional = true, default-features = false }
 ecdsa-core = { version = "=0.15.0-rc.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
@@ -43,10 +43,11 @@ sha3 = { version = "0.10", default-features = false }
 [features]
 default = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "schnorr", "std"]
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc"]
-std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std"]
+std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std", "once_cell?/std"]
 
 arithmetic = ["elliptic-curve/arithmetic"]
 bits = ["arithmetic", "elliptic-curve/bits"]
+critical-section = ["once_cell/critical-section", "precomputed-tables"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/signing", "ecdsa-core/verifying", "sha256"]

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -34,6 +34,12 @@
 //! (Note that 'd' is also equal to the curve order here because `[a1,b1]` and `[a2,b2]` are found
 //! as outputs of the Extended Euclidean Algorithm on inputs 'order' and 'lambda').
 
+#[cfg(all(
+    feature = "precomputed-tables",
+    not(any(feature = "critical-section", feature = "std"))
+))]
+compile_error!("`precomputed-tables` feature requires either `critical-section` or `std`");
+
 use crate::arithmetic::{
     scalar::{Scalar, WideScalar},
     ProjectivePoint,


### PR DESCRIPTION
Instead this uses weak feature activation to enable `once_cell/std` when the `std` feature is enabled, which it is by default.

The `critical-section` feature can be used in cases where `std` is unavailable but `precomputed-tables` are desired.