### PR TITLE
primeorder v0.13.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primeorder"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "elliptic-curve",
  "serdect",

--- a/primeorder/CHANGELOG.md
+++ b/primeorder/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.6 (2023-11-15)
+### Removed
+-  `Invert` bounds on `FieldElement` ([#985])
+
+[#985]: https://github.com/RustCrypto/elliptic-curves/pull/985
+
 ## 0.13.5 (2023-11-15) [YANKED]
 ### Added
 - `alloc` feature ([#982])

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.13.5"
+version = "0.13.6"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve


### PR DESCRIPTION
### Removed
-  `Invert` bounds on `FieldElement` ([#985])

[#985]: https://github.com/RustCrypto/elliptic-curves/pull/985