### PR TITLE
p224: `arithmetic` feature

### DIFF
--- a/.github/workflows/p224.yml
+++ b/.github/workflows/p224.yml
@@ -37,9 +37,9 @@ jobs:
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features wip-arithmetic-do-not-use
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,pkcs8,wip-arithmetic-do-not-use
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,arithmetic,pkcs8
 
   test:
     runs-on: ubuntu-latest

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -32,11 +32,11 @@ default = ["pem", "std"]
 alloc = ["elliptic-curve/alloc"]
 std = ["alloc", "elliptic-curve/std"]
 
-ecdh = ["wip-arithmetic-do-not-use", "elliptic-curve/ecdh"]
+ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8"]
 test-vectors = ["dep:hex-literal"]
-wip-arithmetic-do-not-use = ["dep:primeorder"]
+arithmetic = ["dep:primeorder"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/p224/src/lib.rs
+++ b/p224/src/lib.rs
@@ -15,8 +15,8 @@
     unused_qualifications
 )]
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
-pub mod arithmetic;
+#[cfg(feature = "arithmetic")]
+mod arithmetic;
 
 #[cfg(feature = "ecdh")]
 pub mod ecdh;
@@ -26,7 +26,7 @@ pub mod test_vectors;
 
 pub use elliptic_curve;
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 pub use arithmetic::{scalar::Scalar, AffinePoint, ProjectivePoint};
 
 #[cfg(feature = "pkcs8")]
@@ -45,7 +45,7 @@ pub use elliptic_curve::bigint::U224 as Uint;
 use elliptic_curve::bigint::U256 as Uint;
 
 /// Order of NIST P-224's elliptic curve group (i.e. scalar modulus) in hexadecimal.
-#[cfg(any(target_pointer_width = "32", feature = "wip-arithmetic-do-not-use"))]
+#[cfg(any(target_pointer_width = "32", feature = "arithmetic"))]
 const ORDER_HEX: &str = "ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3d";
 
 /// NIST P-224 elliptic curve.
@@ -81,6 +81,10 @@ impl pkcs8::AssociatedOid for NistP224 {
     const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::new_unwrap("1.3.132.0.33");
 }
 
+/// Blinded scalar.
+#[cfg(feature = "arithmetic")]
+pub type BlindedScalar = elliptic_curve::scalar::BlindedScalar<NistP224>;
+
 /// Compressed SEC1-encoded NIST P-224 curve point.
 pub type CompressedPoint = GenericArray<u8, U29>;
 
@@ -95,14 +99,18 @@ pub type FieldBytes = elliptic_curve::FieldBytes<NistP224>;
 
 impl FieldBytesEncoding<NistP224> for Uint {}
 
+/// Non-zero NIST P-256 scalar field element.
+#[cfg(feature = "arithmetic")]
+pub type NonZeroScalar = elliptic_curve::NonZeroScalar<NistP224>;
+
 /// NIST P-224 public key.
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 pub type PublicKey = elliptic_curve::PublicKey<NistP224>;
 
 /// NIST P-224 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<NistP224>;
 
-#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
+#[cfg(not(feature = "arithmetic"))]
 impl elliptic_curve::sec1::ValidatePublicKey for NistP224 {}
 
 /// Bit representation of a NIST P-224 scalar field element.

--- a/p224/tests/projective.rs
+++ b/p224/tests/projective.rs
@@ -1,6 +1,6 @@
 //! Projective arithmetic tests.
 
-#![cfg(all(feature = "wip-arithmetic-do-not-use", feature = "test-vectors"))]
+#![cfg(all(feature = "arithmetic", feature = "test-vectors"))]
 
 use elliptic_curve::{
     group::ff::PrimeField,


### PR DESCRIPTION
Now that #813 has landed it seems prudent to add a real `arithmetic` feature.

This adds a feature similar to the `p256` and `p384` crates which exposes the following types which provide a curve arithmetic implementation:

- `AffinePoint`
- `ProjectivePoint`
- `Scalar`

The `wip-arithmetic-do-not-use` feature is now removed as well. While technically SemVer breaking, it wasn't supposed to be used in the first place!