### PR TITLE
p521: make `LooseFieldElement` pub

### DIFF
--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -175,27 +175,23 @@ impl FieldElement {
     }
 
     /// Add elements.
-    #[allow(dead_code)] // TODO(tarcieri): currently unused
-    pub(crate) const fn add_loose(&self, rhs: &Self) -> LooseFieldElement {
+    pub const fn add_loose(&self, rhs: &Self) -> LooseFieldElement {
         LooseFieldElement(fiat_p521_add(&self.0, &rhs.0))
     }
 
     /// Double element (add it to itself).
-    #[allow(dead_code)] // TODO(tarcieri): currently unused
     #[must_use]
-    pub(crate) const fn double_loose(&self) -> LooseFieldElement {
+    pub const fn double_loose(&self) -> LooseFieldElement {
         Self::add_loose(self, self)
     }
 
     /// Subtract elements, returning a loose field element.
-    #[allow(dead_code)] // TODO(tarcieri): currently unused
-    pub(crate) const fn sub_loose(&self, rhs: &Self) -> LooseFieldElement {
+    pub const fn sub_loose(&self, rhs: &Self) -> LooseFieldElement {
         LooseFieldElement(fiat_p521_sub(&self.0, &rhs.0))
     }
 
     /// Negate element, returning a loose field element.
-    #[allow(dead_code)] // TODO(tarcieri): currently unused
-    pub(crate) const fn neg_loose(&self) -> LooseFieldElement {
+    pub const fn neg_loose(&self) -> LooseFieldElement {
         LooseFieldElement(fiat_p521_opp(&self.0))
     }
 
@@ -222,7 +218,7 @@ impl FieldElement {
 
     /// Multiply elements.
     pub const fn multiply(&self, rhs: &Self) -> Self {
-        LooseFieldElement::mul(&self.relax(), &rhs.relax())
+        LooseFieldElement::multiply(&self.relax(), &rhs.relax())
     }
 
     /// Square element.

--- a/p521/src/arithmetic/field/loose.rs
+++ b/p521/src/arithmetic/field/loose.rs
@@ -1,22 +1,23 @@
 use super::{field_impl::*, FieldElement};
 use core::ops::Mul;
 
-/// "Loose" field element.
-pub(crate) struct LooseFieldElement(pub(super) fiat_p521_loose_field_element);
+/// "Loose" field element: unreduced and intended to be followed by an
+/// additional operation which will perform a reduction.
+pub struct LooseFieldElement(pub(super) fiat_p521_loose_field_element);
 
 impl LooseFieldElement {
     /// Reduce field element.
-    pub(crate) const fn carry(&self) -> FieldElement {
+    pub const fn carry(&self) -> FieldElement {
         FieldElement(fiat_p521_carry(&self.0))
     }
 
     /// Multiplies two field elements and reduces the result.
-    pub(crate) const fn mul(&self, rhs: &Self) -> FieldElement {
+    pub const fn multiply(&self, rhs: &Self) -> FieldElement {
         FieldElement(fiat_p521_carry_mul(&self.0, &rhs.0))
     }
 
     /// Squares a field element and reduces the result.
-    pub(crate) const fn square(&self) -> FieldElement {
+    pub const fn square(&self) -> FieldElement {
         FieldElement(fiat_p521_carry_square(&self.0))
     }
 }
@@ -54,7 +55,7 @@ impl Mul for LooseFieldElement {
 
     #[inline]
     fn mul(self, rhs: LooseFieldElement) -> FieldElement {
-        Self::mul(&self, &rhs)
+        Self::multiply(&self, &rhs)
     }
 }
 
@@ -63,7 +64,7 @@ impl Mul<&LooseFieldElement> for LooseFieldElement {
 
     #[inline]
     fn mul(self, rhs: &LooseFieldElement) -> FieldElement {
-        Self::mul(&self, rhs)
+        Self::multiply(&self, rhs)
     }
 }
 
@@ -72,6 +73,6 @@ impl Mul<&LooseFieldElement> for &LooseFieldElement {
 
     #[inline]
     fn mul(self, rhs: &LooseFieldElement) -> FieldElement {
-        LooseFieldElement::mul(self, rhs)
+        LooseFieldElement::multiply(self, rhs)
     }
 }


### PR DESCRIPTION
The `FieldElement` type is available via the `FieldElement` associated type of the `primeorder::PrimeCurveArithmetic` trait, principally because it's the only way to make the generic implementation of curve arithmetic formulas work, however certain power users working on things like point encodings can also make use of it.

This type also has a set of `*_loose` operations which return an unreduced `LooseFieldElement`, however these were previously marked `allow(dead_code)`.

This commit makes those methods pub and marks `LooseFieldElement` as `pub` as well. It can't be directly named or imported, but perhaps someone can actually make use of the `*_loose` operations in 3rd party crates, since `p521` itself is not using them.