### PR TITLE
primeorder: improve initialization from uncompressed point

### DIFF
--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -182,8 +182,11 @@ where
             }
             sec1::Coordinates::Uncompressed { x, y } => {
                 C::FieldElement::from_repr(*y).and_then(|y| {
-                    Self::decompress(x, y.is_odd())
-                        .and_then(|point| CtOption::new(point, point.y.ct_eq(&y)))
+                    C::FieldElement::from_repr(*x).and_then(|x| {
+                        let lhs = y * &y;
+                        let rhs = x * &x * &x + &(C::EQUATION_A * &x) + &C::EQUATION_B;
+                        CtOption::new(Self { x, y, infinity: 0 }, lhs.ct_eq(&rhs))
+                    })
                 })
             }
         }


### PR DESCRIPTION
If you already have the uncompressed point, it's faster to just check the x and y against the curve's equation than solving the equation and calculating the modular square root of y².

In my very rough benchmarks, doing 200k ECDH operations with the same P224 uncompressed key, the time went from ~76s to ~38s, a 2x speedup!