### PR TITLE
Field element macro cleanups

### DIFF
--- a/p224/src/arithmetic/field.rs
+++ b/p224/src/arithmetic/field.rs
@@ -51,7 +51,7 @@ const MODULUS: Uint =
 #[derive(Clone, Copy, Debug)]
 pub struct FieldElement(pub(super) Uint);
 
-primeorder::impl_field_element!(
+primeorder::impl_mont_field_element!(
     NistP224,
     FieldElement,
     FieldBytes,

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -61,7 +61,7 @@ use core::ops::{Add, Mul, Sub};
 #[derive(Clone, Copy, Debug, PartialOrd, Ord)]
 pub struct Scalar(Uint);
 
-primeorder::impl_field_element!(
+primeorder::impl_mont_field_element!(
     NistP224,
     Scalar,
     FieldBytes,

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -36,7 +36,7 @@ const R_2: U256 =
 #[derive(Clone, Copy, Debug)]
 pub struct FieldElement(pub(crate) U256);
 
-primeorder::impl_field_element!(
+primeorder::impl_mont_field_element!(
     NistP256,
     FieldElement,
     FieldBytes,

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -44,7 +44,7 @@ pub(crate) const MODULUS: U384 = U384::from_be_hex(FieldElement::MODULUS);
 #[derive(Clone, Copy, Debug)]
 pub struct FieldElement(pub(super) U384);
 
-primeorder::impl_field_element!(
+primeorder::impl_mont_field_element!(
     NistP384,
     FieldElement,
     FieldBytes,

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -69,7 +69,7 @@ use core::ops::{Add, Mul, Sub};
 #[derive(Clone, Copy, Debug, PartialOrd, Ord)]
 pub struct Scalar(U384);
 
-primeorder::impl_field_element!(
+primeorder::impl_mont_field_element!(
     NistP384,
     Scalar,
     FieldBytes,

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -20,8 +20,6 @@
     clippy::identity_op,
     rustdoc::bare_urls
 )]
-// TODO(tarcieri): use all variables
-#![allow(unused_variables)]
 
 // TODO(tarcieri): 32-bit backend?
 #[path = "field/p521_64.rs"]

--- a/primeorder/src/field.rs
+++ b/primeorder/src/field.rs
@@ -1,5 +1,8 @@
-/// Provides both inherent and trait impls for a field element type which are
-/// backed by a core set of arithmetic functions specified as macro arguments.
+/// Implements a field element type whose internal representation is in
+/// Montgomery form, providing a combination of trait impls and inherent impls
+/// which are `const fn` where possible.
+///
+/// Accepts a set of `const fn` arithmetic operation functions as arguments.
 ///
 /// # Inherent impls
 /// - `const ZERO: Self`
@@ -42,7 +45,7 @@
 /// - `MulAssign`
 /// - `Neg`
 #[macro_export]
-macro_rules! impl_field_element {
+macro_rules! impl_mont_field_element {
     (
         $curve:tt,
         $fe:tt,
@@ -364,9 +367,9 @@ macro_rules! impl_field_element {
             }
         }
 
-        $crate::impl_field_op!($fe, $uint, Add, add, $add);
-        $crate::impl_field_op!($fe, $uint, Sub, sub, $sub);
-        $crate::impl_field_op!($fe, $uint, Mul, mul, $mul);
+        $crate::impl_field_op!($fe, Add, add, $add);
+        $crate::impl_field_op!($fe, Sub, sub, $sub);
+        $crate::impl_field_op!($fe, Mul, mul, $mul);
 
         impl AddAssign<$fe> for $fe {
             #[inline]
@@ -449,7 +452,7 @@ macro_rules! impl_field_element {
 /// which thunk to the given function.
 #[macro_export]
 macro_rules! impl_field_op {
-    ($fe:tt, $uint:ty, $op:tt, $op_fn:ident, $func:ident) => {
+    ($fe:tt, $op:tt, $op_fn:ident, $func:ident) => {
         impl ::core::ops::$op for $fe {
             type Output = $fe;
 


### PR DESCRIPTION
- Renames `primeorder::impl_field_element` to `impl_mont_field_element` to reflect it supports a Montgomery internal representation.
- Removes an unused parameter on `impl_field_op` macro.
- Removes some unused code in `p521`'s field element module.