### PR TITLE
primeorder v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primeorder"
-version = "0.13.0-pre"
+version = "0.13.0"
 dependencies = [
  "elliptic-curve",
  "serdect",

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65"
 
 [dependencies]
 elliptic-curve = { version = "0.13", default-features = false, features = ["hazmat", "sec1"] }
-primeorder = { version = "=0.13.0-pre", path = "../primeorder" }
+primeorder = { version = "0.13", path = "../primeorder" }
 
 [features]
 default = ["pem", "std"]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.65"
 
 [dependencies]
 elliptic-curve = { version = "0.13", default-features = false, features = ["hazmat", "sec1"] }
-primeorder = { version = "=0.13.0-pre", path = "../primeorder" }
+primeorder = { version = "0.13", path = "../primeorder" }
 
 # optional dependencies
 ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.65"
 
 [dependencies]
 elliptic-curve = { version = "0.13", default-features = false, features = ["hazmat", "sec1"] }
-primeorder = { version = "=0.13.0-pre", path = "../primeorder" }
+primeorder = { version = "0.13", path = "../primeorder" }
 
 # optional dependencies
 ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.65"
 elliptic-curve = { version = "0.13", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-primeorder = { version = "=0.13.0-pre", optional = true, path = "../primeorder" }
+primeorder = { version = "0.13", optional = true, path = "../primeorder" }
 
 [features]
 default = ["pem", "std"]

--- a/primeorder/CHANGELOG.md
+++ b/primeorder/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.0 (2023-03-03)
+### Added
+- Support curves with any `a`-coefficient ([#728], [#729])
+- `impl_primefield_tests!` macro ([#739])
+
+### Changed
+- Use `AffineCoordinates` trait ([#734])
+- Rename `impl_field_element!` to `impl_mont_field_element!` ([#762])
+- Bump `elliptic-curve` dependency to v0.13 ([#770])
+- Bump `ecdsa` to v0.16 ([#770])
+
+[#728]: https://github.com/RustCrypto/elliptic-curves/pull/728
+[#729]: https://github.com/RustCrypto/elliptic-curves/pull/729
+[#734]: https://github.com/RustCrypto/elliptic-curves/pull/734
+[#739]: https://github.com/RustCrypto/elliptic-curves/pull/739
+[#762]: https://github.com/RustCrypto/elliptic-curves/pull/762
+[#770]: https://github.com/RustCrypto/elliptic-curves/pull/770
+
 ## 0.12.1 (2023-01-22)
 ### Added
 - Impl `From/ToEncodedPoint` for `ProjectivePoint` ([#722])

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.13.0-pre"
+version = "0.13.0"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve


### PR DESCRIPTION
### Added
- Support curves with any `a`-coefficient ([#728], [#729])
- `impl_primefield_tests!` macro ([#739])

### Changed
- Use `AffineCoordinates` trait ([#734])
- Rename `impl_field_element!` to `impl_mont_field_element!` ([#762])
- Bump `elliptic-curve` dependency to v0.13 ([#770])
- Bump `ecdsa` to v0.16 ([#770])

[#728]: https://github.com/RustCrypto/elliptic-curves/pull/728
[#729]: https://github.com/RustCrypto/elliptic-curves/pull/729
[#734]: https://github.com/RustCrypto/elliptic-curves/pull/734
[#739]: https://github.com/RustCrypto/elliptic-curves/pull/739
[#762]: https://github.com/RustCrypto/elliptic-curves/pull/762
[#770]: https://github.com/RustCrypto/elliptic-curves/pull/770