### PR TITLE
sm2: define `PrimeField` constants for `Scalar`

### DIFF
--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -180,12 +180,13 @@ impl PrimeField for Scalar {
     const MODULUS: &'static str = ORDER_HEX;
     const NUM_BITS: u32 = 256;
     const CAPACITY: u32 = 255;
-    const TWO_INV: Self = Self::ZERO; // TODO
-    const MULTIPLICATIVE_GENERATOR: Self = Self::ZERO; // TODO
-    const S: u32 = 0; // TODO
-    const ROOT_OF_UNITY: Self = Self::ZERO; // TODO
-    const ROOT_OF_UNITY_INV: Self = Self::ZERO; // TODO
-    const DELTA: Self = Self::ZERO; // TODO
+    const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
+    const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(3);
+    const S: u32 = 1;
+    const ROOT_OF_UNITY: Self =
+        Self::from_hex("fffffffeffffffffffffffffffffffff7203df6b21c6052b53bbf40939d54122");
+    const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
+    const DELTA: Self = Self::from_u64(9);
 
     #[inline]
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
@@ -286,4 +287,25 @@ impl TryFrom<U256> for Scalar {
     fn try_from(w: U256) -> Result<Self> {
         Option::from(Self::from_uint(w)).ok_or(Error)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Scalar;
+    use elliptic_curve::ff::PrimeField;
+    use primeorder::{impl_field_identity_tests, impl_field_invert_tests, impl_primefield_tests};
+
+    /// t = (modulus - 1) >> S
+    /// 0x7fffffff7fffffffffffffffffffffffb901efb590e30295a9ddfa049ceaa091
+    const T: [u64; 4] = [
+        0xa9ddfa049ceaa091,
+        0xb901efb590e30295,
+        0xffffffffffffffff,
+        0x7fffffff7fffffff,
+    ];
+
+    impl_field_identity_tests!(Scalar);
+    impl_field_invert_tests!(Scalar);
+    // impl_field_sqrt_tests!(Scalar);
+    impl_primefield_tests!(Scalar, T);
 }


### PR DESCRIPTION
Calculated in `sage` as follows:

```sage
sage: p = 0xfffffffeffffffffffffffffffffffff7203df6b21c6052b53bbf40939d54123
sage: multiplicative_generator = GF(p).primitive_element()
sage: p_minus_1_bin = (p - 1).binary()
sage: s = len(p_minus_1_bin) - len(p_minus_1_bin.rstrip('0')) # count trailing zeros in binary
sage: t = (p - 1) >> s
sage: root_of_unity = pow(multiplicative_generator,t,p)
sage: delta = pow(multiplicative_generator, 2^s, p)
sage: multiplicative_generator
3
sage: p_minus_1_bin
'1111111111111111111111111111111011111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111101110010000000111101111101101011001000011100011000000101001010110101001110111011111101000000100100111001110101010100000100100010'
sage: s
1
sage: hex(t)
'0x7fffffff7fffffffffffffffffffffffb901efb590e30295a9ddfa049ceaa091'
sage: hex(root_of_unity)
'0xfffffffeffffffffffffffffffffffff7203df6b21c6052b53bbf40939d54122'
sage: delta
9