### PR TITLE
Bump `elliptic-curve` to v0.13.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,8 +371,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.6"
-source = "git+https://github.com/RustCrypto/traits.git#723a1a309c4d987ec54c4c1f7bfe3686dc8d5a29"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9775b22bc152ad86a0cf23f0f348b884b26add12bf741e7ffc4d4ab2ab4d205"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io.elliptic-curve]
-git = "https://github.com/RustCrypto/traits.git"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.65"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "0.13", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "0.13.7", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
 once_cell = { version = "1.18", optional = true, default-features = false }

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-elliptic-curve = { version = "0.13", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.13.7", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.2", optional = true, default-features = false }


### PR DESCRIPTION
This notably contains the `BatchInvert`, `BatchNormalize`, and `LinearCombinationExt` traits, which we previously got by sourcing the crate from the upstream git repo.