### PR TITLE
p256 v0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "blobby",
  "criterion",

--- a/p256/CHANGELOG.md
+++ b/p256/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.1 (2023-04-10)
+### Changed
+- Bump `primeorder` to v0.13.1 ([#819])
+
+### Fixed
+- Correct product definition for empty iterators ([#802])
+
+[#802]: https://github.com/RustCrypto/elliptic-curves/pull/802
+[#819]: https://github.com/RustCrypto/elliptic-curves/pull/819
+
 ## 0.13.0 (2023-03-03)
 ### Added
 - `PrimeField` constants/tests ([#730], [#737], [#738])

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256"
-version = "0.13.0"
+version = "0.13.1"
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve as defined in SP 800-186, with support for ECDH, ECDSA


### PR DESCRIPTION
### Changed
- Bump `primeorder` to v0.13.1 ([#819])

### Fixed
- Correct product definition for empty iterators ([#802])

[#802]: https://github.com/RustCrypto/elliptic-curves/pull/802
[#819]: https://github.com/RustCrypto/elliptic-curves/pull/819