### PR TITLE
Use `doc_auto_cfg`

### DIFF
--- a/bp256/src/lib.rs
+++ b/bp256/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",

--- a/bp256/src/r1.rs
+++ b/bp256/src/r1.rs
@@ -1,7 +1,6 @@
 //! brainpoolP256r1 elliptic curve: verifiably pseudo-random variant
 
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub mod ecdsa;
 
 use elliptic_curve::bigint::U256;

--- a/bp256/src/r1/ecdsa.rs
+++ b/bp256/src/r1/ecdsa.rs
@@ -9,7 +9,6 @@ pub type Signature = ecdsa::Signature<BrainpoolP256r1>;
 pub type DerSignature = ecdsa::der::Signature<BrainpoolP256r1>;
 
 #[cfg(feature = "sha256")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sha256")))]
 impl ecdsa::hazmat::DigestPrimitive for BrainpoolP256r1 {
     type Digest = sha2::Sha256;
 }

--- a/bp256/src/t1.rs
+++ b/bp256/src/t1.rs
@@ -1,7 +1,6 @@
 //! brainpoolP256t1 elliptic curve: twisted variant
 
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub mod ecdsa;
 
 use elliptic_curve::bigint::U256;

--- a/bp256/src/t1/ecdsa.rs
+++ b/bp256/src/t1/ecdsa.rs
@@ -9,7 +9,6 @@ pub type Signature = ecdsa::Signature<BrainpoolP256t1>;
 pub type DerSignature = ecdsa::der::Signature<BrainpoolP256t1>;
 
 #[cfg(feature = "sha256")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sha256")))]
 impl ecdsa::hazmat::DigestPrimitive for BrainpoolP256t1 {
     type Digest = sha2::Sha256;
 }

--- a/bp384/src/lib.rs
+++ b/bp384/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",

--- a/bp384/src/r1.rs
+++ b/bp384/src/r1.rs
@@ -1,7 +1,6 @@
 //! brainpoolP384r1 elliptic curve: verifiably pseudo-random variant
 
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub mod ecdsa;
 
 use elliptic_curve::bigint::U384;

--- a/bp384/src/r1/ecdsa.rs
+++ b/bp384/src/r1/ecdsa.rs
@@ -9,7 +9,6 @@ pub type Signature = ecdsa::Signature<BrainpoolP384r1>;
 pub type DerSignature = ecdsa::der::Signature<BrainpoolP384r1>;
 
 #[cfg(feature = "sha384")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sha384")))]
 impl ecdsa::hazmat::DigestPrimitive for BrainpoolP384r1 {
     type Digest = sha2::Sha384;
 }

--- a/bp384/src/t1.rs
+++ b/bp384/src/t1.rs
@@ -1,7 +1,6 @@
 //! brainpoolP384t1 elliptic curve: twisted variant
 
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub mod ecdsa;
 
 use elliptic_curve::bigint::U384;

