### PR TITLE
p256 v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.12.0-pre.1"
+version = "0.12.0"
 dependencies = [
  "blobby",
  "criterion",

--- a/bp256/LICENSE-MIT
+++ b/bp256/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021 RustCrypto Developers
+Copyright (c) 2021-2023 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/bp384/LICENSE-MIT
+++ b/bp384/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021 RustCrypto Developers
+Copyright (c) 2021-2023 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/k256/CHANGELOG.md
+++ b/k256/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Impl `From<NonZeroScalar>` for `schnorr::SigningKey` ([#703])
 - Impl `From<SecretKey>` for `schnorr::SigningKey` ([#704])
 - `precomputed-tables` feature ([#697], [#705], [#707])
-- Constructors for scalars from `u128` ([#709])
+- Constructors for `Scalar` from `u128` ([#709])
 
 ### Changed
 - Use weak feature activation; MSRV 1.60 ([#701])

--- a/p256/CHANGELOG.md
+++ b/p256/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.0 (2023-01-16)
+### Added
+- 32-bit scalar backend ([#636])
+- `alloc` feature ([#670])
+- Constructors for `Scalar` from `u128` ([#709])
+
+### Changed
+- Use generic curve arithmetic implementation from `primeorder` crate ([#631], [#716])
+- Use `U256` as the inner type for `FieldElement` ([#634])
+- Update P-256 VOPRF test vectors ([#693])
+- Use weak feature activation; MSRV 1.60 ([#701])
+- Bump `ecdsa` dependency to v0.15 ([#713])
+
+[#631]: https://github.com/RustCrypto/elliptic-curves/pull/631
+[#634]: https://github.com/RustCrypto/elliptic-curves/pull/634
+[#636]: https://github.com/RustCrypto/elliptic-curves/pull/636
+[#670]: https://github.com/RustCrypto/elliptic-curves/pull/670
+[#693]: https://github.com/RustCrypto/elliptic-curves/pull/693
+[#701]: https://github.com/RustCrypto/elliptic-curves/pull/701
+[#709]: https://github.com/RustCrypto/elliptic-curves/pull/709
+[#713]: https://github.com/RustCrypto/elliptic-curves/pull/713
+[#716]: https://github.com/RustCrypto/elliptic-curves/pull/716
+
 ## 0.11.1 (2022-06-12)
 ### Added
 - Re-export low-level `diffie_hellman` function ([#556])

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256"
-version = "0.12.0-pre.1"
+version = "0.12.0"
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve with support for ECDH, ECDSA signing/verification, and general
@@ -31,7 +31,7 @@ blobby = "0.3"
 criterion = "0.4"
 ecdsa-core = { version = "0.15", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
-proptest = "1.0"
+proptest = "1"
 rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]

--- a/p256/LICENSE-MIT
+++ b/p256/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2022 RustCrypto Developers
+Copyright (c) 2020-2023 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/primeorder/LICENSE-MIT
+++ b/primeorder/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2022 RustCrypto Developers
+Copyright (c) 2020-2023 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
### Added
- 32-bit scalar backend ([#636])
- `alloc` feature ([#670])
- Constructors for `Scalar` from `u128` ([#709])

### Changed
- Use generic curve arithmetic implementation from `primeorder` crate ([#631], [#716])
- Use `U256` as the inner type for `FieldElement` ([#634])
- Update P-256 VOPRF test vectors ([#693])
- Use weak feature activation; MSRV 1.60 ([#701])
- Bump `ecdsa` dependency to v0.15 ([#713])

[#631]: https://github.com/RustCrypto/elliptic-curves/pull/631
[#634]: https://github.com/RustCrypto/elliptic-curves/pull/634
[#636]: https://github.com/RustCrypto/elliptic-curves/pull/636
[#670]: https://github.com/RustCrypto/elliptic-curves/pull/670
[#693]: https://github.com/RustCrypto/elliptic-curves/pull/693
[#701]: https://github.com/RustCrypto/elliptic-curves/pull/701
[#709]: https://github.com/RustCrypto/elliptic-curves/pull/709
[#713]: https://github.com/RustCrypto/elliptic-curves/pull/713
[#716]: https://github.com/RustCrypto/elliptic-curves/pull/716