### PR TITLE
Add `FieldBytesEncoding` trait impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,8 +330,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#4af28dd9fa18411b7c8ac09f83ddcfedabe94e29"
+version = "0.16.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcd6964e28e4802aed67abfaddd5e5430f368c54cc3e498d2a6a8444e5361fe5"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -348,8 +349,9 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.0-pre.2"
-source = "git+https://github.com/RustCrypto/traits.git#adbf0ad45be30b6866f733c4f366cdb129ad50ce"
+version = "0.13.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a583fbbbfde04e0ef9c8b84c3bf8e504155a1642f91bf5cc2d6e7355cfb6ac4f"
 dependencies = [
  "base16ct",
  "base64ct",
@@ -912,8 +914,9 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#4af28dd9fa18411b7c8ac09f83ddcfedabe94e29"
+version = "0.4.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b3595c18d975a2c373afdb4f8d17016589e65f9d84305c1c36fc55272def0bd"
 dependencies = [
  "hmac",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
-ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa = { version = "=0.16.0-pre", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.16.0-pre.0", optional = true, default-features = false, features = ["der"] }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [features]

--- a/bp256/src/r1.rs
+++ b/bp256/src/r1.rs
@@ -3,7 +3,11 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
-use elliptic_curve::{bigint::U256, consts::U32};
+use elliptic_curve::{
+    bigint::{ArrayEncoding, U256},
+    consts::U32,
+    FieldBytesEncoding,
+};
 
 #[cfg(feature = "pkcs8")]
 use crate::pkcs8;
@@ -36,13 +40,23 @@ impl pkcs8::AssociatedOid for BrainpoolP256r1 {
         pkcs8::ObjectIdentifier::new_unwrap("1.3.36.3.3.2.8.1.1.7");
 }
 
+/// brainpoolP256r1 SEC1 encoded point.
+pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<BrainpoolP256r1>;
+
 /// brainpoolP256r1 field element serialized as bytes.
 ///
 /// Byte array containing a serialized field element value (base field or scalar).
 pub type FieldBytes = elliptic_curve::FieldBytes<BrainpoolP256r1>;
 
-/// brainpoolP256r1 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<BrainpoolP256r1>;
+impl FieldBytesEncoding<BrainpoolP256r1> for U256 {
+    fn decode_field_bytes(field_bytes: &FieldBytes) -> Self {
+        U256::from_be_byte_array(*field_bytes)
+    }
+
+    fn encode_field_bytes(&self) -> FieldBytes {
+        self.to_be_byte_array()
+    }
+}
 
 /// brainpoolP256r1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP256r1>;

--- a/bp256/src/t1.rs
+++ b/bp256/src/t1.rs
@@ -3,7 +3,11 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
-use elliptic_curve::{bigint::U256, consts::U32};
+use elliptic_curve::{
+    bigint::{ArrayEncoding, U256},
+    consts::U32,
+    FieldBytesEncoding,
+};
 
 #[cfg(feature = "pkcs8")]
 use crate::pkcs8;
@@ -36,13 +40,23 @@ impl pkcs8::AssociatedOid for BrainpoolP256t1 {
         pkcs8::ObjectIdentifier::new_unwrap("1.3.36.3.3.2.8.1.1.8");
 }
 
+/// brainpoolP256t1 SEC1 encoded point.
+pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<BrainpoolP256t1>;
+
 /// brainpoolP256t1 field element serialized as bytes.
 ///
 /// Byte array containing a serialized field element value (base field or scalar).
 pub type FieldBytes = elliptic_curve::FieldBytes<BrainpoolP256t1>;
 
-/// brainpoolP256t1 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<BrainpoolP256t1>;
+impl FieldBytesEncoding<BrainpoolP256t1> for U256 {
+    fn decode_field_bytes(field_bytes: &FieldBytes) -> Self {
+        U256::from_be_byte_array(*field_bytes)
+    }
+
+    fn encode_field_bytes(&self) -> FieldBytes {
+        self.to_be_byte_array()
+    }
+}
 
 /// brainpoolP256t1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP256t1>;

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa = { version = "=0.16.0-pre", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.16.0-pre.0", optional = true, default-features = false, features = ["der"] }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [features]

--- a/bp384/src/r1.rs
+++ b/bp384/src/r1.rs
@@ -3,7 +3,11 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
-use elliptic_curve::{bigint::U384, consts::U48};
+use elliptic_curve::{
+    bigint::{ArrayEncoding, U384},
+    consts::U48,
+    FieldBytesEncoding,
+};
 
 #[cfg(feature = "pkcs8")]
 use crate::pkcs8;
@@ -36,13 +40,23 @@ impl pkcs8::AssociatedOid for BrainpoolP384r1 {
         pkcs8::ObjectIdentifier::new_unwrap("1.3.36.3.3.2.8.1.1.11");
 }
 
+/// brainpoolP384r1 SEC1 encoded point.
+pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<BrainpoolP384r1>;
+
 /// brainpoolP384r1 field element serialized as bytes.
 ///
 /// Byte array containing a serialized field element value (base field or scalar).
 pub type FieldBytes = elliptic_curve::FieldBytes<BrainpoolP384r1>;
 
-/// brainpoolP384r1 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<BrainpoolP384r1>;
+impl FieldBytesEncoding<BrainpoolP384r1> for U384 {
+    fn decode_field_bytes(field_bytes: &FieldBytes) -> Self {
+        U384::from_be_byte_array(*field_bytes)
+    }
+
+    fn encode_field_bytes(&self) -> FieldBytes {
+        self.to_be_byte_array()
+    }
+}
 
 /// brainpoolP384r1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP384r1>;

--- a/bp384/src/t1.rs
+++ b/bp384/src/t1.rs
@@ -3,7 +3,11 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
-use elliptic_curve::{bigint::U384, consts::U48};
+use elliptic_curve::{
+    bigint::{ArrayEncoding, U384},
+    consts::U48,
+    FieldBytesEncoding,
+};
 
 #[cfg(feature = "pkcs8")]
 use crate::pkcs8;
@@ -36,13 +40,23 @@ impl pkcs8::AssociatedOid for BrainpoolP384t1 {
         pkcs8::ObjectIdentifier::new_unwrap("1.3.36.3.3.2.8.1.1.12");
 }
 
+/// brainpoolP384t1 SEC1 encoded point.
+pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<BrainpoolP384t1>;
+
 /// brainpoolP384t1 field element serialized as bytes.
 ///
 /// Byte array containing a serialized field element value (base field or scalar).
 pub type FieldBytes = elliptic_curve::FieldBytes<BrainpoolP384t1>;
 
-/// brainpoolP384t1 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<BrainpoolP384t1>;
+impl FieldBytesEncoding<BrainpoolP384t1> for U384 {
+    fn decode_field_bytes(field_bytes: &FieldBytes) -> Self {
+        U384::from_be_byte_array(*field_bytes)
+    }
+
+    fn encode_field_bytes(&self) -> FieldBytes {
+        self.to_be_byte_array()
+    }
+}
 
 /// brainpoolP384t1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP384t1>;

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -19,11 +19,11 @@ rust-version = "1.61"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "=0.13.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
 once_cell = { version = "1.16", optional = true, default-features = false }
-ecdsa-core = { version = "=0.16.0-pre", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.16.0-pre.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
@@ -32,7 +32,7 @@ signature = { version = "2", optional = true }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.4"
-ecdsa-core = { version = "=0.16.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.16.0-pre.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -160,10 +160,10 @@ use {
     crate::{AffinePoint, FieldBytes, ProjectivePoint, Scalar},
     ecdsa_core::hazmat::{SignPrimitive, VerifyPrimitive},
     elliptic_curve::{
+        bigint::U256,
         ops::{Invert, MulByGenerator, Reduce},
         scalar::IsHigh,
         subtle::CtOption,
-        Curve,
     },
 };
 
@@ -201,7 +201,7 @@ impl SignPrimitive<Secp256k1> for Scalar {
             return Err(Error::new());
         }
 
-        let z = Self::reduce(Secp256k1::decode_field_bytes(z));
+        let z = <Self as Reduce<U256>>::reduce_bytes(z);
 
         // Compute scalar inversion of 𝑘
         let k_inv = Option::<Scalar>::from(k.invert()).ok_or_else(Error::new)?;
@@ -211,7 +211,7 @@ impl SignPrimitive<Secp256k1> for Scalar {
 
         // Lift x-coordinate of 𝑹 (element of base field) into a serialized big
         // integer, then reduce it into an element of the scalar field
-        let r = Self::reduce(Secp256k1::decode_field_bytes(&R.x.to_bytes()));
+        let r = <Self as Reduce<U256>>::reduce_bytes(&R.x.to_bytes());
 
         // Compute 𝒔 as a signature over 𝒓 and 𝒛.
         let s = k_inv * (z + (r * self));

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -59,6 +59,7 @@ use elliptic_curve::{
     bigint::ArrayEncoding,
     consts::{U32, U33, U64},
     generic_array::GenericArray,
+    FieldBytesEncoding,
 };
 
 /// Order of the secp256k1 elliptic curve in hexadecimal.
@@ -90,16 +91,6 @@ impl elliptic_curve::Curve for Secp256k1 {
 
     /// Curve order.
     const ORDER: U256 = ORDER;
-
-    /// Decode unsigned integer from serialized field element.
-    fn decode_field_bytes(field_bytes: &FieldBytes) -> U256 {
-        U256::from_be_byte_array(*field_bytes)
-    }
-
-    /// Encode unsigned integer into serialized field element.
-    fn encode_field_bytes(uint: &U256) -> FieldBytes {
-        uint.to_be_byte_array()
-    }
 }
 
 impl elliptic_curve::PrimeCurve for Secp256k1 {}
@@ -122,16 +113,26 @@ impl pkcs8::AssociatedOid for Secp256k1 {
 /// Compressed SEC1-encoded secp256k1 (K-256) curve point.
 pub type CompressedPoint = GenericArray<u8, U33>;
 
+/// SEC1-encoded secp256k1 (K-256) curve point.
+pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<Secp256k1>;
+
 /// secp256k1 (K-256) field element serialized as bytes.
 ///
 /// Byte array containing a serialized field element value (base field or scalar).
 pub type FieldBytes = elliptic_curve::FieldBytes<Secp256k1>;
 
+impl FieldBytesEncoding<Secp256k1> for U256 {
+    fn decode_field_bytes(field_bytes: &FieldBytes) -> Self {
+        U256::from_be_byte_array(*field_bytes)
+    }
+
+    fn encode_field_bytes(&self) -> FieldBytes {
+        self.to_be_byte_array()
+    }
+}
+
 /// Bytes used by a wide reduction: twice the width of [`FieldBytes`].
 pub type WideBytes = GenericArray<u8, U64>;
-
-/// SEC1-encoded secp256k1 (K-256) curve point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<Secp256k1>;
 
 /// Non-zero secp256k1 (K-256) scalar field element.
 #[cfg(feature = "arithmetic")]

--- a/k256/src/schnorr/signing.rs
+++ b/k256/src/schnorr/signing.rs
@@ -2,8 +2,7 @@
 
 use super::{tagged_hash, Signature, VerifyingKey, AUX_TAG, CHALLENGE_TAG, NONCE_TAG};
 use crate::{
-    AffinePoint, FieldBytes, NonZeroScalar, ProjectivePoint, PublicKey, Scalar, Secp256k1,
-    SecretKey,
+    AffinePoint, FieldBytes, NonZeroScalar, ProjectivePoint, PublicKey, Scalar, SecretKey,
 };
 use elliptic_curve::{
     bigint::U256,
@@ -11,7 +10,6 @@ use elliptic_curve::{
     rand_core::CryptoRngCore,
     subtle::ConditionallySelectable,
     zeroize::{Zeroize, ZeroizeOnDrop},
-    Curve,
 };
 use sha2::{Digest, Sha256};
 use signature::{
@@ -100,13 +98,13 @@ impl SigningKey {
         let verifying_point = AffinePoint::from(k.verifying_key);
         let r = verifying_point.x.normalize();
 
-        let e = <Scalar as Reduce<U256>>::reduce(Secp256k1::decode_field_bytes(
+        let e = <Scalar as Reduce<U256>>::reduce_bytes(
             &tagged_hash(CHALLENGE_TAG)
                 .chain_update(r.to_bytes())
                 .chain_update(self.verifying_key.to_bytes())
                 .chain_update(msg_digest)
                 .finalize(),
-        ));
+        );
 
         let s = *secret_key + e * *self.secret_key;
         let s = Option::from(NonZeroScalar::new(s)).ok_or_else(Error::new)?;

--- a/k256/src/schnorr/verifying.rs
+++ b/k256/src/schnorr/verifying.rs
@@ -1,12 +1,11 @@
 //! Taproot Schnorr verifying key.
 
 use super::{tagged_hash, Signature, CHALLENGE_TAG};
-use crate::{AffinePoint, FieldBytes, ProjectivePoint, PublicKey, Scalar, Secp256k1};
+use crate::{AffinePoint, FieldBytes, ProjectivePoint, PublicKey, Scalar};
 use elliptic_curve::{
     bigint::U256,
     ops::{LinearCombination, Reduce},
     point::DecompactPoint,
-    Curve,
 };
 use sha2::{
     digest::{consts::U32, FixedOutput},
@@ -64,13 +63,13 @@ impl PrehashVerifier<Signature> for VerifyingKey {
         let prehash: [u8; 32] = prehash.try_into().map_err(|_| Error::new())?;
         let (r, s) = signature.split();
 
-        let e = <Scalar as Reduce<U256>>::reduce(Secp256k1::decode_field_bytes(
+        let e = <Scalar as Reduce<U256>>::reduce_bytes(
             &tagged_hash(CHALLENGE_TAG)
                 .chain_update(signature.r.to_bytes())
                 .chain_update(self.to_bytes())
                 .chain_update(prehash)
                 .finalize(),
-        ));
+        );
 
         let R = ProjectivePoint::lincomb(
             &ProjectivePoint::GENERATOR,

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 
 [features]
 default = ["pem", "std"]

--- a/p224/src/lib.rs
+++ b/p224/src/lib.rs
@@ -16,6 +16,7 @@ pub use elliptic_curve::{self, bigint::U256};
 use elliptic_curve::{
     consts::{U28, U29},
     generic_array::GenericArray,
+    FieldBytesEncoding,
 };
 
 /// NIST P-224 elliptic curve.
@@ -52,14 +53,16 @@ impl pkcs8::AssociatedOid for NistP224 {
 /// Compressed SEC1-encoded NIST P-224 curve point.
 pub type CompressedPoint = GenericArray<u8, U29>;
 
+/// NIST P-224 SEC1 encoded point.
+pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP224>;
+
 /// NIST P-224 field element serialized as bytes.
 ///
 /// Byte array containing a serialized field element value (base field or
 /// scalar).
 pub type FieldBytes = elliptic_curve::FieldBytes<NistP224>;
 
-/// NIST P-224 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP224>;
+impl FieldBytesEncoding<NistP224> for U256 {}
 
 /// NIST P-224 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<NistP224>;

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -17,11 +17,11 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 primeorder = { version = "=0.13.0-pre", path = "../primeorder" }
 
 # optional dependencies
-ecdsa-core = { version = "=0.16.0-pre", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.16.0-pre.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
@@ -29,7 +29,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.4"
-ecdsa-core = { version = "=0.16.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.16.0-pre.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "1"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p256/benches/field.rs
+++ b/p256/benches/field.rs
@@ -7,14 +7,14 @@ use hex_literal::hex;
 use p256::FieldElement;
 
 fn test_field_element_x() -> FieldElement {
-    FieldElement::from_sec1(
+    FieldElement::from_bytes(
         &hex!("1ccbe91c075fc7f4f033bfa248db8fccd3565de94bbfb12f3c59ff46c271bf83").into(),
     )
     .unwrap()
 }
 
 fn test_field_element_y() -> FieldElement {
-    FieldElement::from_sec1(
+    FieldElement::from_bytes(
         &hex!("ce4014c68811f9a21a1fdb2c0e6113e06db7ca93b7404e78dc7ccd5ca89a4ca9").into(),
     )
     .unwrap()

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -37,9 +37,8 @@ impl PrimeCurveParams for NistP256 {
         .sub(&FieldElement::ONE)
         .sub(&FieldElement::ONE);
 
-    const EQUATION_B: FieldElement = FieldElement::from_be_hex(
-        "5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b",
-    );
+    const EQUATION_B: FieldElement =
+        FieldElement::from_hex("5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b");
 
     /// Base point of P-256.
     ///
@@ -50,11 +49,7 @@ impl PrimeCurveParams for NistP256 {
     /// Gᵧ = 4fe342e2 fe1a7f9b 8ee7eb4a 7c0f9e16 2bce3357 6b315ece cbb64068 37bf51f5
     /// ```
     const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_be_hex(
-            "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
-        ),
-        FieldElement::from_be_hex(
-            "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
-        ),
+        FieldElement::from_hex("6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296"),
+        FieldElement::from_hex("4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5"),
     );
 }

--- a/p256/src/arithmetic/hash2curve.rs
+++ b/p256/src/arithmetic/hash2curve.rs
@@ -69,7 +69,7 @@ impl MapToCurve for FieldElement {
         let (qx, qy) = self.osswu();
 
         // TODO(tarcieri): assert that `qy` is correct? less circuitous conversion?
-        AffinePoint::decompress(&qx.to_sec1(), qy.is_odd())
+        AffinePoint::decompress(&qx.to_bytes(), qy.is_odd())
             .unwrap()
             .into()
     }
@@ -211,8 +211,8 @@ mod tests {
                 };
             }
 
-            assert_eq!(u[0].to_sec1().as_slice(), test_vector.u_0);
-            assert_eq!(u[1].to_sec1().as_slice(), test_vector.u_1);
+            assert_eq!(u[0].to_bytes().as_slice(), test_vector.u_0);
+            assert_eq!(u[1].to_bytes().as_slice(), test_vector.u_1);
 
             let q0 = u[0].map_to_curve();
             assert_point_eq!(q0, test_vector.q0_x, test_vector.q0_y);

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -17,11 +17,11 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 primeorder = { version = "=0.13.0-pre", path = "../primeorder" }
 
 # optional dependencies
-ecdsa-core = { version = "=0.16.0-pre", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.16.0-pre.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
@@ -29,7 +29,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.4"
-ecdsa-core = { version = "=0.16.0-pre", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.16.0-pre.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p384/benches/field.rs
+++ b/p384/benches/field.rs
@@ -7,14 +7,14 @@ use hex_literal::hex;
 use p384::FieldElement;
 
 fn test_field_element_x() -> FieldElement {
-    FieldElement::from_sec1(
+    FieldElement::from_bytes(
         hex!("c2b47944fb5de342d03285880177ca5f7d0f2fcad7678cce4229d6e1932fcac11bfc3c3e97d942a3c56bf34123013dbf").into()
     )
     .unwrap()
 }
 
 fn test_field_element_y() -> FieldElement {
-    FieldElement::from_sec1(
+    FieldElement::from_bytes(
         hex!("37257906a8223866eda0743c519616a76a758ae58aee81c5fd35fbf3a855b7754a36d4a0672df95d6c44a81cf7620c2d").into()
     )
     .unwrap()

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -44,7 +44,7 @@ impl PrimeCurveParams for NistP384 {
 
     /// b = b3312fa7 e23ee7e4 988e056b e3f82d19 181d9c6e fe814112
     ///     0314088f 5013875a c656398d 8a2ed19d 2a85c8ed d3ec2aef
-    const EQUATION_B: FieldElement = FieldElement::from_be_hex("b3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef");
+    const EQUATION_B: FieldElement = FieldElement::from_hex("b3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef");
 
     /// Base point of P-384.
     ///
@@ -60,7 +60,7 @@ impl PrimeCurveParams for NistP384 {
     /// NOTE: coordinate field elements have been translated into the Montgomery
     /// domain.
     const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_be_hex("aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7"),
-        FieldElement::from_be_hex("3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f"),
+        FieldElement::from_hex("aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7"),
+        FieldElement::from_hex("3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f"),
     );
 }

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -25,7 +25,7 @@
 mod field_impl;
 
 use self::field_impl::*;
-use crate::FieldBytes;
+use crate::{FieldBytes, NistP384};
 use core::{
     iter::{Product, Sum},
     ops::{AddAssign, MulAssign, Neg, SubAssign},
@@ -45,6 +45,7 @@ pub(crate) const MODULUS: U384 = U384::from_be_hex(FieldElement::MODULUS);
 pub struct FieldElement(pub(super) U384);
 
 primeorder::impl_field_element!(
+    NistP384,
     FieldElement,
     FieldBytes,
     U384,
@@ -60,19 +61,6 @@ primeorder::impl_field_element!(
 );
 
 impl FieldElement {
-    /// Parse the given byte array as an SEC1-encoded field element.
-    ///
-    /// Returns `None` if the byte array does not contain a big-endian integer in
-    /// the range `[0, p)`.
-    pub fn from_sec1(bytes: FieldBytes) -> CtOption<Self> {
-        Self::from_be_bytes(bytes)
-    }
-
-    /// Returns the SEC1 encoding of this field element.
-    pub fn to_sec1(self) -> FieldBytes {
-        self.to_be_bytes()
-    }
-
     /// Compute [`FieldElement`] inversion: `1 / self`.
     pub fn invert(&self) -> CtOption<Self> {
         let ret = impl_field_invert!(
@@ -135,18 +123,21 @@ impl PrimeField for FieldElement {
     const TWO_INV: Self = Self::ZERO; // TODO
     const MULTIPLICATIVE_GENERATOR: Self = Self(U384::from_u32(19));
     const S: u32 = 1;
-    const ROOT_OF_UNITY: Self = Self::from_be_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffe");
+    const ROOT_OF_UNITY: Self = Self::from_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffe");
     const ROOT_OF_UNITY_INV: Self = Self::ZERO; // TODO
     const DELTA: Self = Self::ZERO; // TODO
 
+    #[inline]
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
-        Self::from_be_bytes(bytes)
+        Self::from_bytes(&bytes)
     }
 
+    #[inline]
     fn to_repr(&self) -> FieldBytes {
-        self.to_be_bytes()
+        self.to_bytes()
     }
 
+    #[inline]
     fn is_odd(&self) -> Choice {
         self.is_odd()
     }

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -70,6 +70,7 @@ use core::ops::{Add, Mul, Sub};
 pub struct Scalar(U384);
 
 primeorder::impl_field_element!(
+    NistP384,
     Scalar,
     FieldBytes,
     U384,
@@ -157,14 +158,6 @@ impl Scalar {
     pub const fn shr_vartime(&self, shift: usize) -> Scalar {
         Self(self.0.shr_vartime(shift))
     }
-
-    /// Returns the SEC1 encoding of this scalar.
-    ///
-    /// Required for running test vectors.
-    #[cfg(test)]
-    pub fn to_bytes(&self) -> FieldBytes {
-        self.to_be_bytes()
-    }
 }
 
 impl AsRef<Scalar> for Scalar {
@@ -219,18 +212,21 @@ impl PrimeField for Scalar {
     const TWO_INV: Self = Self::ZERO; // TODO
     const MULTIPLICATIVE_GENERATOR: Self = Self(U384::from_u64(2));
     const S: u32 = 1;
-    const ROOT_OF_UNITY: Self = Self::from_be_hex("ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972");
+    const ROOT_OF_UNITY: Self = Self::from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972");
     const ROOT_OF_UNITY_INV: Self = Self::ZERO; // TODO
     const DELTA: Self = Self::ZERO; // TODO
 
+    #[inline]
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
-        Self::from_be_bytes(bytes)
+        Self::from_bytes(&bytes)
     }
 
+    #[inline]
     fn to_repr(&self) -> FieldBytes {
-        self.to_be_bytes()
+        self.to_bytes()
     }
 
+    #[inline]
     fn is_odd(&self) -> Choice {
         self.is_odd()
     }
@@ -356,10 +352,10 @@ mod tests {
     fn from_to_bytes_roundtrip() {
         let k: u64 = 42;
         let mut bytes = FieldBytes::default();
-        bytes[40..].copy_from_slice(k.to_le_bytes().as_ref());
+        bytes[40..].copy_from_slice(k.to_be_bytes().as_ref());
 
         let scalar = Scalar::from_repr(bytes).unwrap();
-        assert_eq!(bytes, scalar.to_be_bytes());
+        assert_eq!(bytes, scalar.to_bytes());
     }
 
     /// Basic tests that multiplication works.

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 
 [features]
 default = ["pem", "std"]

--- a/p521/src/lib.rs
+++ b/p521/src/lib.rs
@@ -20,7 +20,7 @@ pub use elliptic_curve::{self, bigint::U576};
 #[cfg(feature = "pkcs8")]
 pub use elliptic_curve::pkcs8;
 
-use elliptic_curve::{consts::U66, generic_array::GenericArray};
+use elliptic_curve::{consts::U66, generic_array::GenericArray, FieldBytesEncoding};
 
 /// NIST P-521 elliptic curve.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
@@ -62,14 +62,16 @@ impl pkcs8::AssociatedOid for NistP521 {
 /// Compressed SEC1-encoded NIST P-521 curve point.
 pub type CompressedPoint = GenericArray<u8, U66>;
 
+/// NIST P-521 SEC1 encoded point.
+pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP521>;
+
 /// NIST P-521 field element serialized as bytes.
 ///
 /// Byte array containing a serialized field element value (base field or
 /// scalar).
 pub type FieldBytes = elliptic_curve::FieldBytes<NistP521>;
 
-/// NIST P-521 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP521>;
+impl FieldBytesEncoding<NistP521> for U576 {}
 
 /// NIST P-521 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<NistP521>;

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.2", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.1", optional = true, default-features = false }

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -18,7 +18,7 @@ use elliptic_curve::{
     },
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, CtOption},
     zeroize::DefaultIsZeroes,
-    Error, FieldBytes, FieldBytesSize, PublicKey, Result, Scalar,
+    Error, FieldBytes, FieldBytesEncoding, FieldBytesSize, PublicKey, Result, Scalar,
 };
 
 #[cfg(feature = "serde")]
@@ -66,8 +66,8 @@ where
     /// Conditionally negate [`AffinePoint`] for use with point compaction.
     fn to_compact(self) -> Self {
         let neg_self = -self;
-        let choice = C::decode_field_bytes(&self.y.to_repr())
-            .ct_gt(&C::decode_field_bytes(&neg_self.y.to_repr()));
+        let choice = C::Uint::decode_field_bytes(&self.y.to_repr())
+            .ct_gt(&C::Uint::decode_field_bytes(&neg_self.y.to_repr()));
 
         Self {
             x: self.x,


### PR DESCRIPTION
The `elliptic-curve` v0.13.0-pre.3 release refactored encoding onto a `FieldBytesEncoding` trait which provides curve-specific conversions between `Uint` and `FieldBytes`.

This commit adds these trait impls and otherwise cleans up serialization-related code to use the new API.

The `*_be_*` and `*_le_*` APIs have all been removed in favor of curves having a canonical endianness each. That's customizable on a per-curve basis via `FieldBytesEncoding`.

Also bumps `ecdsa` to v0.16.0-pre.0.