### PR TITLE
NCC audit fixes

### DIFF
--- a/k256/src/ecdh.rs
+++ b/k256/src/ecdh.rs
@@ -40,7 +40,7 @@ pub use elliptic_curve::ecdh::diffie_hellman;
 
 use crate::{AffinePoint, Secp256k1};
 
-/// NIST P-256 Ephemeral Diffie-Hellman Secret.
+/// secp256k1 Ephemeral Diffie-Hellman Secret.
 pub type EphemeralSecret = elliptic_curve::ecdh::EphemeralSecret<Secp256k1>;
 
 /// Shared secret value computed via ECDH key agreement.

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -213,7 +213,7 @@ impl SignPrimitive<Secp256k1> for Scalar {
         // Compute 𝒔 as a signature over 𝒓 and 𝒛.
         let s = k_inv * (z + (r * self));
 
-        if s.is_zero().into() {
+        if s.is_zero().into() || r.is_zero().into() {
             return Err(Error::new());
         }
 


### PR DESCRIPTION
(Audit is not finished, so this is a draft)

- Check for r=0 in addition to s=0 in `try_sign_prehashed()` - even though it's very unlikely, but so is s=0, and FIPS186-5 requires this check.