### PR TITLE
Fix minimal version of `ecdsa` dependency

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -32,7 +32,7 @@ signature = { version = "2", optional = true }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.5"
-ecdsa-core = { version = "0.16", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.16.8", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -20,13 +20,13 @@ elliptic-curve = { version = "0.13", default-features = false, features = ["hazm
 sec1 = { version = "0.7.3", default-features = false }
 
 # optional dependencies
-ecdsa-core = { version = "0.16.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.16.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primeorder = { version = "0.13.1", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.16", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.16.8", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "0.13", features = ["dev"], path = "../primeorder" }
 

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.65"
 elliptic-curve = { version = "0.13.5", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.16.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.16.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primeorder = { version = "0.13.1", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
@@ -27,7 +27,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
-ecdsa-core = { version = "0.16", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.16.8", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "0.13", features = ["dev"], path = "../primeorder" }
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.65"
 elliptic-curve = { version = "0.13.5", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.16.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primeorder = { version = "0.13", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
@@ -29,7 +29,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.5"
-ecdsa-core = { version = "0.16", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.16.8", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "0.13", features = ["dev"], path = "../primeorder" }
 proptest = "1"

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.65"
 elliptic-curve = { version = "0.13", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.16.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primeorder = { version = "0.13.1", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
@@ -29,7 +29,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.5"
-ecdsa-core = { version = "0.16", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.16.8", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "0.13", features = ["dev"], path = "../primeorder" }
 proptest = "1.2"


### PR DESCRIPTION
In k256 crate, in `[dependencies]`, the minimal version of **ecdsa** crate is **0.16.8**. But in `[dev-dependencies]` in the same crate the minimal version of **ecdsa** is **0.16.0**. This leads to compiling different versions of **ecdsa** crate in complex dependency tree, especially when using **-Zminimal-versions** option. Additionally there are differences in crate **ecdsa** between version 0.16.0 and 0.16.8, such that prevents us to compile a project when 0.16.0 version is used by the Rust compiler.

This PR assigns the same minimal version of **ecdsa** in all crates of this project, exactly as it was originally updated in k256 crate.