### PR TITLE
Update references to NIST SP 800-186

### DIFF
--- a/bp256/README.md
+++ b/bp256/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: Brainpool P-256 elliptic curves
+# [RustCrypto]: Brainpool P-256 elliptic curves
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -54,4 +54,5 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (general links)
 
+[RustCrypto]: https://github.com/rustcrypto/
 [`elliptic-curve`]: https://github.com/RustCrypto/traits/tree/master/elliptic-curve

--- a/bp384/README.md
+++ b/bp384/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: Brainpool P-384 elliptic curves
+# [RustCrypto]: Brainpool P-384 elliptic curves
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -54,4 +54,5 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (general links)
 
+[RustCrypto]: https://github.com/rustcrypto/
 [`elliptic-curve`]: https://github.com/RustCrypto/traits/tree/master/elliptic-curve

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "p224"
 version = "0.0.0"
-description = "Pure Rust implementation of the NIST P-224 (a.k.a. secp224r1) elliptic curve"
+description = """
+Pure Rust implementation of the NIST P-224 (a.k.a. secp224r1) elliptic curve
+as defined in SP 800-186
+"""
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/p224"

--- a/p224/README.md
+++ b/p224/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: NIST P-224 (secp224r1) elliptic curve
+# [RustCrypto]: NIST P-224 (secp224r1) elliptic curve
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -34,12 +34,11 @@ USE AT YOUR OWN RISK!
 
 ## About P-224
 
-NIST P-224 is a Weierstrass curve specified in FIPS 186-4: Digital Signature
-Standard (DSS):
+NIST P-224 is a Weierstrass curve specified in [SP 800-186]:
+Recommendations for Discrete Logarithm-based Cryptography:
+Elliptic Curve Domain Parameters.
 
-<https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
-
-Also known as secp224r1 (SECG)
+Also known as secp224r1 (SECG).
 
 ## Minimum Supported Rust Version
 
@@ -83,6 +82,8 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (general links)
 
+[RustCrypto]: https://github.com/rustcrypto/
 [`elliptic-curve`]: https://github.com/RustCrypto/traits/tree/master/elliptic-curve
 [ECDH]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie-Hellman
 [ECDSA]: https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
