### PR TITLE
sm2: factor out `distid` module

### DIFF
--- a/sm2/src/distid.rs
+++ b/sm2/src/distid.rs
@@ -1,0 +1,44 @@
+//! Distinguished identifier support.
+
+use crate::{AffinePoint, Hash, Sm2};
+use elliptic_curve::{
+    sec1::{self, ToEncodedPoint},
+    Error, Result,
+};
+use primeorder::PrimeCurveParams;
+use sm3::{Digest, Sm3};
+
+/// Type which represents distinguishing identifiers.
+pub(crate) type DistId = str;
+
+/// Compute user information hash `Z` according to [draft-shen-sm2-ecdsa § 5.1.4.4].
+///
+/// ```text
+/// ZA=H256(ENTLA || IDA || a || b || xG || yG || xA || yA)
+/// ```
+///
+/// [draft-shen-sm2-ecdsa § 5.1.4.4]: https://datatracker.ietf.org/doc/html/draft-shen-sm2-ecdsa-02#section-5.1.4.4
+pub(crate) fn hash_z(distid: &DistId, public_key: &impl AsRef<AffinePoint>) -> Result<Hash> {
+    let entla: u16 = distid
+        .len()
+        .checked_mul(8)
+        .and_then(|l| l.try_into().ok())
+        .ok_or(Error)?;
+
+    let mut sm3 = Sm3::new();
+    sm3.update(entla.to_be_bytes());
+    sm3.update(distid);
+    sm3.update(Sm2::EQUATION_A.to_bytes());
+    sm3.update(Sm2::EQUATION_B.to_bytes());
+    sm3.update(Sm2::GENERATOR.0.to_bytes());
+    sm3.update(Sm2::GENERATOR.1.to_bytes());
+
+    match public_key.as_ref().to_encoded_point(false).coordinates() {
+        sec1::Coordinates::Uncompressed { x, y } => {
+            sm3.update(x);
+            sm3.update(y);
+            Ok(sm3.finalize())
+        }
+        _ => Err(Error),
+    }
+}

--- a/sm2/src/dsa.rs
+++ b/sm2/src/dsa.rs
@@ -16,8 +16,8 @@
 //!
 //! // Signing
 //! let secret_key = SecretKey::random(&mut OsRng); // serialize with `::to_bytes()`
-//! let dist_id = "example@rustcrypto.org"; // distinguishing identifier
-//! let signing_key = SigningKey::new(dist_id, &secret_key)?;
+//! let distid = "example@rustcrypto.org"; // distinguishing identifier
+//! let signing_key = SigningKey::new(distid, &secret_key)?;
 //! let verifying_key_bytes = signing_key.verifying_key().to_sec1_bytes();
 //! let message = b"test message";
 //! let signature: Signature = signing_key.sign(message);
@@ -25,7 +25,7 @@
 //! // Verifying
 //! use sm2::dsa::{VerifyingKey, signature::Verifier};
 //!
-//! let verifying_key = VerifyingKey::from_sec1_bytes(dist_id, &verifying_key_bytes)?;
+//! let verifying_key = VerifyingKey::from_sec1_bytes(distid, &verifying_key_bytes)?;
 //! verifying_key.verify(message, &signature)?;
 //! # Ok(())
 //! # }
@@ -53,9 +53,6 @@ use alloc::vec::Vec;
 
 /// SM2DSA signature serialized as bytes.
 pub type SignatureBytes = [u8; Signature::BYTE_SIZE];
-
-/// SM3 hash output.
-type Hash = sm3::digest::Output<sm3::Sm3>;
 
 /// Primitive scalar type (works without the `arithmetic` feature).
 type ScalarPrimitive = elliptic_curve::ScalarPrimitive<Sm2>;

--- a/sm2/src/dsa/signing.rs
+++ b/sm2/src/dsa/signing.rs
@@ -15,7 +15,9 @@
 #![allow(non_snake_case)]
 
 use super::{Signature, VerifyingKey};
