### PR TITLE
sm2: add `dsa` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,6 +1125,20 @@ dependencies = [
  "elliptic-curve",
  "hex-literal",
  "primeorder",
+ "proptest",
+ "rand_core",
+ "rfc6979",
+ "signature",
+ "sm3",
+]
+
+[[package]]
+name = "sm3"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f943a7c5e3089f2bd046221d1e9f4fa59396bf0fe966360983649683086215da"
+dependencies = [
+ "digest",
 ]
 
 [[package]]

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -20,16 +20,23 @@ elliptic-curve = { version = "0.13", default-features = false, features = ["hazm
 
 # optional dependencies
 primeorder = { version = "0.13.1", optional = true, path = "../primeorder" }
+rfc6979 = { version = "0.4", optional = true }
+signature = { version = "2", optional = true }
+sm3 = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"
+proptest = "1"
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
 default = ["arithmetic", "pem", "std"]
 alloc = ["elliptic-curve/alloc"]
-std = ["alloc", "elliptic-curve/std"]
+std = ["alloc", "elliptic-curve/std", "signature?/std"]
 
-arithmetic = ["elliptic-curve/arithmetic", "primeorder"]
+arithmetic = ["elliptic-curve/arithmetic", "dep:primeorder"]
+dsa = ["arithmetic", "dep:rfc6979", "dep:signature", "dep:sm3"]
+getrandom = ["rand_core/getrandom"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8"]
 

--- a/sm2/README.md
+++ b/sm2/README.md
@@ -29,10 +29,9 @@ USE AT YOUR OWN RISK!
 ShangMi 2 (SM2) is a Weierstrass curve specified in [GM/T 0003-2012]:
 Cryptography Industry Standard of the People's Republic of China.
 
-The SM2 cryptosystem is composed of three distinct algorithms, which are NOT
-yet implemented by this crate:
+The SM2 cryptosystem is composed of three distinct algorithms:
 
-- [ ] **SM2DSA**: digital signature algorithm defined in [GBT.32918.2-2016], [ISO.IEC.14888-3] (SM2-2)
+- [x] **SM2DSA**: digital signature algorithm defined in [GBT.32918.2-2016], [ISO.IEC.14888-3] (SM2-2)
 - [ ] **SM2KEP**: key exchange protocol defined in [GBT.32918.3-2016] (SM2-3)
 - [ ] **SM2PKE**: public key encryption algorithm defined in [GBT.32918.4-2016] (SM2-4)
 

--- a/sm2/src/arithmetic/field.rs
+++ b/sm2/src/arithmetic/field.rs
@@ -11,6 +11,10 @@
 //! users may pick which license to apply.
 
 #![allow(
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
+    clippy::integer_arithmetic,
     clippy::should_implement_trait,
     clippy::suspicious_op_assign_impl,
     clippy::unused_unit,

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -1,12 +1,17 @@
 //! SM2 scalar field elements.
 
-#[cfg_attr(target_pointer_width = "32", path = "scalar/sm2_scalar_32.rs")]
-#[cfg_attr(target_pointer_width = "64", path = "scalar/sm2_scalar_64.rs")]
-#[allow(
+#![allow(
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
     clippy::identity_op,
+    clippy::integer_arithmetic,
     clippy::too_many_arguments,
     clippy::unnecessary_cast
 )]
+
+#[cfg_attr(target_pointer_width = "32", path = "scalar/sm2_scalar_32.rs")]
+#[cfg_attr(target_pointer_width = "64", path = "scalar/sm2_scalar_64.rs")]
 mod scalar_impl;
 
 use self::scalar_impl::*;

--- a/sm2/src/dsa.rs
+++ b/sm2/src/dsa.rs
@@ -1,0 +1,203 @@
+//! SM2 Digital Signature Algorithm (SM2DSA) as defined in [draft-shen-sm2-ecdsa § 5].
+//!
+//! ## Usage
+//!
+//! NOTE: requires the `dsa` crate feature enabled, and `rand_core` dependency
+//! with `getrandom` feature enabled.
+//!
+#![cfg_attr(feature = "std", doc = "```")]
+#![cfg_attr(not(feature = "std"), doc = "```ignore")]
+//! # fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! use rand_core::OsRng; // requires 'getrandom` feature
+//! use sm2::{
+//!     dsa::{Signature, SigningKey, signature::Signer},
+//!     SecretKey
+//! };
+//!
+//! // Signing
+//! let secret_key = SecretKey::random(&mut OsRng); // serialize with `::to_bytes()`
+//! let dist_id = "example@rustcrypto.org"; // distinguishing identifier
+//! let signing_key = SigningKey::new(dist_id, &secret_key)?;
+//! let verifying_key_bytes = signing_key.verifying_key().to_sec1_bytes();
+//! let message = b"test message";
+//! let signature: Signature = signing_key.sign(message);
+//!
+//! // Verifying
+//! use sm2::dsa::{VerifyingKey, signature::Verifier};
+//!
+//! let verifying_key = VerifyingKey::from_sec1_bytes(dist_id, &verifying_key_bytes)?;
+//! verifying_key.verify(message, &signature)?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [draft-shen-sm2-ecdsa § 5]: https://datatracker.ietf.org/doc/html/draft-shen-sm2-ecdsa-02#section-5
+
+#[cfg(feature = "arithmetic")]
+mod signing;
+#[cfg(feature = "arithmetic")]
+mod verifying;
+
+pub use signature;
+
+#[cfg(feature = "arithmetic")]
+pub use self::{signing::SigningKey, verifying::VerifyingKey};
+
+use crate::{FieldBytes, NonZeroScalar, Sm2};
+use core::fmt::{self, Debug};
+use elliptic_curve::generic_array::sequence::Concat;
+use signature::{Error, Result, SignatureEncoding};
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+/// SM2DSA signature serialized as bytes.
+pub type SignatureBytes = [u8; Signature::BYTE_SIZE];
+
+/// SM3 hash output.
+type Hash = sm3::digest::Output<sm3::Sm3>;
+
+/// Primitive scalar type (works without the `arithmetic` feature).
+type ScalarPrimitive = elliptic_curve::ScalarPrimitive<Sm2>;
+
+/// SM2DSA signature.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct Signature {
+    r: ScalarPrimitive,
+    s: ScalarPrimitive,
+}
+
+impl Signature {
+    /// Size of an encoded SM2DSA signature in bytes.
+    pub const BYTE_SIZE: usize = 64;
+
+    /// Parse an SM2DSA signature from a byte array.
+    pub fn from_bytes(bytes: &SignatureBytes) -> Result<Self> {
+        let (r_bytes, s_bytes) = bytes.split_at(Self::BYTE_SIZE / 2);
+        let r = ScalarPrimitive::from_slice(r_bytes).map_err(|_| Error::new())?;
+        let s = ScalarPrimitive::from_slice(s_bytes).map_err(|_| Error::new())?;
+
+        if r.is_zero().into() || s.is_zero().into() {
+            return Err(Error::new());
+        }
+
+        Ok(Self { r, s })
+    }
+
+    /// Parse an SM2DSA signature from a byte slice.
+    pub fn from_slice(bytes: &[u8]) -> Result<Self> {
+        SignatureBytes::try_from(bytes)
+            .map_err(|_| Error::new())?
+            .try_into()
+    }
+
+    /// Create a [`Signature`] from the serialized `r` and `s` scalar values
+    /// which comprise the signature.
+    #[inline]
+    pub fn from_scalars(r: impl Into<FieldBytes>, s: impl Into<FieldBytes>) -> Result<Self> {
+        Self::try_from(r.into().concat(s.into()).as_slice())
+    }
+
+    /// Serialize this signature as bytes.
+    pub fn to_bytes(&self) -> SignatureBytes {
+        let mut ret = [0; Self::BYTE_SIZE];
+        let (r_bytes, s_bytes) = ret.split_at_mut(Self::BYTE_SIZE / 2);
+        r_bytes.copy_from_slice(&self.r.to_bytes());
+        s_bytes.copy_from_slice(&self.s.to_bytes());
+        ret
+    }
+
+    /// Bytes for the `R` component of a signature.
+    pub fn r_bytes(&self) -> FieldBytes {
+        self.r.to_bytes()
+    }
+
+    /// Bytes for the `s` component of a signature.
+    pub fn s_bytes(&self) -> FieldBytes {
+        self.s.to_bytes()
+    }
+
+    /// Convert this signature into a byte vector.
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.to_bytes().to_vec()
+    }
+}
+
+#[cfg(feature = "arithmetic")]
+impl Signature {
+    /// Get the `r` component of this signature
+    pub fn r(&self) -> NonZeroScalar {
+        NonZeroScalar::new(self.r.into()).unwrap()
+    }
+
+    /// Get the `s` component of this signature
+    pub fn s(&self) -> NonZeroScalar {
+        NonZeroScalar::new(self.s.into()).unwrap()
+    }
+
+    /// Split the signature into its `r` and `s` scalars.
+    pub fn split_scalars(&self) -> (NonZeroScalar, NonZeroScalar) {
+        (self.r(), self.s())
+    }
+}
+
+impl Debug for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "sm2::dsa::Signature(")?;
+
+        for byte in self.to_bytes() {
+            write!(f, "{:02X}", byte)?;
+        }
+
+        write!(f, ")")
+    }
+}
+
+impl From<Signature> for SignatureBytes {
+    fn from(signature: Signature) -> SignatureBytes {
+        signature.to_bytes()
+    }
+}
+
+impl From<&Signature> for SignatureBytes {
+    fn from(signature: &Signature) -> SignatureBytes {
+        signature.to_bytes()
+    }
+}
+
+impl SignatureEncoding for Signature {
+    type Repr = SignatureBytes;
+
+    fn to_bytes(&self) -> Self::Repr {
+        self.into()
+    }
+
+    fn encoded_len(&self) -> usize {
+        Self::BYTE_SIZE
+    }
+}
+
+impl TryFrom<SignatureBytes> for Signature {
+    type Error = Error;
+
+    fn try_from(signature: SignatureBytes) -> Result<Signature> {
+        Signature::from_bytes(&signature)
+    }
+}
+
+impl TryFrom<&SignatureBytes> for Signature {
+    type Error = Error;
+
+    fn try_from(signature: &SignatureBytes) -> Result<Signature> {
+        Signature::from_bytes(signature)
+    }
+}
+
+impl TryFrom<&[u8]> for Signature {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Signature> {
+        Signature::from_slice(bytes)
+    }
+}

