### PR TITLE
fix compilation errors if only the feature hash2curve is enabled

### DIFF
--- a/p256/src/arithmetic/hash2curve.rs
+++ b/p256/src/arithmetic/hash2curve.rs
@@ -93,7 +93,9 @@ impl FromOkm for Scalar {
 
 #[cfg(test)]
 mod tests {
-    use crate::{arithmetic::field::MODULUS, FieldElement, NistP256, Scalar, U256};
+    #[cfg(feature = "expose-field")]
+    use crate::FieldElement;
+    use crate::{arithmetic::field::MODULUS, NistP256, Scalar, U256};
     use elliptic_curve::{
         bigint::{ArrayEncoding, CheckedSub, NonZero, U384},
         consts::U48,
@@ -105,8 +107,10 @@ mod tests {
     };
     use hex_literal::hex;
     use proptest::{num::u64::ANY, prelude::ProptestConfig, proptest};
+    #[cfg(feature = "sha256")]
     use sha2::Sha256;
 
+    #[cfg(feature = "expose-field")]
     #[test]
     fn params() {
         let params = <FieldElement as OsswuMap>::PARAMS;
@@ -122,6 +126,7 @@ mod tests {
         assert_eq!(params.c2, c2);
     }
 
+    #[cfg(feature = "expose-field")]
     #[allow(dead_code)] // TODO(tarcieri): fix commented out code
     #[test]
     fn hash_to_curve() {
@@ -241,6 +246,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "sha256")]
     /// Taken from <https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-voprf#appendix-A.3>.
     #[test]
     fn hash_to_scalar_voprf() {

--- a/p256/tests/ecdsa.rs
+++ b/p256/tests/ecdsa.rs
@@ -1,6 +1,6 @@
 //! ECDSA tests.
 
-#![cfg(feature = "arithmetic")]
+#![cfg(all(feature = "arithmetic", feature = "ecdsa"))]
 
 use elliptic_curve::ops::Reduce;
 use p256::{


### PR DESCRIPTION
Without this patch:

```
$ cargo test --no-default-features --features hash2curve
   Compiling p256 v0.13.2 (/home/capitol/project/elliptic-curves/p256)
error[E0432]: unresolved import `crate::FieldElement`
  --> p256/src/arithmetic/hash2curve.rs:96:45
   |
96 |     use crate::{arithmetic::field::MODULUS, FieldElement, NistP256, Scalar, U256};
   |                                             ^^^^^^^^^^^^ no `FieldElement` in the root
   |
   = help: consider importing this struct through its public re-export instead:
           crate::arithmetic::FieldElement
note: found an item that was configured out
  --> p256/src/lib.rs:47:28
   |
47 | pub use arithmetic::field::FieldElement;
   |                            ^^^^^^^^^^^^
   = note: the item is gated behind the `expose-field` feature

error[E0432]: unresolved import `sha2`
   --> p256/src/arithmetic/hash2curve.rs:108:9
    |
108 |     use sha2::Sha256;
    |         ^^^^ use of undeclared crate or module `sha2`

error[E0432]: unresolved import `p256::ecdsa`
 --> p256/tests/ecdsa.rs:7:5
  |
7 |     ecdsa::{SigningKey, VerifyingKey},
  |     ^^^^^ could not find `ecdsa` in `p256`

error[E0283]: type annotations needed
  --> p256/tests/ecdsa.rs:14:70
   |
14 |         <NonZeroScalar as Reduce<U256>>::reduce_bytes(&bytes.into()).into()
   |                                                                      ^^^^
   |
   = note: cannot satisfy `_: From<NonZeroScalar<NistP256>>`
   = note: required for `NonZeroScalar<NistP256>` to implement `Into<_>`
help: try using a fully qualified path to specify the expected types
   |
14 |         <NonZeroScalar<NistP256> as Into<T>>::into(<NonZeroScalar as Reduce<U256>>::reduce_bytes(&bytes.into()))
   |         +++++++++++++++++++++++++++++++++++++++++++                                                            ~

error[E0282]: type annotations needed
  --> p256/tests/ecdsa.rs:22:30
   |
22 |         let (signature, v) = sk.sign_recoverable(msg).unwrap();
   |                              ^^ cannot infer type

Some errors have detailed explanations: E0282, E0283, E0432.
For more information about an error, try `rustc --explain E0282`.
error: could not compile `p256` (test "ecdsa") due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
warning: unused import: `group::cofactor::CofactorGroup`
   --> p256/src/arithmetic/hash2curve.rs:101:9
    |
101 |         group::cofactor::CofactorGroup,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default

warning: unused import: `MapToCurve`
   --> p256/src/arithmetic/hash2curve.rs:102:64
    |
102 |         hash2curve::{self, ExpandMsgXmd, FromOkm, GroupDigest, MapToCurve, OsswuMap},
    |                                                                ^^^^^^^^^^

For more information about this error, try `rustc --explain E0432`.
warning: `p256` (lib test) generated 2 warnings
error: could not compile `p256` (lib test) due to 2 previous errors; 2 warnings emitted
```