### PR TITLE
bp384: define `PrimeField` constants for `FieldElement`

### DIFF
--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -286,7 +286,7 @@ mod tests {
     use primeorder::{impl_field_identity_tests, impl_field_invert_tests, impl_primefield_tests};
 
     /// t = (modulus - 1) >> S
-    /// 0x54fdabedd0f754de1f3305484ec1c6b9371dfb11ea9310141009a40e8fb729bb'
+    /// 0x54fdabedd0f754de1f3305484ec1c6b9371dfb11ea9310141009a40e8fb729bb
     const T: [u64; 4] = [
         0x1009a40e8fb729bb,
         0x371dfb11ea931014,

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -256,11 +256,11 @@ impl PrimeField for FieldElement {
     const NUM_BITS: u32 = 384;
     const CAPACITY: u32 = 383;
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
-    const MULTIPLICATIVE_GENERATOR: Self = Self::ZERO; // TODO
-    const S: u32 = 0; // TODO
-    const ROOT_OF_UNITY: Self = Self::ZERO; // TODO
-    const ROOT_OF_UNITY_INV: Self = Self::ZERO; // TODO
-    const DELTA: Self = Self::ZERO; // TODO
+    const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(3);
+    const S: u32 = 1;
+    const ROOT_OF_UNITY: Self = Self::from_hex("8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec52");
+    const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
+    const DELTA: Self = Self::from_u64(9);
 
     #[inline]
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
@@ -276,4 +276,27 @@ impl PrimeField for FieldElement {
     fn is_odd(&self) -> Choice {
         self.is_odd()
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FieldElement;
+    use elliptic_curve::ff::PrimeField;
+    use primeorder::{impl_field_identity_tests, impl_field_invert_tests, impl_primefield_tests};
+
+    /// t = (modulus - 1) >> S
+    /// 0x465c8f41519c369407aeb7bf287320ef8a97b884f6aa2b5a0958ed0cbfdb8891d669d394c80e8d38c3a380099883f629
+    const T: [u64; 6] = [
+        0xc3a380099883f629,
+        0xd669d394c80e8d38,
+        0x958ed0cbfdb8891,
+        0x8a97b884f6aa2b5a,
+        0x7aeb7bf287320ef,
+        0x465c8f41519c3694,
+    ];
+
+    impl_field_identity_tests!(FieldElement);
+    impl_field_invert_tests!(FieldElement);
+    //impl_field_sqrt_tests!(FieldElement);
+    impl_primefield_tests!(FieldElement, T);
 }


### PR DESCRIPTION
Calculated in `sage` as follows:

```sage
sage: p = 0x8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec53
sage: multiplicative_generator = GF(p).primitive_element()
sage: p_minus_1_bin = (p - 1).binary()
sage: s = len(p_minus_1_bin) - len(p_minus_1_bin.rstrip('0')) # count trailing zeros in binary
sage: t = (p - 1) >> s
sage: root_of_unity = pow(multiplicative_generator,t,p)
sage: delta = pow(multiplicative_generator, 2^s, p)
sage: multiplicative_generator
3
sage: p_minus_1_bin
'100011001011100100011110100000101010001100111000011011010010100000001111010111010110111101111110010100001110011001000001110111110001010100101111011100010000100111101101010101000101011010110100000100101011000111011010000110010111111110110111000100010010001110101100110100111010011100101001100100000001110100011010011100011000011101000111000000000001001100110001000001111110110001010010'
sage: s
1
sage: hex(t)
'0x465c8f41519c369407aeb7bf287320ef8a97b884f6aa2b5a0958ed0cbfdb8891d669d394c80e8d38c3a380099883f629'
sage: hex(root_of_unity)
'0x8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec52'
sage: delta
9
```