### PR TITLE
Revert "bp256/bp384: `arithmetic` feature (#878)"

### DIFF
--- a/.github/workflows/bp256.yml
+++ b/.github/workflows/bp256.yml
@@ -37,13 +37,12 @@ jobs:
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha256
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,ecdsa,pem,pkcs8,serde,sha256
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,pem,pkcs8,serde,sha256
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/bp384.yml
+++ b/.github/workflows/bp384.yml
@@ -37,13 +37,12 @@ jobs:
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha384
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,ecdsa,pem,pkcs8,serde,sha384
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,pem,pkcs8,serde,sha384
 
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -12,13 +12,10 @@ and can be easily used for bare-metal or WebAssembly programming.
 
 ## Crates
 
-NOTE: Most crates have field/point arithmetic implementations gated under the
-`arithmetic` cargo feature as noted in the `arithmetic` column below:
-
 | Name      | Curve              | `arithmetic`? | Crates.io                                                                                 | Documentation                                                              | Build Status                                                                                               |
 |-----------|--------------------|---------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
-| [`bp256`] | brainpoolP256r1/t1 | ✅            | [![crates.io](https://img.shields.io/crates/v/bp256.svg)](https://crates.io/crates/bp256) | [![Documentation](https://docs.rs/bp256/badge.svg)](https://docs.rs/bp256) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/bp256/badge.svg?branch=master&event=push) |
-| [`bp384`] | brainpoolP384r1/t1 | ✅            | [![crates.io](https://img.shields.io/crates/v/bp384.svg)](https://crates.io/crates/bp384) | [![Documentation](https://docs.rs/bp384/badge.svg)](https://docs.rs/bp384) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/bp384/badge.svg?branch=master&event=push) |
+| [`bp256`] | brainpoolP256r1/t1 | 🚧            | [![crates.io](https://img.shields.io/crates/v/bp256.svg)](https://crates.io/crates/bp256) | [![Documentation](https://docs.rs/bp256/badge.svg)](https://docs.rs/bp256) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/bp256/badge.svg?branch=master&event=push) |
+| [`bp384`] | brainpoolP384r1/t1 | 🚧            | [![crates.io](https://img.shields.io/crates/v/bp384.svg)](https://crates.io/crates/bp384) | [![Documentation](https://docs.rs/bp384/badge.svg)](https://docs.rs/bp384) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/bp384/badge.svg?branch=master&event=push) |
 | [`k256`]  | [secp256k1]        | ✅            | [![crates.io](https://img.shields.io/crates/v/k256.svg)](https://crates.io/crates/k256)   | [![Documentation](https://docs.rs/k256/badge.svg)](https://docs.rs/k256)   | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/k256/badge.svg?branch=master&event=push)  |
 | [`p192`]  | [NIST P-192]       | ✅            | [![crates.io](https://img.shields.io/crates/v/p192.svg)](https://crates.io/crates/p192)   | [![Documentation](https://docs.rs/p192/badge.svg)](https://docs.rs/p192)   | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/p192/badge.svg?branch=master&event=push)  |
 | [`p224`]  | [NIST P-224]       | ✅            | [![crates.io](https://img.shields.io/crates/v/p224.svg)](https://crates.io/crates/p224)   | [![Documentation](https://docs.rs/p224/badge.svg)](https://docs.rs/p224)   | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/p224/badge.svg?branch=master&event=push)  |
@@ -27,7 +24,8 @@ NOTE: Most crates have field/point arithmetic implementations gated under the
 | [`p521`]  | [NIST P-521]       | 🚧            | [![crates.io](https://img.shields.io/crates/v/p521.svg)](https://crates.io/crates/p521)   | [![Documentation](https://docs.rs/p521/badge.svg)](https://docs.rs/p521)   | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/p521/badge.svg?branch=master&event=push)  |
 | [`sm2`]   | [SM2]              | ✅            | [![crates.io](https://img.shields.io/crates/v/sm2.svg)](https://crates.io/crates/sm2)   | [![Documentation](https://docs.rs/sm2/badge.svg)](https://docs.rs/sm2)   | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/sm2/badge.svg?branch=master&event=push)  |
 
-🚧: curve arithmetic implementation under construction
+NOTE: Some crates contain field/point arithmetic implementations gated under the
+`arithmetic` cargo feature as noted above.
 
 Please see our [tracking issue for additional elliptic curves][other-curves]
 if you are interested in curves beyond the ones listed here.

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -25,11 +25,11 @@ default = ["pkcs8", "std"]
 alloc = ["ecdsa?/alloc", "elliptic-curve/alloc"]
 std = ["alloc", "ecdsa?/std", "elliptic-curve/std"]
 
-arithmetic = ["dep:primeorder"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]
-serde = ["ecdsa/serde", "elliptic-curve/serde", "primeorder?/serde"]
+serde = ["ecdsa/serde", "elliptic-curve/serde"]
 sha256 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
+wip-arithmetic-do-not-use = ["dep:primeorder"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/bp256/src/lib.rs
+++ b/bp256/src/lib.rs
@@ -18,13 +18,13 @@
 pub mod r1;
 pub mod t1;
 
-#[cfg(feature = "arithmetic")]
+#[cfg(feature = "wip-arithmetic-do-not-use")]
 mod arithmetic;
 
 pub use crate::{r1::BrainpoolP256r1, t1::BrainpoolP256t1};
 pub use elliptic_curve::{self, bigint::U256};
 
-#[cfg(feature = "arithmetic")]
+#[cfg(feature = "wip-arithmetic-do-not-use")]
 pub use crate::arithmetic::scalar::Scalar;
 
 #[cfg(feature = "pkcs8")]
@@ -32,7 +32,7 @@ pub use elliptic_curve::pkcs8;
 
 use elliptic_curve::generic_array::{typenum::U32, GenericArray};
 
-#[cfg(feature = "arithmetic")]
+#[cfg(feature = "wip-arithmetic-do-not-use")]
 pub(crate) use crate::arithmetic::field::FieldElement;
 
 /// Byte representation of a base/scalar field element of a given curve.

--- a/bp256/src/r1.rs
+++ b/bp256/src/r1.rs
@@ -3,10 +3,10 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
-#[cfg(feature = "arithmetic")]
+#[cfg(feature = "wip-arithmetic-do-not-use")]
 mod arithmetic;
 
-#[cfg(feature = "arithmetic")]
+#[cfg(feature = "wip-arithmetic-do-not-use")]
 pub use {
     self::arithmetic::{AffinePoint, ProjectivePoint},
     crate::Scalar,
@@ -70,5 +70,5 @@ impl FieldBytesEncoding<BrainpoolP256r1> for U256 {
 /// brainpoolP256r1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP256r1>;
 
-#[cfg(not(feature = "arithmetic"))]
+#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
 impl elliptic_curve::sec1::ValidatePublicKey for BrainpoolP256r1 {}

--- a/bp256/src/t1.rs
+++ b/bp256/src/t1.rs
@@ -3,10 +3,10 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
-#[cfg(feature = "arithmetic")]
+#[cfg(feature = "wip-arithmetic-do-not-use")]
 mod arithmetic;
 
-#[cfg(feature = "arithmetic")]
+#[cfg(feature = "wip-arithmetic-do-not-use")]
 pub use {
     self::arithmetic::{AffinePoint, ProjectivePoint},
     crate::Scalar,
@@ -70,5 +70,5 @@ impl FieldBytesEncoding<BrainpoolP256t1> for U256 {
 /// brainpoolP256t1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP256t1>;
 
-#[cfg(not(feature = "arithmetic"))]
+#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
 impl elliptic_curve::sec1::ValidatePublicKey for BrainpoolP256t1 {}

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -25,11 +25,11 @@ default = ["pkcs8", "std"]
 alloc = ["ecdsa?/alloc", "elliptic-curve/alloc"]
 std = ["alloc", "ecdsa?/std", "elliptic-curve/std"]
 
-arithmetic = ["dep:primeorder"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]
-serde = ["ecdsa/serde", "elliptic-curve/serde", "primeorder?/serde"]
+serde = ["ecdsa/serde", "elliptic-curve/serde"]
 sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
+wip-arithmetic-do-not-use = ["dep:primeorder"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/bp384/src/lib.rs
+++ b/bp384/src/lib.rs
@@ -18,13 +18,13 @@
 pub mod r1;
 pub mod t1;
 
-#[cfg(feature = "arithmetic")]
+#[cfg(feature = "wip-arithmetic-do-not-use")]
 mod arithmetic;
 
 pub use crate::{r1::BrainpoolP384r1, t1::BrainpoolP384t1};
 pub use elliptic_curve::{self, bigint::U384};
 
-#[cfg(feature = "arithmetic")]
+#[cfg(feature = "wip-arithmetic-do-not-use")]
 pub use crate::arithmetic::scalar::Scalar;
 
 #[cfg(feature = "pkcs8")]
@@ -32,7 +32,7 @@ pub use elliptic_curve::pkcs8;
 
 use elliptic_curve::generic_array::{typenum::U48, GenericArray};
 
-#[cfg(feature = "arithmetic")]
+#[cfg(feature = "wip-arithmetic-do-not-use")]
 pub(crate) use crate::arithmetic::field::FieldElement;
 
 /// Byte representation of a base/scalar field element of a given curve.

--- a/bp384/src/r1.rs
+++ b/bp384/src/r1.rs
@@ -3,10 +3,10 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
-#[cfg(feature = "arithmetic")]
+#[cfg(feature = "wip-arithmetic-do-not-use")]
 mod arithmetic;
 
-#[cfg(feature = "arithmetic")]
+#[cfg(feature = "wip-arithmetic-do-not-use")]
 pub use {
     self::arithmetic::{AffinePoint, ProjectivePoint},
     crate::Scalar,
@@ -70,5 +70,5 @@ impl FieldBytesEncoding<BrainpoolP384r1> for U384 {
 /// brainpoolP384r1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP384r1>;
 
-#[cfg(not(feature = "arithmetic"))]
+#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
 impl elliptic_curve::sec1::ValidatePublicKey for BrainpoolP384r1 {}

--- a/bp384/src/t1.rs
+++ b/bp384/src/t1.rs
@@ -3,10 +3,10 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
-#[cfg(feature = "arithmetic")]
+#[cfg(feature = "wip-arithmetic-do-not-use")]
 mod arithmetic;
 
-#[cfg(feature = "arithmetic")]
+#[cfg(feature = "wip-arithmetic-do-not-use")]
 pub use {
     self::arithmetic::{AffinePoint, ProjectivePoint},
     crate::Scalar,
@@ -70,5 +70,5 @@ impl FieldBytesEncoding<BrainpoolP384t1> for U384 {
 /// brainpoolP384t1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP384t1>;
 
-#[cfg(not(feature = "arithmetic"))]
+#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
 impl elliptic_curve::sec1::ValidatePublicKey for BrainpoolP384t1 {}


### PR DESCRIPTION
This reverts commit 7e35ecb9f9db8d2e1704ba19a246071f4235a37f.

ECDH is failing. Not ready for this yet.