### PR TITLE
Add inline annotations on conditional_select in p256, k256, and primeorder

### DIFF
--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -323,6 +323,7 @@ impl PrimeField for FieldElement {
 }
 
 impl ConditionallySelectable for FieldElement {
+    #[inline(always)]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self(FieldElementImpl::conditional_select(&(a.0), &(b.0), choice))
     }

--- a/k256/src/arithmetic/field/field_10x26.rs
+++ b/k256/src/arithmetic/field/field_10x26.rs
@@ -674,6 +674,7 @@ impl Default for FieldElement10x26 {
 }
 
 impl ConditionallySelectable for FieldElement10x26 {
+    #[inline(always)]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self([
             u32::conditional_select(&a.0[0], &b.0[0], choice),

--- a/k256/src/arithmetic/field/field_5x52.rs
+++ b/k256/src/arithmetic/field/field_5x52.rs
@@ -461,6 +461,7 @@ impl Default for FieldElement5x52 {
 }
 
 impl ConditionallySelectable for FieldElement5x52 {
+    #[inline(always)]
     fn conditional_select(
         a: &FieldElement5x52,
         b: &FieldElement5x52,

--- a/k256/src/arithmetic/field/field_impl.rs
+++ b/k256/src/arithmetic/field/field_impl.rs
@@ -142,6 +142,7 @@ impl Default for FieldElementImpl {
 }
 
 impl ConditionallySelectable for FieldElementImpl {
+    #[inline(always)]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         // 1. It's debug only, so it shouldn't present a security risk
         // 2. Being normalized does is independent from the field element value;

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -473,6 +473,7 @@ impl PrimeField for FieldElement {
 }
 
 impl ConditionallySelectable for FieldElement {
+    #[inline(always)]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self(U256::conditional_select(&a.0, &b.0, choice))
     }

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -96,6 +96,7 @@ impl<C> ConditionallySelectable for AffinePoint<C>
 where
     C: PrimeCurveParams,
 {
+    #[inline(always)]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self {
             x: C::FieldElement::conditional_select(&a.x, &b.x, choice),

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -172,6 +172,7 @@ impl<C> ConditionallySelectable for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
 {
+    #[inline(always)]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self {
             x: C::FieldElement::conditional_select(&a.x, &b.x, choice),


### PR DESCRIPTION
This seems to help situations where the Rust compiler otherwise will not completely inline conditional_select, causing algoritms which depend on this to become significantly slower than they would otherwise.

See #940 for discussion.