### PR TITLE
Bump `ecdsa` dependency to v0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.15.0-rc.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13191c3401bb08c4d972fad3e887f87ef409ebd5da573eab14aa66f5f7b5a0db"
+checksum = "82508ce57bd2b245e9914411800f87fd8fc8288f501bb26919cb9b2ee964028f"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -1029,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.0.0-rc.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27af965d7572471973d1307767b3d7ecaff1b7a26674bbbe16877e5dc4cc60d"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "digest",
  "rand_core",

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.60"
 elliptic-curve = { version = "0.12", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa = { version = "=0.15.0-rc.1", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.15", optional = true, default-features = false, features = ["der"] }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [features]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.60"
 elliptic-curve = { version = "0.12", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa = { version = "=0.15.0-rc.1", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.15", optional = true, default-features = false, features = ["der"] }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [features]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -23,16 +23,16 @@ elliptic-curve = { version = "0.12.3", default-features = false, features = ["ha
 
 # optional dependencies
 once_cell = { version = "1.16", optional = true, default-features = false }
-ecdsa-core = { version = "=0.15.0-rc.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
-signature = { version = "=2.0.0-rc.1", optional = true }
+signature = { version = "2", optional = true }
 
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.4"
-ecdsa-core = { version = "=0.15.0-rc.1", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.15", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -21,7 +21,7 @@ elliptic-curve = { version = "0.12", default-features = false, features = ["hazm
 primeorder = { version = "=0.0.2", path = "../primeorder" }
 
 # optional dependencies
-ecdsa-core = { version = "=0.15.0-rc.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
@@ -29,7 +29,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.4"
-ecdsa-core = { version = "=0.15.0-rc.1", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.15", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -21,7 +21,7 @@ elliptic-curve = { version = "0.12", default-features = false, features = ["hazm
 primeorder = { version = "=0.0.2", path = "../primeorder" }
 
 # optional dependencies
-ecdsa-core = { version = "=0.15.0-rc.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
@@ -29,7 +29,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.4"
-ecdsa-core = { version = "=0.15.0-rc.1", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.15", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/signatures/pull/620