### PR TITLE
Bump `elliptic-curve` to v0.13.0-pre.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,8 +330,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.0-pre.0"
-source = "git+https://github.com/RustCrypto/signatures.git#82776dc4cc21d665788a1ab04bcfaabf30fb86db"
+version = "0.16.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4b03f6cc5266bc4eae6f67eaa9bf9833633384b8e5ca7445c7c6dda41bd4c8"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -348,8 +349,9 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.0-pre.4"
-source = "git+https://github.com/RustCrypto/traits.git#d14be8eb1510812efc7422711ee285ee79f76a80"
+version = "0.13.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1ed75d4b5bc2388c2160e14532c72fa6c9d23b37b742f2c81d3577954e1e23a"
 dependencies = [
  "base16ct",
  "base64ct",
@@ -913,7 +915,8 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/RustCrypto/signatures.git#82776dc4cc21d665788a1ab04bcfaabf30fb86db"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b3595c18d975a2c373afdb4f8d17016589e65f9d84305c1c36fc55272def0bd"
 dependencies = [
  "hmac",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
-elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa = { version = "=0.16.0-pre.0", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.16.0-pre.1", optional = true, default-features = false, features = ["der"] }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [features]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa = { version = "=0.16.0-pre.0", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.16.0-pre.1", optional = true, default-features = false, features = ["der"] }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [features]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -19,11 +19,11 @@ rust-version = "1.61"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
 once_cell = { version = "1.16", optional = true, default-features = false }
-ecdsa-core = { version = "=0.16.0-pre.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.16.0-pre.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
@@ -32,7 +32,7 @@ signature = { version = "2", optional = true }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.4"
-ecdsa-core = { version = "=0.16.0-pre.0", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.16.0-pre.1", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
 
 [features]
 default = ["pem", "std"]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -17,11 +17,11 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
 primeorder = { version = "=0.13.0-pre", path = "../primeorder" }
 
 # optional dependencies
-ecdsa-core = { version = "=0.16.0-pre.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.16.0-pre.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
@@ -29,7 +29,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.4"
-ecdsa-core = { version = "=0.16.0-pre.0", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.16.0-pre.1", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "1"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -17,11 +17,11 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
 primeorder = { version = "=0.13.0-pre", path = "../primeorder" }
 
 # optional dependencies
-ecdsa-core = { version = "=0.16.0-pre.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.16.0-pre.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
 serdect = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
@@ -29,7 +29,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.4"
-ecdsa-core = { version = "=0.16.0-pre.0", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.16.0-pre.1", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 proptest = "1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
 
 [features]
 default = ["pem", "std"]

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.5", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.1", optional = true, default-features = false }


### PR DESCRIPTION
Also bumps `ecdsa` to v0.16.0-pre.1