### PR TITLE
k256: fast `invert_vartime` using Stein's algorithm

### DIFF
--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -902,6 +902,28 @@ mod tests {
         }
     }
 
+    /// Basic tests that invert works.
+    #[test]
+    fn invert() {
+        assert!(bool::from(Scalar::ZERO.invert().is_none()));
+        assert_eq!(Scalar::from(2u64).invert().unwrap(), Scalar::TWO_INV);
+        assert_eq!(
+            Scalar::ROOT_OF_UNITY.invert_vartime().unwrap(),
+            Scalar::ROOT_OF_UNITY_INV
+        );
+
+        // invert_vartime
+        assert!(bool::from(Scalar::ZERO.invert_vartime().is_none()));
+        assert_eq!(
+            Scalar::from(2u64).invert_vartime().unwrap(),
+            Scalar::TWO_INV
+        );
+        assert_eq!(
+            Scalar::ROOT_OF_UNITY.invert_vartime().unwrap(),
+            Scalar::ROOT_OF_UNITY_INV
+        );
+    }
+
     #[test]
     fn negate() {
         let zero_neg = -Scalar::ZERO;


### PR DESCRIPTION
Adapts the implementation originally contributed to the `p256` crate by @nickray to the `k256` crate.

Implementation is checked against the constant-time `Scalar::invert` using proptests (where `Scalar::invert` is in turn proptested against `num-bigint`).

It results in a ~9% ECDSA verification performance improvement according to our criterion benchmarks:

```
ecdsa/verify_prehashed  time:   [67.681 µs 67.734 µs 67.796 µs]
                        change: [-9.4013% -9.2055% -9.0011%] (p = 0.00 < 0.05)
                        Performance has improved.
```