### PR TITLE
k256+primeorder: add `batch_normalize_generic`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 [[package]]
 name = "elliptic-curve"
 version = "0.13.6"
-source = "git+https://github.com/ycscaly/traits?branch=batch_invert#017fa2972f23b9e67bcbff2ccca2f1905b8f4aa3"
+source = "git+https://github.com/RustCrypto/traits.git#4a663341473273c73fd2ca7e37dadd9ba7013fd2"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ members = [
 [profile.dev]
 opt-level = 2
 
-[patch.crates-io]
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
+[patch.crates-io.elliptic-curve]
+git = "https://github.com/RustCrypto/traits.git"

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -388,7 +388,7 @@ static GEN_LOOKUP_TABLE: Lazy<[LookupTable; 33]> = Lazy::new(precompute_gen_look
 fn precompute_gen_lookup_table() -> [LookupTable; 33] {
     let mut gen = ProjectivePoint::GENERATOR;
     let mut res = [LookupTable::default(); 33];
-    #[allow(clippy::needless_range_loop)]
+
     for i in 0..33 {
         res[i] = LookupTable::from(&gen);
         // We are storing tables spaced by two radix steps,

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -5,6 +5,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
+#![allow(clippy::needless_range_loop)]
 #![forbid(unsafe_code)]
 #![warn(
     clippy::mod_module_files,


### PR DESCRIPTION
Adds a generic implementation of `batch_normalize` which abstracts over backing storages.

This is just implemented in `k256` for now, but could potentially be further abstracted and extracted into `elliptic-curve`.