### PR TITLE
primeorder v0.13.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primeorder"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "elliptic-curve",
  "serdect",

--- a/primeorder/CHANGELOG.md
+++ b/primeorder/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.4 (2023-11-15)
+### Added
+- `BatchInvert` and `BatchNormalize` impls ([#971])
+
+### Changed
+- Bump `elliptic-curve` to v0.13.7 ([#979])
+
+[#971]: https://github.com/RustCrypto/elliptic-curves/pull/971
+[#979]: https://github.com/RustCrypto/elliptic-curves/pull/979
+
 ## 0.13.3 (2023-11-02)
 ### Added
 - Inline annotations on `conditional_select` ([#942])

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.13.3"
+version = "0.13.4"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve


### PR DESCRIPTION
### Added
- `BatchInvert` and `BatchNormalize` impls ([#971])

### Changed
- Bump `elliptic-curve` to v0.13.7 ([#979])

[#971]: https://github.com/RustCrypto/elliptic-curves/pull/971
[#979]: https://github.com/RustCrypto/elliptic-curves/pull/979