### PR TITLE
primeorder: remove `Invert` bounds on `FieldElement`

### DIFF
--- a/primeorder/CHANGELOG.md
+++ b/primeorder/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.13.5 (2023-11-15)
+## 0.13.5 (2023-11-15) [YANKED]
 ### Added
 - `alloc` feature ([#982])
 
 [#982]: https://github.com/RustCrypto/elliptic-curves/pull/982
 
-## 0.13.4 (2023-11-15)
+## 0.13.4 (2023-11-15) [YANKED]
 ### Added
 - `BatchInvert` and `BatchNormalize` impls ([#971])
 

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -25,8 +25,6 @@ pub use elliptic_curve::{
     self, generic_array, point::Double, Field, FieldBytes, PrimeCurve, PrimeField,
 };
 
-use elliptic_curve::ops::Invert;
-use elliptic_curve::subtle::CtOption;
 use elliptic_curve::CurveArithmetic;
 
 /// Parameters for elliptic curves of prime order which can be described by the
@@ -38,8 +36,8 @@ pub trait PrimeCurveParams:
     + CurveArithmetic<ProjectivePoint = ProjectivePoint<Self>>
 {
     /// Base field element type.
-    type FieldElement: PrimeField<Repr = FieldBytes<Self>>
-        + Invert<Output = CtOption<Self::FieldElement>>;
+    // TODO(tarcieri): add `Invert` bound
+    type FieldElement: PrimeField<Repr = FieldBytes<Self>>;
 
     /// [Point arithmetic](point_arithmetic) implementation, might be optimized for this specific curve
     type PointArithmetic: point_arithmetic::PointArithmetic<Self>;

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -17,7 +17,7 @@ use elliptic_curve::{
         prime::{PrimeCurve, PrimeGroup},
         Group, GroupEncoding,
     },
-    ops::{BatchInvert, LinearCombination, MulByGenerator},
+    ops::{BatchInvert, Invert, LinearCombination, MulByGenerator},
     point::Double,
     rand_core::RngCore,
     sec1::{
@@ -333,19 +333,21 @@ where
         ProjectivePoint::to_affine(self)
     }
 
-    #[cfg(feature = "alloc")]
-    #[inline]
-    fn batch_normalize(projective: &[Self], affine: &mut [Self::AffineRepr]) {
-        assert_eq!(projective.len(), affine.len());
-        let mut zs = vec![C::FieldElement::ONE; projective.len()];
-        batch_normalize_generic(projective, zs.as_mut_slice(), affine);
-    }
+    // TODO(tarcieri): re-enable when we can add `Invert` bounds on `FieldElement`
+    // #[cfg(feature = "alloc")]
+    // #[inline]
+    // fn batch_normalize(projective: &[Self], affine: &mut [Self::AffineRepr]) {
+    //     assert_eq!(projective.len(), affine.len());
+    //     let mut zs = vec![C::FieldElement::ONE; projective.len()];
+    //     batch_normalize_generic(projective, zs.as_mut_slice(), affine);
+    // }
 }
 
 impl<const N: usize, C> BatchNormalize<[ProjectivePoint<C>; N]> for ProjectivePoint<C>
 where
     Self: Double,
     C: PrimeCurveParams,
+    C::FieldElement: Invert<Output = CtOption<C::FieldElement>>,
 {
     type Output = [Self::AffineRepr; N];
 
@@ -363,6 +365,7 @@ impl<C> BatchNormalize<[ProjectivePoint<C>]> for ProjectivePoint<C>
 where
     Self: Double,
     C: PrimeCurveParams,
+    C::FieldElement: Invert<Output = CtOption<C::FieldElement>>,
 {
     type Output = Vec<Self::AffineRepr>;
 


### PR DESCRIPTION
...as an associated type of `PrimeCurveParams`. This was an accidental breaking change which broke the build for released crates:

https://github.com/RustCrypto/elliptic-curves/issues/984