### PR TITLE
[WIP] p521: impl `FieldElement::invert`

### DIFF
--- a/p521/src/arithmetic/field/loose.rs
+++ b/p521/src/arithmetic/field/loose.rs
@@ -11,7 +11,7 @@ impl LooseFieldElement {
     }
 
     /// Multiplies two field elements and reduces the result.
-    pub(crate) const fn mul(&self, rhs: &Self) -> FieldElement {
+    pub(crate) const fn multiply(&self, rhs: &Self) -> FieldElement {
         FieldElement(fiat_p521_carry_mul(&self.0, &rhs.0))
     }
 
@@ -54,7 +54,7 @@ impl Mul for LooseFieldElement {
 
     #[inline]
     fn mul(self, rhs: LooseFieldElement) -> FieldElement {
-        Self::mul(&self, &rhs)
+        Self::multiply(&self, &rhs)
     }
 }
 
@@ -63,7 +63,7 @@ impl Mul<&LooseFieldElement> for LooseFieldElement {
 
     #[inline]
     fn mul(self, rhs: &LooseFieldElement) -> FieldElement {
-        Self::mul(&self, rhs)
+        Self::multiply(&self, rhs)
     }
 }
 
@@ -72,6 +72,6 @@ impl Mul<&LooseFieldElement> for &LooseFieldElement {
 
     #[inline]
     fn mul(self, rhs: &LooseFieldElement) -> FieldElement {
-        LooseFieldElement::mul(self, rhs)
+        LooseFieldElement::multiply(self, rhs)
     }
 }


### PR DESCRIPTION
Warning: broken! Do not use.

Adapts the addition chain generated by `addchain` into Rust:

https://github.com/mmcloughlin/addchain

Not working for some reason (possibly an issue with the fiat-crypto field arithmetic)

```
test arithmetic::field::tests::invert ... FAILED

failures:

---- arithmetic::field::tests::invert stdout ----
thread 'arithmetic::field::tests::invert' panicked at 'assertion failed: `(left == right)`
  left: `FieldElement([0, 0, 288230376151711744, 288230376151711743, 288230376151711743, 288230376151711743, 288230376151711743, 288230376151711743, 144115188075855871])`,
 right: `FieldElement([1, 0, 0, 0, 0, 0, 0, 0, 0])`', p521/src/arithmetic/field.rs:600:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```