### PR TITLE
p224/p256/p384: make `primeorder` dependency optional

### DIFF
--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,7 +17,9 @@ rust-version = "1.65"
 
 [dependencies]
 elliptic-curve = { version = "0.13", default-features = false, features = ["hazmat", "sec1"] }
-primeorder = { version = "0.13", path = "../primeorder" }
+
+# optional features
+primeorder = { version = "0.13", optional = true, path = "../primeorder" }
 
 [features]
 default = ["pem", "std"]
@@ -26,7 +28,7 @@ std = ["alloc", "elliptic-curve/std"]
 
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8"]
-wip-arithmetic-do-not-use = []
+wip-arithmetic-do-not-use = ["dep:primeorder"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,11 +18,11 @@ rust-version = "1.65"
 
 [dependencies]
 elliptic-curve = { version = "0.13", default-features = false, features = ["hazmat", "sec1"] }
-primeorder = { version = "0.13", path = "../primeorder" }
 
 # optional dependencies
 ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
+primeorder = { version = "0.13", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
@@ -39,7 +39,7 @@ default = ["arithmetic", "ecdsa", "pkcs8", "std"]
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std"]
 
-arithmetic = ["elliptic-curve/arithmetic"]
+arithmetic = ["dep:primeorder", "elliptic-curve/arithmetic"]
 bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,11 +18,11 @@ rust-version = "1.65"
 
 [dependencies]
 elliptic-curve = { version = "0.13", default-features = false, features = ["hazmat", "sec1"] }
-primeorder = { version = "0.13", path = "../primeorder" }
 
 # optional dependencies
 ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.3", optional = true }
+primeorder = { version = "0.13", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
@@ -39,7 +39,7 @@ default = ["arithmetic", "ecdh", "ecdsa", "pem", "std"]
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std"]
 
-arithmetic = ["elliptic-curve/arithmetic", "elliptic-curve/digest"]
+arithmetic = ["dep:primeorder", "elliptic-curve/arithmetic", "elliptic-curve/digest"]
 bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]


### PR DESCRIPTION
It's not needed when the `arithmetic` feature is disabled