### PR TITLE
p384 v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.13.0-pre"
+version = "0.13.0"
 dependencies = [
  "blobby",
  "criterion",

--- a/p384/CHANGELOG.md
+++ b/p384/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.0 (2023-03-03)
+### Added
+- `PrimeField` constants/tests ([#730], [#737], [#738])
+- `const fn` inversions for all field elements ([#736])
+
+### Changed
+- `FieldBytesEncoding` trait impls ([#732])
+- Update `hash2curve` implementations to new API ([#735])
+- Impl `Invert` trait for `Scalar` types ([#741])
+- Bump `ecdsa` dependency to v0.16 ([#770])
+- Bump `elliptic-curve` dependency to v0.13 ([#770])
+- Bump `primeorder` dependency to v0.13 ([#777])
+
+### Fixed
+- Point compactabtility check ([#772])
+
+[#730]: https://github.com/RustCrypto/elliptic-curves/pull/730
+[#732]: https://github.com/RustCrypto/elliptic-curves/pull/732
+[#735]: https://github.com/RustCrypto/elliptic-curves/pull/735
+[#736]: https://github.com/RustCrypto/elliptic-curves/pull/736
+[#737]: https://github.com/RustCrypto/elliptic-curves/pull/737
+[#738]: https://github.com/RustCrypto/elliptic-curves/pull/738
+[#741]: https://github.com/RustCrypto/elliptic-curves/pull/741
+[#770]: https://github.com/RustCrypto/elliptic-curves/pull/770
+[#772]: https://github.com/RustCrypto/elliptic-curves/pull/772
+[#777]: https://github.com/RustCrypto/elliptic-curves/pull/777
+
 ## 0.12.0 (2023-01-16)
 ### Added
 - `alloc` feature ([#670])

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p384"
-version = "0.13.0-pre"
+version = "0.13.0"
 description = """
 Pure Rust implementation of the NIST P-384 (a.k.a. secp384r1) elliptic curve
 as defined in SP 800-186 with support for ECDH, ECDSA signing/verification,


### PR DESCRIPTION
### Added
- `PrimeField` constants/tests ([#730], [#737], [#738])
- `const fn` inversions for all field elements ([#736])

### Changed
- `FieldBytesEncoding` trait impls ([#732])
- Update `hash2curve` implementations to new API ([#735])
- Impl `Invert` trait for `Scalar` types ([#741])
- Bump `ecdsa` dependency to v0.16 ([#770])
- Bump `elliptic-curve` dependency to v0.13 ([#770])
- Bump `primeorder` dependency to v0.13 ([#777])

### Fixed
- Point compactabtility check ([#772])

[#730]: https://github.com/RustCrypto/elliptic-curves/pull/730
[#732]: https://github.com/RustCrypto/elliptic-curves/pull/732
[#735]: https://github.com/RustCrypto/elliptic-curves/pull/735
[#736]: https://github.com/RustCrypto/elliptic-curves/pull/736
[#737]: https://github.com/RustCrypto/elliptic-curves/pull/737
[#738]: https://github.com/RustCrypto/elliptic-curves/pull/738
[#741]: https://github.com/RustCrypto/elliptic-curves/pull/741
[#770]: https://github.com/RustCrypto/elliptic-curves/pull/770
[#772]: https://github.com/RustCrypto/elliptic-curves/pull/772
[#777]: https://github.com/RustCrypto/elliptic-curves/pull/777