### PR TITLE
bp384 v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "bp384"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/bp256/CHANGELOG.md
+++ b/bp256/CHANGELOG.md
@@ -5,10 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.6.0 (2023-03-02)
+### Added
+- `FieldBytesEncoding` trait impls ([#732])
+
 ### Changed
 - Bump `elliptic-curve` dependency to v0.13 ([#770])
 - Bump `ecdsa` to v0.16 ([#770])
 
+[#732]: https://github.com/RustCrypto/elliptic-curves/pull/732
 [#770]: https://github.com/RustCrypto/elliptic-curves/pull/770
 
 ## 0.5.0 (2023-01-15)

--- a/bp384/CHANGELOG.md
+++ b/bp384/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2023-03-02)
+### Added
+- `FieldBytesEncoding` trait impls ([#732])
+
+### Changed
+- Bump `elliptic-curve` dependency to v0.13 ([#770])
+- Bump `ecdsa` to v0.16 ([#770])
+
+[#732]: https://github.com/RustCrypto/elliptic-curves/pull/732
+[#770]: https://github.com/RustCrypto/elliptic-curves/pull/770
+
 ## 0.5.0 (2023-01-15)
 ### Added
 - `alloc` feature ([#670])

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp384"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
### Added
- `FieldBytesEncoding` trait impls ([#732])

### Changed
- Bump `elliptic-curve` dependency to v0.13 ([#770])
- Bump `ecdsa` to v0.16 ([#770])

[#732]: https://github.com/RustCrypto/elliptic-curves/pull/732
[#770]: https://github.com/RustCrypto/elliptic-curves/pull/770