### PR TITLE
Update field.rs

### DIFF
--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -703,7 +703,7 @@ mod tests {
         assert!(y.normalize().is_odd().unwrap_u8() == 0);
 
         // This panics since `y` is not normalized.
-        let _result = y.is_odd().unwrap_u8();
+        let _result = y.is_odd();
     }
 
     prop_compose! {


### PR DESCRIPTION
This clarifies test `unnormalized_is_odd` slightly, since the panic is in `is_odd`, not `unwrap_u8`.

Feel free to close this if you think this is unnecessary.