### PR TITLE
p224: add `ecdh` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,7 @@ dependencies = [
  "elliptic-curve",
  "hex-literal 0.4.1",
  "primeorder",
+ "rand_core",
 ]
 
 [[package]]

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -25,12 +25,14 @@ primeorder = { version = "0.13", optional = true, path = "../primeorder" }
 [dev-dependencies]
 hex-literal = "0.4"
 primeorder = { version = "0.13", features = ["dev"], path = "../primeorder" }
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
 default = ["pem", "std"]
 alloc = ["elliptic-curve/alloc"]
 std = ["alloc", "elliptic-curve/std"]
 
+ecdh = ["wip-arithmetic-do-not-use", "elliptic-curve/ecdh"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8"]
 test-vectors = ["dep:hex-literal"]

--- a/p224/src/ecdh.rs
+++ b/p224/src/ecdh.rs
@@ -1,7 +1,7 @@
 //! Elliptic Curve Diffie-Hellman (Ephemeral) Support.
 //!
 //! This module contains a high-level interface for performing ephemeral
-//! Diffie-Hellman key exchanges using the secp384r1 elliptic curve.
+//! Diffie-Hellman key exchanges using the secp224r1 elliptic curve.
 //!
 //! # Usage
 //!
@@ -9,7 +9,7 @@
 //! exchange, nicknamed "Alice" and "Bob".
 //!
 //! ```
-//! use p384::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
+//! use p224::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
 //! use rand_core::OsRng; // requires 'getrandom' feature
 //!
 //! // Alice
@@ -38,10 +38,10 @@
 
 pub use elliptic_curve::ecdh::diffie_hellman;
 
-use crate::NistP384;
+use crate::NistP224;
 
-/// NIST P-384 Ephemeral Diffie-Hellman Secret.
-pub type EphemeralSecret = elliptic_curve::ecdh::EphemeralSecret<NistP384>;
+/// NIST P-224 Ephemeral Diffie-Hellman Secret.
+pub type EphemeralSecret = elliptic_curve::ecdh::EphemeralSecret<NistP224>;
 
 /// Shared secret value computed via ECDH key agreement.
-pub type SharedSecret = elliptic_curve::ecdh::SharedSecret<NistP384>;
+pub type SharedSecret = elliptic_curve::ecdh::SharedSecret<NistP224>;

--- a/p224/src/lib.rs
+++ b/p224/src/lib.rs
@@ -18,6 +18,9 @@
 #[cfg(feature = "wip-arithmetic-do-not-use")]
 pub mod arithmetic;
 
+#[cfg(feature = "ecdh")]
+pub mod ecdh;
+
 #[cfg(any(feature = "test-vectors", test))]
 pub mod test_vectors;
 
@@ -91,6 +94,10 @@ pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP224>;
 pub type FieldBytes = elliptic_curve::FieldBytes<NistP224>;
 
 impl FieldBytesEncoding<NistP224> for Uint {}
+
+/// NIST P-224 public key.
+#[cfg(feature = "wip-arithmetic-do-not-use")]
+pub type PublicKey = elliptic_curve::PublicKey<NistP224>;
 
 /// NIST P-224 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<NistP224>;

--- a/p256/src/ecdh.rs
+++ b/p256/src/ecdh.rs
@@ -1,7 +1,7 @@
 //! Elliptic Curve Diffie-Hellman (Ephemeral) Support.
 //!
 //! This module contains a high-level interface for performing ephemeral
-//! Diffie-Hellman key exchanges using the secp256k1 elliptic curve.
+//! Diffie-Hellman key exchanges using the secp256r1 elliptic curve.
 //!
 //! # Usage
 //!


### PR DESCRIPTION
Adds a feature for performing elliptic curve Diffie-Hellman similar to the same feature in the `p256` and `p384` crates.