--- a/sm2/src/dsa/signing.rs
+++ b/sm2/src/dsa/signing.rs
@@ -1,0 +1,189 @@
+//! Support for SM2DSA signing.
+//!
+//! ## Algorithm
+//!
+//! ```text
+//! A1: set M~=ZA || M
+//! A2: calculate e=Hv(M~)
+//! A3: pick a random number k in [1, n-1] via a random number generator
+//! A4: calculate the elliptic curve point (x1, y1)=[k]G
+//! A5: calculate r=(e+x1) modn, return to A3 if r=0 or r+k=n
+//! A6: calculate s=((1+dA)^(-1)*(k-r*dA)) modn, return to A3 if s=0
+//! A7: the digital signature of M is (r, s)
+//! ```
+
+#![allow(non_snake_case)]
+
+use super::{Signature, VerifyingKey};
+use crate::{FieldBytes, NonZeroScalar, ProjectivePoint, PublicKey, Scalar, SecretKey, Sm2};
+use core::fmt::{self, Debug};
+use elliptic_curve::{
+    generic_array::typenum::Unsigned,
+    ops::{MulByGenerator, Reduce},
+    point::AffineCoordinates,
+    subtle::{Choice, ConstantTimeEq},
+    Curve, FieldBytesEncoding, PrimeField,
+};
+use signature::{hazmat::PrehashSigner, Error, KeypairRef, Result, Signer};
+use sm3::Sm3;
+
+/// SM2DSA secret key used for signing messages and producing signatures.
+///
+/// ## Usage
+///
+/// The [`signature`] crate defines the following traits which are the
+/// primary API for signing:
+///
+/// - [`Signer`]: sign a message using this key
+/// - [`PrehashSigner`]: sign the low-level raw output bytes of a message digest
+#[derive(Clone)]
+pub struct SigningKey {
+    /// Secret key.
+    secret_scalar: NonZeroScalar,
+
+    /// Verifying key for this signing key.
+    verifying_key: VerifyingKey,
+}
+
+impl SigningKey {
+    /// Create signing key from a signer's distinguishing identifier and
+    /// secret key.
+    pub fn new(dist_id: &str, secret_key: &SecretKey) -> Result<Self> {
+        Self::from_nonzero_scalar(dist_id, secret_key.to_nonzero_scalar())
+    }
+
+    /// Parse signing key from big endian-encoded bytes.
+    pub fn from_bytes(dist_id: &str, bytes: &FieldBytes) -> Result<Self> {
+        Self::from_slice(dist_id, bytes)
+    }
+
+    /// Parse signing key from big endian-encoded byte slice containing a secret
+    /// scalar value.
+    pub fn from_slice(dist_id: &str, slice: &[u8]) -> Result<Self> {
+        let secret_scalar = NonZeroScalar::try_from(slice).map_err(|_| Error::new())?;
+        Self::from_nonzero_scalar(dist_id, secret_scalar)
+    }
+
+    /// Create a signing key from a non-zero scalar.
+    pub fn from_nonzero_scalar(dist_id: &str, secret_scalar: NonZeroScalar) -> Result<Self> {
+        let public_key = PublicKey::from_secret_scalar(&secret_scalar);
+        let verifying_key = VerifyingKey::new(dist_id, public_key)?;
+        Ok(Self {
+            secret_scalar,
+            verifying_key,
+        })
+    }
+
+    /// Serialize as bytes.
+    pub fn to_bytes(&self) -> FieldBytes {
+        self.secret_scalar.to_bytes()
+    }
+
+    /// Borrow the secret [`NonZeroScalar`] value for this key.
+    ///
+    /// # ⚠️ Warning
+    ///
+    /// This value is key material.
+    ///
+    /// Please treat it with the care it deserves!
+    pub fn as_nonzero_scalar(&self) -> &NonZeroScalar {
+        &self.secret_scalar
+    }
+
+    /// Get the [`VerifyingKey`] which corresponds to this [`SigningKey`].
+    pub fn verifying_key(&self) -> &VerifyingKey {
+        &self.verifying_key
+    }
+
+    /// Get the distinguishing identifier for this key.
+    #[cfg(feature = "alloc")]
+    pub fn dist_id(&self) -> &str {
+        self.verifying_key.dist_id()
+    }
+}
+
+//
+// `*Signer` trait impls
+//
+
+impl PrehashSigner<Signature> for SigningKey {
+    fn sign_prehash(&self, prehash: &[u8]) -> Result<Signature> {
+        if prehash.len() != <Sm2 as Curve>::FieldBytesSize::USIZE {
+            return Err(Error::new());
+        }
+
+        // A2: calculate e=Hv(M~)
+        let e = Scalar::reduce_bytes(FieldBytes::from_slice(prehash));
+
+        // A3: pick a random number k in [1, n-1] via a random number generator
+        let k = Scalar::from_repr(rfc6979::generate_k::<Sm3, _>(
+            &self.secret_scalar.to_repr(),
+            &FieldBytesEncoding::<Sm2>::encode_field_bytes(&Sm2::ORDER),
+            &e.to_bytes(),
+            &[],
+        ))
+        .unwrap();
+
+        // A4: calculate the elliptic curve point (x1, y1)=[k]G
+        let R = ProjectivePoint::mul_by_generator(&k).to_affine();
+
+        // A5: calculate r=(e+x1) modn, return to A3 if r=0 or r+k=n
+        let r = e + Scalar::reduce_bytes(&R.x());
+        if bool::from(r.is_zero() | (r + k).ct_eq(&Scalar::ZERO)) {
+            return Err(Error::new());
+        }
+
+        // A6: calculate s=((1+dA)^(-1)*(k-r*dA)) modn, return to A3 if s=0
+        let d_plus_1_inv = Option::<Scalar>::from((*self.secret_scalar + Scalar::ONE).invert())
+            .ok_or_else(Error::new)?;
+
+        let s = d_plus_1_inv * (k - (r * *self.secret_scalar));
+
+        // A7: the digital signature of M is (r, s)
+        Signature::from_scalars(r, s)
+    }
+}
+
+impl Signer<Signature> for SigningKey {
+    fn try_sign(&self, msg: &[u8]) -> Result<Signature> {
+        // A1: set M~=ZA || M
+        let hash = self.verifying_key.hash_msg(msg);
+        self.sign_prehash(&hash)
+    }
+}
+
+//
+// Other trait impls
+//
+
+impl AsRef<VerifyingKey> for SigningKey {
+    fn as_ref(&self) -> &VerifyingKey {
+        &self.verifying_key
+    }
+}
+
+impl ConstantTimeEq for SigningKey {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.secret_scalar.ct_eq(&other.secret_scalar)
+    }
+}
+
+impl Debug for SigningKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SigningKey")
+            .field("verifying_key", &self.verifying_key)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Constant-time comparison
+impl Eq for SigningKey {}
+impl PartialEq for SigningKey {
+    fn eq(&self, other: &SigningKey) -> bool {
+        self.ct_eq(other).into()
+    }
+}
+
+impl KeypairRef for SigningKey {
+    type VerifyingKey = VerifyingKey;
+}

