### PR TITLE
bp256: `CurveArithmetic` + `PrimeCurveParams`

### DIFF
--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -36,8 +36,8 @@ use elliptic_curve::{
 #[cfg(doc)]
 use core::ops::{Add, Mul, Sub};
 
-/// Element of the brainpoolP256's scalar field.
-#[derive(Clone, Copy)]
+/// Element of brainpoolP256's scalar field.
+#[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(pub(super) U256);
 
 impl Scalar {

--- a/bp256/src/lib.rs
+++ b/bp256/src/lib.rs
@@ -24,10 +24,16 @@ mod arithmetic;
 pub use crate::{r1::BrainpoolP256r1, t1::BrainpoolP256t1};
 pub use elliptic_curve::{self, bigint::U256};
 
+#[cfg(feature = "wip-arithmetic-do-not-use")]
+pub use crate::arithmetic::scalar::Scalar;
+
 #[cfg(feature = "pkcs8")]
 pub use elliptic_curve::pkcs8;
 
 use elliptic_curve::generic_array::{typenum::U32, GenericArray};
+
+#[cfg(feature = "wip-arithmetic-do-not-use")]
+pub(crate) use crate::arithmetic::field::FieldElement;
 
 /// Byte representation of a base/scalar field element of a given curve.
 pub type FieldBytes = GenericArray<u8, U32>;

--- a/bp256/src/r1.rs
+++ b/bp256/src/r1.rs
@@ -3,6 +3,15 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
+#[cfg(feature = "wip-arithmetic-do-not-use")]
+mod arithmetic;
+
+#[cfg(feature = "wip-arithmetic-do-not-use")]
+pub use {
+    self::arithmetic::{AffinePoint, ProjectivePoint},
+    crate::Scalar,
+};
+
 use crate::ORDER;
 use elliptic_curve::{
     bigint::{ArrayEncoding, U256},
@@ -61,4 +70,5 @@ impl FieldBytesEncoding<BrainpoolP256r1> for U256 {
 /// brainpoolP256r1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP256r1>;
 
+#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
 impl elliptic_curve::sec1::ValidatePublicKey for BrainpoolP256r1 {}

--- a/bp256/src/r1/arithmetic.rs
+++ b/bp256/src/r1/arithmetic.rs
@@ -1,0 +1,63 @@
+//! brainpoolP256r1 curve arithmetic implementation.
+
+use super::BrainpoolP256r1;
+use crate::{FieldElement, Scalar};
+use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use primeorder::{point_arithmetic, PrimeCurveParams};
+
+/// Elliptic curve point in affine coordinates.
+pub type AffinePoint = primeorder::AffinePoint<BrainpoolP256r1>;
+
+/// Elliptic curve point in projective coordinates.
+pub type ProjectivePoint = primeorder::ProjectivePoint<BrainpoolP256r1>;
+
+/// Primitive scalar type.
+pub type ScalarPrimitive = elliptic_curve::ScalarPrimitive<BrainpoolP256r1>;
+
+impl CurveArithmetic for BrainpoolP256r1 {
+    type AffinePoint = AffinePoint;
+    type ProjectivePoint = ProjectivePoint;
+    type Scalar = Scalar;
+}
+
+impl PrimeCurveArithmetic for BrainpoolP256r1 {
+    type CurveGroup = ProjectivePoint;
+}
+
+impl PrimeCurveParams for BrainpoolP256r1 {
+    type FieldElement = FieldElement;
+    type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
+
+    const EQUATION_A: FieldElement =
+        FieldElement::from_hex("7d5a0975fc2c3057eef67530417affe7fb8055c126dc5c6ce94a4b44f330b5d9");
+    const EQUATION_B: FieldElement =
+        FieldElement::from_hex("26dc5c6ce94a4b44f330b5d9bbd77cbf958416295cf7e1ce6bccdc18ff8c07b6");
+    const GENERATOR: (FieldElement, FieldElement) = (
+        FieldElement::from_hex("8bd2aeb9cb7e57cb2c4b482ffc81b7afb9de27e1e3bd23c23a4453bd9ace3262"),
+        FieldElement::from_hex("547ef835c3dac4fd97f8461a14611dc9c27745132ded8e545c1d54c72f046997"),
+    );
+}
+
+impl From<ScalarPrimitive> for Scalar {
+    fn from(w: ScalarPrimitive) -> Self {
+        Scalar::from(&w)
+    }
+}
+
+impl From<&ScalarPrimitive> for Scalar {
+    fn from(w: &ScalarPrimitive) -> Scalar {
+        Scalar::from_uint_unchecked(*w.as_uint())
+    }
+}
+
+impl From<Scalar> for ScalarPrimitive {
+    fn from(scalar: Scalar) -> ScalarPrimitive {
+        ScalarPrimitive::from(&scalar)
+    }
+}
+
+impl From<&Scalar> for ScalarPrimitive {
+    fn from(scalar: &Scalar) -> ScalarPrimitive {
+        ScalarPrimitive::new(scalar.into()).unwrap()
+    }
+}

--- a/bp256/src/t1.rs
+++ b/bp256/src/t1.rs
@@ -3,6 +3,15 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
+#[cfg(feature = "wip-arithmetic-do-not-use")]
+mod arithmetic;
+
+#[cfg(feature = "wip-arithmetic-do-not-use")]
+pub use {
+    self::arithmetic::{AffinePoint, ProjectivePoint},
+    crate::Scalar,
+};
+
 use crate::ORDER;
 use elliptic_curve::{
     bigint::{ArrayEncoding, U256},
@@ -61,4 +70,5 @@ impl FieldBytesEncoding<BrainpoolP256t1> for U256 {
 /// brainpoolP256t1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP256t1>;
 
+#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
 impl elliptic_curve::sec1::ValidatePublicKey for BrainpoolP256t1 {}

--- a/bp256/src/t1/arithmetic.rs
+++ b/bp256/src/t1/arithmetic.rs
@@ -1,0 +1,63 @@
+//! brainpoolP256t1 curve arithmetic implementation.
+
+use super::BrainpoolP256t1;
+use crate::{FieldElement, Scalar};
+use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use primeorder::{point_arithmetic, PrimeCurveParams};
+
+/// Elliptic curve point in affine coordinates.
+pub type AffinePoint = primeorder::AffinePoint<BrainpoolP256t1>;
+
+/// Elliptic curve point in projective coordinates.
+pub type ProjectivePoint = primeorder::ProjectivePoint<BrainpoolP256t1>;
+
+/// Primitive scalar type.
+pub type ScalarPrimitive = elliptic_curve::ScalarPrimitive<BrainpoolP256t1>;
+
+impl CurveArithmetic for BrainpoolP256t1 {
+    type AffinePoint = AffinePoint;
+    type ProjectivePoint = ProjectivePoint;
+    type Scalar = Scalar;
+}
+
+impl PrimeCurveArithmetic for BrainpoolP256t1 {
+    type CurveGroup = ProjectivePoint;
+}
+
+impl PrimeCurveParams for BrainpoolP256t1 {
+    type FieldElement = FieldElement;
+    type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
+
+    const EQUATION_A: FieldElement =
+        FieldElement::from_hex("a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5374");
+    const EQUATION_B: FieldElement =
+        FieldElement::from_hex("662c61c430d84ea4fe66a7733d0b76b7bf93ebc4af2f49256ae58101fee92b04");
+    const GENERATOR: (FieldElement, FieldElement) = (
+        FieldElement::from_hex("a3e8eb3cc1cfe7b7732213b23a656149afa142c47aafbc2b79a191562e1305f4"),
+        FieldElement::from_hex("2d996c823439c56d7f7b22e14644417e69bcb6de39d027001dabe8f35b25c9be"),
+    );
+}
+
+impl From<ScalarPrimitive> for Scalar {
+    fn from(w: ScalarPrimitive) -> Self {
+        Scalar::from(&w)
+    }
+}
+
+impl From<&ScalarPrimitive> for Scalar {
+    fn from(w: &ScalarPrimitive) -> Scalar {
+        Scalar::from_uint_unchecked(*w.as_uint())
+    }
+}
+
+impl From<Scalar> for ScalarPrimitive {
+    fn from(scalar: Scalar) -> ScalarPrimitive {
+        ScalarPrimitive::from(&scalar)
+    }
+}
+
+impl From<&Scalar> for ScalarPrimitive {
+    fn from(scalar: &Scalar) -> ScalarPrimitive {
+        ScalarPrimitive::new(scalar.into()).unwrap()
+    }
+}


### PR DESCRIPTION
Adds impls of the `CurveArithmetic` and `PrimeCurveArithmetic` traits, the latter of which defines the coefficients of the curve equation as well as the coordinates of the generator point.

Impls have been added for both `Brainpool256r1` and `Brainpool256t1`, which use different curve equation coefficients and generators, but share the base and scalar field implementations.