### PR TITLE
p192: define `PrimeField` constants for `FieldElement`

### DIFF
--- a/p192/src/arithmetic/field.rs
+++ b/p192/src/arithmetic/field.rs
@@ -111,12 +111,12 @@ impl PrimeField for FieldElement {
     const MODULUS: &'static str = MODULUS_HEX;
     const NUM_BITS: u32 = 192;
     const CAPACITY: u32 = 191;
-    const TWO_INV: Self = Self::ZERO; // TODO
-    const MULTIPLICATIVE_GENERATOR: Self = Self::ZERO; // TODO
-    const S: u32 = 0; // TODO
-    const ROOT_OF_UNITY: Self = Self::ZERO; // TODO
-    const ROOT_OF_UNITY_INV: Self = Self::ZERO; // TODO
-    const DELTA: Self = Self::ZERO; // TODO
+    const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
+    const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(11);
+    const S: u32 = 1;
+    const ROOT_OF_UNITY: Self = Self::from_hex("fffffffffffffffffffffffffffffffefffffffffffffffe");
+    const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
+    const DELTA: Self = Self::from_u64(121);
 
     #[inline]
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
@@ -132,4 +132,19 @@ impl PrimeField for FieldElement {
     fn is_odd(&self) -> Choice {
         self.is_odd()
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FieldElement;
+    use elliptic_curve::ff::PrimeField;
+    use primeorder::{impl_field_identity_tests, impl_field_invert_tests, impl_primefield_tests};
+
+    /// t = (modulus - 1) >> S
+    const T: [u64; 3] = [0x7fffffffffffffff, 0xffffffffffffffff, 0x7fffffffffffffff];
+
+    impl_field_identity_tests!(FieldElement);
+    impl_field_invert_tests!(FieldElement);
+    // impl_field_sqrt_tests!(FieldElement);
+    impl_primefield_tests!(FieldElement, T);
 }


### PR DESCRIPTION
Calculated in `sage` as follows:

```sage
sage: p = 0xfffffffffffffffffffffffffffffffeffffffffffffffff
sage: multiplicative_generator = GF(p).primitive_element()
sage: p_minus_1_bin = (p - 1).binary()
sage: s = len(p_minus_1_bin) - len(p_minus_1_bin.rstrip('0')) # count trailing zeros in binary
sage: t = (p - 1) >> s
sage: root_of_unity = pow(multiplicative_generator,t,p)
sage: delta = pow(multiplicative_generator, 2^s, p)
sage: multiplicative_generator
11
sage: p_minus_1_bin
'111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111101111111111111111111111111111111111111111111111111111111111111110'
sage: s
1
sage: hex(t)
'0x7fffffffffffffffffffffffffffffff7fffffffffffffff'
sage: hex(root_of_unity)
'0xfffffffffffffffffffffffffffffffefffffffffffffffe'
sage: delta
121
```