### PR TITLE
p256: enable `pem` feature by default

### DIFF
--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -36,7 +36,7 @@ proptest = "1"
 rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
-default = ["arithmetic", "ecdsa", "pkcs8", "std"]
+default = ["arithmetic", "ecdsa", "pem", "std"]
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std"]
 


### PR DESCRIPTION
Better matches `p384`