### PR TITLE
p224 v0.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "p224"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "blobby",
  "ecdsa",

--- a/p224/CHANGELOG.md
+++ b/p224/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.2 (2023-04-15)
+### Changed
+- Enable `arithmetic` and `ecdsa` by default ([#833])
+
+### Fixed
+- Have `serde` feature enable `primeorder/serde` ([#851])
+
+[#833]: https://github.com/RustCrypto/elliptic-curves/pull/833
+[#851]: https://github.com/RustCrypto/elliptic-curves/pull/851
+
 ## 0.13.1 (2023-04-09)
 ### Added
 - Projective arithmetic tests ([#813])

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p224"
-version = "0.13.1"
+version = "0.13.2"
 description = """
 Pure Rust implementation of the NIST P-224 (a.k.a. secp224r1) elliptic curve
 as defined in SP 800-186

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -59,6 +59,14 @@ use core::ops::{Add, Mul, Sub};
 ///   operations over field elements represented as bits (requires `bits` feature)
 ///
 /// Please see the documentation for the relevant traits for more information.
+///
+/// # Warning: `sqrt` unimplemented!
+///
+/// `Scalar::sqrt` has not been implemented and will panic if invoked!
+///
+/// See [RustCrypto/elliptic-curves#847] for more info.
+///
+/// [RustCrypto/elliptic-curves#847]: https://github.com/RustCrypto/elliptic-curves/issues/847
 #[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(Uint);
 


### PR DESCRIPTION
### Changed
- Enable `arithmetic` and `ecdsa` by default ([#833])

### Fixed
- Have `serde` feature enable `primeorder/serde` ([#851])

[#833]: https://github.com/RustCrypto/elliptic-curves/pull/833
[#851]: https://github.com/RustCrypto/elliptic-curves/pull/851