### PR TITLE
Bump `elliptic-curve` to v0.13.0-pre.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.16.0-pre.0"
-source = "git+https://github.com/RustCrypto/signatures.git#4e2b0b2cfcfaef61a1e8851080cf640313a6e516"
+source = "git+https://github.com/daxpedda/signatures.git?branch=elliptic-curve-0.13.0-pre.4#af08b16130c5471c098bdf9be295ed213b3ffd2f"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -348,8 +348,8 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.0-pre.3"
-source = "git+https://github.com/RustCrypto/traits.git#771f5dfcf232d54f7cca25d0b90c1705b21217a5"
+version = "0.13.0-pre.4"
+source = "git+https://github.com/RustCrypto/traits.git#d57b54b9fcf5b28745547cb9fef313ab09780918"
 dependencies = [
  "base16ct",
  "base64ct",
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/RustCrypto/signatures.git#4e2b0b2cfcfaef61a1e8851080cf640313a6e516"
+source = "git+https://github.com/daxpedda/signatures.git?branch=elliptic-curve-0.13.0-pre.4#af08b16130c5471c098bdf9be295ed213b3ffd2f"
 dependencies = [
  "hmac",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ members = [
 opt-level = 2
 
 [patch.crates-io]
-ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
+ecdsa = { git = "https://github.com/daxpedda/signatures.git", branch = "elliptic-curve-0.13.0-pre.4" }
 elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
 ecdsa = { version = "=0.16.0-pre.0", optional = true, default-features = false, features = ["der"] }

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
 ecdsa = { version = "=0.16.0-pre.0", optional = true, default-features = false, features = ["der"] }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.61"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
 once_cell = { version = "1.16", optional = true, default-features = false }

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["hazmat", "sec1"] }
 
 [features]
 default = ["pem", "std"]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["hazmat", "sec1"] }
 primeorder = { version = "=0.13.0-pre", path = "../primeorder" }
 
 # optional dependencies

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -178,12 +178,6 @@ impl Scalar {
         res
     }
 
-    /// Faster inversion using Stein's algorithm
-    #[allow(non_snake_case)]
-    pub fn invert_vartime(&self) -> CtOption<Self> {
-        elliptic_curve::scalar::invert_vartime::<NistP256>(self)
-    }
-
     /// Is integer representing equivalence class odd?
     pub fn is_odd(&self) -> Choice {
         self.0.is_odd()

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["hazmat", "sec1"] }
 primeorder = { version = "=0.13.0-pre", path = "../primeorder" }
 
 # optional dependencies

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["hazmat", "sec1"] }
 
 [features]
 default = ["pem", "std"]

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.1", optional = true, default-features = false }


### PR DESCRIPTION
Builds on top of https://github.com/RustCrypto/signatures/pull/652.

Would it be possible to make a `p256`/`p384` v0.13.0-pre.0 release?