### PR TITLE
p521 v0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "base16ct",
  "blobby",

--- a/p521/CHANGELOG.md
+++ b/p521/CHANGELOG.md
@@ -4,5 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.1 (2023-11-09)
+### Added
+- Bernstein-Yang scalar inversions ([#786])
+- VOPRF support ([#924])
+- `arithmetic` feature ([#953])
+- `ecdh` feature ([#954])
+- `ecdsa` feature ([#956])
+
+[#786]: https://github.com/RustCrypto/elliptic-curves/pull/786
+[#924]: https://github.com/RustCrypto/elliptic-curves/pull/924
+[#953]: https://github.com/RustCrypto/elliptic-curves/pull/953
+[#954]: https://github.com/RustCrypto/elliptic-curves/pull/954
+[#956]: https://github.com/RustCrypto/elliptic-curves/pull/956
+
 ## 0.13.0 (2023-03-03)
 - Initial release

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p521"
-version = "0.13.0"
+version = "0.13.1"
 description = """
 Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve
 as defined in SP 800-186

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -124,7 +124,6 @@ impl FieldElement {
     /// Does *not* perform a check that the field element does not overflow the order.
     ///
     /// This method is primarily intended for defining internal constants.
-    #[allow(dead_code)]
     pub(crate) const fn from_hex(hex: &str) -> Self {
         Self::from_uint_unchecked(U576::from_be_hex(hex))
     }
@@ -178,26 +177,26 @@ impl FieldElement {
     }
 
     /// Add elements.
-    #[allow(dead_code)] // TODO(tarcieri): use this
+    #[allow(dead_code)] // TODO(tarcieri): currently unused
     pub(crate) const fn add_loose(&self, rhs: &Self) -> LooseFieldElement {
         LooseFieldElement(fiat_p521_add(&self.0, &rhs.0))
     }
 
     /// Double element (add it to itself).
-    #[allow(dead_code)] // TODO(tarcieri): use this
+    #[allow(dead_code)] // TODO(tarcieri): currently unused
     #[must_use]
     pub(crate) const fn double_loose(&self) -> LooseFieldElement {
         Self::add_loose(self, self)
     }
 
     /// Subtract elements, returning a loose field element.
-    #[allow(dead_code)] // TODO(tarcieri): use this
+    #[allow(dead_code)] // TODO(tarcieri): currently unused
     pub(crate) const fn sub_loose(&self, rhs: &Self) -> LooseFieldElement {
         LooseFieldElement(fiat_p521_sub(&self.0, &rhs.0))
     }
 
     /// Negate element, returning a loose field element.
-    #[allow(dead_code)] // TODO(tarcieri): use this
+    #[allow(dead_code)] // TODO(tarcieri): currently unused
     pub(crate) const fn neg_loose(&self) -> LooseFieldElement {
         LooseFieldElement(fiat_p521_opp(&self.0))
     }


### PR DESCRIPTION
### Added
- Bernstein-Yang scalar inversions ([#786])
- VOPRF support ([#924])
- `arithmetic` feature ([#953])
- `ecdh` feature ([#954])
- `ecdsa` feature ([#956])

[#786]: https://github.com/RustCrypto/elliptic-curves/pull/786
[#924]: https://github.com/RustCrypto/elliptic-curves/pull/924
[#953]: https://github.com/RustCrypto/elliptic-curves/pull/953
[#954]: https://github.com/RustCrypto/elliptic-curves/pull/954
[#956]: https://github.com/RustCrypto/elliptic-curves/pull/956