### PR TITLE
Update hash2curve implementations to new API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "elliptic-curve"
 version = "0.13.0-pre.3"
-source = "git+https://github.com/RustCrypto/traits.git#cd2ecd3bff18ad4c162ac41f275f405537dc439c"
+source = "git+https://github.com/RustCrypto/traits.git#771f5dfcf232d54f7cca25d0b90c1705b21217a5"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/k256/src/arithmetic/hash2curve.rs
+++ b/k256/src/arithmetic/hash2curve.rs
@@ -369,7 +369,7 @@ mod tests {
             let mut u = [FieldElement::default(), FieldElement::default()];
             hash2curve::hash_to_field::<ExpandMsgXmd<Sha256>, FieldElement>(
                 &[test_vector.msg],
-                DST,
+                &[DST],
                 &mut u,
             )
             .unwrap();
@@ -392,7 +392,7 @@ mod tests {
             assert_eq!(ap.y.to_bytes().as_slice(), test_vector.p_y);
 
             // complete run
-            let pt = Secp256k1::hash_from_bytes::<ExpandMsgXmd<Sha256>>(&[test_vector.msg], DST)
+            let pt = Secp256k1::hash_from_bytes::<ExpandMsgXmd<Sha256>>(&[test_vector.msg], &[DST])
                 .unwrap();
             let apt = pt.to_affine();
             assert_eq!(apt.x.to_bytes().as_slice(), test_vector.p_x);

--- a/p256/src/arithmetic/hash2curve.rs
+++ b/p256/src/arithmetic/hash2curve.rs
@@ -191,7 +191,7 @@ mod tests {
             let mut u = [FieldElement::default(), FieldElement::default()];
             hash2curve::hash_to_field::<ExpandMsgXmd<Sha256>, FieldElement>(
                 &[test_vector.msg],
-                DST,
+                &[DST],
                 &mut u,
             )
             .unwrap();
@@ -224,8 +224,8 @@ mod tests {
             assert_point_eq!(p, test_vector.p_x, test_vector.p_y);
 
             // complete run
-            let pt =
-                NistP256::hash_from_bytes::<ExpandMsgXmd<Sha256>>(&[test_vector.msg], DST).unwrap();
+            let pt = NistP256::hash_from_bytes::<ExpandMsgXmd<Sha256>>(&[test_vector.msg], &[DST])
+                .unwrap();
             assert_point_eq!(pt, test_vector.p_x, test_vector.p_y);
         }
     }
@@ -274,7 +274,7 @@ mod tests {
                         test_vector.key_info,
                         &counter.to_be_bytes(),
                     ],
-                    test_vector.dst,
+                    &[test_vector.dst],
                 )
                 .unwrap();
 

--- a/p384/src/arithmetic/hash2curve.rs
+++ b/p384/src/arithmetic/hash2curve.rs
@@ -194,7 +194,7 @@ mod tests {
             let mut u = [FieldElement::default(), FieldElement::default()];
             hash2curve::hash_to_field::<ExpandMsgXmd<Sha384>, FieldElement>(
                 &[test_vector.msg],
-                DST,
+                &[DST],
                 &mut u,
             )
             .unwrap();
@@ -227,8 +227,8 @@ mod tests {
             assert_point_eq!(p, test_vector.p_x, test_vector.p_y);
 
             // complete run
-            let pt =
-                NistP384::hash_from_bytes::<ExpandMsgXmd<Sha384>>(&[test_vector.msg], DST).unwrap();
+            let pt = NistP384::hash_from_bytes::<ExpandMsgXmd<Sha384>>(&[test_vector.msg], &[DST])
+                .unwrap();
             assert_point_eq!(pt, test_vector.p_x, test_vector.p_y);
         }
     }
@@ -277,7 +277,7 @@ mod tests {
                         test_vector.key_info,
                         &counter.to_be_bytes(),
                     ],
-                    test_vector.dst,
+                    &[test_vector.dst],
                 )
                 .unwrap();
 


### PR DESCRIPTION
Follow up to https://github.com/RustCrypto/traits/pull/1238.

Cc @tarcieri.