### PR TITLE
k256: add complete end-to-end Ethereum signature recovery test

### DIFF
--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -286,11 +286,12 @@ mod tests {
     #[cfg(feature = "sha256")]
     mod recovery {
         use crate::{
-            ecdsa::{RecoveryId, Signature, VerifyingKey},
+            ecdsa::{signature::DigestVerifier, RecoveryId, Signature, SigningKey, VerifyingKey},
             EncodedPoint,
         };
         use hex_literal::hex;
         use sha2::{Digest, Sha256};
+        use sha3::Keccak256;
 
         /// Signature recovery test vectors
         struct RecoveryTestVector {
@@ -332,6 +333,38 @@ mod tests {
                 let pk = VerifyingKey::recover_from_digest(digest, &sig, recid).unwrap();
                 assert_eq!(&vector.pk[..], EncodedPoint::from(&pk).as_bytes());
             }
+        }
+
+        /// End-to-end example which ensures RFC6979 is implemented in the same
+        /// way as other Ethereum libraries, using HMAC-DRBG-SHA-256 for RFC6979,
+        /// and Keccak256 for hashing the message.
+        ///
+        /// Test vectors adapted from:
+        /// <https://github.com/gakonst/ethers-rs/blob/ba00f549/ethers-signers/src/wallet/private_key.rs#L197>
+        #[test]
+        fn ethereum_end_to_end_example() {
+            let signing_key = SigningKey::from_bytes(
+                &hex!("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318").into(),
+            )
+            .unwrap();
+
+            let msg = hex!(
+                "e9808504e3b29200831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca0080018080"
+            );
+            let digest = Keccak256::new_with_prefix(msg);
+
+            let (sig, recid) = signing_key.sign_digest_recoverable(digest.clone()).unwrap();
+            assert_eq!(
+                sig.to_bytes().as_slice(),
+                &hex!("c9cf86333bcb065d140032ecaab5d9281bde80f21b9687b3e94161de42d51895727a108a0b8d101465414033c3f705a9c7b826e596766046ee1183dbc8aeaa68")
+            );
+            assert_eq!(recid, RecoveryId::from_byte(0).unwrap());
+
+            let verifying_key =
+                VerifyingKey::recover_from_digest(digest.clone(), &sig, recid).unwrap();
+
+            assert_eq!(signing_key.verifying_key(), &verifying_key);
+            assert!(verifying_key.verify_digest(digest, &sig).is_ok());
         }
     }
 


### PR DESCRIPTION
Adds a test which signs a message using Keccak256 as the digest function, testing that the resulting signature matches the one produced by web3.js, as used in the ethers-rs test vectors.

After the signature has been produced, it recovers the `VerifyingKey` from the message digest and signature, testing that it's the correct `VerifyingKey`, and also testing that it successfully verifies the signature.