### PR TITLE
fix compactabtility check

### DIFF
--- a/p256/tests/affine.rs
+++ b/p256/tests/affine.rs
@@ -125,7 +125,7 @@ fn noncompatible_is_none() {
         175, 232, 180, 255, 91, 106, 124, 191, 224, 31, 177, 208, 236, 127, 191, 169, 201, 217,
         75, 141, 184, 175, 120, 85, 171, 8, 54, 57, 33, 177, 83, 211,
     ];
-    let secret = p256::SecretKey::from_be_bytes(&noncompactable_secret).unwrap();
+    let secret = p256::SecretKey::from_bytes(&noncompactable_secret).unwrap();
     let is_compactable = secret.public_key().as_affine().to_compact_encoded_point().is_some().unwrap_u8();
     assert_eq!(is_compactable, 0);
 }

--- a/p256/tests/affine.rs
+++ b/p256/tests/affine.rs
@@ -118,3 +118,14 @@ fn identity_encoding() {
             .is_identity()
     ))
 }
+
+#[test]
+fn noncompatible_is_none() {
+    let noncompactable_secret = [
+        175, 232, 180, 255, 91, 106, 124, 191, 224, 31, 177, 208, 236, 127, 191, 169, 201, 217,
+        75, 141, 184, 175, 120, 85, 171, 8, 54, 57, 33, 177, 83, 211,
+    ];
+    let secret = p256::SecretKey::from_be_bytes(&noncompactable_secret).unwrap();
+    let is_compactable = secret.public_key().as_affine().to_compact_encoded_point().is_some().unwrap_u8();
+    assert_eq!(is_compactable, 0);
+}

--- a/p256/tests/affine.rs
+++ b/p256/tests/affine.rs
@@ -122,10 +122,15 @@ fn identity_encoding() {
 #[test]
 fn noncompatible_is_none() {
     let noncompactable_secret = [
-        175, 232, 180, 255, 91, 106, 124, 191, 224, 31, 177, 208, 236, 127, 191, 169, 201, 217,
-        75, 141, 184, 175, 120, 85, 171, 8, 54, 57, 33, 177, 83, 211,
+        175, 232, 180, 255, 91, 106, 124, 191, 224, 31, 177, 208, 236, 127, 191, 169, 201, 217, 75,
+        141, 184, 175, 120, 85, 171, 8, 54, 57, 33, 177, 83, 211,
     ];
     let secret = p256::SecretKey::from_bytes(&noncompactable_secret).unwrap();
-    let is_compactable = secret.public_key().as_affine().to_compact_encoded_point().is_some().unwrap_u8();
+    let is_compactable = secret
+        .public_key()
+        .as_affine()
+        .to_compact_encoded_point()
+        .is_some()
+        .unwrap_u8();
     assert_eq!(is_compactable, 0);
 }

--- a/p256/tests/affine.rs
+++ b/p256/tests/affine.rs
@@ -121,13 +121,15 @@ fn identity_encoding() {
 
 #[test]
 fn noncompatible_is_none() {
-    let noncompactable_secret = [
+    use elliptic_curve::generic_array::GenericArray;
+    let noncompactable_secret = GenericArray::from([
         175, 232, 180, 255, 91, 106, 124, 191, 224, 31, 177, 208, 236, 127, 191, 169, 201, 217, 75,
         141, 184, 175, 120, 85, 171, 8, 54, 57, 33, 177, 83, 211,
-    ];
-    let secret = p256::SecretKey::from_bytes(&noncompactable_secret).unwrap();
-    let is_compactable = secret
-        .public_key()
+    ]);
+    let public_key = p256::SecretKey::from_bytes(&noncompactable_secret)
+        .unwrap()
+        .public_key();
+    let is_compactable = public_key
         .as_affine()
         .to_compact_encoded_point()
         .is_some()

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -328,7 +328,7 @@ where
         bytes[1..].copy_from_slice(&point.x.to_repr());
 
         let encoded = EncodedPoint::<C>::from_bytes(bytes);
-        let is_some = Choice::from(encoded.is_ok() as u8);
+        let is_some = point.y.ct_eq(&self.y);
         CtOption::new(encoded.unwrap_or_default(), is_some)
     }
 }


### PR DESCRIPTION
The function `to_compact_encoded_point` should return a CtOption where is_some set to 0 if the AffinePoint is non-compactable.

The current implementation checks if the EncodedPoint from bytes decodes properly to determine compactability. However, the EncodedPoint will always decode just fine, even when a non-compactable point has been compacted. 

Instead, what needs to be checked is if the compacted point and the original affine points Y coordinates match.