### PR TITLE
primeorder: add `alloc` feature

### DIFF
--- a/.github/workflows/primeorder.yml
+++ b/.github/workflows/primeorder.yml
@@ -36,6 +36,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
 
   test:
     runs-on: ubuntu-latest

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -23,7 +23,8 @@ elliptic-curve = { version = "0.13.7", default-features = false, features = ["ar
 serdect = { version = "0.2", optional = true, default-features = false }
 
 [features]
-std = ["elliptic-curve/std"]
+alloc = ["elliptic-curve/alloc"]
+std = ["alloc", "elliptic-curve/std"]
 
 dev = []
 serde = ["elliptic-curve/serde", "serdect"]

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -8,6 +8,10 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc = include_str!("../README.md")]
 
+#[cfg(feature = "alloc")]
+#[macro_use]
+extern crate alloc;
+
 pub mod point_arithmetic;
 
 mod affine;

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -29,6 +29,9 @@ use elliptic_curve::{
     BatchNormalize, Error, FieldBytes, FieldBytesSize, PublicKey, Result, Scalar,
 };
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 /// Point on a Weierstrass curve in projective coordinates.
 #[derive(Clone, Copy, Debug)]
 pub struct ProjectivePoint<C: PrimeCurveParams> {
@@ -334,7 +337,7 @@ where
     #[inline]
     fn batch_normalize(projective: &[Self], affine: &mut [Self::AffineRepr]) {
         assert_eq!(projective.len(), affine.len());
-        let mut zs = vec![FieldElement::ONE; projective.len()];
+        let mut zs = vec![C::FieldElement::ONE; projective.len()];
         batch_normalize_generic(projective, zs.as_mut_slice(), affine);
     }
 }
@@ -364,7 +367,7 @@ where
     type Output = Vec<Self::AffineRepr>;
 
     #[inline]
-    fn batch_normalize(points: &[Self; N]) -> Vec<Self::AffineRepr> {
+    fn batch_normalize(points: &[Self]) -> Vec<Self::AffineRepr> {
         let mut zs = vec![C::FieldElement::ONE; points.len()];
         let mut affine_points = vec![AffinePoint::IDENTITY; points.len()];
         batch_normalize_generic(points, zs.as_mut_slice(), &mut affine_points);


### PR DESCRIPTION
There was previously code gated under `cfg(feature = "alloc")` but no `alloc` feature had actually been delcared.

This adds one and fixes some issues with the gated code.