### PR TITLE
primeorder: extract `impl_primefield_tests!` macro

### DIFF
--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -158,6 +158,7 @@ mod tests {
     use super::FieldElement;
     use crate::{test_vectors::field::DBL_TEST_VECTORS, FieldBytes};
     use elliptic_curve::{bigint::U256, ff::PrimeField};
+    use primeorder::impl_primefield_tests;
     use proptest::{num, prelude::*};
 
     /// t = (modulus - 1) >> S
@@ -168,42 +169,7 @@ mod tests {
         0x7fffffff80000000,
     ];
 
-    #[test]
-    fn two_inv_constant() {
-        assert_eq!(
-            FieldElement::from(2u32) * FieldElement::TWO_INV,
-            FieldElement::ONE
-        );
-    }
-
-    #[test]
-    fn root_of_unity_constant() {
-        // ROOT_OF_UNITY^{2^s} mod m == 1
-        assert_eq!(
-            FieldElement::ROOT_OF_UNITY.pow_vartime(&[1u64 << FieldElement::S, 0, 0, 0]),
-            FieldElement::ONE
-        );
-
-        // MULTIPLICATIVE_GENERATOR^{t} mod m == ROOT_OF_UNITY
-        assert_eq!(
-            FieldElement::MULTIPLICATIVE_GENERATOR.pow_vartime(&T),
-            FieldElement::ROOT_OF_UNITY
-        )
-    }
-
-    #[test]
-    fn root_of_unity_inv_constant() {
-        assert_eq!(
-            FieldElement::ROOT_OF_UNITY * FieldElement::ROOT_OF_UNITY_INV,
-            FieldElement::ONE
-        );
-    }
-
-    #[test]
-    fn delta_constant() {
-        // DELTA^{t} mod m == 1
-        assert_eq!(FieldElement::DELTA.pow_vartime(&T), FieldElement::ONE);
-    }
+    impl_primefield_tests!(FieldElement, T);
 
     #[test]
     fn zero_is_additive_identity() {

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -685,6 +685,7 @@ mod tests {
     use super::Scalar;
     use crate::{FieldBytes, SecretKey};
     use elliptic_curve::group::ff::{Field, PrimeField};
+    use primeorder::impl_primefield_tests;
 
     /// t = (modulus - 1) >> S
     const T: [u64; 4] = [
@@ -694,39 +695,7 @@ mod tests {
         0x0ffffffff0000000,
     ];
 
-    #[test]
-    fn two_inv_constant() {
-        assert_eq!(Scalar::from(2u32) * Scalar::TWO_INV, Scalar::ONE);
-    }
-
-    #[test]
-    fn root_of_unity_constant() {
-        // ROOT_OF_UNITY^{2^s} mod m == 1
-        assert_eq!(
-            Scalar::ROOT_OF_UNITY.pow_vartime(&[1u64 << Scalar::S, 0, 0, 0]),
-            Scalar::ONE
-        );
-
-        // MULTIPLICATIVE_GENERATOR^{t} mod m == ROOT_OF_UNITY
-        assert_eq!(
-            Scalar::MULTIPLICATIVE_GENERATOR.pow_vartime(&T),
-            Scalar::ROOT_OF_UNITY
-        )
-    }
-
-    #[test]
-    fn root_of_unity_inv_constant() {
-        assert_eq!(
-            Scalar::ROOT_OF_UNITY * Scalar::ROOT_OF_UNITY_INV,
-            Scalar::ONE
-        );
-    }
-
-    #[test]
-    fn delta_constant() {
-        // DELTA^{t} mod m == 1
-        assert_eq!(Scalar::DELTA.pow_vartime(&T), Scalar::ONE);
-    }
+    impl_primefield_tests!(Scalar, T);
 
     #[test]
     fn from_to_bytes_roundtrip() {

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -155,6 +155,7 @@ impl PrimeField for FieldElement {
 mod tests {
     use super::FieldElement;
     use elliptic_curve::ff::PrimeField;
+    use primeorder::impl_primefield_tests;
 
     /// t = (modulus - 1) >> S
     const T: [u64; 6] = [
@@ -166,42 +167,7 @@ mod tests {
         0x7fffffffffffffff,
     ];
 
-    #[test]
-    fn two_inv_constant() {
-        assert_eq!(
-            FieldElement::from(2u32) * FieldElement::TWO_INV,
-            FieldElement::ONE
-        );
-    }
-
-    #[test]
-    fn root_of_unity_constant() {
-        // ROOT_OF_UNITY^{2^s} mod m == 1
-        assert_eq!(
-            FieldElement::ROOT_OF_UNITY.pow_vartime(&[1u64 << FieldElement::S, 0, 0, 0]),
-            FieldElement::ONE
-        );
-
-        // MULTIPLICATIVE_GENERATOR^{t} mod m == ROOT_OF_UNITY
-        assert_eq!(
-            FieldElement::MULTIPLICATIVE_GENERATOR.pow_vartime(&T),
-            FieldElement::ROOT_OF_UNITY
-        )
-    }
-
-    #[test]
-    fn root_of_unity_inv_constant() {
-        assert_eq!(
-            FieldElement::ROOT_OF_UNITY * FieldElement::ROOT_OF_UNITY_INV,
-            FieldElement::ONE
-        );
-    }
-
-    #[test]
-    fn delta_constant() {
-        // DELTA^{t} mod m == 1
-        assert_eq!(FieldElement::DELTA.pow_vartime(&T), FieldElement::ONE);
-    }
+    impl_primefield_tests!(FieldElement, T);
 
     /// Basic tests that field inversion works.
     #[test]

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -355,6 +355,7 @@ mod tests {
     use super::Scalar;
     use crate::FieldBytes;
     use elliptic_curve::ff::PrimeField;
+    use primeorder::impl_primefield_tests;
 
     /// t = (modulus - 1) >> S
     const T: [u64; 6] = [
@@ -366,39 +367,7 @@ mod tests {
         0x7fffffffffffffff,
     ];
 
-    #[test]
-    fn two_inv_constant() {
-        assert_eq!(Scalar::from(2u32) * Scalar::TWO_INV, Scalar::ONE);
-    }
-
-    #[test]
-    fn root_of_unity_constant() {
-        // ROOT_OF_UNITY^{2^s} mod m == 1
-        assert_eq!(
-            Scalar::ROOT_OF_UNITY.pow_vartime(&[1u64 << Scalar::S, 0, 0, 0]),
-            Scalar::ONE
-        );
-
-        // MULTIPLICATIVE_GENERATOR^{t} mod m == ROOT_OF_UNITY
-        assert_eq!(
-            Scalar::MULTIPLICATIVE_GENERATOR.pow_vartime(&T),
-            Scalar::ROOT_OF_UNITY
-        )
-    }
-
-    #[test]
-    fn root_of_unity_inv_constant() {
-        assert_eq!(
-            Scalar::ROOT_OF_UNITY * Scalar::ROOT_OF_UNITY_INV,
-            Scalar::ONE
-        );
-    }
-
-    #[test]
-    fn delta_constant() {
-        // DELTA^{t} mod m == 1
-        assert_eq!(Scalar::DELTA.pow_vartime(&T), Scalar::ONE);
-    }
+    impl_primefield_tests!(Scalar, T);
 
     #[test]
     fn from_to_bytes_roundtrip() {

--- a/primeorder/src/dev.rs
+++ b/primeorder/src/dev.rs
@@ -1,0 +1,1 @@
+//! Development-related functionality.

--- a/primeorder/src/field.rs
+++ b/primeorder/src/field.rs
@@ -478,3 +478,40 @@ macro_rules! impl_field_op {
         }
     };
 }
+
+/// Implement tests for the `PrimeField` trait.
+#[macro_export]
+macro_rules! impl_primefield_tests {
+    ($fe:tt, $t:expr) => {
+        #[test]
+        fn two_inv_constant() {
+            assert_eq!($fe::from(2u32) * $fe::TWO_INV, $fe::ONE);
+        }
+
+        #[test]
+        fn root_of_unity_constant() {
+            // ROOT_OF_UNITY^{2^s} mod m == 1
+            assert_eq!(
+                $fe::ROOT_OF_UNITY.pow_vartime(&[1u64 << $fe::S, 0, 0, 0]),
+                $fe::ONE
+            );
+
+            // MULTIPLICATIVE_GENERATOR^{t} mod m == ROOT_OF_UNITY
+            assert_eq!(
+                $fe::MULTIPLICATIVE_GENERATOR.pow_vartime(&$t),
+                $fe::ROOT_OF_UNITY
+            )
+        }
+
+        #[test]
+        fn root_of_unity_inv_constant() {
+            assert_eq!($fe::ROOT_OF_UNITY * $fe::ROOT_OF_UNITY_INV, $fe::ONE);
+        }
+
+        #[test]
+        fn delta_constant() {
+            // DELTA^{t} mod m == 1
+            assert_eq!($fe::DELTA.pow_vartime(&$t), $fe::ONE);
+        }
+    };
+}


### PR DESCRIPTION
Extracts the tests duplicated between the `FieldElement` and `Scalar` types of the `p256` and `p384` crates into a macro which writes them.

It currently adds tests for the associated constants but could be further expanded in the future.