--- a/bp384/src/t1/ecdsa.rs
+++ b/bp384/src/t1/ecdsa.rs
@@ -9,7 +9,6 @@ pub type Signature = ecdsa::Signature<BrainpoolP384t1>;
 pub type DerSignature = ecdsa::der::Signature<BrainpoolP384t1>;
 
 #[cfg(feature = "sha384")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sha384")))]
 impl ecdsa::hazmat::DigestPrimitive for BrainpoolP384t1 {
     type Digest = sha2::Sha384;
 }

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -35,7 +35,6 @@ use serdect::serde::{de, ser, Deserialize, Serialize};
 ///
 /// [SEC1]: https://www.secg.org/sec1-v2.pdf
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub struct AffinePoint {
     /// x-coordinate
     pub(crate) x: FieldElement,
@@ -338,7 +337,6 @@ impl TryFrom<&AffinePoint> for PublicKey {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl Serialize for AffinePoint {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
@@ -349,7 +347,6 @@ impl Serialize for AffinePoint {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Deserialize<'de> for AffinePoint {
     fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -39,7 +39,6 @@ impl PrimeCurveArithmetic for Secp256k1 {
 
 /// A point on the secp256k1 curve in projective coordinates.
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub struct ProjectivePoint {
     x: FieldElement,
     y: FieldElement,

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -74,7 +74,6 @@ const FRAC_MODULUS_2: U256 = ORDER.shr_vartime(1);
 /// The serialization is a fixed-width big endian encoding. When used with
 /// textual formats, the binary data is encoded as hexadecimal.
 #[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub struct Scalar(pub(crate) U256);
 
 impl Scalar {
@@ -340,7 +339,6 @@ impl PrimeField for Scalar {
 }
 
 #[cfg(feature = "bits")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
 impl PrimeFieldBits for Scalar {
     #[cfg(target_pointer_width = "32")]
     type ReprBits = [u32; 8];
@@ -605,7 +603,6 @@ impl ReduceNonZero<U512> for Scalar {
 }
 
 #[cfg(feature = "bits")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
 impl From<&Scalar> for ScalarBits {
     fn from(scalar: &Scalar) -> ScalarBits {
         scalar.0.to_words().into()
@@ -637,7 +634,6 @@ impl From<&Scalar> for U256 {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl Serialize for Scalar {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -648,7 +644,6 @@ impl Serialize for Scalar {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Deserialize<'de> for Scalar {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -175,22 +175,18 @@ pub type DerSignature = ecdsa_core::der::Signature<Secp256k1>;
 
 /// ECDSA/secp256k1 signing key
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub type SigningKey = ecdsa_core::SigningKey<Secp256k1>;
 
 /// ECDSA/secp256k1 verification key (i.e. public key)
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub type VerifyingKey = ecdsa_core::VerifyingKey<Secp256k1>;
 
 #[cfg(feature = "sha256")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sha256")))]
 impl ecdsa_core::hazmat::DigestPrimitive for Secp256k1 {
     type Digest = sha2::Sha256;
 }
 
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 impl SignPrimitive<Secp256k1> for Scalar {
     #[allow(non_snake_case, clippy::many_single_char_names)]
     fn try_sign_prehashed<K>(
@@ -237,7 +233,6 @@ impl SignPrimitive<Secp256k1> for Scalar {
 }
 
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 impl VerifyPrimitive<Secp256k1> for AffinePoint {}
 
 #[cfg(all(test, feature = "ecdsa", feature = "arithmetic"))]

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
@@ -30,19 +30,15 @@
 mod arithmetic;
 
 #[cfg(feature = "ecdh")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdh")))]
 pub mod ecdh;
 
 #[cfg(feature = "ecdsa-core")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa-core")))]
 pub mod ecdsa;
 
 #[cfg(feature = "schnorr")]
-#[cfg_attr(docsrs, doc(cfg(feature = "schnorr")))]
 pub mod schnorr;
 
 #[cfg(any(feature = "test-vectors", test))]
-#[cfg_attr(docsrs, doc(cfg(feature = "test-vectors")))]
 pub mod test_vectors;
 
 pub use elliptic_curve::{self, bigint::U256};
@@ -54,11 +50,9 @@ pub use arithmetic::{affine::AffinePoint, projective::ProjectivePoint, scalar::S
 pub use arithmetic::FieldElement;
 
 #[cfg(feature = "pkcs8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub use elliptic_curve::pkcs8;
 
 #[cfg(feature = "sha2")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sha2")))]
 pub use sha2;
 
 use elliptic_curve::{consts::U33, generic_array::GenericArray};
@@ -97,7 +91,6 @@ impl elliptic_curve::PointCompression for Secp256k1 {
 }
 
 #[cfg(feature = "jwk")]
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl elliptic_curve::JwkParameters for Secp256k1 {
     const CRV: &'static str = "secp256k1";
 }
@@ -134,5 +127,4 @@ impl elliptic_curve::sec1::ValidatePublicKey for Secp256k1 {}
 
 /// Bit representation of a secp256k1 (K-256) scalar field element.
 #[cfg(feature = "bits")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
 pub type ScalarBits = elliptic_curve::ScalarBits<Secp256k1>;

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -14,14 +14,11 @@ use elliptic_curve::{
 use primeorder::PrimeCurveParams;
 
 /// Elliptic curve point in affine coordinates.
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type AffinePoint = primeorder::AffinePoint<NistP256>;
 
 /// Elliptic curve point in projective coordinates.
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type ProjectivePoint = primeorder::ProjectivePoint<NistP256>;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl PrimeCurveParams for NistP256 {
     type FieldElement = FieldElement;
 
@@ -56,22 +53,18 @@ impl PrimeCurveParams for NistP256 {
     );
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl AffineArithmetic for NistP256 {
     type AffinePoint = AffinePoint;
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl ProjectiveArithmetic for NistP256 {
     type ProjectivePoint = ProjectivePoint;
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl PrimeCurveArithmetic for NistP256 {
     type CurveGroup = ProjectivePoint;
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl ScalarArithmetic for NistP256 {
     type Scalar = Scalar;
 }

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -79,7 +79,6 @@ pub const MU: [u64; 5] = [
 /// The serialization is a fixed-width big endian encoding. When used with
 /// textual formats, the binary data is encoded as hexadecimal.
 #[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub struct Scalar(pub(crate) U256);
 
 impl Scalar {
@@ -335,7 +334,6 @@ impl PrimeField for Scalar {
 }
 
 #[cfg(feature = "bits")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
 impl PrimeFieldBits for Scalar {
     #[cfg(target_pointer_width = "32")]
     type ReprBits = [u32; 8];
@@ -453,7 +451,6 @@ impl From<&Scalar> for U256 {
 }
 
 #[cfg(feature = "bits")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
 impl From<&Scalar> for ScalarBits {
     fn from(scalar: &Scalar) -> ScalarBits {
         scalar.0.to_words().into()
@@ -614,7 +611,6 @@ impl ConstantTimeEq for Scalar {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl Serialize for Scalar {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -625,7 +621,6 @@ impl Serialize for Scalar {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Deserialize<'de> for Scalar {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/p256/src/arithmetic/scalar/blinded.rs
+++ b/p256/src/arithmetic/scalar/blinded.rs
@@ -14,7 +14,6 @@ use elliptic_curve::{
 /// This provides a randomly blinded impl of [`Invert`] which is useful for
 /// ECDSA ephemeral (`k`) scalars.
 #[derive(Clone)]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub struct BlindedScalar {
     /// Actual scalar value
     scalar: Scalar,

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -57,16 +57,13 @@ pub type DerSignature = ecdsa_core::der::Signature<NistP256>;
 
 /// ECDSA/P-256 signing key
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub type SigningKey = ecdsa_core::SigningKey<NistP256>;
 
 /// ECDSA/P-256 verification key (i.e. public key)
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub type VerifyingKey = ecdsa_core::VerifyingKey<NistP256>;
 
 #[cfg(feature = "sha256")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sha256")))]
 impl ecdsa_core::hazmat::DigestPrimitive for NistP256 {
     type Digest = sha2::Sha256;
 }

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
@@ -30,15 +30,12 @@
 mod arithmetic;
 
 #[cfg(feature = "ecdh")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdh")))]
 pub mod ecdh;
 
 #[cfg(feature = "ecdsa-core")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa-core")))]
 pub mod ecdsa;
 
 #[cfg(any(feature = "test-vectors", test))]
-#[cfg_attr(docsrs, doc(cfg(feature = "test-vectors")))]
 pub mod test_vectors;
 
 pub use elliptic_curve::{self, bigint::U256};
@@ -53,7 +50,6 @@ pub use arithmetic::{
 pub use arithmetic::field::FieldElement;
 
 #[cfg(feature = "pkcs8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub use elliptic_curve::pkcs8;
 
 use elliptic_curve::{consts::U33, generic_array::GenericArray};
@@ -118,7 +114,6 @@ impl elliptic_curve::PointCompaction for NistP256 {
 }
 
 #[cfg(feature = "jwk")]
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl elliptic_curve::JwkParameters for NistP256 {
     const CRV: &'static str = "P-256";
 }
@@ -141,12 +136,10 @@ pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP256>;
 
 /// Non-zero NIST P-256 scalar field element.
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type NonZeroScalar = elliptic_curve::NonZeroScalar<NistP256>;
 
 /// NIST P-256 public key.
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type PublicKey = elliptic_curve::PublicKey<NistP256>;
 
 /// NIST P-256 secret key.
@@ -157,11 +150,9 @@ impl elliptic_curve::sec1::ValidatePublicKey for NistP256 {}
 
 /// Bit representation of a NIST P-256 scalar field element.
 #[cfg(feature = "bits")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
 pub type ScalarBits = elliptic_curve::ScalarBits<NistP256>;
 
 #[cfg(feature = "voprf")]
-#[cfg_attr(docsrs, doc(cfg(feature = "voprf")))]
 impl elliptic_curve::VoprfParameters for NistP256 {
     /// See <https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-08.html#section-4.3-1.3>.
     const ID: u16 = 0x0003;

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -19,11 +19,9 @@ use elliptic_curve::{
 use primeorder::PrimeCurveParams;
 
 /// Elliptic curve point in affine coordinates.
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type AffinePoint = primeorder::AffinePoint<NistP384>;
 
 /// Elliptic curve point in projective coordinates.
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type ProjectivePoint = primeorder::ProjectivePoint<NistP384>;
 
 impl PrimeCurveParams for NistP384 {

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -63,7 +63,6 @@ use core::ops::{Add, Mul, Sub};
 /// The serialization is a fixed-width big endian encoding. When used with
 /// textual formats, the binary data is encoded as hexadecimal.
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub struct Scalar(U384);
 
 primeorder::impl_field_element!(
@@ -196,7 +195,6 @@ impl PrimeField for Scalar {
 }
 
 #[cfg(feature = "bits")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
 impl PrimeFieldBits for Scalar {
     type ReprBits = fiat_p384_scalar_montgomery_domain_field_element;
 
@@ -298,7 +296,6 @@ impl TryFrom<U384> for Scalar {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl Serialize for Scalar {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
@@ -309,7 +306,6 @@ impl Serialize for Scalar {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Deserialize<'de> for Scalar {
     fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where

--- a/p384/src/ecdsa.rs
+++ b/p384/src/ecdsa.rs
@@ -54,16 +54,13 @@ pub type DerSignature = ecdsa_core::der::Signature<NistP384>;
 
 /// ECDSA/P-384 signing key
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub type SigningKey = ecdsa_core::SigningKey<NistP384>;
 
 /// ECDSA/P-384 verification key (i.e. public key)
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub type VerifyingKey = ecdsa_core::VerifyingKey<NistP384>;
 
 #[cfg(feature = "sha384")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sha384")))]
 impl ecdsa_core::hazmat::DigestPrimitive for NistP384 {
     type Digest = sha2::Sha384;
 }

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
@@ -23,15 +23,12 @@
 mod arithmetic;
 
 #[cfg(feature = "ecdh")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdh")))]
 pub mod ecdh;
 
 #[cfg(feature = "ecdsa-core")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa-core")))]
 pub mod ecdsa;
 
 #[cfg(any(feature = "test-vectors", test))]
-#[cfg_attr(docsrs, doc(cfg(feature = "test-vectors")))]
 pub mod test_vectors;
 
 pub use elliptic_curve::{self, bigint::U384};
@@ -43,7 +40,6 @@ pub use arithmetic::{scalar::Scalar, AffinePoint, ProjectivePoint};
 pub use arithmetic::field::FieldElement;
 
 #[cfg(feature = "pkcs8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub use elliptic_curve::pkcs8;
 
 use elliptic_curve::{consts::U49, generic_array::GenericArray};
@@ -73,7 +69,6 @@ impl elliptic_curve::PointCompaction for NistP384 {
 }
 
 #[cfg(feature = "jwk")]
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl elliptic_curve::JwkParameters for NistP384 {
     const CRV: &'static str = "P-384";
 }
@@ -97,12 +92,10 @@ pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP384>;
 
 /// Non-zero NIST P-384 scalar field element.
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type NonZeroScalar = elliptic_curve::NonZeroScalar<NistP384>;
 
 /// NIST P-384 public key.
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type PublicKey = elliptic_curve::PublicKey<NistP384>;
 
 /// NIST P-384 secret key.
@@ -113,11 +106,9 @@ impl elliptic_curve::sec1::ValidatePublicKey for NistP384 {}
 
 /// Bit representation of a NIST P-384 scalar field element.
 #[cfg(feature = "bits")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
 pub type ScalarBits = elliptic_curve::ScalarBits<NistP384>;
 
 #[cfg(feature = "voprf")]
-#[cfg_attr(docsrs, doc(cfg(feature = "voprf")))]
 impl elliptic_curve::VoprfParameters for NistP384 {
     /// See <https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-08.html#section-4.4-1.2>.
     type Hash = sha2::Sha384;

--- a/p521/src/lib.rs
+++ b/p521/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
@@ -18,7 +18,6 @@
 pub use elliptic_curve::{self, bigint::U576};
 
 #[cfg(feature = "pkcs8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub use elliptic_curve::pkcs8;
 
 use elliptic_curve::{consts::U66, generic_array::GenericArray};
@@ -48,7 +47,6 @@ impl elliptic_curve::PointCompaction for NistP521 {
 }
 
 #[cfg(feature = "jwk")]
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl elliptic_curve::JwkParameters for NistP521 {
     const CRV: &'static str = "P-521";
 }

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -444,7 +444,6 @@ where
 //
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<C> Serialize for AffinePoint<C>
 where
     C: PrimeCurveParams,
@@ -461,7 +460,6 @@ where
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, C> Deserialize<'de> for AffinePoint<C>
 where
     C: PrimeCurveParams,

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"


### PR DESCRIPTION
Replaces manual `cfg(doc(...))` annotations by automatically generating them instead using `doc_auto_cfg`.