### PR TITLE
bp256: define `PrimeField` constants for `FieldElement`

### DIFF
--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -256,11 +256,12 @@ impl PrimeField for FieldElement {
     const NUM_BITS: u32 = 256;
     const CAPACITY: u32 = 255;
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
-    const MULTIPLICATIVE_GENERATOR: Self = Self::ZERO; // TODO
-    const S: u32 = 0; // TODO
-    const ROOT_OF_UNITY: Self = Self::ZERO; // TODO
-    const ROOT_OF_UNITY_INV: Self = Self::ZERO; // TODO
-    const DELTA: Self = Self::ZERO; // TODO
+    const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(11);
+    const S: u32 = 1;
+    const ROOT_OF_UNITY: Self =
+        Self::from_hex("a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5376");
+    const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
+    const DELTA: Self = Self::from_u64(121);
 
     #[inline]
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
@@ -276,4 +277,25 @@ impl PrimeField for FieldElement {
     fn is_odd(&self) -> Choice {
         self.is_odd()
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FieldElement;
+    use elliptic_curve::ff::PrimeField;
+    use primeorder::{impl_field_identity_tests, impl_field_invert_tests, impl_primefield_tests};
+
+    /// t = (modulus - 1) >> S
+    /// 0x54fdabedd0f754de1f3305484ec1c6b9371dfb11ea9310141009a40e8fb729bb'
+    const T: [u64; 4] = [
+        0x1009a40e8fb729bb,
+        0x371dfb11ea931014,
+        0x1f3305484ec1c6b9,
+        0x54fdabedd0f754de,
+    ];
+
+    impl_field_identity_tests!(FieldElement);
+    impl_field_invert_tests!(FieldElement);
+    //impl_field_sqrt_tests!(FieldElement);
+    impl_primefield_tests!(FieldElement, T);
 }


### PR DESCRIPTION
Calculated in `sage` as follows:

```sage
sage: p = 0xa9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5377
sage: multiplicative_generator = GF(p).primitive_element()
sage: p_minus_1_bin = (p - 1).binary()
sage: s = len(p_minus_1_bin) - len(p_minus_1_bin.rstrip('0')) # count trailing zeros in binary sage: t = (p - 1) >> s
sage: root_of_unity = pow(multiplicative_generator,t,p)
sage: delta = pow(multiplicative_generator, 2^s, p)
sage: multiplicative_generator
11
sage: p_minus_1_bin
'1010100111111011010101111101101110100001111011101010100110111100001111100110011000001010100100001001110110000011100011010111001001101110001110111111011000100011110101010010011000100000001010000010000000010011010010000001110100011111011011100101001101110110'
sage: s
1
sage: hex(t)
'0x54fdabedd0f754de1f3305484ec1c6b9371dfb11ea9310141009a40e8fb729bb'
sage: hex(root_of_unity)
'0xa9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5376'
sage: delta
121
```