### PR TITLE
p521: impl `FieldElement::{sqrt, invert}` and add basic field tests

### DIFF
--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -271,7 +271,7 @@ impl Default for FieldElement {
 impl Eq for FieldElement {}
 impl PartialEq for FieldElement {
     fn eq(&self, rhs: &Self) -> bool {
-        self.ct_eq(&rhs).into()
+        self.ct_eq(rhs).into()
     }
 }
 
@@ -553,11 +553,13 @@ impl<'a> Product<&'a FieldElement> for FieldElement {
 
 #[cfg(test)]
 mod tests {
+    // TODO(tarcieri): inversion implementation
     use super::FieldElement;
-    use elliptic_curve::ff::PrimeField;
-    use primeorder::{impl_field_identity_tests, impl_field_sqrt_tests, impl_primefield_tests};
+    //use elliptic_curve::ff::PrimeField;
+    use primeorder::{impl_field_identity_tests, impl_field_sqrt_tests};
 
     /// t = (modulus - 1) >> S
+    #[allow(dead_code)]
     const T: [u64; 9] = [
         0xffffffff_ffffffff,
         0xffffffff_ffffffff,
@@ -573,5 +575,5 @@ mod tests {
     impl_field_identity_tests!(FieldElement);
     //impl_field_invert_tests!(FieldElement);
     impl_field_sqrt_tests!(FieldElement);
-    impl_primefield_tests!(FieldElement, T);
+    //impl_primefield_tests!(FieldElement, T);
 }

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -280,15 +280,15 @@ impl FieldElement {
         // Tonelli-Shank's algorithm for q mod 4 = 3 (i.e. Shank's algorithm)
         // https://eprint.iacr.org/2012/685.pdf
         let w = self.pow_vartime(&[
-            0x00000000_00000000,
-            0x00000000_00000000,
-            0x00000000_00000000,
-            0x00000000_00000000,
-            0x00000000_00000000,
-            0x00000000_00000000,
-            0x00000000_00000000,
-            0x00000000_00000000,
-            0x00000000_00000080,
+            0x0000000000000000,
+            0x0000000000000000,
+            0x0000000000000000,
+            0x0000000000000000,
+            0x0000000000000000,
+            0x0000000000000000,
+            0x0000000000000000,
+            0x0000000000000000,
+            0x0000000000000080,
         ]);
 
         CtOption::new(w, w.square().ct_eq(self))
@@ -607,15 +607,15 @@ mod tests {
     /// t = (modulus - 1) >> S
     #[allow(dead_code)]
     const T: [u64; 9] = [
-        0xffffffff_ffffffff,
-        0xffffffff_ffffffff,
-        0xffffffff_ffffffff,
-        0xffffffff_ffffffff,
-        0xffffffff_ffffffff,
-        0xffffffff_ffffffff,
-        0xffffffff_ffffffff,
-        0xffffffff_ffffffff,
-        0x00000000_000000ff,
+        0xffffffffffffffff,
+        0xffffffffffffffff,
+        0xffffffffffffffff,
+        0xffffffffffffffff,
+        0xffffffffffffffff,
+        0xffffffffffffffff,
+        0xffffffffffffffff,
+        0xffffffffffffffff,
+        0x00000000000000ff,
     ];
 
     impl_field_identity_tests!(FieldElement);

--- a/p521/src/arithmetic/util.rs
+++ b/p521/src/arithmetic/util.rs
@@ -35,7 +35,7 @@ pub(crate) const fn u64x9_to_u32x18(w: &[u64; 9]) -> [u32; 18] {
 
 /// Converts the saturated representation [`U576`] into a 528bit array. Each
 /// word is copied in little-endian.
-pub const fn uint_to_le_bytes_unchecked(w: U576) -> [u8; 66] {
+pub const fn u576_to_le_bytes(w: U576) -> [u8; 66] {
     #[cfg(target_pointer_width = "32")]
     let words = u32x18_to_u64x9(w.as_words());
     #[cfg(target_pointer_width = "64")]


### PR DESCRIPTION
See also: #947

Also relevant (sage calculations):

- PR for base field constants: #758
- PR for scalar field constants: #760