### PR TITLE
primeorder v0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,7 +816,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primeorder"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "elliptic-curve",
  "serdect",

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -21,7 +21,7 @@ elliptic-curve = { version = "0.13.4", default-features = false, features = ["ha
 # optional dependencies
 ecdsa-core = { version = "0.16.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
-primeorder = { version = "0.13", optional = true, path = "../primeorder" }
+primeorder = { version = "0.13.1", optional = true, path = "../primeorder" }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-elliptic-curve = { version = "0.13", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "0.13.1", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -22,7 +22,7 @@ elliptic-curve = { version = "0.13", default-features = false, features = ["hazm
 # optional dependencies
 ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
-primeorder = { version = "0.13", optional = true, path = "../primeorder" }
+primeorder = { version = "0.13.1", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
 

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.65"
 elliptic-curve = { version = "0.13", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-primeorder = { version = "0.13", optional = true, path = "../primeorder" }
+primeorder = { version = "0.13.1", optional = true, path = "../primeorder" }
 
 [features]
 default = ["pem", "std"]

--- a/primeorder/CHANGELOG.md
+++ b/primeorder/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.1 (2023-04-09)
+### Added
+- `impl_bernstein_yang_invert!` macro ([#786])
+- `impl_field_invert_tests!` macro ([#786])
+- `impl_field_identity_tests!` macro ([#790])
+- `impl_field_sqrt_tests!` macro ([#790], [#800])
+
+### Fixed
+- Correct product definition for empty iterators ([#802])
+
+[#786]: https://github.com/RustCrypto/elliptic-curves/pull/786
+[#790]: https://github.com/RustCrypto/elliptic-curves/pull/790
+[#800]: https://github.com/RustCrypto/elliptic-curves/pull/800
+[#802]: https://github.com/RustCrypto/elliptic-curves/pull/802
+
 ## 0.13.0 (2023-03-03)
 ### Added
 - Support curves with any `a`-coefficient ([#728], [#729])

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.13.0"
+version = "0.13.1"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve


### PR DESCRIPTION
### Added
- `impl_bernstein_yang_invert!` macro ([#786])
- `impl_field_invert_tests!` macro ([#786])
- `impl_field_identity_tests!` macro ([#790])
- `impl_field_sqrt_tests!` macro ([#790], [#800])

### Fixed
- Correct product definition for empty iterators ([#802])

[#786]: https://github.com/RustCrypto/elliptic-curves/pull/786
[#790]: https://github.com/RustCrypto/elliptic-curves/pull/790
[#800]: https://github.com/RustCrypto/elliptic-curves/pull/800
[#802]: https://github.com/RustCrypto/elliptic-curves/pull/802