### PR TITLE
k256: simplify internal helper functions in the scalar arithmetic

### DIFF
--- a/k256/src/arithmetic/scalar/wide64.rs
+++ b/k256/src/arithmetic/scalar/wide64.rs
@@ -221,28 +221,18 @@ impl WideScalar {
     }
 }
 
-/// Constant-time comparison.
-#[inline(always)]
-fn ct_less(a: u64, b: u64) -> u64 {
-    // Do not convert to Choice since it is only used internally,
-    // and we don't want loss of performance.
-    (a < b) as u64
-}
-
 /// Add a to the number defined by (c0,c1,c2). c2 must never overflow.
 fn sumadd(a: u64, c0: u64, c1: u64, c2: u64) -> (u64, u64, u64) {
-    let new_c0 = c0.wrapping_add(a); // overflow is handled on the next line
-    let over = ct_less(new_c0, a);
-    let new_c1 = c1.wrapping_add(over); // overflow is handled on the next line
-    let new_c2 = c2 + ct_less(new_c1, over); // never overflows by contract
+    let (new_c0, carry0) = c0.overflowing_add(a);
+    let (new_c1, carry1) = c1.overflowing_add(carry0 as u64);
+    let new_c2 = c2 + (carry1 as u64);
     (new_c0, new_c1, new_c2)
 }
 
-/// Add a to the number defined by (c0,c1). c1 must never overflow, c2 must be zero.
+/// Add a to the number defined by (c0,c1). c1 must never overflow.
 fn sumadd_fast(a: u64, c0: u64, c1: u64) -> (u64, u64) {
-    let new_c0 = c0.wrapping_add(a); // overflow is handled on the next line
-    let new_c1 = c1 + ct_less(new_c0, a); // never overflows by contract (verified the next line)
-    debug_assert!((new_c1 != 0) | (new_c0 >= a));
+    let (new_c0, carry0) = c0.overflowing_add(a);
+    let new_c1 = c1 + (carry0 as u64);
     (new_c0, new_c1)
 }
 
@@ -252,11 +242,11 @@ fn muladd(a: u64, b: u64, c0: u64, c1: u64, c2: u64) -> (u64, u64, u64) {
     let th = (t >> 64) as u64; // at most 0xFFFFFFFFFFFFFFFE
     let tl = t as u64;
 
-    let new_c0 = c0.wrapping_add(tl); // overflow is handled on the next line
-    let new_th = th + u64::from(new_c0 < tl); // at most 0xFFFFFFFFFFFFFFFF
-    let new_c1 = c1.wrapping_add(new_th); // overflow is handled on the next line
-    let new_c2 = c2 + ct_less(new_c1, new_th); // never overflows by contract (verified in the next line)
-    debug_assert!((new_c1 >= new_th) || (new_c2 != 0));
+    let (new_c0, carry0) = c0.overflowing_add(tl);
+    let new_th = th.wrapping_add(carry0 as u64); // at most 0xFFFFFFFFFFFFFFFF
+    let (new_c1, carry1) = c1.overflowing_add(new_th);
+    let new_c2 = c2 + (carry1 as u64);
+
     (new_c0, new_c1, new_c2)
 }
 
@@ -266,9 +256,9 @@ fn muladd_fast(a: u64, b: u64, c0: u64, c1: u64) -> (u64, u64) {
     let th = (t >> 64) as u64; // at most 0xFFFFFFFFFFFFFFFE
     let tl = t as u64;
 
-    let new_c0 = c0.wrapping_add(tl); // overflow is handled on the next line
-    let new_th = th + ct_less(new_c0, tl); // at most 0xFFFFFFFFFFFFFFFF
-    let new_c1 = c1 + new_th; // never overflows by contract (verified in the next line)
-    debug_assert!(new_c1 >= new_th);
+    let (new_c0, carry0) = c0.overflowing_add(tl);
+    let new_th = th.wrapping_add(carry0 as u64); // at most 0xFFFFFFFFFFFFFFFF
+    let new_c1 = c1 + new_th;
+
     (new_c0, new_c1)
 }


### PR DESCRIPTION
- use `overflowing_add()` instead of the explicit `ct_less()`. Seems to compile to the same assembly code. 
- use checked addition (the default for arithmetic operations) instead of an explicit `debug_assert()`

I am 99% sure that `overflowing_add()` will compile to the same (or safer) assembly... On the weird architectures where there's no `adc` or an equivalent (are there any even?), `<` may very easily not be constant-time too. 
