### PR TITLE
k256+p256+p384: add `PrimeField` constant tests

### DIFF
--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -518,10 +518,9 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO(tarcieri): debug failure
     fn two_inv_constant() {
         assert_eq!(
-            FieldElement::from(2u64) * FieldElement::TWO_INV,
+            (FieldElement::from(2u64) * FieldElement::TWO_INV).normalize(),
             FieldElement::ONE
         );
     }
@@ -531,16 +530,17 @@ mod tests {
     fn root_of_unity_constant() {
         // ROOT_OF_UNITY^{2^s} mod m == 1
         assert_eq!(
-            FieldElement::ROOT_OF_UNITY.pow_vartime(&[1u64 << FieldElement::S, 0, 0, 0]),
+            FieldElement::ROOT_OF_UNITY
+                .pow_vartime(&[1u64 << FieldElement::S, 0, 0, 0])
+                .normalize(),
             FieldElement::ONE
         );
     }
 
     #[test]
-    #[ignore] // TODO(tarcieri): debug failure
     fn root_of_unity_inv_constant() {
         assert_eq!(
-            FieldElement::ROOT_OF_UNITY * FieldElement::ROOT_OF_UNITY_INV,
+            (FieldElement::ROOT_OF_UNITY * FieldElement::ROOT_OF_UNITY_INV).normalize(),
             FieldElement::ONE
         );
     }

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -493,6 +493,7 @@ impl<'a> Product<&'a FieldElement> for FieldElement {
 
 #[cfg(test)]
 mod tests {
+    use elliptic_curve::ff::{Field, PrimeField};
     use num_bigint::{BigUint, ToBigUint};
     use proptest::prelude::*;
 
@@ -514,6 +515,34 @@ mod tests {
         fn to_biguint(&self) -> Option<BigUint> {
             Some(bytes_to_biguint(self.to_bytes().as_ref()))
         }
+    }
+
+    #[test]
+    #[ignore] // TODO(tarcieri): debug failure
+    fn two_inv_constant() {
+        assert_eq!(
+            FieldElement::from(2u64) * FieldElement::TWO_INV,
+            FieldElement::ONE
+        );
+    }
+
+    #[test]
+    #[ignore] // TODO(tarcieri): debug failure
+    fn root_of_unity_constant() {
+        // ROOT_OF_UNITY^{2^s} mod m == 1
+        assert_eq!(
+            FieldElement::ROOT_OF_UNITY.pow_vartime(&[1u64 << FieldElement::S, 0, 0, 0]),
+            FieldElement::ONE
+        );
+    }
+
+    #[test]
+    #[ignore] // TODO(tarcieri): debug failure
+    fn root_of_unity_inv_constant() {
+        assert_eq!(
+            FieldElement::ROOT_OF_UNITY * FieldElement::ROOT_OF_UNITY_INV,
+            FieldElement::ONE
+        );
     }
 
     #[test]

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -550,6 +550,22 @@ mod tests {
     }
 
     #[test]
+    fn delta_constant() {
+        const T: [u64; 4] = [
+            0xffffffff7ffffe17,
+            0xffffffffffffffff,
+            0xffffffffffffffff,
+            0x7fffffffffffffff,
+        ];
+
+        // DELTA^{t} mod m == 1
+        assert_eq!(
+            FieldElement::DELTA.pow_vartime(&T).normalize(),
+            FieldElement::ONE
+        );
+    }
+
+    #[test]
     fn zero_is_additive_identity() {
         let zero = FieldElement::ZERO;
         let one = FieldElement::ONE;

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -98,6 +98,11 @@ impl FieldElement {
         FieldElementImpl::from_bytes(bytes).map(Self)
     }
 
+    /// Convert a `u64` to a field element.
+    pub const fn from_u64(w: u64) -> Self {
+        Self(FieldElementImpl::from_u64(w))
+    }
+
     /// Returns the SEC1 encoding of this field element.
     pub fn to_bytes(self) -> FieldBytes {
         self.0.normalize().to_bytes()
@@ -290,8 +295,8 @@ impl PrimeField for FieldElement {
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f, 0xff,
         0xfe, 0x18,
     ]));
-    const MULTIPLICATIVE_GENERATOR: Self = Self(FieldElementImpl::from_u64(3));
-    const S: u32 = 0;
+    const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(3);
+    const S: u32 = 1;
     const ROOT_OF_UNITY: Self = Self(FieldElementImpl::from_bytes_unchecked(&[
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0xff,
@@ -302,7 +307,7 @@ impl PrimeField for FieldElement {
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0xff,
         0xfc, 0x2e,
     ]));
-    const DELTA: Self = Self(FieldElementImpl::from_u64(9));
+    const DELTA: Self = Self::from_u64(9);
 
     fn from_repr(repr: Self::Repr) -> CtOption<Self> {
         Self::from_bytes(&repr)
@@ -526,7 +531,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO(tarcieri): debug failure
     fn root_of_unity_constant() {
         // ROOT_OF_UNITY^{2^s} mod m == 1
         assert_eq!(

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -12,7 +12,7 @@ use core::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, ShrAssign, Sub, SubAssign},
 };
 use elliptic_curve::{
-    bigint::{self, prelude::*, Limb, Word, U256, U512},
+    bigint::{prelude::*, Limb, Word, U256, U512},
     ff::{self, Field, PrimeField},
     ops::{Reduce, ReduceNonZero},
     rand_core::{CryptoRngCore, RngCore},
@@ -36,7 +36,7 @@ use num_bigint::{BigUint, ToBigUint};
 
 /// Constant representing the modulus
 /// n = FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364141
-const MODULUS: [Word; bigint::nlimbs!(256)] = ORDER.to_words();
+const MODULUS: [Word; U256::LIMBS] = ORDER.to_words();
 
 /// Constant representing the modulus / 2
 const FRAC_MODULUS_2: U256 = ORDER.shr_vartime(1);
@@ -777,6 +777,19 @@ mod tests {
             Scalar::ROOT_OF_UNITY * Scalar::ROOT_OF_UNITY_INV,
             Scalar::ONE
         );
+    }
+
+    #[test]
+    fn delta_constant() {
+        const T: [u64; 4] = [
+            0xeeff497a3340d905,
+            0xfaeabb739abd2280,
+            0xffffffffffffffff,
+            0x03ffffffffffffff,
+        ];
+
+        // DELTA^{t} mod m == 1
+        assert_eq!(Scalar::DELTA.pow_vartime(&T), Scalar::ONE);
     }
 
     #[test]

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -758,6 +758,28 @@ mod tests {
     }
 
     #[test]
+    fn two_inv_constant() {
+        assert_eq!(Scalar::from(2u32) * Scalar::TWO_INV, Scalar::ONE);
+    }
+
+    #[test]
+    fn root_of_unity_constant() {
+        // ROOT_OF_UNITY^{2^s} mod m == 1
+        assert_eq!(
+            Scalar::ROOT_OF_UNITY.pow_vartime(&[1u64 << Scalar::S, 0, 0, 0]),
+            Scalar::ONE
+        );
+    }
+
+    #[test]
+    fn root_of_unity_inv_constant() {
+        assert_eq!(
+            Scalar::ROOT_OF_UNITY * Scalar::ROOT_OF_UNITY_INV,
+            Scalar::ONE
+        );
+    }
+
+    #[test]
     fn is_high() {
         // 0 is not high
         let high: bool = Scalar::ZERO.is_high().into();

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -195,7 +195,7 @@ mod tests {
         ];
 
         // DELTA^{t} mod m == 1
-        assert_eq!(FieldElement::DELTA.pow_vartime(&T), FieldElement::ONE,);
+        assert_eq!(FieldElement::DELTA.pow_vartime(&T), FieldElement::ONE);
     }
 
     #[test]

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -135,7 +135,7 @@ impl PrimeField for FieldElement {
     const ROOT_OF_UNITY: Self =
         Self::from_hex("ffffffff00000001000000000000000000000000fffffffffffffffffffffffe");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
-    const DELTA: Self = Self::ZERO; // TODO
+    const DELTA: Self = Self::from_u64(36);
 
     #[inline]
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
@@ -182,6 +182,20 @@ mod tests {
         assert_eq!(
             FieldElement::ROOT_OF_UNITY * FieldElement::ROOT_OF_UNITY_INV,
             FieldElement::ONE
+        );
+    }
+
+    #[test]
+    fn delta_constant() {
+        // DELTA^{t} mod m == 1
+        assert_eq!(
+            FieldElement::DELTA.pow_vartime(&[
+                0xffffffffffffffff,
+                0x000000007fffffff,
+                0x8000000000000000,
+                0x7fffffff80000000,
+            ]),
+            FieldElement::ONE,
         );
     }
 

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -187,16 +187,15 @@ mod tests {
 
     #[test]
     fn delta_constant() {
+        const T: [u64; 4] = [
+            0xffffffffffffffff,
+            0x000000007fffffff,
+            0x8000000000000000,
+            0x7fffffff80000000,
+        ];
+
         // DELTA^{t} mod m == 1
-        assert_eq!(
-            FieldElement::DELTA.pow_vartime(&[
-                0xffffffffffffffff,
-                0x000000007fffffff,
-                0x8000000000000000,
-                0x7fffffff80000000,
-            ]),
-            FieldElement::ONE,
-        );
+        assert_eq!(FieldElement::DELTA.pow_vartime(&T), FieldElement::ONE,);
     }
 
     #[test]

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -132,9 +132,8 @@ impl PrimeField for FieldElement {
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(6);
     const S: u32 = 1;
-    const ROOT_OF_UNITY: Self = Self(U256::from_be_hex(
-        "ffffffff00000001000000000000000000000000fffffffffffffffffffffffe",
-    ));
+    const ROOT_OF_UNITY: Self =
+        Self::from_hex("ffffffff00000001000000000000000000000000fffffffffffffffffffffffe");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
     const DELTA: Self = Self::ZERO; // TODO
 
@@ -170,7 +169,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO(tarcieri): debug failure
     fn root_of_unity_constant() {
         // ROOT_OF_UNITY^{2^s} mod m == 1
         assert_eq!(

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -158,8 +158,34 @@ impl PrimeField for FieldElement {
 mod tests {
     use super::FieldElement;
     use crate::{test_vectors::field::DBL_TEST_VECTORS, FieldBytes};
-    use elliptic_curve::bigint::U256;
+    use elliptic_curve::{bigint::U256, ff::PrimeField};
     use proptest::{num, prelude::*};
+
+    #[test]
+    fn two_inv_constant() {
+        assert_eq!(
+            FieldElement::from(2u32) * FieldElement::TWO_INV,
+            FieldElement::ONE
+        );
+    }
+
+    #[test]
+    #[ignore] // TODO(tarcieri): debug failure
+    fn root_of_unity_constant() {
+        // ROOT_OF_UNITY^{2^s} mod m == 1
+        assert_eq!(
+            FieldElement::ROOT_OF_UNITY.pow_vartime(&[1u64 << FieldElement::S, 0, 0, 0]),
+            FieldElement::ONE
+        );
+    }
+
+    #[test]
+    fn root_of_unity_inv_constant() {
+        assert_eq!(
+            FieldElement::ROOT_OF_UNITY * FieldElement::ROOT_OF_UNITY_INV,
+            FieldElement::ONE
+        );
+    }
 
     #[test]
     fn zero_is_additive_identity() {

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -718,7 +718,7 @@ mod tests {
         ];
 
         // DELTA^{t} mod m == 1
-        assert_eq!(Scalar::DELTA.pow_vartime(&T), Scalar::ONE,);
+        assert_eq!(Scalar::DELTA.pow_vartime(&T), Scalar::ONE);
     }
 
     #[test]

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -157,7 +157,7 @@ impl Scalar {
 
     /// Exponentiates `self` by `exp`, where `exp` is a little-endian order integer
     /// exponent.
-    pub(crate) const fn pow_vartime(&self, exp: &[u64]) -> Self {
+    pub const fn pow_vartime(&self, exp: &[u64]) -> Self {
         let mut res = Self::ONE;
 
         let mut i = exp.len();
@@ -299,7 +299,7 @@ impl PrimeField for Scalar {
         "ffc97f062a770992ba807ace842a3dfc1546cad004378daf0592d7fbb41e6602",
     ));
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
-    const DELTA: Self = Self::ZERO; // TODO
+    const DELTA: Self = Self(U256::from_u64(33232930569601));
 
     /// Attempts to parse the given byte array as an SEC1-encoded scalar.
     ///
@@ -706,6 +706,19 @@ mod tests {
             Scalar::ROOT_OF_UNITY * Scalar::ROOT_OF_UNITY_INV,
             Scalar::ONE
         );
+    }
+
+    #[test]
+    fn delta_constant() {
+        const T: [u64; 4] = [
+            0x4f3b9cac2fc63255,
+            0xfbce6faada7179e8,
+            0x0fffffffffffffff,
+            0x0ffffffff0000000,
+        ];
+
+        // DELTA^{t} mod m == 1
+        assert_eq!(Scalar::DELTA.pow_vartime(&T), Scalar::ONE,);
     }
 
     #[test]

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -687,6 +687,28 @@ mod tests {
     use elliptic_curve::group::ff::{Field, PrimeField};
 
     #[test]
+    fn two_inv_constant() {
+        assert_eq!(Scalar::from(2u32) * Scalar::TWO_INV, Scalar::ONE);
+    }
+
+    #[test]
+    fn root_of_unity_constant() {
+        // ROOT_OF_UNITY^{2^s} mod m == 1
+        assert_eq!(
+            Scalar::ROOT_OF_UNITY.pow_vartime(&[1u64 << Scalar::S, 0, 0, 0]),
+            Scalar::ONE
+        );
+    }
+
+    #[test]
+    fn root_of_unity_inv_constant() {
+        assert_eq!(
+            Scalar::ROOT_OF_UNITY * Scalar::ROOT_OF_UNITY_INV,
+            Scalar::ONE
+        );
+    }
+
+    #[test]
     fn from_to_bytes_roundtrip() {
         let k: u64 = 42;
         let mut bytes = FieldBytes::default();

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -133,7 +133,7 @@ impl PrimeField for FieldElement {
     const S: u32 = 1;
     const ROOT_OF_UNITY: Self = Self::from_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffe");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
-    const DELTA: Self = Self::ZERO; // TODO
+    const DELTA: Self = Self::from_u64(49);
 
     #[inline]
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
@@ -179,6 +179,21 @@ mod tests {
             FieldElement::ROOT_OF_UNITY * FieldElement::ROOT_OF_UNITY_INV,
             FieldElement::ONE
         );
+    }
+
+    #[test]
+    fn delta_constant() {
+        const T: [u64; 6] = [
+            0x000000007fffffff,
+            0x7fffffff80000000,
+            0xffffffffffffffff,
+            0xffffffffffffffff,
+            0xffffffffffffffff,
+            0x7fffffffffffffff,
+        ];
+
+        // DELTA^{t} mod m == 1
+        assert_eq!(FieldElement::DELTA.pow_vartime(&T), FieldElement::ONE);
     }
 
     /// Basic tests that field inversion works.

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -154,6 +154,32 @@ impl PrimeField for FieldElement {
 #[cfg(test)]
 mod tests {
     use super::FieldElement;
+    use elliptic_curve::ff::PrimeField;
+
+    #[test]
+    fn two_inv_constant() {
+        assert_eq!(
+            FieldElement::from(2u32) * FieldElement::TWO_INV,
+            FieldElement::ONE
+        );
+    }
+
+    #[test]
+    fn root_of_unity_constant() {
+        // ROOT_OF_UNITY^{2^s} mod m == 1
+        assert_eq!(
+            FieldElement::ROOT_OF_UNITY.pow_vartime(&[1u64 << FieldElement::S, 0, 0, 0]),
+            FieldElement::ONE
+        );
+    }
+
+    #[test]
+    fn root_of_unity_inv_constant() {
+        assert_eq!(
+            FieldElement::ROOT_OF_UNITY * FieldElement::ROOT_OF_UNITY_INV,
+            FieldElement::ONE
+        );
+    }
 
     /// Basic tests that field inversion works.
     #[test]

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -222,7 +222,7 @@ impl PrimeField for Scalar {
     const S: u32 = 1;
     const ROOT_OF_UNITY: Self = Self::from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
-    const DELTA: Self = Self::ZERO; // TODO
+    const DELTA: Self = Self::from_u64(4);
 
     #[inline]
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
@@ -376,6 +376,21 @@ mod tests {
             Scalar::ROOT_OF_UNITY * Scalar::ROOT_OF_UNITY_INV,
             Scalar::ONE
         );
+    }
+
+    #[test]
+    fn delta_constant() {
+        const T: [u64; 6] = [
+            0x76760cb5666294b9,
+            0xac0d06d9245853bd,
+            0xe3b1a6c0fa1b96ef,
+            0xffffffffffffffff,
+            0xffffffffffffffff,
+            0x7fffffffffffffff,
+        ];
+
+        // DELTA^{t} mod m == 1
+        assert_eq!(Scalar::DELTA.pow_vartime(&T), Scalar::ONE);
     }
 
     #[test]

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -357,6 +357,28 @@ mod tests {
     use elliptic_curve::ff::PrimeField;
 
     #[test]
+    fn two_inv_constant() {
+        assert_eq!(Scalar::from(2u32) * Scalar::TWO_INV, Scalar::ONE);
+    }
+
+    #[test]
+    fn root_of_unity_constant() {
+        // ROOT_OF_UNITY^{2^s} mod m == 1
+        assert_eq!(
+            Scalar::ROOT_OF_UNITY.pow_vartime(&[1u64 << Scalar::S, 0, 0, 0]),
+            Scalar::ONE
+        );
+    }
+
+    #[test]
+    fn root_of_unity_inv_constant() {
+        assert_eq!(
+            Scalar::ROOT_OF_UNITY * Scalar::ROOT_OF_UNITY_INV,
+            Scalar::ONE
+        );
+    }
+
+    #[test]
     fn from_to_bytes_roundtrip() {
         let k: u64 = 42;
         let mut bytes = FieldBytes::default();


### PR DESCRIPTION
Adds tests for the `TWO_INV`, `ROOT_OF_UNITY`, and `ROOT_OF_UNITY_INV` constants, based on the tests generated via `ff_derive`.

Some of them are currently failing and have been annotated with `#[ignore]` and a TODO comment.