### PR TITLE
p521: fix panics when decoding `FieldElement`s

### DIFF
--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -628,6 +628,7 @@ impl<'a> Product<&'a FieldElement> for FieldElement {
 mod tests {
     use super::FieldElement;
     use elliptic_curve::ff::PrimeField;
+    use hex_literal::hex;
     use primeorder::{
         impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
         impl_primefield_tests,
@@ -650,4 +651,12 @@ mod tests {
     impl_field_invert_tests!(FieldElement);
     impl_field_sqrt_tests!(FieldElement);
     impl_primefield_tests!(FieldElement, T);
+
+    /// Regression test for RustCrypto/elliptic-curves#965
+    #[test]
+    fn decode_invalid_field_element_returns_err() {
+        let overflowing_bytes = hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+        let ct_option = FieldElement::from_bytes(overflowing_bytes.as_ref().into());
+        assert!(bool::from(ct_option.is_none()));
+    }
 }

--- a/p521/src/arithmetic/util.rs
+++ b/p521/src/arithmetic/util.rs
@@ -57,20 +57,6 @@ pub const fn u576_to_le_bytes(w: U576) -> [u8; 66] {
         i += 1;
     }
     let last_word = words[8].to_le_bytes();
-    debug_assert!(
-        last_word[1] <= 0x1,
-        "Input bound for the result[65] is [0x0 ~> 0x1]"
-    );
-    debug_assert!(
-        last_word[2] == 0
-            && last_word[3] == 0
-            && last_word[4] == 0
-            && last_word[5] == 0
-            && last_word[6] == 0
-            && last_word[7] == 0,
-        "Expected last word to have leading zeroes"
-    );
-
     result[i * 8] = last_word[0];
     result[(i * 8) + 1] = last_word[1];
 


### PR DESCRIPTION
Some `debug_assert!`s were getting triggered on inputs that need to be handled without panicking.

Fixes #965

cc @MasterAwesome 