### PR TITLE
p256+p384: add `const fn` inversions for all field elements

### DIFF
--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -53,24 +53,6 @@ primeorder::impl_field_element!(
 );
 
 impl FieldElement {
-    /// Returns `self^by`, where `by` is a little-endian integer exponent.
-    ///
-    /// **This operation is variable time with respect to the exponent.** If the exponent
-    /// is fixed, this operation is effectively constant time.
-    pub fn pow_vartime(&self, by: &[u64; 4]) -> Self {
-        let mut res = Self::ONE;
-        for e in by.iter().rev() {
-            for i in (0..64).rev() {
-                res = res.square();
-
-                if ((*e >> i) & 1) == 1 {
-                    res = res * self;
-                }
-            }
-        }
-        res
-    }
-
     /// Returns the multiplicative inverse of self, if self is non-zero.
     pub fn invert(&self) -> CtOption<Self> {
         CtOption::new(self.invert_unchecked(), !self.is_zero())
@@ -147,8 +129,8 @@ impl PrimeField for FieldElement {
     const MODULUS: &'static str = MODULUS_HEX;
     const NUM_BITS: u32 = 256;
     const CAPACITY: u32 = 255;
-    const TWO_INV: Self = Self::ONE.add(&Self::ONE).invert_unchecked();
-    const MULTIPLICATIVE_GENERATOR: Self = Self::from_uint_unchecked(U256::from_u8(6));
+    const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
+    const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(6);
     const S: u32 = 1;
     const ROOT_OF_UNITY: Self = Self(U256::from_be_hex(
         "ffffffff00000001000000000000000000000000fffffffffffffffffffffffe",

--- a/p384/src/arithmetic/macros.rs
+++ b/p384/src/arithmetic/macros.rs
@@ -17,11 +17,15 @@ macro_rules! impl_field_invert {
         let mut d = 1;
         let mut f = $msat();
         let mut g = [0; $nlimbs + 1];
-        let mut v = Default::default();
+        let mut v = [0; $nlimbs];
         let mut r = $one;
         let mut i = 0;
+        let mut j = 0;
 
-        g[..$nlimbs].copy_from_slice($a.as_ref());
+        while j < $nlimbs {
+            g[j] = $a[j];
+            j += 1;
+        }
 
         while i < ITERATIONS - ITERATIONS % 2 {
             let (out1, out2, out3, out4, out5) = $divstep(d, &f, &g, &v, &r);

--- a/primeorder/src/field.rs
+++ b/primeorder/src/field.rs
@@ -118,6 +118,13 @@ macro_rules! impl_field_element {
                 Self::from_uint_unchecked(<$uint>::from_be_hex(hex))
             }
 
+            /// Convert a `u64` into a [`
+            #[doc = stringify!($fe)]
+            /// `].
+            pub const fn from_u64(w: u64) -> Self {
+                Self::from_uint_unchecked(<$uint>::from_u64(w))
+            }
+
             /// Decode [`
             #[doc = stringify!($fe)]
             /// `] from [`
@@ -222,6 +229,32 @@ macro_rules! impl_field_element {
             #[must_use]
             pub const fn square(&self) -> Self {
                 Self(<$uint>::from_words($square(self.0.as_words())))
+            }
+
+            /// Returns `self^exp`, where `exp` is a little-endian integer exponent.
+            ///
+            /// **This operation is variable time with respect to the exponent.**
+            ///
+            /// If the exponent is fixed, this operation is effectively constant time.
+            pub const fn pow_vartime(&self, exp: &[u64]) -> Self {
+                let mut res = Self::ONE;
+                let mut i = exp.len();
+
+                while i > 0 {
+                    i -= 1;
+
+                    let mut j = 64;
+                    while j > 0 {
+                        j -= 1;
+                        res = res.square();
+
+                        if ((exp[i] >> j) & 1) == 1 {
+                            res = res.multiply(self);
+                        }
+                    }
+                }
+
+                res
             }
         }
 


### PR DESCRIPTION
This adds an internal `invert_unchecked` method to all field element types, which is `const fn`.

It's used to impl the `PrimeField` constants which are inversions of other constant values.