### PR TITLE
p256: ECDSA verifying key recovery test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc302fd9b18d66834a6f092d10ea85489c0ca8ad6b7304092135fab171d853cd"
+checksum = "19c5cb402c5c958281c7c0702edea7b780d03b86b606497ca3a10fcd3fc393ac"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -330,17 +330,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
 
 [[package]]
 name = "ecdsa"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644d3b8674a5fc5b929ae435bca85c2323d85ccb013a5509c2ac9ee11a6284ba"
+checksum = "106401dadc137d05cb0d4ab4d42be089746aefdfe8992df4d0edcf351c16ddca"
 dependencies = [
  "der",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "serdect",
@@ -355,9 +357,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d"
+checksum = "22cdacd4d6ed3f9b98680b679c0e52a823b8a2c7a97358d508fe247f2180c282"
 dependencies = [
  "base16ct",
  "base64ct",
@@ -765,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34154ec92c136238e7c210443538e64350962b8e2788cadcf5f781a6da70c36"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -1103,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
+checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
 dependencies = [
  "base64ct",
  "der",

--- a/p256/tests/ecdsa.rs
+++ b/p256/tests/ecdsa.rs
@@ -1,0 +1,26 @@
+//! ECDSA tests.
+
+#![cfg(feature = "arithmetic")]
+
+use elliptic_curve::ops::Reduce;
+use p256::{
+    ecdsa::{SigningKey, VerifyingKey},
+    NonZeroScalar, U256,
+};
+use proptest::prelude::*;
+
+prop_compose! {
+    fn signing_key()(bytes in any::<[u8; 32]>()) -> SigningKey {
+        <NonZeroScalar as Reduce<U256>>::reduce_bytes(&bytes.into()).into()
+    }
+}
+
+proptest! {
+    #[test]
+    fn recover_from_msg(sk in signing_key()) {
+        let msg = b"example";
+        let (signature, v) = sk.sign_recoverable(msg).unwrap();
+        let recovered_vk = VerifyingKey::recover_from_msg(msg, &signature, v).unwrap();
+        prop_assert_eq!(sk.verifying_key(), &recovered_vk);
+    }
+}


### PR DESCRIPTION
Also bumps `ecdsa` to v0.16.4, which contains a bugfix: RustCrypto/signatures#702

This test confirms it's fixed.