### PR TITLE
p521: remove `pub` from `arithmetic` module

### DIFF
--- a/p521/src/lib.rs
+++ b/p521/src/lib.rs
@@ -16,7 +16,7 @@
 )]
 
 #[cfg(feature = "arithmetic")]
-pub mod arithmetic;
+mod arithmetic;
 
 #[cfg(feature = "ecdh")]
 pub mod ecdh;

--- a/p521/tests/projective.rs
+++ b/p521/tests/projective.rs
@@ -7,8 +7,8 @@ use elliptic_curve::{
     sec1::{self, ToEncodedPoint},
 };
 use p521::{
-    arithmetic::{AffinePoint, ProjectivePoint, Scalar},
     test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
+    AffinePoint, ProjectivePoint, Scalar,
 };
 use primeorder::{impl_projective_arithmetic_tests, Double};
 


### PR DESCRIPTION
The relevant types from the `arithmetic` module are available via re-exports, so direct access to the module is unnecessary. It was accidentally exposed in the v0.13.1 release (#958).

Exposing the module directly is inconsistent with p192/p224/p256/p384, so this removes it. This is technically a breaking change, but it was added in v0.13.1 which was released a few minutes ago, and will be yanked after this is released.