### PR TITLE
primeorder v0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,7 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "primeorder"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "elliptic-curve",
  "serdect",

--- a/primeorder/CHANGELOG.md
+++ b/primeorder/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.1 (2023-01-22)
+### Added
+- Impl `From/ToEncodedPoint` for `ProjectivePoint` ([#722])
+
+[#722]: https://github.com/RustCrypto/elliptic-curves/pull/722
+
 ## 0.12.0 (2023-01-16)
 
 Initial stable release.

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.12.0"
+version = "0.12.1"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve


### PR DESCRIPTION
### Added
- Impl `From/ToEncodedPoint` for `ProjectivePoint` ([#722])

[#722]: https://github.com/RustCrypto/elliptic-curves/pull/722