--- a/sm2/src/dsa/verifying.rs
+++ b/sm2/src/dsa/verifying.rs
@@ -1,0 +1,224 @@
+//! Support for verifying SM2DSA signatures.
+//!
+//! ## Algorithm
+//!
+//! ```text
+//! B1: verify whether r' in [1,n-1], verification failed if not
+//! B2: verify whether s' in [1,n-1], verification failed if not
+//! B3: set M'~=ZA || M'
+//! B4: calculate e'=Hv(M'~)
+//! B5: calculate t = (r' + s') modn, verification failed if t=0
+//! B6: calculate the point (x1', y1')=[s']G + [t]PA
+//! B7: calculate R=(e'+x1') modn, verification pass if yes, otherwise failed
+//! ```
+
+use super::{Hash, Signature};
+use crate::{AffinePoint, EncodedPoint, FieldBytes, ProjectivePoint, PublicKey, Scalar, Sm2};
+use elliptic_curve::{
+    generic_array::typenum::Unsigned,
+    ops::{LinearCombination, Reduce},
+    point::AffineCoordinates,
+    sec1::{self, ToEncodedPoint},
+    Curve, Group,
+};
+use primeorder::PrimeCurveParams;
+use signature::{hazmat::PrehashVerifier, Error, Result, Verifier};
+use sm3::{digest::Digest, Sm3};
+
+#[cfg(feature = "alloc")]
+use alloc::{boxed::Box, string::String};
+
+/// SM2DSA public key used for verifying signatures are valid for a given
+/// message.
+///
+/// ## Usage
+///
+/// The [`signature`] crate defines the following traits which are the
+/// primary API for verifying:
+///
+/// - [`Verifier`]: verify a message against a provided key and signature
+/// - [`PrehashVerifier`]: verify the low-level raw output bytes of a message digest
+///
+/// # `serde` support
+///
+/// When the `serde` feature of this crate is enabled, it provides support for
+/// serializing and deserializing ECDSA signatures using the `Serialize` and
+/// `Deserialize` traits.
+///
+/// The serialization leverages the encoding used by the [`PublicKey`] type,
+/// which is a binary-oriented ASN.1 DER encoding.
+#[derive(Clone, Debug)]
+pub struct VerifyingKey {
+    /// Signer's public key.
+    public_key: PublicKey,
+
+    /// Signer's user information hash `Z`.
+    identity_hash: Hash,
+
+    /// Distinguishing identifier used to compute `Z`.
+    #[cfg(feature = "alloc")]
+    dist_id: String,
+}
+
+impl VerifyingKey {
+    /// Initialize [`VerifyingKey`] from a signer's distinguishing identifier
+    /// and public key.
+    pub fn new(dist_id: &str, public_key: PublicKey) -> Result<Self> {
+        let entla: u16 = dist_id
+            .len()
+            .checked_mul(8)
+            .and_then(|l| l.try_into().ok())
+            .ok_or_else(Error::new)?;
+
+        // Compute user information hash `Z` according to draft-shen-sm2-ecdsa § 5.1.4.4.
+        //
+        // ZA=H256(ENTLA || IDA || a || b || xG || yG || xA || yA)
+        let mut sm3 = Sm3::new();
+        sm3.update(entla.to_be_bytes());
+        sm3.update(dist_id);
+        sm3.update(Sm2::EQUATION_A.to_bytes());
+        sm3.update(Sm2::EQUATION_B.to_bytes());
+        sm3.update(Sm2::GENERATOR.0.to_bytes());
+        sm3.update(Sm2::GENERATOR.1.to_bytes());
+
+        match public_key.to_encoded_point(false).coordinates() {
+            sec1::Coordinates::Uncompressed { x, y } => {
+                sm3.update(x);
+                sm3.update(y);
+                Ok(Self {
+                    identity_hash: sm3.finalize(),
+                    public_key,
+                    #[cfg(feature = "alloc")]
+                    dist_id: dist_id.into(),
+                })
+            }
+            _ => Err(Error::new()),
+        }
+    }
+
+    /// Initialize [`VerifyingKey`] from a SEC1-encoded public key.
+    pub fn from_sec1_bytes(dist_id: &str, bytes: &[u8]) -> Result<Self> {
+        let public_key = PublicKey::from_sec1_bytes(bytes).map_err(|_| Error::new())?;
+        Self::new(dist_id, public_key)
+    }
+
+    /// Initialize [`VerifyingKey`] from an affine point.
+    ///
+    /// Returns an [`Error`] if the given affine point is the additive identity
+    /// (a.k.a. point at infinity).
+    pub fn from_affine(dist_id: &str, affine: AffinePoint) -> Result<Self> {
+        let public_key = PublicKey::from_affine(affine).map_err(|_| Error::new())?;
+        Self::new(dist_id, public_key)
+    }
+
+    /// Borrow the inner [`AffinePoint`] for this public key.
+    pub fn as_affine(&self) -> &AffinePoint {
+        self.public_key.as_affine()
+    }
+
+    /// Get the distinguishing identifier for this key.
+    #[cfg(feature = "alloc")]
+    pub fn dist_id(&self) -> &str {
+        self.dist_id.as_str()
+    }
+
+    /// Convert this [`VerifyingKey`] into the
+    /// `Elliptic-Curve-Point-to-Octet-String` encoding described in
+    /// SEC 1: Elliptic Curve Cryptography (Version 2.0) section 2.3.3
+    /// (page 10).
+    ///
+    /// <http://www.secg.org/sec1-v2.pdf>
+    #[cfg(feature = "alloc")]
+    pub fn to_sec1_bytes(&self) -> Box<[u8]> {
+        self.public_key.to_sec1_bytes()
+    }
+
+    /// Compute message hash `e` according to [draft-shen-sm2-ecdsa § 5.2.1]
+    ///
+    /// [draft-shen-sm2-ecdsa § 5.2.1]: https://datatracker.ietf.org/doc/html/draft-shen-sm2-ecdsa-02#section-5.2.1
+    pub(crate) fn hash_msg(&self, msg: &[u8]) -> Hash {
+        Sm3::new_with_prefix(self.identity_hash)
+            .chain_update(msg)
+            .finalize()
+    }
+}
+
+//
+// `*Verifier` trait impls
+//
+
+impl PrehashVerifier<Signature> for VerifyingKey {
+    fn verify_prehash(&self, prehash: &[u8], signature: &Signature) -> Result<()> {
+        if prehash.len() != <Sm2 as Curve>::FieldBytesSize::USIZE {
+            return Err(Error::new());
+        }
+
+        // B1: verify whether r' in [1,n-1], verification failed if not
+        let r = signature.r(); // NonZeroScalar checked at signature parse time
+
+        // B2: verify whether s' in [1,n-1], verification failed if not
+        let s = signature.s(); // NonZeroScalar checked at signature parse time
+
+        // B4: calculate e'=Hv(M'~)
+        let e = Scalar::reduce_bytes(FieldBytes::from_slice(prehash));
+
+        // B5: calculate t = (r' + s') modn, verification failed if t=0
+        let t = *r + *s;
+        if t.is_zero().into() {
+            return Err(Error::new());
+        }
+
+        // B6: calculate the point (x1', y1')=[s']G + [t]PA
+        let x = ProjectivePoint::lincomb(
+            &ProjectivePoint::generator(),
+            &s,
+            &ProjectivePoint::from(&self.public_key),
+            &t,
+        )
+        .to_affine()
+        .x();
+
+        // B7: calculate R=(e'+x1') modn, verification pass if yes, otherwise failed
+        if *r == e + Scalar::reduce_bytes(&x) {
+            Ok(())
+        } else {
+            Err(Error::new())
+        }
+    }
+}
+
+impl Verifier<Signature> for VerifyingKey {
+    fn verify(&self, msg: &[u8], signature: &Signature) -> Result<()> {
+        // B3: set M'~=ZA || M'
+        let hash = self.hash_msg(msg);
+        self.verify_prehash(&hash, signature)
+    }
+}
+
+//
+// Other trait impls
+//
+
+impl AsRef<AffinePoint> for VerifyingKey {
+    fn as_ref(&self) -> &AffinePoint {
+        self.as_affine()
+    }
+}
+
+impl From<VerifyingKey> for PublicKey {
+    fn from(verifying_key: VerifyingKey) -> PublicKey {
+        verifying_key.public_key
+    }
+}
+
+impl From<&VerifyingKey> for PublicKey {
+    fn from(verifying_key: &VerifyingKey) -> PublicKey {
+        verifying_key.public_key
+    }
+}
+
+impl ToEncodedPoint<Sm2> for VerifyingKey {
+    fn to_encoded_point(&self, compress: bool) -> EncodedPoint {
+        self.as_affine().to_encoded_point(compress)
+    }
+}

