### PR TITLE
p521: fix projective arithmetic tests

### DIFF
--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -25,6 +25,7 @@ primeorder = { version = "0.13.1", optional = true, path = "../primeorder" }
 
 [dev-dependencies]
 hex-literal = "0.4"
+primeorder = { version = "0.13", features = ["dev"], path = "../primeorder" }
 
 [features]
 default = ["pem", "std"]

--- a/p521/tests/projective.rs
+++ b/p521/tests/projective.rs
@@ -1,14 +1,14 @@
 //! Projective arithmetic tests.
 
-#![cfg(all(feature = "arithmetic", feature = "test-vectors"))]
+#![cfg(all(feature = "wip-arithmetic-do-not-use", feature = "test-vectors"))]
 
 use elliptic_curve::{
     group::ff::PrimeField,
     sec1::{self, ToEncodedPoint},
 };
 use p521::{
+    arithmetic::{AffinePoint, ProjectivePoint, Scalar},
     test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
-    AffinePoint, ProjectivePoint, Scalar,
 };
 use primeorder::{impl_projective_arithmetic_tests, Double};
 

--- a/primeorder/src/dev.rs
+++ b/primeorder/src/dev.rs
@@ -139,12 +139,15 @@ macro_rules! impl_projective_arithmetic_tests {
                 .iter()
                 .enumerate()
                 .map(|(k, coords)| (<$scalar>::from(k as u64 + 1), *coords))
-                .chain(
-                    $mul_vectors
-                        .iter()
-                        .cloned()
-                        .map(|(k, x, y)| (<$scalar>::from_repr(k.into()).unwrap(), (x, y))),
-                )
+                .chain($mul_vectors.iter().cloned().map(|(k, x, y)| {
+                    (
+                        <$scalar>::from_repr(
+                            $crate::generic_array::GenericArray::clone_from_slice(&k),
+                        )
+                        .unwrap(),
+                        (x, y),
+                    )
+                }))
             {
                 let p = generator * &k;
                 assert_point_eq!(p, coords);

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -17,7 +17,9 @@ mod field;
 mod projective;
 
 pub use crate::{affine::AffinePoint, projective::ProjectivePoint};
-pub use elliptic_curve::{self, point::Double, Field, FieldBytes, PrimeCurve, PrimeField};
+pub use elliptic_curve::{
+    self, generic_array, point::Double, Field, FieldBytes, PrimeCurve, PrimeField,
+};
 
 use elliptic_curve::CurveArithmetic;
 


### PR DESCRIPTION
The tests added in #950 weren't actually running due to feature gating (the feature is named `wip-arithmetic-do-not-use`, but the conditional gating was using `arithmetic` instead).

It turns out a small modification to `primeorder` was needed, since the `impl_projective_arithmetic_tests` macro was relying on `Into` conversions from core arrays to `GenericArray` which top out at 64-element arrays, and `p521`'s field elements are 66-bytes.

With the modification in place, the tests pass!