### PR TITLE
p521: Improve `Debug` for unsaturated math

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,6 +778,7 @@ dependencies = [
 name = "p521"
 version = "0.13.0"
 dependencies = [
+ "base16ct",
  "elliptic-curve",
  "primeorder",
  "sha2",

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -21,6 +21,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 
 # optional dependencies
 primeorder = { version = "0.13.1", optional = true, path = "../primeorder" }
+base16ct = "0.2.0"
 
 [features]
 default = ["pem", "std"]

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -51,8 +51,44 @@ const MODULUS_HEX: &str = "00000000000001fffffffffffffffffffffffffffffffffffffff
 const MODULUS: U576 = U576::from_be_hex(MODULUS_HEX);
 
 /// Element of the secp521r1 base field used for curve coordinates.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct FieldElement(fiat_p521_tight_field_element);
+
+impl core::fmt::Debug for FieldElement {
+    /// Formatting machinery for [`FieldElement`]
+    ///
+    /// # Why
+    /// ```
+    /// let fe1 = FieldElement([9, 0, 0, 0, 0, 0, 0, 0, 0]);
+    /// let fe2 = FieldElement([
+    ///     8,
+    ///     0,
+    ///     288230376151711744,
+    ///     288230376151711743,
+    ///     288230376151711743,
+    ///     288230376151711743,
+    ///     288230376151711743,
+    ///     288230376151711743,
+    ///     144115188075855871,
+    /// ]);
+    /// ```
+    ///
+    /// For the above example, deriving [`core::fmt::Debug`] will result in returning 2 different strings,
+    /// which are in reality the same due to p521's unsaturated math, instead print the output as a hex string in
+    /// big-endian
+    ///
+    /// This makes debugging easier.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut bytes = fiat_p521_to_bytes(&self.0);
+        bytes.reverse();
+
+        write!(f, "0x")?;
+        for b in bytes {
+            write!(f, "{b:02X}")?;
+        }
+        Ok(())
+    }
+}
 
 impl FieldElement {
     /// Zero element.

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -58,7 +58,7 @@ impl core::fmt::Debug for FieldElement {
     /// Formatting machinery for [`FieldElement`]
     ///
     /// # Why
-    /// ```
+    /// ```ignore
     /// let fe1 = FieldElement([9, 0, 0, 0, 0, 0, 0, 0, 0]);
     /// let fe2 = FieldElement([
     ///     8,

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -81,12 +81,10 @@ impl core::fmt::Debug for FieldElement {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut bytes = fiat_p521_to_bytes(&self.0);
         bytes.reverse();
-
-        write!(f, "0x")?;
-        for b in bytes {
-            write!(f, "{b:02X}")?;
-        }
-        Ok(())
+        let formatter = base16ct::HexDisplay(&bytes);
+        f.debug_tuple("FieldElement")
+            .field(&format_args!("0x{formatter:X}"))
+            .finish()
     }
 }
 


### PR DESCRIPTION
When using p521, the limbs can be populated differently which when deriving [`Debug`] shows up as different values for equal FieldElements, this can lead to confusion.

See:
- https://github.com/RustCrypto/elliptic-curves/pull/946#issuecomment-1789749836, equal field elements were considered as unequal.
- https://github.com/RustCrypto/elliptic-curves/pull/946#discussion_r1380388316, assert_eq! wasn't meaningful.