### PR TITLE
k256: rename `lincomb_generic` to `lincomb` and expose it.

### DIFF
--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -12,6 +12,7 @@ pub(crate) mod scalar;
 mod dev;
 
 pub use field::FieldElement;
+pub use mul::lincomb;
 
 use self::{affine::AffinePoint, projective::ProjectivePoint, scalar::Scalar};
 use crate::Secp256k1;

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -310,7 +310,7 @@ fn static_zip_map<T: Copy, S: Copy, V: Copy, const N: usize>(
 
 /// Calculates a linear combination `sum(x[i] * k[i])`, `i = 0..N`
 #[inline(always)]
-fn lincomb_generic<const N: usize>(xs: &[ProjectivePoint; N], ks: &[Scalar; N]) -> ProjectivePoint {
+pub fn lincomb<const N: usize>(xs: &[ProjectivePoint; N], ks: &[Scalar; N]) -> ProjectivePoint {
     let rs = static_map(
         |k| decompose_scalar(&k),
         ks,
@@ -429,7 +429,7 @@ impl MulByGenerator for ProjectivePoint {
 
 #[inline(always)]
 fn mul(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
-    lincomb_generic(&[*x], &[*k])
+    lincomb(&[*x], &[*k])
 }
 
 impl LinearCombination for ProjectivePoint {
@@ -439,7 +439,7 @@ impl LinearCombination for ProjectivePoint {
         y: &ProjectivePoint,
         l: &Scalar,
     ) -> ProjectivePoint {
-        lincomb_generic(&[*x, *y], &[*k, *l])
+        lincomb(&[*x, *y], &[*k, *l])
     }
 }
 

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -28,6 +28,8 @@
 
 #[cfg(feature = "arithmetic")]
 mod arithmetic;
+#[cfg(feature = "arithmetic")]
+pub use arithmetic::lincomb;
 
 #[cfg(feature = "ecdh")]
 pub mod ecdh;

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -28,8 +28,6 @@
 
 #[cfg(feature = "arithmetic")]
 mod arithmetic;
-#[cfg(feature = "arithmetic")]
-pub use arithmetic::lincomb;
 
 #[cfg(feature = "ecdh")]
 pub mod ecdh;
@@ -46,7 +44,7 @@ pub mod test_vectors;
 pub use elliptic_curve::{self, bigint::U256};
 
 #[cfg(feature = "arithmetic")]
-pub use arithmetic::{affine::AffinePoint, projective::ProjectivePoint, scalar::Scalar};
+pub use arithmetic::{affine::AffinePoint, lincomb, projective::ProjectivePoint, scalar::Scalar};
 
 #[cfg(feature = "expose-field")]
 pub use arithmetic::FieldElement;


### PR DESCRIPTION
Resolves #921 