### PR TITLE
primeorder: simplified `impl_field_sqrt_tests!`

### DIFF
--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -752,7 +752,10 @@ mod tests {
     use super::Scalar;
     use crate::{FieldBytes, SecretKey};
     use elliptic_curve::group::ff::{Field, PrimeField};
-    use primeorder::{impl_field_identity_tests, impl_field_invert_tests, impl_primefield_tests};
+    use primeorder::{
+        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
+        impl_primefield_tests,
+    };
 
     /// t = (modulus - 1) >> S
     const T: [u64; 4] = [
@@ -764,7 +767,7 @@ mod tests {
 
     impl_field_identity_tests!(Scalar);
     impl_field_invert_tests!(Scalar);
-    // impl_field_sqrt_tests!(Scalar); // TODO(tarcieri): debug test failures
+    impl_field_sqrt_tests!(Scalar);
     impl_primefield_tests!(Scalar, T);
 
     #[test]
@@ -792,16 +795,6 @@ mod tests {
 
         assert_eq!(minus_three * &minus_two, minus_two * &minus_three);
         assert_eq!(six, minus_two * &minus_three);
-    }
-
-    /// Basic tests that sqrt works.
-    #[test]
-    fn sqrt() {
-        for &n in &[1u64, 4, 9, 16, 25, 36, 49, 64] {
-            let scalar = Scalar::from(n);
-            let sqrt = scalar.sqrt().unwrap();
-            assert_eq!(sqrt.square(), scalar);
-        }
     }
 
     /// Tests that a Scalar can be safely converted to a SecretKey and back

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -373,7 +373,10 @@ mod tests {
     use super::Scalar;
     use crate::FieldBytes;
     use elliptic_curve::ff::PrimeField;
-    use primeorder::{impl_field_identity_tests, impl_field_invert_tests, impl_primefield_tests};
+    use primeorder::{
+        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
+        impl_primefield_tests,
+    };
 
     /// t = (modulus - 1) >> S
     const T: [u64; 6] = [
@@ -387,7 +390,7 @@ mod tests {
 
     impl_field_identity_tests!(Scalar);
     impl_field_invert_tests!(Scalar);
-    // impl_field_sqrt_tests!(Scalar); // TODO(tarcieri): debug test failures
+    impl_field_sqrt_tests!(Scalar);
     impl_primefield_tests!(Scalar, T);
 
     #[test]
@@ -415,15 +418,5 @@ mod tests {
 
         assert_eq!(minus_three * minus_two, minus_two * minus_three);
         assert_eq!(six, minus_two * minus_three);
-    }
-
-    /// Basic tests that sqrt works.
-    #[test]
-    fn sqrt() {
-        for &n in &[1u64, 4, 9, 16, 25, 36, 49, 64] {
-            let scalar = Scalar::from(n);
-            let sqrt = scalar.sqrt().unwrap();
-            assert_eq!(sqrt.square(), scalar);
-        }
     }
 }

--- a/primeorder/src/field.rs
+++ b/primeorder/src/field.rs
@@ -586,11 +586,6 @@ macro_rules! impl_field_sqrt_tests {
     ($fe:tt) => {
         #[test]
         fn sqrt() {
-            let one = $fe::ONE;
-            let two = one + &one;
-            let four = two.square();
-            assert_eq!(four.sqrt().unwrap(), two);
-
             for &n in &[1u64, 4, 9, 16, 25, 36, 49, 64] {
                 let fe = $fe::from(n);
                 let sqrt = fe.sqrt().unwrap();


### PR DESCRIPTION
Changes the test to only check that sqrt round trips back when squared.

Closes #789