### PR TITLE
p521 v0.13.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "base16ct",
  "blobby",

--- a/p521/CHANGELOG.md
+++ b/p521/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.3 (2023-11-11)
+### Added
+- Implement hash2curve ([#964])
+
+### Fixed
+- Panics when decoding `FieldElement`s ([#967])
+
+[#964]: https://github.com/RustCrypto/elliptic-curves/pull/964
+[#967]: https://github.com/RustCrypto/elliptic-curves/pull/967
+
 ## 0.13.2 (2023-11-09)
 ### Added
 - `serde` feature ([#962])

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p521"
-version = "0.13.2"
+version = "0.13.3"
 description = """
 Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve
 as defined in SP 800-186


### PR DESCRIPTION
### Added
- Implement hash2curve ([#964])

### Fixed
- Panics when decoding `FieldElement`s ([#967])

[#964]: https://github.com/RustCrypto/elliptic-curves/pull/964
[#967]: https://github.com/RustCrypto/elliptic-curves/pull/967