### PR TITLE
primeorder: algorithm specialization using `equation_a::Is*` ZSTs

### DIFF
--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -11,7 +11,7 @@ use crate::NistP256;
 use elliptic_curve::{
     AffineArithmetic, PrimeCurveArithmetic, ProjectiveArithmetic, ScalarArithmetic,
 };
-use primeorder::{CurveEquationAIsMinusThree, PrimeCurveParams};
+use primeorder::{equation_a, PrimeCurveParams};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<NistP256>;
@@ -21,7 +21,7 @@ pub type ProjectivePoint = primeorder::ProjectivePoint<NistP256>;
 
 impl PrimeCurveParams for NistP256 {
     type FieldElement = FieldElement;
-    type CurveEquationAProperties = CurveEquationAIsMinusThree;
+    type EquationAProperties = equation_a::IsMinusThree;
 
     const ZERO: FieldElement = FieldElement::ZERO;
     const ONE: FieldElement = FieldElement::ONE;

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -11,7 +11,7 @@ use crate::NistP256;
 use elliptic_curve::{
     AffineArithmetic, PrimeCurveArithmetic, ProjectiveArithmetic, ScalarArithmetic,
 };
-use primeorder::PrimeCurveParams;
+use primeorder::{CurveEquationAIsMinusThree, PrimeCurveParams};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<NistP256>;
@@ -21,6 +21,7 @@ pub type ProjectivePoint = primeorder::ProjectivePoint<NistP256>;
 
 impl PrimeCurveParams for NistP256 {
     type FieldElement = FieldElement;
+    type CurveEquationAProperties = CurveEquationAIsMinusThree;
 
     const ZERO: FieldElement = FieldElement::ZERO;
     const ONE: FieldElement = FieldElement::ONE;

--- a/p256/tests/projective.rs
+++ b/p256/tests/projective.rs
@@ -8,6 +8,7 @@ use elliptic_curve::{
 };
 use p256::test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS};
 use p256::{AffinePoint, ProjectivePoint, Scalar};
+use primeorder::Double;
 
 /// Assert that the provided projective point matches the given test vector.
 // TODO(tarcieri): use coordinate APIs. See zkcrypto/group#30

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -16,7 +16,7 @@ use crate::NistP384;
 use elliptic_curve::{
     AffineArithmetic, PrimeCurveArithmetic, ProjectiveArithmetic, ScalarArithmetic,
 };
-use primeorder::{CurveEquationAIsMinusThree, PrimeCurveParams};
+use primeorder::{equation_a, PrimeCurveParams};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<NistP384>;
@@ -26,7 +26,7 @@ pub type ProjectivePoint = primeorder::ProjectivePoint<NistP384>;
 
 impl PrimeCurveParams for NistP384 {
     type FieldElement = FieldElement;
-    type CurveEquationAProperties = CurveEquationAIsMinusThree;
+    type EquationAProperties = equation_a::IsMinusThree;
 
     const ZERO: FieldElement = FieldElement::ZERO;
     const ONE: FieldElement = FieldElement::ONE;

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -16,7 +16,7 @@ use crate::NistP384;
 use elliptic_curve::{
     AffineArithmetic, PrimeCurveArithmetic, ProjectiveArithmetic, ScalarArithmetic,
 };
-use primeorder::PrimeCurveParams;
+use primeorder::{CurveEquationAIsMinusThree, PrimeCurveParams};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<NistP384>;
@@ -26,6 +26,7 @@ pub type ProjectivePoint = primeorder::ProjectivePoint<NistP384>;
 
 impl PrimeCurveParams for NistP384 {
     type FieldElement = FieldElement;
+    type CurveEquationAProperties = CurveEquationAIsMinusThree;
 
     const ZERO: FieldElement = FieldElement::ZERO;
     const ONE: FieldElement = FieldElement::ONE;

--- a/p384/tests/projective.rs
+++ b/p384/tests/projective.rs
@@ -10,6 +10,7 @@ use p384::{
     test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
     AffinePoint, ProjectivePoint, Scalar,
 };
+use primeorder::Double;
 
 /// Assert that the provided projective point matches the given test vector.
 // TODO(tarcieri): use coordinate APIs. See zkcrypto/group#30

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::op_ref)]
 
-use crate::{PrimeCurveParams, ProjectivePoint};
+use crate::{Double, PrimeCurveParams, ProjectivePoint};
 use core::{
     borrow::Borrow,
     ops::{Mul, Neg},
@@ -283,6 +283,7 @@ where
     C: PrimeCurveParams,
     FieldBytes<C>: Copy,
     FieldSize<C>: ModulusSize,
+    ProjectivePoint<C>: Double,
     CompressedPoint<C>: Copy,
     <UncompressedPointSize<C> as ArrayLength<u8>>::ArrayType: Copy,
 {
@@ -405,6 +406,7 @@ impl<C, S> Mul<S> for AffinePoint<C>
 where
     C: PrimeCurveParams,
     S: Borrow<Scalar<C>>,
+    ProjectivePoint<C>: Double,
 {
     type Output = ProjectivePoint<C>;
 

--- a/primeorder/src/equation_a.rs
+++ b/primeorder/src/equation_a.rs
@@ -10,20 +10,25 @@
 //! on `PrimeCurveParams::EQUATION_A` in the future (including ones which
 //! could be used as trait bounds).
 
-/// Sealed trait which identifies special properties of the curve's
-/// 𝒂-coefficient.
-pub trait CurveEquationAProperties {}
+mod sealed {
+    /// Sealed trait which identifies special properties of the curve's
+    /// 𝒂-coefficient.
+    pub trait EquationAProperties {}
+}
+
+// Allow crate-local visibility
+pub(crate) use sealed::EquationAProperties;
 
 /// The 𝒂-coefficient of the short Weierstrass equation is 0.
-pub struct CurveEquationAIsZero {}
+pub struct IsZero {}
 
 /// The 𝒂-coefficient of the short Weierstrass equation is -3.
-pub struct CurveEquationAIsMinusThree {}
+pub struct IsMinusThree {}
 
 /// The 𝒂-coefficient of the short Weierstrass equation does not have specific
 /// properties which allow for an optimized implementation.
-pub struct CurveEquationAIsGeneric {}
+pub struct IsGeneric {}
 
-impl CurveEquationAProperties for CurveEquationAIsZero {}
-impl CurveEquationAProperties for CurveEquationAIsMinusThree {}
-impl CurveEquationAProperties for CurveEquationAIsGeneric {}
+impl EquationAProperties for IsZero {}
+impl EquationAProperties for IsMinusThree {}
+impl EquationAProperties for IsGeneric {}

--- a/primeorder/src/equation_a.rs
+++ b/primeorder/src/equation_a.rs
@@ -1,0 +1,23 @@
+//! Support for formulas specialized to the short Weierstrass equation's
+//! 𝒂-coefficient.
+//!
+//! This module is largely a workaround for things which should be possible
+//! to implement more elegantly with future Rust features like
+//! `generic_const_exprs` and `impl const Trait`.
+//!
+//! In absence of such features, we define traits that capture properties of
+//! the 𝒂-coefficient which could potentially be written as const expressions
+//! on `PrimeCurveParams::EQUATION_A` in the future (including ones which
+//! could be used as trait bounds).
+
+use super::PrimeCurveParams;
+
+/// The 𝒂-coefficient of the short Weierstrass equation is 0.
+pub trait CurveEquationAIsZero: PrimeCurveParams {}
+
+/// The 𝒂-coefficient of the short Weierstrass equation is -3.
+pub trait CurveEquationAIsMinusThree: PrimeCurveParams {}
+
+/// The 𝒂-coefficient of the short Weierstrass equation does not have specific
+/// properties which allow for an optimized implementation.
+pub trait CurveEquationAIsGeneric: PrimeCurveParams {}

--- a/primeorder/src/equation_a.rs
+++ b/primeorder/src/equation_a.rs
@@ -5,19 +5,25 @@
 //! to implement more elegantly with future Rust features like
 //! `generic_const_exprs` and `impl const Trait`.
 //!
-//! In absence of such features, we define traits that capture properties of
+//! In absence of such features, we define ZSTs that identify properties of
 //! the 𝒂-coefficient which could potentially be written as const expressions
 //! on `PrimeCurveParams::EQUATION_A` in the future (including ones which
 //! could be used as trait bounds).
 
-use super::PrimeCurveParams;
+/// Sealed trait which identifies special properties of the curve's
+/// 𝒂-coefficient.
+pub trait CurveEquationAProperties {}
 
 /// The 𝒂-coefficient of the short Weierstrass equation is 0.
-pub trait CurveEquationAIsZero: PrimeCurveParams {}
+pub struct CurveEquationAIsZero {}
 
 /// The 𝒂-coefficient of the short Weierstrass equation is -3.
-pub trait CurveEquationAIsMinusThree: PrimeCurveParams {}
+pub struct CurveEquationAIsMinusThree {}
 
 /// The 𝒂-coefficient of the short Weierstrass equation does not have specific
 /// properties which allow for an optimized implementation.
-pub trait CurveEquationAIsGeneric: PrimeCurveParams {}
+pub struct CurveEquationAIsGeneric {}
+
+impl CurveEquationAProperties for CurveEquationAIsZero {}
+impl CurveEquationAProperties for CurveEquationAIsMinusThree {}
+impl CurveEquationAProperties for CurveEquationAIsGeneric {}

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -8,14 +8,14 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc = include_str!("../README.md")]
 
+pub mod equation_a;
+
 mod affine;
-mod equation_a;
 mod field;
 mod projective;
 
 pub use crate::{
     affine::AffinePoint,
-    equation_a::{CurveEquationAIsGeneric, CurveEquationAIsMinusThree, CurveEquationAIsZero},
     projective::{Double, ProjectivePoint},
 };
 pub use elliptic_curve::{self, Field, FieldBytes, PrimeCurve, PrimeField};
@@ -34,7 +34,7 @@ pub trait PrimeCurveParams:
     type FieldElement: PrimeField<Repr = FieldBytes<Self>>;
 
     /// Special properties of the `a`-coefficient.
-    type CurveEquationAProperties: equation_a::CurveEquationAProperties;
+    type EquationAProperties: equation_a::EquationAProperties;
 
     /// Zero element of the base field.
     // TODO(tarcieri): use `Field` trait instead. See zkcrypto/ff#87

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -9,10 +9,15 @@
 #![doc = include_str!("../README.md")]
 
 mod affine;
+mod equation_a;
 mod field;
 mod projective;
 
-pub use crate::{affine::AffinePoint, projective::ProjectivePoint};
+pub use crate::{
+    affine::AffinePoint,
+    equation_a::{CurveEquationAIsGeneric, CurveEquationAIsMinusThree, CurveEquationAIsZero},
+    projective::{Double, ProjectivePoint},
+};
 pub use elliptic_curve::{self, Field, FieldBytes, PrimeCurve, PrimeField};
 
 use elliptic_curve::{AffineArithmetic, ProjectiveArithmetic, ScalarArithmetic};

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -33,6 +33,9 @@ pub trait PrimeCurveParams:
     /// Base field element type.
     type FieldElement: PrimeField<Repr = FieldBytes<Self>>;
 
+    /// Special properties of the `a`-coefficient.
+    type CurveEquationAProperties: equation_a::CurveEquationAProperties;
+
     /// Zero element of the base field.
     // TODO(tarcieri): use `Field` trait instead. See zkcrypto/ff#87
     const ZERO: Self::FieldElement;

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -201,6 +201,7 @@ pub trait Double {
     fn double(&self) -> Self;
 }
 
+// TODO(tarcieri): impls for `CurveEquationAIsGeneric` and `CurveEquationAIsZero`
 impl<C> Double for ProjectivePoint<C>
 where
     C: PrimeCurveParams<CurveEquationAProperties = CurveEquationAIsMinusThree>,

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -203,7 +203,7 @@ pub trait Double {
 
 impl<C> Double for ProjectivePoint<C>
 where
-    C: PrimeCurveParams + CurveEquationAIsMinusThree,
+    C: PrimeCurveParams<CurveEquationAProperties = CurveEquationAIsMinusThree>,
 {
     /// We implement the exception-free point doubling formula from
     /// Renes-Costello-Batina 2015 (Algorithm 6), for prime order short

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -205,9 +205,10 @@ impl<C> Double for ProjectivePoint<C>
 where
     C: PrimeCurveParams<CurveEquationAProperties = CurveEquationAIsMinusThree>,
 {
-    /// We implement the exception-free point doubling formula from
-    /// Renes-Costello-Batina 2015 (Algorithm 6), for prime order short
-    /// Weierstrass curves `y² = x³ + ax + b` where `a = -3`.
+    /// Adapted from Renes-Costello-Batina 2015 (Algorithm 6)
+    ///
+    /// Exception-free point doubling formula for prime order short Weierstrass
+    /// curves `y² = x³ + ax + b` where `a = -3`.
     ///
     /// The comments after each lines indicate which algorithm steps
     /// are being performed.


### PR DESCRIPTION
Extracts a `Double` trait (which should probably go in `elliptic_curve::ops`) which allows for multiple overlapping impls based on specific properties of the curve's a-coefficient.

The previous inherent `double()` method is now gated on `equation_a::IsMinus3`.