--- a/sm2/src/lib.rs
+++ b/sm2/src/lib.rs
@@ -8,6 +8,16 @@
 #![forbid(unsafe_code)]
 #![warn(
     clippy::mod_module_files,
+    clippy::cast_lossless,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::checked_conversions,
+    clippy::implicit_saturating_sub,
+    clippy::integer_arithmetic,
+    clippy::panic,
+    clippy::panic_in_result_fn,
     clippy::unwrap_used,
     missing_docs,
     rust_2018_idioms,
@@ -15,10 +25,17 @@
     unused_qualifications
 )]
 
+#[cfg(feature = "alloc")]
+#[allow(unused_extern_crates)]
+extern crate alloc;
+
+#[cfg(feature = "dsa")]
+pub mod dsa;
+
 #[cfg(feature = "arithmetic")]
 mod arithmetic;
 
-pub use elliptic_curve;
+pub use elliptic_curve::{self, bigint::U256};
 
 #[cfg(feature = "arithmetic")]
 pub use arithmetic::{scalar::Scalar, AffinePoint, ProjectivePoint};
@@ -27,7 +44,7 @@ pub use arithmetic::{scalar::Scalar, AffinePoint, ProjectivePoint};
 pub use elliptic_curve::pkcs8;
 
 use elliptic_curve::{
-    bigint::{ArrayEncoding, U256},
+    bigint::ArrayEncoding,
     consts::U32,
     generic_array::{typenum::U33, GenericArray},
     FieldBytesEncoding,

--- a/sm2/tests/sm2dsa.rs
+++ b/sm2/tests/sm2dsa.rs
@@ -1,0 +1,62 @@
+//! ECDSA tests.
+
+#![cfg(feature = "dsa")]
+
+use elliptic_curve::ops::Reduce;
+use hex_literal::hex;
+use proptest::prelude::*;
+use sm2::{
+    dsa::{
+        signature::{Signer, Verifier},
+        Signature, SigningKey, VerifyingKey,
+    },
+    NonZeroScalar, Scalar, U256,
+};
+
+const PUBLIC_KEY: [u8; 65] = hex!("0408D77AE04C01CC4C1104360DD8AF6B6F7DF334283D7C1A6AFD5652407B87BEE5014E2A57C36C150D16324DC664E31E6432359609C4E79847A5B161C8C7364C8A");
+const IDENTITY: &str = "example@rustcrypto.org";
+const MSG: &[u8] = b"testing";
+
+// Created using:
+// $ openssl pkeyutl -sign -in - -inkey pkcs8-private-key.pem -out sig -digest sm3 -pkeyopt distid:example@rustcrypto.org
+const SIG: [u8; 64] = hex!(
+    "d1dcccedd9fb785e0f67c16b7c52901625c0b69de9bca2144acc7be713cad2fc" // r
+    "f7d1eae6e3a157b36c65f672f738ca8b46298bf149a6510072c431b49cd88b1c" // s
+);
+
+#[test]
+fn verify_test_vector() {
+    let vk = VerifyingKey::from_sec1_bytes(IDENTITY, &PUBLIC_KEY).unwrap();
+    let sig = Signature::try_from(&SIG).unwrap();
+    assert!(vk.verify(MSG, &sig).is_ok());
+}
+
+prop_compose! {
+    fn signing_key()(bytes in any::<[u8; 32]>()) -> SigningKey {
+        loop {
+            let scalar = <Scalar as Reduce<U256>>::reduce_bytes(&bytes.into());
+            if let Some(scalar) = Option::from(NonZeroScalar::new(scalar)) {
+                return SigningKey::from_nonzero_scalar(IDENTITY, scalar).unwrap();
+            }
+        }
+    }
+}
+
+proptest! {
+    #[test]
+    fn sign_and_verify(sk in signing_key()) {
+        let signature = sk.sign(MSG);
+        prop_assert!(sk.verifying_key().verify(MSG, &signature).is_ok());
+    }
+
+    #[test]
+    fn reject_invalid_signature(sk in signing_key(), byte in 0usize..32, bit in 0usize..8) {
+        let mut signature_bytes = sk.sign(MSG).to_bytes();
+
+        // tweak signature to make it invalid
+        signature_bytes[byte] ^= 1 << bit;
+
+        let signature = Signature::from_bytes(&signature_bytes).unwrap();
+        prop_assert!(sk.verifying_key().verify(MSG, &signature).is_err());
+    }
+}


### PR DESCRIPTION
Implements SM2DSA, a digital signature algorithm specified in GBT.32918.2-2016 as well as draft-shen-sm2-ecdsa.

The implementation draws a lot of inspiration from the `ecdsa` crate, including the use of RFC6979 for deriving the ephemeral scalar `k`.

Tested against a signature test vector created using OpenSSL 3.0.8 using the PKCS#8 example keys which were added in #848.