### PR TITLE
sm2 v0.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "sm2"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "elliptic-curve",
  "hex-literal",

--- a/sm2/CHANGELOG.md
+++ b/sm2/CHANGELOG.md
@@ -4,13 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.13.1 (2023-04-15)
+## 0.13.2 (2023-04-15)
+### Changed
+- Factor out `distid` module ([#865])
+
+[#865]: https://github.com/RustCrypto/elliptic-curves/pull/865
+
+## 0.13.1 (2023-04-15) [YANKED]
 ### Added
 - Enable `dsa` feature by default ([#862])
 
 [#862]: https://github.com/RustCrypto/elliptic-curves/pull/862
 
-## 0.13.0 (2023-04-15)
+## 0.13.0 (2023-04-15) [YANKED]
 - Initial RustCrypto release
 
 ## 0.0.1 (2020-03-02)

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm2"
-version = "0.13.1"
+version = "0.13.2"
 description = """
 Pure Rust implementation of the SM2 elliptic curve as defined in the Chinese
 national standard GM/T 0003-2012 as well as ISO/IEC 14888. Includes support for


### PR DESCRIPTION
### Changed
- Factor out `distid` module ([#865])

[#865]: https://github.com/RustCrypto/elliptic-curves/pull/865