### PR TITLE
primeorder v0.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,7 +865,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primeorder"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "elliptic-curve",
  "serdect",

--- a/primeorder/CHANGELOG.md
+++ b/primeorder/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.2 (2023-05-29)
+### Changed
+- Improve decoding performance for uncompressed SEC1 points ([#891])
+
+[#891]: https://github.com/RustCrypto/elliptic-curves/pull/891
+
 ## 0.13.1 (2023-04-09)
 ### Added
 - `impl_bernstein_yang_invert!` macro ([#786])

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.13.1"
+version = "0.13.2"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve


### PR DESCRIPTION
### Changed
- Improve decoding performance for uncompressed SEC1 points ([#891])

[#891]: https://github.com/RustCrypto/elliptic-curves/pull/891