### PR TITLE
p192: `arithmetic` feature

### DIFF
--- a/.github/workflows/p192.yml
+++ b/.github/workflows/p192.yml
@@ -37,9 +37,9 @@ jobs:
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features wip-arithmetic-do-not-use
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,pkcs8,wip-arithmetic-do-not-use
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,arithmetic,pkcs8
 
   test:
     runs-on: ubuntu-latest

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -28,13 +28,13 @@ hex-literal = "0.4"
 primeorder = { version = "0.13", features = ["dev"], path = "../primeorder" }
 
 [features]
-default = ["pem", "std"]
+default = ["arithmetic", "pem", "std"]
 alloc = ["elliptic-curve/alloc"]
 std = ["alloc", "elliptic-curve/std"]
 
+arithmetic = ["elliptic-curve/arithmetic", "primeorder"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8"]
-wip-arithmetic-do-not-use = ["elliptic-curve/arithmetic", "primeorder"]
 test-vectors = ["hex-literal"]
 
 [package.metadata.docs.rs]

--- a/p192/src/arithmetic.rs
+++ b/p192/src/arithmetic.rs
@@ -7,9 +7,7 @@
 pub(crate) mod field;
 pub(crate) mod scalar;
 
-pub use self::scalar::Scalar;
-
-use self::field::FieldElement;
+use self::{field::FieldElement, scalar::Scalar};
 use crate::NistP192;
 use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
 use primeorder::{point_arithmetic, PrimeCurveParams};

--- a/p192/src/lib.rs
+++ b/p192/src/lib.rs
@@ -15,13 +15,16 @@
     unused_qualifications
 )]
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
-pub mod arithmetic;
+#[cfg(feature = "arithmetic")]
+mod arithmetic;
 
 #[cfg(any(feature = "test-vectors", test))]
 pub mod test_vectors;
 
 pub use elliptic_curve;
+
+#[cfg(feature = "arithmetic")]
+pub use arithmetic::{scalar::Scalar, AffinePoint, ProjectivePoint};
 
 #[cfg(feature = "pkcs8")]
 pub use elliptic_curve::pkcs8;
@@ -84,7 +87,7 @@ impl FieldBytesEncoding<NistP192> for U192 {
     }
 }
 
-#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
+#[cfg(not(feature = "arithmetic"))]
 impl elliptic_curve::sec1::ValidatePublicKey for NistP192 {}
 
 /// Bit representation of a NIST P-192 scalar field element.

--- a/p192/tests/projective.rs
+++ b/p192/tests/projective.rs
@@ -1,14 +1,14 @@
 //! Projective arithmetic tests.
 
-#![cfg(all(feature = "wip-arithmetic-do-not-use", feature = "test-vectors"))]
+#![cfg(all(feature = "arithmetic", feature = "test-vectors"))]
 
 use elliptic_curve::{
     group::ff::PrimeField,
     sec1::{self, ToEncodedPoint},
 };
 use p192::{
-    arithmetic::{AffinePoint, ProjectivePoint, Scalar},
     test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
+    AffinePoint, ProjectivePoint, Scalar,
 };
 use primeorder::{impl_projective_arithmetic_tests, Double};
 


### PR DESCRIPTION
Now that #837 has landed it seems prudent to add a real `arithmetic` feature.

This adds a feature similar to the `p224`/`p256`/`p384` crates which exposes the following types which provide a curve arithmetic implementation:

- `AffinePoint`
- `ProjectivePoint`
- `Scalar`