### PR TITLE
p521: `arithmetic` feature

### DIFF
--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -29,15 +29,15 @@ hex-literal = "0.4"
 primeorder = { version = "0.13.3", features = ["dev"], path = "../primeorder" }
 
 [features]
-default = ["pem", "std"]
+default = ["arithmetic", "pem", "std"]
 alloc = ["elliptic-curve/alloc"]
 std = ["alloc", "elliptic-curve/std"]
 
+arithmetic = ["dep:primeorder"]
 jwk = ["elliptic-curve/jwk"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8"]
 test-vectors = ["dep:hex-literal"]
-wip-arithmetic-do-not-use = ["dep:primeorder"]
 voprf = ["elliptic-curve/voprf", "dep:sha2"]
 
 [package.metadata.docs.rs]

--- a/p521/src/lib.rs
+++ b/p521/src/lib.rs
@@ -15,11 +15,14 @@
     unused_qualifications
 )]
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 pub mod arithmetic;
 
 #[cfg(any(feature = "test-vectors", test))]
 pub mod test_vectors;
+
+#[cfg(feature = "arithmetic")]
+pub use arithmetic::{scalar::Scalar, AffinePoint, ProjectivePoint};
 
 pub use elliptic_curve::{self, bigint::U576};
 

--- a/p521/tests/projective.rs
+++ b/p521/tests/projective.rs
@@ -1,6 +1,6 @@
 //! Projective arithmetic tests.
 
-#![cfg(all(feature = "wip-arithmetic-do-not-use", feature = "test-vectors"))]
+#![cfg(all(feature = "arithmetic", feature = "test-vectors"))]
 
 use elliptic_curve::{
     group::ff::PrimeField,


### PR DESCRIPTION
Now that #946, #950, and #951 have landed it seems prudent to add a real `arithmetic` feature.

This adds a feature similar to the other crates in this repo which exposes the following types which provide a curve arithmetic implementation:

- `AffinePoint`
- `ProjectivePoint`
- `Scalar`

The `wip-arithmetic-do-not-use` feature is now removed as well. While technically SemVer breaking, it wasn't supposed to be used in the first place!

Closes #947