### PR TITLE
bign256 v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bign256"
-version = "0.0.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "elliptic-curve",

--- a/bign256/CHANGELOG.md
+++ b/bign256/CHANGELOG.md
@@ -4,3 +4,5 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.0 (2023-06-27)
+- Initial release

--- a/bign256/Cargo.toml
+++ b/bign256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bign256"
-version = "0.0.0"
+version = "0.13.0"
 description = """
 Pure Rust implementation of the Bign P-256 (a.k.a. bign-curve256v1)
 elliptic curve as defined in STB 34.101.45-2013, with


### PR DESCRIPTION
Initial release (other versions skipped to synchronize with `elliptic-curve`/`ff`/`group`)