### PR TITLE
sm2: enable `dsa` feature by default

### DIFF
--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -32,7 +32,7 @@ proptest = "1"
 rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
-default = ["arithmetic", "pem", "std"]
+default = ["arithmetic", "dsa", "pem", "std"]
 alloc = ["elliptic-curve/alloc"]
 std = ["alloc", "elliptic-curve/std", "signature?/std"]
 


### PR DESCRIPTION
It's currently the main use case for this crate