### PR TITLE
primeorder v0.13.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,7 +840,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primeorder"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "elliptic-curve",
  "serdect",

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -21,12 +21,12 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 
 # optional dependencies
 hex-literal = { version = "0.4", optional = true }
-primeorder = { version = "0.13.1", optional = true, path = "../primeorder" }
+primeorder = { version = "0.13.3", optional = true, path = "../primeorder" }
 base16ct = "0.2.0"
 
 [dev-dependencies]
 hex-literal = "0.4"
-primeorder = { version = "0.13", features = ["dev"], path = "../primeorder" }
+primeorder = { version = "0.13.3", features = ["dev"], path = "../primeorder" }
 
 [features]
 default = ["pem", "std"]

--- a/primeorder/CHANGELOG.md
+++ b/primeorder/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.3 (2023-11-02)
+### Added
+- Inline annotations on `conditional_select` ([#942])
+
+### Changed
+- Support field elements larger than 64-bytes in `impl_projective_arithmetic_tests!` ([#951])
+
+[#942]: https://github.com/RustCrypto/elliptic-curves/pull/942
+[#951]: https://github.com/RustCrypto/elliptic-curves/pull/951
+
 ## 0.13.2 (2023-05-29)
 ### Changed
 - Improve decoding performance for uncompressed SEC1 points ([#891])

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.13.2"
+version = "0.13.3"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve


### PR DESCRIPTION
### Added
- Inline annotations on `conditional_select` ([#942])

### Changed
- Support field elements larger than 64-bytes in `impl_projective_arithmetic_tests!` ([#951])

[#942]: https://github.com/RustCrypto/elliptic-curves/pull/942
[#951]: https://github.com/RustCrypto/elliptic-curves/pull/951