### PR TITLE
bp384: `CurveArithmetic` + `PrimeCurveParams`

### DIFF
--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -37,7 +37,7 @@ use elliptic_curve::{
 use core::ops::{Add, Mul, Sub};
 
 /// Element of the brainpoolP384's scalar field.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(pub(super) U384);
 
 impl Scalar {

--- a/bp384/src/lib.rs
+++ b/bp384/src/lib.rs
@@ -24,10 +24,16 @@ mod arithmetic;
 pub use crate::{r1::BrainpoolP384r1, t1::BrainpoolP384t1};
 pub use elliptic_curve::{self, bigint::U384};
 
+#[cfg(feature = "wip-arithmetic-do-not-use")]
+pub use crate::arithmetic::scalar::Scalar;
+
 #[cfg(feature = "pkcs8")]
 pub use elliptic_curve::pkcs8;
 
 use elliptic_curve::generic_array::{typenum::U48, GenericArray};
+
+#[cfg(feature = "wip-arithmetic-do-not-use")]
+pub(crate) use crate::arithmetic::field::FieldElement;
 
 /// Byte representation of a base/scalar field element of a given curve.
 pub type FieldBytes = GenericArray<u8, U48>;

--- a/bp384/src/r1.rs
+++ b/bp384/src/r1.rs
@@ -3,6 +3,15 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
+#[cfg(feature = "wip-arithmetic-do-not-use")]
+mod arithmetic;
+
+#[cfg(feature = "wip-arithmetic-do-not-use")]
+pub use {
+    self::arithmetic::{AffinePoint, ProjectivePoint},
+    crate::Scalar,
+};
+
 use crate::ORDER;
 use elliptic_curve::{
     bigint::{ArrayEncoding, U384},
@@ -61,4 +70,5 @@ impl FieldBytesEncoding<BrainpoolP384r1> for U384 {
 /// brainpoolP384r1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP384r1>;
 
+#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
 impl elliptic_curve::sec1::ValidatePublicKey for BrainpoolP384r1 {}

--- a/bp384/src/r1/arithmetic.rs
+++ b/bp384/src/r1/arithmetic.rs
@@ -1,0 +1,63 @@
+//! brainpoolP384r1 curve arithmetic implementation.
+
+use super::BrainpoolP384r1;
+use crate::{FieldElement, Scalar};
+use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use primeorder::{point_arithmetic, PrimeCurveParams};
+
+/// Elliptic curve point in affine coordinates.
+pub type AffinePoint = primeorder::AffinePoint<BrainpoolP384r1>;
+
+/// Elliptic curve point in projective coordinates.
+pub type ProjectivePoint = primeorder::ProjectivePoint<BrainpoolP384r1>;
+
+/// Primitive scalar type.
+pub type ScalarPrimitive = elliptic_curve::ScalarPrimitive<BrainpoolP384r1>;
+
+impl CurveArithmetic for BrainpoolP384r1 {
+    type AffinePoint = AffinePoint;
+    type ProjectivePoint = ProjectivePoint;
+    type Scalar = Scalar;
+}
+
+impl PrimeCurveArithmetic for BrainpoolP384r1 {
+    type CurveGroup = ProjectivePoint;
+}
+
+impl PrimeCurveParams for BrainpoolP384r1 {
+    type FieldElement = FieldElement;
+    type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
+
+    const EQUATION_A: FieldElement =
+        FieldElement::from_hex("7bc382c63d8c150c3c72080ace05afa0c2bea28e4fb22787139165efba91f90f8aa5814a503ad4eb04a8c7dd22ce2826");
+    const EQUATION_B: FieldElement =
+        FieldElement::from_hex("04a8c7dd22ce28268b39b55416f0447c2fb77de107dcd2a62e880ea53eeb62d57cb4390295dbc9943ab78696fa504c11");
+    const GENERATOR: (FieldElement, FieldElement) = (
+        FieldElement::from_hex("1d1c64f068cf45ffa2a63a81b7c13f6b8847a3e77ef14fe3db7fcafe0cbd10e8e826e03436d646aaef87b2e247d4af1e"),
+        FieldElement::from_hex("8abe1d7520f9c2a45cb1eb8e95cfd55262b70b29feec5864e19c054ff99129280e4646217791811142820341263c5315"),
+    );
+}
+
+impl From<ScalarPrimitive> for Scalar {
+    fn from(w: ScalarPrimitive) -> Self {
+        Scalar::from(&w)
+    }
+}
+
+impl From<&ScalarPrimitive> for Scalar {
+    fn from(w: &ScalarPrimitive) -> Scalar {
+        Scalar::from_uint_unchecked(*w.as_uint())
+    }
+}
+
+impl From<Scalar> for ScalarPrimitive {
+    fn from(scalar: Scalar) -> ScalarPrimitive {
+        ScalarPrimitive::from(&scalar)
+    }
+}
+
+impl From<&Scalar> for ScalarPrimitive {
+    fn from(scalar: &Scalar) -> ScalarPrimitive {
+        ScalarPrimitive::new(scalar.into()).unwrap()
+    }
+}

--- a/bp384/src/t1.rs
+++ b/bp384/src/t1.rs
@@ -3,6 +3,15 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
+#[cfg(feature = "wip-arithmetic-do-not-use")]
+mod arithmetic;
+
+#[cfg(feature = "wip-arithmetic-do-not-use")]
+pub use {
+    self::arithmetic::{AffinePoint, ProjectivePoint},
+    crate::Scalar,
+};
+
 use crate::ORDER;
 use elliptic_curve::{
     bigint::{ArrayEncoding, U384},
@@ -61,4 +70,5 @@ impl FieldBytesEncoding<BrainpoolP384t1> for U384 {
 /// brainpoolP384t1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP384t1>;
 
+#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
 impl elliptic_curve::sec1::ValidatePublicKey for BrainpoolP384t1 {}

--- a/bp384/src/t1/arithmetic.rs
+++ b/bp384/src/t1/arithmetic.rs
@@ -1,0 +1,63 @@
+//! brainpoolP384t1 curve arithmetic implementation.
+
+use super::BrainpoolP384t1;
+use crate::{FieldElement, Scalar};
+use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use primeorder::{point_arithmetic, PrimeCurveParams};
+
+/// Elliptic curve point in affine coordinates.
+pub type AffinePoint = primeorder::AffinePoint<BrainpoolP384t1>;
+
+/// Elliptic curve point in projective coordinates.
+pub type ProjectivePoint = primeorder::ProjectivePoint<BrainpoolP384t1>;
+
+/// Primitive scalar type.
+pub type ScalarPrimitive = elliptic_curve::ScalarPrimitive<BrainpoolP384t1>;
+
+impl CurveArithmetic for BrainpoolP384t1 {
+    type AffinePoint = AffinePoint;
+    type ProjectivePoint = ProjectivePoint;
+    type Scalar = Scalar;
+}
+
+impl PrimeCurveArithmetic for BrainpoolP384t1 {
+    type CurveGroup = ProjectivePoint;
+}
+
+impl PrimeCurveParams for BrainpoolP384t1 {
+    type FieldElement = FieldElement;
+    type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
+
+    const EQUATION_A: FieldElement =
+        FieldElement::from_hex("8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec50");
+    const EQUATION_B: FieldElement =
+        FieldElement::from_hex("7f519eada7bda81bd826dba647910f8c4b9346ed8ccdc64e4b1abd11756dce1d2074aa263b88805ced70355a33b471ee");
+    const GENERATOR: (FieldElement, FieldElement) = (
+        FieldElement::from_hex("18de98b02db9a306f2afcd7235f72a819b80ab12ebd653172476fecd462aabffc4ff191b946a5f54d8d0aa2f418808cc"),
+        FieldElement::from_hex("25ab056962d30651a114afd2755ad336747f93475b7a1fca3b88f2b6a208ccfe469408584dc2b2912675bf5b9e582928"),
+    );
+}
+
+impl From<ScalarPrimitive> for Scalar {
+    fn from(w: ScalarPrimitive) -> Self {
+        Scalar::from(&w)
+    }
+}
+
+impl From<&ScalarPrimitive> for Scalar {
+    fn from(w: &ScalarPrimitive) -> Scalar {
+        Scalar::from_uint_unchecked(*w.as_uint())
+    }
+}
+
+impl From<Scalar> for ScalarPrimitive {
+    fn from(scalar: Scalar) -> ScalarPrimitive {
+        ScalarPrimitive::from(&scalar)
+    }
+}
+
+impl From<&Scalar> for ScalarPrimitive {
+    fn from(scalar: &Scalar) -> ScalarPrimitive {
+        ScalarPrimitive::new(scalar.into()).unwrap()
+    }
+}


### PR DESCRIPTION
Adds impls of the `CurveArithmetic` and `PrimeCurveArithmetic` traits, the latter of which defines the coefficients of the curve equation as well as the coordinates of the generator point.

Impls have been added for both `Brainpool384r1` and `Brainpool384t1`, which use different curve equation coefficients and generators, but share the base and scalar field implementations.