+[SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -3,8 +3,8 @@ name = "p256"
 version = "0.13.0-pre"
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
-elliptic curve with support for ECDH, ECDSA signing/verification, and general
-purpose curve arithmetic
+elliptic curve as defined in SP 800-186, with support for ECDH, ECDSA
+signing/verification, and general purpose curve arithmetic
 """
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/p256/README.md
+++ b/p256/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: NIST P-256 (secp256r1) elliptic curve
+# [RustCrypto]: NIST P-256 (secp256r1) elliptic curve
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -34,10 +34,9 @@ USE AT YOUR OWN RISK!
 
 ## About NIST P-256
 
-NIST P-256 is a Weierstrass curve specified in FIPS 186-4: Digital Signature
-Standard (DSS):
-
-<https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
+NIST P-256 is a Weierstrass curve specified in [SP 800-186]:
+Recommendations for Discrete Logarithm-based Cryptography:
+Elliptic Curve Domain Parameters.
 
 Also known as prime256v1 (ANSI X9.62) and secp256r1 (SECG), it's included in
 the US National Security Agency's "Suite B" and is widely used in protocols
@@ -85,6 +84,8 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (general links)
 
+[RustCrypto]: https://github.com/rustcrypto/
 [`elliptic-curve`]: https://github.com/RustCrypto/traits/tree/master/elliptic-curve
 [ECDH]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie-Hellman
 [ECDSA]: https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
+[SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -1,4 +1,8 @@
 //! Pure Rust implementation of group operations on secp256r1.
+//!
+//! Curve parameters can be found in [NIST SP 800-186] § G.1.2: Curve P-256.
+//!
+//! [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
 
 pub(crate) mod field;
 #[cfg(feature = "hash2curve")]
@@ -27,22 +31,22 @@ impl PrimeCurveArithmetic for NistP256 {
     type CurveGroup = ProjectivePoint;
 }
 
+/// Adapted from [NIST SP 800-186] § G.1.2: Curve P-256.
+///
+/// [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
 impl PrimeCurveParams for NistP256 {
     type FieldElement = FieldElement;
     type EquationAProperties = equation_a::IsMinusThree;
 
     /// a = -3
-    const EQUATION_A: FieldElement = FieldElement::ZERO
-        .sub(&FieldElement::ONE)
-        .sub(&FieldElement::ONE)
-        .sub(&FieldElement::ONE);
+    const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();
 
     const EQUATION_B: FieldElement =
         FieldElement::from_hex("5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b");
 
     /// Base point of P-256.
     ///
-    /// Defined in FIPS 186-4 § D.1.2.3:
+    /// Defined in NIST SP 800-186 § G.1.2:
     ///
     /// ```text
     /// Gₓ = 6b17d1f2 e12c4247 f8bce6e5 63a440f2 77037d81 2deb33a0 f4a13945 d898c296

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -76,9 +76,9 @@ const ORDER_HEX: &str = "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac
 /// NIST P-256 elliptic curve.
 ///
 /// This curve is also known as prime256v1 (ANSI X9.62) and secp256r1 (SECG)
-/// and is specified in FIPS 186-4: Digital Signature Standard (DSS):
-///
-/// <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
+/// and is specified in [NIST SP 800-186]:
+/// Recommendations for Discrete Logarithm-based Cryptography:
+/// Elliptic Curve Domain Parameters.
 ///
 /// It's included in the US National Security Agency's "Suite B" and is widely
 /// used in protocols like TLS and the associated X.509 PKI.
@@ -91,7 +91,9 @@ const ORDER_HEX: &str = "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac
 /// ```
 ///
 /// † *NOTE: the specific origins of this constant have never been fully disclosed
-///   (it is the SHA-1 digest of an inexplicable NSA-selected constant)*
+///   (it is the SHA-1 digest of an unknown NSA-selected constant)*
+///
+/// [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct NistP256;
 

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -3,8 +3,8 @@ name = "p384"
 version = "0.13.0-pre"
 description = """
 Pure Rust implementation of the NIST P-384 (a.k.a. secp384r1) elliptic curve
-with support for ECDH, ECDSA signing/verification, and general purpose curve
-arithmetic support.
+as defined in SP 800-186 with support for ECDH, ECDSA signing/verification,
+and general purpose curve arithmetic support.
 """
 authors = ["RustCrypto Developers", "Frank Denis <github@pureftpd.org>"]
 license = "Apache-2.0 OR MIT"

--- a/p384/README.md
+++ b/p384/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: NIST P-384 (secp384r1) elliptic curve
+# [RustCrypto]: NIST P-384 (secp384r1) elliptic curve
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -34,10 +34,9 @@ USE AT YOUR OWN RISK!
 
 ## About P-384
 
-NIST P-384 is a Weierstrass curve specified in FIPS 186-4: Digital Signature
-Standard (DSS):
-
-<https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
+NIST P-384 is a Weierstrass curve specified in [SP 800-186]:
+Recommendations for Discrete Logarithm-based Cryptography:
+Elliptic Curve Domain Parameters.
 
 Also known as secp384r1 (SECG), it's included in the US National Security
 Agency's "Suite B" and is widely used in protocols like TLS and the associated
@@ -85,6 +84,8 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (general links)
 
+[RustCrypto]: https://github.com/rustcrypto/
 [`elliptic-curve`]: https://github.com/RustCrypto/traits/tree/master/elliptic-curve
 [ECDH]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie-Hellman
 [ECDSA]: https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
+[SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -1,9 +1,8 @@
 //! Pure Rust implementation of group operations on secp384r1.
 //!
-//! Curve parameters can be found in FIPS 186-4: Digital Signature Standard
-//! (DSS): <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
+//! Curve parameters can be found in [NIST SP 800-186] § G.1.3: Curve P-384.
 //!
-//! See section D.1.2.4: Curve P-384.
+//! [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
 
 #[macro_use]
 mod macros;
@@ -34,15 +33,15 @@ impl PrimeCurveArithmetic for NistP384 {
     type CurveGroup = ProjectivePoint;
 }
 
+/// Adapted from [NIST SP 800-186] § G.1.3: Curve P-384.
+///
+/// [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
 impl PrimeCurveParams for NistP384 {
     type FieldElement = FieldElement;
     type EquationAProperties = equation_a::IsMinusThree;
 
     /// a = -3 (0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc)
-    const EQUATION_A: FieldElement = FieldElement::ZERO
-        .sub(&FieldElement::ONE)
-        .sub(&FieldElement::ONE)
-        .sub(&FieldElement::ONE);
+    const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();
 
     /// b = b3312fa7 e23ee7e4 988e056b e3f82d19 181d9c6e fe814112
     ///     0314088f 5013875a c656398d 8a2ed19d 2a85c8ed d3ec2aef
@@ -50,7 +49,7 @@ impl PrimeCurveParams for NistP384 {
 
     /// Base point of P-384.
     ///
-    /// Defined in FIPS 186-4 § D.1.2.4:
+    /// Defined in NIST SP 800-186 § G.1.3: Curve P-384.
     ///
     /// ```text
     /// Gₓ = aa87ca22 be8b0537 8eb1c71e f320ad74 6e1d3b62 8ba79b98
@@ -58,9 +57,6 @@ impl PrimeCurveParams for NistP384 {
     /// Gᵧ = 3617de4a 96262c6f 5d9e98bf 9292dc29 f8f41dbd 289a147c
     ///      e9da3113 b5f0b8c0 0a60b1ce 1d7e819d 7a431d7c 90ea0e5f
     /// ```
-    ///
-    /// NOTE: coordinate field elements have been translated into the Montgomery
-    /// domain.
     const GENERATOR: (FieldElement, FieldElement) = (
         FieldElement::from_hex("aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7"),
         FieldElement::from_hex("3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f"),

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -107,6 +107,7 @@ impl FieldBytesEncoding<NistP384> for U384 {
         self.to_be_byte_array()
     }
 }
+
 /// Non-zero NIST P-384 scalar field element.
 #[cfg(feature = "arithmetic")]
 pub type NonZeroScalar = elliptic_curve::NonZeroScalar<NistP384>;

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "p521"
 version = "0.0.0"
-description = "Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve"
+description = """
+Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve
+as defined in SP 800-186
+"""
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/p521"

--- a/p521/README.md
+++ b/p521/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: NIST P-521 (secp521r1) elliptic curve
+# [RustCrypto]: NIST P-521 (secp521r1) elliptic curve
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -13,10 +13,11 @@ Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve.
 
 ## About P-521
 
-NIST P-521 is a Weierstrass curve specified in FIPS 186-4: Digital Signature
-Standard (DSS):
+NIST P-521 is a Weierstrass curve specified in [SP 800-186]:
+Recommendations for Discrete Logarithm-based Cryptography:
+Elliptic Curve Domain Parameters.
 
-<https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
+Also known as secp521r1 (SECG).
 
 ## Minimum Supported Rust Version
 
@@ -60,4 +61,6 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (links)
 
+[RustCrypto]: https://github.com/rustcrypto/
 [`elliptic-curve`]: https://github.com/RustCrypto/traits/tree/master/elliptic-curve
+[SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final

--- a/primeorder/README.md
+++ b/primeorder/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: Prime Order Elliptic Curve Formulas
+# [RustCrypto]: Prime Order Elliptic Curve Formulas
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -81,6 +81,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (links)
 
+[RustCrypto]: https://github.com/rustcrypto/
 [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
 [Weierstrass equation]: https://crypto.stanford.edu/pbc/notes/elliptic/weier.html
 [`p256`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p256


### PR DESCRIPTION
Previously the NIST curves were specified in FIPS 186-4: Digital Signature Standard.

NIST has just released a new document, SP 800-186, which splits the curve definitions out separate from the signature algorithm definitions:

https://csrc.nist.gov/publications/detail/sp/800-186/final

This updates previous references to FIPS 186-4 (that is, ones which don't relate to ECDSA) to use SP 800-186 instead.