### PR TITLE
k256: fix comment

### DIFF
--- a/k256/src/ecdh.rs
+++ b/k256/src/ecdh.rs
@@ -40,7 +40,7 @@ pub use elliptic_curve::ecdh::diffie_hellman;
 
 use crate::{AffinePoint, Secp256k1};
 
-/// NIST P-256 Ephemeral Diffie-Hellman Secret.
+/// secp256k1 Ephemeral Diffie-Hellman Secret.
 pub type EphemeralSecret = elliptic_curve::ecdh::EphemeralSecret<Secp256k1>;
 
 /// Shared secret value computed via ECDH key agreement.


### PR DESCRIPTION
Copy/paste where NIST P-256 wasn't changed to secp256k1