-use crate::{FieldBytes, NonZeroScalar, ProjectivePoint, PublicKey, Scalar, SecretKey, Sm2};
+use crate::{
+    DistId, FieldBytes, NonZeroScalar, ProjectivePoint, PublicKey, Scalar, SecretKey, Sm2,
+};
 use core::fmt::{self, Debug};
 use elliptic_curve::{
     generic_array::typenum::Unsigned,
@@ -48,26 +50,26 @@ pub struct SigningKey {
 impl SigningKey {
     /// Create signing key from a signer's distinguishing identifier and
     /// secret key.
-    pub fn new(dist_id: &str, secret_key: &SecretKey) -> Result<Self> {
-        Self::from_nonzero_scalar(dist_id, secret_key.to_nonzero_scalar())
+    pub fn new(distid: &DistId, secret_key: &SecretKey) -> Result<Self> {
+        Self::from_nonzero_scalar(distid, secret_key.to_nonzero_scalar())
     }
 
     /// Parse signing key from big endian-encoded bytes.
-    pub fn from_bytes(dist_id: &str, bytes: &FieldBytes) -> Result<Self> {
-        Self::from_slice(dist_id, bytes)
+    pub fn from_bytes(distid: &DistId, bytes: &FieldBytes) -> Result<Self> {
+        Self::from_slice(distid, bytes)
     }
 
     /// Parse signing key from big endian-encoded byte slice containing a secret
     /// scalar value.
-    pub fn from_slice(dist_id: &str, slice: &[u8]) -> Result<Self> {
+    pub fn from_slice(distid: &DistId, slice: &[u8]) -> Result<Self> {
         let secret_scalar = NonZeroScalar::try_from(slice).map_err(|_| Error::new())?;
-        Self::from_nonzero_scalar(dist_id, secret_scalar)
+        Self::from_nonzero_scalar(distid, secret_scalar)
     }
 
     /// Create a signing key from a non-zero scalar.
-    pub fn from_nonzero_scalar(dist_id: &str, secret_scalar: NonZeroScalar) -> Result<Self> {
+    pub fn from_nonzero_scalar(distid: &DistId, secret_scalar: NonZeroScalar) -> Result<Self> {
         let public_key = PublicKey::from_secret_scalar(&secret_scalar);
-        let verifying_key = VerifyingKey::new(dist_id, public_key)?;
+        let verifying_key = VerifyingKey::new(distid, public_key)?;
         Ok(Self {
             secret_scalar,
             verifying_key,
@@ -97,8 +99,8 @@ impl SigningKey {
 
     /// Get the distinguishing identifier for this key.
     #[cfg(feature = "alloc")]
-    pub fn dist_id(&self) -> &str {
-        self.verifying_key.dist_id()
+    pub fn distid(&self) -> &DistId {
+        self.verifying_key.distid()
     }
 }
 

--- a/sm2/src/lib.rs
+++ b/sm2/src/lib.rs
@@ -34,6 +34,8 @@ pub mod dsa;
 
 #[cfg(feature = "arithmetic")]
 mod arithmetic;
+#[cfg(feature = "dsa")]
+mod distid;
 
 pub use elliptic_curve::{self, bigint::U256};
 
@@ -50,9 +52,16 @@ use elliptic_curve::{
     FieldBytesEncoding,
 };
 
+#[cfg(feature = "dsa")]
+use crate::distid::DistId;
+
 /// Order of SM2's elliptic curve group (i.e. scalar modulus) serialized as
 /// hexadecimal.
 const ORDER_HEX: &str = "fffffffeffffffffffffffffffffffff7203df6b21c6052b53bbf40939d54123";
+
+/// SM3 hash output.
+#[cfg(feature = "dsa")]
+type Hash = sm3::digest::Output<sm3::Sm3>;
 
 /// SM2 elliptic curve.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]


### PR DESCRIPTION
This code is reusable across all of the SM2 algorithms.

This commit decouples it from the SM2DSA implementation.