### PR TITLE
bp384 v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "bp384"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/bp384/CHANGELOG.md
+++ b/bp384/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2023-01-15)
+### Added
+- `alloc` feature ([#670])
+
+### Changed
+- Use weak feature activation; MSRV 1.60 ([#701])
+- Bump `ecdsa` dependency to v0.15 ([#713])
+
+[#670]: https://github.com/RustCrypto/elliptic-curves/pull/670
+[#701]: https://github.com/RustCrypto/elliptic-curves/pull/701
+[#713]: https://github.com/RustCrypto/elliptic-curves/pull/713
+
 ## 0.4.0 (2022-05-09)
 ### Changed
 - Have `pkcs8` feature activate `ecdsa/pkcs8` ([#538])

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp384"
-version = "0.4.0"
+version = "0.5.0"
 description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
### Added
- `alloc` feature ([#670])

### Changed
- Use weak feature activation; MSRV 1.60 ([#701])
- Bump `ecdsa` dependency to v0.15 ([#713])

[#670]: https://github.com/RustCrypto/elliptic-curves/pull/670
[#701]: https://github.com/RustCrypto/elliptic-curves/pull/701
[#713]: https://github.com/RustCrypto/elliptic-curves/pull/713