### PR TITLE
primeorder v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,6 @@ name = "p224"
 version = "0.12.0-pre"
 dependencies = [
  "elliptic-curve",
- "primeorder",
 ]
 
 [[package]]
@@ -748,7 +747,7 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "primeorder"
-version = "0.0.2"
+version = "0.12.0"
 dependencies = [
  "elliptic-curve",
  "serdect",

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = "1.60"
 
 [dependencies]
 elliptic-curve = { version = "0.12", default-features = false, features = ["hazmat", "sec1"] }
-primeorder = { version = "=0.0.2", path = "../primeorder" }
 
 [features]
 default = ["pem", "std"]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.60"
 
 [dependencies]
 elliptic-curve = { version = "0.12", default-features = false, features = ["hazmat", "sec1"] }
-primeorder = { version = "=0.0.2", path = "../primeorder" }
+primeorder = { version = "0.12", path = "../primeorder" }
 
 # optional dependencies
 ecdsa-core = { version = "0.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.60"
 
 [dependencies]
 elliptic-curve = { version = "0.12", default-features = false, features = ["hazmat", "sec1"] }
-primeorder = { version = "=0.0.2", path = "../primeorder" }
+primeorder = { version = "0.12", path = "../primeorder" }
 
 # optional dependencies
 ecdsa-core = { version = "0.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/primeorder/CHANGELOG.md
+++ b/primeorder/CHANGELOG.md
@@ -4,5 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.0 (2023-01-16)
+
+Initial stable release.
+
+NOTE: other versions skipped to synchronize version numbers with
+`elliptic-curve`, `k256`, `p256`, and `p384`.
+
+## 0.0.2 (2022-12-29)
+
 ## 0.0.1 (2022-11-06)
-- Initial release

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.0.2"
+version = "0.12.0"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve


### PR DESCRIPTION
Initial stable release.

NOTE: other versions skipped to synchronize version numbers with `elliptic-curve`, `k256`, `p256`, and `p384`.
