### PR TITLE
p192: public key-only documentation

### DIFF
--- a/p192/README.md
+++ b/p192/README.md
@@ -21,13 +21,17 @@ considered too weak for modern usage.
 
 For more information, see:
 [NIST Special Publication 800-131A Revision 2]:
-Transitioning the Use of Cryptographic Algorithms and Key Lengths:
+"Transitioning the Use of Cryptographic Algorithms and Key Lengths":
 
 > ECDSA and EdDSA: The security strength provided by an elliptic-curve-based
 > signature algorithm is no greater than 1/2 of the length of the domain
 > parameter n. Therefore, the length of n shall be at least 224 bits to meet
 > the minimum security-strength requirement of 112 bits for Federal
 > Government use.
+
+Following the recommendations from this document, this crate only provides
+public-key operations intended for legacy interop purposes. There is
+deliberately no `SecretKey`, ECDH support, or ECDSA `SigningKey`.
 
 ### Unaudited!
 

--- a/p192/src/ecdsa.rs
+++ b/p192/src/ecdsa.rs
@@ -11,6 +11,20 @@
 //!   services or hardware devices (HSM or crypto hardware wallet).
 //! - `ecdsa`: provides `ecdsa-core` features plus [`VerifyingKey`] types
 //!   which natively implement ECDSA/P-192 verification.
+//!
+//! ## Verification only
+//!
+//! Following guidance from [NIST Special Publication 800-131A Revision 2]:
+//! "Transitioning the Use of Cryptographic Algorithms and Key Lengths", this
+//! crate only supports ECDSA verification, not signing.
+//!
+//! From Section 3: Digital Signatures:
+//!
+//! > ECDSA: See FIPS 186-238 and FIPS 186-4, which include specifications of
+//! > elliptic curves that may continue to be used for signature verification but not
+//! > signature generation: B-163, K-163 and P-192.
+//!
+//! [NIST Special Publication 800-131A Revision 2]: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf
 
 pub use ecdsa_core::signature::{self, Error};
 #[cfg(feature = "ecdsa")]


### PR DESCRIPTION
Add documentation referring to NIST Special Publication 800-131A Revision 2: Transitioning the Use of Cryptographic Algorithms and Key Lengths, which notes that the `p192` crate follows its recommendations to only implement public key operations as opposed to secret key ops.