### PR TITLE
Expand field element tests

### DIFF
--- a/p224/src/arithmetic/field.rs
+++ b/p224/src/arithmetic/field.rs
@@ -330,7 +330,10 @@ impl PrimeField for FieldElement {
 mod tests {
     use super::FieldElement;
     use elliptic_curve::ff::PrimeField;
-    use primeorder::{impl_field_invert_tests, impl_field_sqrt_tests, impl_primefield_tests};
+    use primeorder::{
+        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
+        impl_primefield_tests,
+    };
 
     /// t = (modulus - 1) >> S
     const T: [u64; 4] = [
@@ -340,6 +343,7 @@ mod tests {
         0x0000000000000000,
     ];
 
+    impl_field_identity_tests!(FieldElement);
     impl_field_invert_tests!(FieldElement);
     impl_field_sqrt_tests!(FieldElement);
     impl_primefield_tests!(FieldElement, T);

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -299,9 +299,7 @@ impl TryFrom<Uint> for Scalar {
 mod tests {
     use super::Scalar;
     use elliptic_curve::PrimeField;
-    use primeorder::{impl_field_invert_tests, impl_primefield_tests};
-
-    // NOTE: t = 0x3fffffffffffffffffffffffffffc5a8b82e3c0f84f74a5157170a8f
+    use primeorder::{impl_field_identity_tests, impl_field_invert_tests, impl_primefield_tests};
 
     /// t = (modulus - 1) >> S
     const T: [u64; 4] = [
@@ -311,6 +309,8 @@ mod tests {
         0x000000003fffffff,
     ];
 
+    impl_field_identity_tests!(Scalar);
     impl_field_invert_tests!(Scalar);
+    // impl_field_sqrt_tests!(Scalar); // TODO(tarcieri): not yet implemented
     impl_primefield_tests!(Scalar, T);
 }

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -158,7 +158,10 @@ mod tests {
     use super::FieldElement;
     use crate::{test_vectors::field::DBL_TEST_VECTORS, FieldBytes};
     use elliptic_curve::{bigint::U256, ff::PrimeField};
-    use primeorder::impl_primefield_tests;
+    use primeorder::{
+        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
+        impl_primefield_tests,
+    };
     use proptest::{num, prelude::*};
 
     /// t = (modulus - 1) >> S
@@ -169,21 +172,10 @@ mod tests {
         0x7fffffff80000000,
     ];
 
+    impl_field_identity_tests!(FieldElement);
+    impl_field_invert_tests!(FieldElement);
+    impl_field_sqrt_tests!(FieldElement);
     impl_primefield_tests!(FieldElement, T);
-
-    #[test]
-    fn zero_is_additive_identity() {
-        let zero = FieldElement::ZERO;
-        let one = FieldElement::ONE;
-        assert_eq!(zero.add(&zero), zero);
-        assert_eq!(one.add(&zero), one);
-    }
-
-    #[test]
-    fn one_is_multiplicative_identity() {
-        let one = FieldElement::ONE;
-        assert_eq!(one.multiply(&one), one);
-    }
 
     #[test]
     fn from_bytes() {
@@ -262,26 +254,6 @@ mod tests {
         let two = one + &one;
         let four = two.square();
         assert_eq!(two.pow_vartime(&[2, 0, 0, 0]), four);
-    }
-
-    #[test]
-    fn invert() {
-        assert!(bool::from(FieldElement::ZERO.invert().is_none()));
-
-        let one = FieldElement::ONE;
-        assert_eq!(one.invert().unwrap(), one);
-
-        let two = one + &one;
-        let inv_two = two.invert().unwrap();
-        assert_eq!(two * &inv_two, one);
-    }
-
-    #[test]
-    fn sqrt() {
-        let one = FieldElement::ONE;
-        let two = one + &one;
-        let four = two.square();
-        assert_eq!(four.sqrt().unwrap(), two);
     }
 
     proptest! {

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -745,7 +745,7 @@ mod tests {
     use super::Scalar;
     use crate::{FieldBytes, SecretKey};
     use elliptic_curve::group::ff::{Field, PrimeField};
-    use primeorder::impl_primefield_tests;
+    use primeorder::{impl_field_identity_tests, impl_field_invert_tests, impl_primefield_tests};
 
     /// t = (modulus - 1) >> S
     const T: [u64; 4] = [
@@ -755,6 +755,9 @@ mod tests {
         0x0ffffffff0000000,
     ];
 
+    impl_field_identity_tests!(Scalar);
+    impl_field_invert_tests!(Scalar);
+    // impl_field_sqrt_tests!(Scalar); // TODO(tarcieri): debug test failures
     impl_primefield_tests!(Scalar, T);
 
     #[test]
@@ -782,23 +785,6 @@ mod tests {
 
         assert_eq!(minus_three * &minus_two, minus_two * &minus_three);
         assert_eq!(six, minus_two * &minus_three);
-    }
-
-    /// Basic tests that scalar inversion works.
-    #[test]
-    fn invert() {
-        let one = Scalar::ONE;
-        let three = one + &one + &one;
-        let inv_three = three.invert().unwrap();
-        // println!("1/3 = {:x?}", &inv_three);
-        assert_eq!(three * &inv_three, one);
-
-        let minus_three = -three;
-        // println!("-3 = {:x?}", &minus_three);
-        let inv_minus_three = minus_three.invert().unwrap();
-        assert_eq!(inv_minus_three, -inv_three);
-        // println!("-1/3 = {:x?}", &inv_minus_three);
-        assert_eq!(three * &inv_minus_three, -one);
     }
 
     /// Basic tests that sqrt works.

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -158,7 +158,10 @@ impl PrimeField for FieldElement {
 mod tests {
     use super::FieldElement;
     use elliptic_curve::ff::PrimeField;
-    use primeorder::{impl_field_invert_tests, impl_field_sqrt_tests, impl_primefield_tests};
+    use primeorder::{
+        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
+        impl_primefield_tests,
+    };
 
     /// t = (modulus - 1) >> S
     const T: [u64; 6] = [
@@ -170,6 +173,7 @@ mod tests {
         0x7fffffffffffffff,
     ];
 
+    impl_field_identity_tests!(FieldElement);
     impl_field_invert_tests!(FieldElement);
     impl_field_sqrt_tests!(FieldElement);
     impl_primefield_tests!(FieldElement, T);

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -366,7 +366,7 @@ mod tests {
     use super::Scalar;
     use crate::FieldBytes;
     use elliptic_curve::ff::PrimeField;
-    use primeorder::{impl_field_invert_tests, impl_primefield_tests};
+    use primeorder::{impl_field_identity_tests, impl_field_invert_tests, impl_primefield_tests};
 
     /// t = (modulus - 1) >> S
     const T: [u64; 6] = [
@@ -378,7 +378,9 @@ mod tests {
         0x7fffffffffffffff,
     ];
 
+    impl_field_identity_tests!(Scalar);
     impl_field_invert_tests!(Scalar);
+    // impl_field_sqrt_tests!(Scalar); // TODO(tarcieri): debug test failures
     impl_primefield_tests!(Scalar, T);
 
     #[test]

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -648,7 +648,7 @@ impl TryFrom<U576> for Scalar {
 mod tests {
     use super::Scalar;
     use elliptic_curve::PrimeField;
-    use primeorder::{impl_field_invert_tests, impl_primefield_tests};
+    use primeorder::{impl_field_identity_tests, impl_field_invert_tests, impl_primefield_tests};
 
     /// t = (modulus - 1) >> S
     const T: [u64; 9] = [
@@ -663,6 +663,7 @@ mod tests {
         0x000000000000003f,
     ];
 
+    impl_field_identity_tests!(Scalar);
     impl_field_invert_tests!(Scalar);
     impl_primefield_tests!(Scalar, T);
 }

--- a/primeorder/src/field.rs
+++ b/primeorder/src/field.rs
@@ -539,11 +539,30 @@ macro_rules! impl_bernstein_yang_invert {
     }};
 }
 
+/// Implement field element identity tests.
+#[macro_export]
+macro_rules! impl_field_identity_tests {
+    ($fe:tt) => {
+        #[test]
+        fn zero_is_additive_identity() {
+            let zero = $fe::ZERO;
+            let one = $fe::ONE;
+            assert_eq!(zero.add(&zero), zero);
+            assert_eq!(one.add(&zero), one);
+        }
+
+        #[test]
+        fn one_is_multiplicative_identity() {
+            let one = $fe::ONE;
+            assert_eq!(one.multiply(&one), one);
+        }
+    };
+}
+
 /// Implement field element inversion tests.
 #[macro_export]
 macro_rules! impl_field_invert_tests {
     ($fe:tt) => {
-        /// Basic tests that field inversion works.
         #[test]
         fn invert() {
             let one = $fe::ONE;
@@ -565,13 +584,18 @@ macro_rules! impl_field_invert_tests {
 #[macro_export]
 macro_rules! impl_field_sqrt_tests {
     ($fe:tt) => {
-        /// Basic test that `sqrt` works.
         #[test]
         fn sqrt() {
-            let one = FieldElement::ONE;
+            let one = $fe::ONE;
             let two = one + &one;
             let four = two.square();
             assert_eq!(four.sqrt().unwrap(), two);
+
+            for &n in &[1u64, 4, 9, 16, 25, 36, 49, 64] {
+                let fe = $fe::from(n);
+                let sqrt = fe.sqrt().unwrap();
+                assert_eq!(sqrt.square(), fe);
+            }
         }
     };
 }


### PR DESCRIPTION
- Add `impl_field_identity_tests!`
- Use `impl_field_sqrt_tests!`

NOTE: this change uncovered some test failures with `p256::Scalar::sqrt` and `p384::Scalar::sqrt` implementations, tracked as #789.

There are now TODOs in the relevant places in the code.