### PR TITLE
p224/p256/p384: better `Debug` for field elements

### DIFF
--- a/p224/src/arithmetic/field.rs
+++ b/p224/src/arithmetic/field.rs
@@ -28,6 +28,7 @@ mod field_impl;
 use self::field_impl::*;
 use crate::{FieldBytes, NistP224, Uint};
 use core::{
+    fmt::{self, Debug},
     iter::{Product, Sum},
     ops::{AddAssign, MulAssign, Neg, SubAssign},
 };
@@ -48,7 +49,7 @@ const MODULUS: Uint =
     Uint::from_be_hex("00000000ffffffffffffffffffffffffffffffff000000000000000000000001");
 
 /// Element of the secp224r1 base field used for curve coordinates.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct FieldElement(pub(super) Uint);
 
 primeorder::impl_mont_field_element!(
@@ -323,6 +324,12 @@ impl PrimeField for FieldElement {
     #[inline]
     fn is_odd(&self) -> Choice {
         self.is_odd()
+    }
+}
+
+impl Debug for FieldElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FieldElement(0x{:X})", &self.0)
     }
 }
 

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -14,6 +14,7 @@ mod scalar_impl;
 use self::scalar_impl::*;
 use crate::{FieldBytes, FieldBytesEncoding, NistP224, SecretKey, Uint, ORDER_HEX};
 use core::{
+    fmt::{self, Debug},
     iter::{Product, Sum},
     ops::{AddAssign, MulAssign, Neg, Shr, ShrAssign, SubAssign},
 };
@@ -59,7 +60,7 @@ use core::ops::{Add, Mul, Sub};
 ///   operations over field elements represented as bits (requires `bits` feature)
 ///
 /// Please see the documentation for the relevant traits for more information.
-#[derive(Clone, Copy, Debug, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(Uint);
 
 primeorder::impl_mont_field_element!(
@@ -292,6 +293,12 @@ impl TryFrom<Uint> for Scalar {
 
     fn try_from(w: Uint) -> Result<Self> {
         Option::from(Self::from_uint(w)).ok_or(Error)
+    }
+}
+
+impl Debug for Scalar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Scalar(0x{:X})", &self.0)
     }
 }
 

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -9,6 +9,7 @@ mod field_impl;
 use self::field_impl::*;
 use crate::{FieldBytes, NistP256};
 use core::{
+    fmt::{self, Debug},
     iter::{Product, Sum},
     ops::{AddAssign, Mul, MulAssign, Neg, SubAssign},
 };
@@ -33,7 +34,7 @@ const R_2: U256 =
 ///
 /// The internal representation is in little-endian order. Elements are always in
 /// Montgomery form; i.e., FieldElement(a) = aR mod p, with R = 2^256.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct FieldElement(pub(crate) U256);
 
 primeorder::impl_mont_field_element!(
@@ -150,6 +151,12 @@ impl PrimeField for FieldElement {
     #[inline]
     fn is_odd(&self) -> Choice {
         self.is_odd()
+    }
+}
+
+impl Debug for FieldElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FieldElement(0x{:X})", &self.0)
     }
 }
 

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -7,6 +7,7 @@ mod scalar_impl;
 use self::scalar_impl::barrett_reduce;
 use crate::{FieldBytes, NistP256, SecretKey, ORDER_HEX};
 use core::{
+    fmt::{self, Debug},
     iter::{Product, Sum},
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, ShrAssign, Sub, SubAssign},
 };
@@ -79,7 +80,7 @@ pub const MU: [u64; 5] = [
 ///
 /// The serialization is a fixed-width big endian encoding. When used with
 /// textual formats, the binary data is encoded as hexadecimal.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Default)]
 pub struct Scalar(pub(crate) U256);
 
 impl Scalar {
@@ -717,6 +718,12 @@ impl ConditionallySelectable for Scalar {
 impl ConstantTimeEq for Scalar {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
+    }
+}
+
+impl Debug for Scalar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Scalar(0x{:X})", &self.0)
     }
 }
 

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -27,6 +27,7 @@ mod field_impl;
 use self::field_impl::*;
 use crate::{FieldBytes, NistP384};
 use core::{
+    fmt::{self, Debug},
     iter::{Product, Sum},
     ops::{AddAssign, MulAssign, Neg, SubAssign},
 };
@@ -42,7 +43,7 @@ use primeorder::impl_bernstein_yang_invert;
 pub(crate) const MODULUS: U384 = U384::from_be_hex(FieldElement::MODULUS);
 
 /// Element of the secp384r1 base field used for curve coordinates.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct FieldElement(pub(super) U384);
 
 primeorder::impl_mont_field_element!(
@@ -151,6 +152,12 @@ impl PrimeField for FieldElement {
     #[inline]
     fn is_odd(&self) -> Choice {
         self.is_odd()
+    }
+}
+
+impl Debug for FieldElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FieldElement(0x{:X})", &self.0)
     }
 }
 

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -14,6 +14,7 @@ mod scalar_impl;
 use self::scalar_impl::*;
 use crate::{FieldBytes, NistP384, SecretKey, ORDER_HEX, U384};
 use core::{
+    fmt::{self, Debug},
     iter::{Product, Sum},
     ops::{AddAssign, MulAssign, Neg, Shr, ShrAssign, SubAssign},
 };
@@ -67,7 +68,7 @@ use core::ops::{Add, Mul, Sub};
 ///
 /// The serialization is a fixed-width big endian encoding. When used with
 /// textual formats, the binary data is encoded as hexadecimal.
-#[derive(Clone, Copy, Debug, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(U384);
 
 primeorder::impl_mont_field_element!(
@@ -338,6 +339,12 @@ impl TryFrom<U384> for Scalar {
 
     fn try_from(w: U384) -> Result<Self> {
         Option::from(Self::from_uint(w)).ok_or(Error)
+    }
+}
+
+impl Debug for Scalar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Scalar(0x{:X})", &self.0)
     }
 }
 


### PR DESCRIPTION
Updates the `Debug` impls on `FieldElement` and `Scalar` to print the inner bigint value as hex.