### PR TITLE
sm2: `arithmetic` feature

### DIFF
--- a/.github/workflows/sm2.yml
+++ b/.github/workflows/sm2.yml
@@ -37,9 +37,9 @@ jobs:
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features wip-arithmetic-do-not-use
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,pkcs8,wip-arithmetic-do-not-use
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,arithmetic,pkcs8
 
   test:
     runs-on: ubuntu-latest

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -25,13 +25,13 @@ primeorder = { version = "0.13.1", optional = true, path = "../primeorder" }
 hex-literal = "0.4"
 
 [features]
-default = ["pem", "std"]
+default = ["arithmetic", "pem", "std"]
 alloc = ["elliptic-curve/alloc"]
 std = ["alloc", "elliptic-curve/std"]
 
+arithmetic = ["elliptic-curve/arithmetic", "primeorder"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8"]
-wip-arithmetic-do-not-use = ["elliptic-curve/arithmetic", "primeorder"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/sm2/src/lib.rs
+++ b/sm2/src/lib.rs
@@ -15,10 +15,13 @@
     unused_qualifications
 )]
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
-pub mod arithmetic;
+#[cfg(feature = "arithmetic")]
+mod arithmetic;
 
 pub use elliptic_curve;
+
+#[cfg(feature = "arithmetic")]
+pub use arithmetic::{scalar::Scalar, AffinePoint, ProjectivePoint};
 
 #[cfg(feature = "pkcs8")]
 pub use elliptic_curve::pkcs8;
@@ -84,17 +87,17 @@ impl FieldBytesEncoding<Sm2> for U256 {
 }
 
 /// Non-zero scalar field element.
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 pub type NonZeroScalar = elliptic_curve::NonZeroScalar<Sm2>;
 
 /// SM2 public key: wrapper type for an elliptic curve point.
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 pub type PublicKey = elliptic_curve::PublicKey<Sm2>;
 
 /// SM2 secret key: wrapper point for a secret scalar.
 pub type SecretKey = elliptic_curve::SecretKey<Sm2>;
 
-#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
+#[cfg(not(feature = "arithmetic"))]
 impl elliptic_curve::sec1::ValidatePublicKey for Sm2 {}
 
 /// Bit representation of a SM2 scalar field element.

--- a/sm2/tests/pkcs8.rs
+++ b/sm2/tests/pkcs8.rs
@@ -5,10 +5,10 @@
 use hex_literal::hex;
 use sm2::pkcs8::DecodePrivateKey;
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 use sm2::pkcs8::DecodePublicKey;
 
