### PR TITLE
p224 v0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "p224"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "blobby",
  "ecdsa",

--- a/p224/CHANGELOG.md
+++ b/p224/CHANGELOG.md
@@ -4,5 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.1 (2023-04-09)
+### Added
+- Projective arithmetic tests ([#813])
+- `ecdh` feature ([#814])
+- `arithmetic` feature ([#815])
+- `ecdsa` feature ([#816])
+- FIPS 186-4 ECDSA test vectors ([#817])
+- Wycheproof test vectors ([#818])
+- Bump `primeorder` to v0.13.1 ([#819])
+
+### Changed
+- Better `Debug` for field elements ([#798])
+- Make `primeorder` dependency optional ([#799])
+
+[#798]: https://github.com/RustCrypto/elliptic-curves/pull/798
+[#799]: https://github.com/RustCrypto/elliptic-curves/pull/799
+[#813]: https://github.com/RustCrypto/elliptic-curves/pull/813
+[#814]: https://github.com/RustCrypto/elliptic-curves/pull/814
+[#815]: https://github.com/RustCrypto/elliptic-curves/pull/815
+[#816]: https://github.com/RustCrypto/elliptic-curves/pull/816
+[#817]: https://github.com/RustCrypto/elliptic-curves/pull/817
+[#818]: https://github.com/RustCrypto/elliptic-curves/pull/818
+[#819]: https://github.com/RustCrypto/elliptic-curves/pull/819
+
 ## 0.13.0 (2023-03-03)
 - Initial release

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p224"
-version = "0.13.0"
+version = "0.13.1"
 description = """
 Pure Rust implementation of the NIST P-224 (a.k.a. secp224r1) elliptic curve
 as defined in SP 800-186

--- a/primeorder/README.md
+++ b/primeorder/README.md
@@ -24,6 +24,7 @@ y² = x³ + ax + b
 
 It's used to implement the following elliptic curves:
 
+- [`p224`]: NIST P-224
 - [`p256`]: NIST P-256
 - [`p384`]: NIST P-384
 
@@ -84,5 +85,6 @@ dual licensed as above, without any additional terms or conditions.
 [RustCrypto]: https://github.com/rustcrypto/
 [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
 [Weierstrass equation]: https://crypto.stanford.edu/pbc/notes/elliptic/weier.html
+[`p224`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p224
 [`p256`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p256
 [`p384`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p256

--- a/primeorder/src/dev.rs
+++ b/primeorder/src/dev.rs
@@ -1,5 +1,7 @@
 //! Development-related functionality.
 
+// TODO(tarcieri): move all development-related macros into this module
+
 /// Implement projective arithmetic tests.
 #[macro_export]
 macro_rules! impl_projective_arithmetic_tests {

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -8,11 +8,11 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc = include_str!("../README.md")]
 
-#[cfg(feature = "dev")]
-pub mod dev;
 pub mod point_arithmetic;
 
 mod affine;
+#[cfg(feature = "dev")]
+mod dev;
 mod field;
 mod projective;
 


### PR DESCRIPTION
### Added
- Projective arithmetic tests ([#813])
- `ecdh` feature ([#814])
- `arithmetic` feature ([#815])
- `ecdsa` feature ([#816])
- FIPS 186-4 ECDSA test vectors ([#817])
- Wycheproof test vectors ([#818])
- Bump `primeorder` to v0.13.1 ([#819])

### Changed
- Better `Debug` for field elements ([#798])
- Make `primeorder` dependency optional ([#799])

[#798]: https://github.com/RustCrypto/elliptic-curves/pull/798
[#799]: https://github.com/RustCrypto/elliptic-curves/pull/799
[#813]: https://github.com/RustCrypto/elliptic-curves/pull/813
[#814]: https://github.com/RustCrypto/elliptic-curves/pull/814
[#815]: https://github.com/RustCrypto/elliptic-curves/pull/815
[#816]: https://github.com/RustCrypto/elliptic-curves/pull/816
[#817]: https://github.com/RustCrypto/elliptic-curves/pull/817
[#818]: https://github.com/RustCrypto/elliptic-curves/pull/818
[#819]: https://github.com/RustCrypto/elliptic-curves/pull/819
