### PR TITLE
k256 v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.12.0-pre.0"
+version = "0.12.0"
 dependencies = [
  "blobby",
  "cfg-if",

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.0 (2022-01-16)
+### Added
+- `alloc` feature ([#670])
+- Impl `FromOkm` for `Scalar` ([#673])
+- Impl `Prehash*` and `KeypairRef` for Schnorr keys ([#689])
+- `schnorr::SigningKey::as_nonzero_scalar` ([#690])
+- Impl `From<NonZeroScalar>` for `schnorr::SigningKey` ([#703])
+- Impl `From<SecretKey>` for `schnorr::SigningKey` ([#704])
+- `precomputed-tables` feature ([#697], [#705], [#707])
+- Constructors for scalars from `u128` ([#709])
+
+### Changed
+- Use weak feature activation; MSRV 1.60 ([#701])
+- Bump `ecdsa` dependency to v0.15 ([#713])
+
+### Removed
+- `ecdsa::recoverable` module; see documentation for replacements ([#675])
+
+[#670]: https://github.com/RustCrypto/elliptic-curves/pull/670
+[#673]: https://github.com/RustCrypto/elliptic-curves/pull/673
+[#675]: https://github.com/RustCrypto/elliptic-curves/pull/675
+[#689]: https://github.com/RustCrypto/elliptic-curves/pull/689
+[#690]: https://github.com/RustCrypto/elliptic-curves/pull/690
+[#697]: https://github.com/RustCrypto/elliptic-curves/pull/697
+[#701]: https://github.com/RustCrypto/elliptic-curves/pull/701
+[#703]: https://github.com/RustCrypto/elliptic-curves/pull/703
+[#704]: https://github.com/RustCrypto/elliptic-curves/pull/704
+[#705]: https://github.com/RustCrypto/elliptic-curves/pull/705
+[#707]: https://github.com/RustCrypto/elliptic-curves/pull/707
+[#709]: https://github.com/RustCrypto/elliptic-curves/pull/709
+[#713]: https://github.com/RustCrypto/elliptic-curves/pull/713
+
 ## 0.11.6 (2022-09-27)
 ### Added
 - `ecdsa::recoverable::Signature::from_digest_bytes_trial_recovery` ([#660])

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.12.0-pre.0"
+version = "0.12.0"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification/public-key recovery, Taproot Schnorr signatures,


### PR DESCRIPTION
### Added
- `alloc` feature ([#670])
- Impl `FromOkm` for `Scalar` ([#673])
- Impl `Prehash*` and `KeypairRef` for Schnorr keys ([#689])
- `schnorr::SigningKey::as_nonzero_scalar` ([#690])
- Impl `From<NonZeroScalar>` for `schnorr::SigningKey` ([#703])
- Impl `From<SecretKey>` for `schnorr::SigningKey` ([#704])
- `precomputed-tables` feature ([#697], [#705], [#707])
- Constructors for scalars from `u128` ([#709])

### Changed
- Use weak feature activation; MSRV 1.60 ([#701])
- Bump `ecdsa` dependency to v0.15 ([#713])

### Removed
- `ecdsa::recoverable` module; see documentation for replacements ([#675])

[#670]: https://github.com/RustCrypto/elliptic-curves/pull/670
[#673]: https://github.com/RustCrypto/elliptic-curves/pull/673
[#675]: https://github.com/RustCrypto/elliptic-curves/pull/675
[#689]: https://github.com/RustCrypto/elliptic-curves/pull/689
[#690]: https://github.com/RustCrypto/elliptic-curves/pull/690
[#697]: https://github.com/RustCrypto/elliptic-curves/pull/697
[#701]: https://github.com/RustCrypto/elliptic-curves/pull/701
[#703]: https://github.com/RustCrypto/elliptic-curves/pull/703
[#704]: https://github.com/RustCrypto/elliptic-curves/pull/704
[#705]: https://github.com/RustCrypto/elliptic-curves/pull/705
[#707]: https://github.com/RustCrypto/elliptic-curves/pull/707
[#709]: https://github.com/RustCrypto/elliptic-curves/pull/709
[#713]: https://github.com/RustCrypto/elliptic-curves/pull/713