-#[cfg(all(feature = "wip-arithmetic-do-not-use", feature = "pem"))]
+#[cfg(all(feature = "arithmetic", feature = "pem"))]
 use {
     elliptic_curve::sec1::ToEncodedPoint,
     sm2::elliptic_curve::pkcs8::{EncodePrivateKey, EncodePublicKey},
@@ -18,7 +18,7 @@ use {
 const PKCS8_PRIVATE_KEY_DER: &[u8; 138] = include_bytes!("examples/pkcs8-private-key.der");
 
 /// DER-encoded PKCS#8 public key
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 const PKCS8_PUBLIC_KEY_DER: &[u8; 91] = include_bytes!("examples/pkcs8-public-key.der");
 
 /// PEM-encoded PKCS#8 private key
@@ -26,7 +26,7 @@ const PKCS8_PUBLIC_KEY_DER: &[u8; 91] = include_bytes!("examples/pkcs8-public-ke
 const PKCS8_PRIVATE_KEY_PEM: &str = include_str!("examples/pkcs8-private-key.pem");
 
 /// PEM-encoded PKCS#8 public key
-#[cfg(all(feature = "wip-arithmetic-do-not-use", feature = "pem"))]
+#[cfg(all(feature = "arithmetic", feature = "pem"))]
 const PKCS8_PUBLIC_KEY_PEM: &str = include_str!("examples/pkcs8-public-key.pem");
 
 /// Extracted via `openssl ec -in pkcs8-private-key.pem -noout -text`
@@ -39,7 +39,7 @@ const PKCS8_PUBLIC_KEY_PEM: &str = include_str!("examples/pkcs8-public-key.pem")
 ///     64:e3:1e:64:32:35:96:09:c4:e7:98:47:a5:b1:61:
 ///     c8:c7:36:4c:8a
 /// ```
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 const SEC1_PUBLIC_KEY: [u8; 65] = hex!("0408D77AE04C01CC4C1104360DD8AF6B6F7DF334283D7C1A6AFD5652407B87BEE5014E2A57C36C150D16324DC664E31E6432359609C4E79847A5B161C8C7364C8A");
 
 #[test]
@@ -48,14 +48,14 @@ fn decode_pkcs8_private_key_from_der() {
     let expected_scalar = hex!("4BB8DF505722299592CBED4283B354A13FF5D3FEEB3A0660C5BDF3C87C559499");
     assert_eq!(secret_key.to_bytes().as_slice(), &expected_scalar[..]);
 
-    #[cfg(feature = "wip-arithmetic-do-not-use")]
+    #[cfg(feature = "arithmetic")]
     assert_eq!(
         secret_key.public_key().to_encoded_point(false).as_bytes(),
         &SEC1_PUBLIC_KEY[..]
     );
 }
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 #[test]
 fn decode_pkcs8_public_key_from_der() {
     let public_key = sm2::PublicKey::from_public_key_der(&PKCS8_PUBLIC_KEY_DER[..]).unwrap();
@@ -76,7 +76,7 @@ fn decode_pkcs8_private_key_from_pem() {
     assert_eq!(secret_key.to_bytes(), der_key.to_bytes());
 }
 
-#[cfg(all(feature = "wip-arithmetic-do-not-use", feature = "pem"))]
+#[cfg(all(feature = "arithmetic", feature = "pem"))]
 #[test]
 fn decode_pkcs8_public_key_from_pem() {
     let public_key = PKCS8_PUBLIC_KEY_PEM.parse::<sm2::PublicKey>().unwrap();
@@ -86,7 +86,7 @@ fn decode_pkcs8_public_key_from_pem() {
     assert_eq!(public_key, der_key);
 }
 
-#[cfg(all(feature = "wip-arithmetic-do-not-use", feature = "pem"))]
+#[cfg(all(feature = "arithmetic", feature = "pem"))]
 #[test]
 fn encode_pkcs8_private_key_to_der() {
     let original_secret_key = sm2::SecretKey::from_pkcs8_der(&PKCS8_PRIVATE_KEY_DER[..]).unwrap();
@@ -94,7 +94,7 @@ fn encode_pkcs8_private_key_to_der() {
     assert_eq!(reencoded_secret_key.as_bytes(), &PKCS8_PRIVATE_KEY_DER[..]);
 }
 
-#[cfg(all(feature = "wip-arithmetic-do-not-use", feature = "pem"))]
+#[cfg(all(feature = "arithmetic", feature = "pem"))]
 #[test]
 fn encode_pkcs8_public_key_to_der() {
     let original_public_key =
@@ -103,7 +103,7 @@ fn encode_pkcs8_public_key_to_der() {
     assert_eq!(reencoded_public_key.as_ref(), &PKCS8_PUBLIC_KEY_DER[..]);
 }
 
-#[cfg(all(feature = "wip-arithmetic-do-not-use", feature = "pem"))]
+#[cfg(all(feature = "arithmetic", feature = "pem"))]
 #[test]
 fn encode_pkcs8_private_key_to_pem() {
     let original_secret_key = sm2::SecretKey::from_pkcs8_der(&PKCS8_PRIVATE_KEY_DER[..]).unwrap();
@@ -113,7 +113,7 @@ fn encode_pkcs8_private_key_to_pem() {
     assert_eq!(reencoded_secret_key.as_str(), PKCS8_PRIVATE_KEY_PEM);
 }
 
-#[cfg(all(feature = "wip-arithmetic-do-not-use", feature = "pem"))]
+#[cfg(all(feature = "arithmetic", feature = "pem"))]
 #[test]
 fn encode_pkcs8_public_key_to_pem() {
     let original_public_key =


### PR DESCRIPTION
This adds a feature similar to the `p224`/`p256`/`p384` crates which exposes the following types which provide a curve arithmetic implementation:

- `AffinePoint`
- `ProjectivePoint`
- `Scalar`