### PR TITLE
p384 v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.12.0-pre.1"
+version = "0.12.0"
 dependencies = [
  "blobby",
  "criterion",

--- a/p384/CHANGELOG.md
+++ b/p384/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.0 (2023-01-16)
+### Added
+- `alloc` feature ([#670])
+- Constructors for `Scalar` from `u128` ([#709])
+
+### Changed
+- Use generic curve arithmetic implementation from `primeorder` crate ([#631], [#716])
+- Use weak feature activation; MSRV 1.60 ([#701])
+- Bump `ecdsa` dependency to v0.15 ([#713])
+
+[#631]: https://github.com/RustCrypto/elliptic-curves/pull/631
+[#670]: https://github.com/RustCrypto/elliptic-curves/pull/670
+[#701]: https://github.com/RustCrypto/elliptic-curves/pull/701
+[#709]: https://github.com/RustCrypto/elliptic-curves/pull/709
+[#713]: https://github.com/RustCrypto/elliptic-curves/pull/713
+[#716]: https://github.com/RustCrypto/elliptic-curves/pull/716
+
 ## 0.11.2 (2022-08-03)
 ### Added
 - Re-export low-level `diffie_hellman` function ([#627])

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p384"
-version = "0.12.0-pre.1"
+version = "0.12.0"
 description = """
 Pure Rust implementation of the NIST P-384 (a.k.a. secp384r1) elliptic curve
 with support for ECDH, ECDSA signing/verification, and general purpose curve


### PR DESCRIPTION
### Added
- `alloc` feature ([#670])
- Constructors for `Scalar` from `u128` ([#709])

### Changed
- Use generic curve arithmetic implementation from `primeorder` crate ([#631], [#716])
- Use weak feature activation; MSRV 1.60 ([#701])
- Bump `ecdsa` dependency to v0.15 ([#713])

[#631]: https://github.com/RustCrypto/elliptic-curves/pull/631
[#670]: https://github.com/RustCrypto/elliptic-curves/pull/670
[#701]: https://github.com/RustCrypto/elliptic-curves/pull/701
[#709]: https://github.com/RustCrypto/elliptic-curves/pull/709
[#713]: https://github.com/RustCrypto/elliptic-curves/pull/713
[#716]: https://github.com/RustCrypto/elliptic-curves/pull/716