### PR TITLE
p521: merge `u576_to_le_bytes` into `FieldBytes::from_uint_unchecked`

### DIFF
--- a/p521/src/arithmetic/util.rs
+++ b/p521/src/arithmetic/util.rs
@@ -1,7 +1,5 @@
 //! Utility functions.
 
-use elliptic_curve::bigint::U576;
-
 /// Convert an 18-element array of `u32` into a 9-element array of `u16`,
 /// assuming integer arrays are in little-endian order.
 #[cfg(target_pointer_width = "32")]
@@ -31,34 +29,4 @@ pub(crate) const fn u64x9_to_u32x18(w: &[u64; 9]) -> [u32; 18] {
     }
 
     ret
-}
-
-/// Converts the saturated representation [`U576`] into a 528bit array. Each
-/// word is copied in little-endian.
-pub const fn u576_to_le_bytes(w: U576) -> [u8; 66] {
-    #[cfg(target_pointer_width = "32")]
-    let words = u32x18_to_u64x9(w.as_words());
-    #[cfg(target_pointer_width = "64")]
-    let words = w.as_words();
-
-    let mut result: [u8; 66] = [0u8; 66];
-    let mut i = 0;
-    while i < words.len() - 1 {
-        let word = words[i].to_le_bytes();
-        let start = i * 8;
-        result[start] = word[0];
-        result[start + 1] = word[1];
-        result[start + 2] = word[2];
-        result[start + 3] = word[3];
-        result[start + 4] = word[4];
-        result[start + 5] = word[5];
-        result[start + 6] = word[6];
-        result[start + 7] = word[7];
-        i += 1;
-    }
-    let last_word = words[8].to_le_bytes();
-    result[i * 8] = last_word[0];
-    result[(i * 8) + 1] = last_word[1];
-
-    result
 }


### PR DESCRIPTION
Moves `u576_to_le_bytes` from the `util` module to inside of `from_uint_unchecked`.

The old function in the `util` module was not general-purpose, but really specialized to the case of decoding P-521 base field elements in the unsaturated format used by fiat-crypto's Solinas prime backend.

Additionally `FieldElement::from_uint_unchecked` is the only caller, and it really is an implementation detail of that function.