### PR TITLE
add more inlines for better efficiency

### DIFF
--- a/k256/benches/ecdsa.rs
+++ b/k256/benches/ecdsa.rs
@@ -1,6 +1,6 @@
 //! secp256k1 scalar arithmetic benchmarks
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ecdsa_core::{
     elliptic_curve::group::prime::PrimeCurveAffine,
     hazmat::{SignPrimitive, VerifyPrimitive},
@@ -44,14 +44,22 @@ fn bench_ecdsa(c: &mut Criterion) {
     let z = test_scalar_z();
 
     group.bench_function("try_sign_prehashed", |b| {
-        b.iter(|| d.try_sign_prehashed(k, &z).unwrap())
+        b.iter(|| {
+            black_box(d)
+                .try_sign_prehashed(black_box(k), &black_box(z))
+                .unwrap()
+        })
     });
 
     let q = (AffinePoint::generator() * d).to_affine();
     let s = d.try_sign_prehashed(k, &z).unwrap().0;
 
     group.bench_function("verify_prehashed", |b| {
-        b.iter(|| q.verify_prehashed(&z, &s).unwrap())
+        b.iter(|| {
+            black_box(q)
+                .verify_prehashed(&black_box(z), &black_box(s))
+                .unwrap()
+        })
     });
 
     group.finish();

--- a/k256/benches/field.rs
+++ b/k256/benches/field.rs
@@ -1,7 +1,7 @@
 //! secp256k1 field element benchmarks
 
 use criterion::{
-    criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, Criterion,
+    black_box, criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, Criterion,
 };
 use k256::FieldElement;
 
@@ -31,33 +31,35 @@ fn test_field_element_y() -> FieldElement {
 
 fn bench_field_element_normalize_weak<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let x = test_field_element_x();
-    group.bench_function("normalize_weak", |b| b.iter(|| x.normalize_weak()));
+    group.bench_function("normalize_weak", |b| {
+        b.iter(|| black_box(x).normalize_weak())
+    });
 }
 
 fn bench_field_element_normalize<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let x = test_field_element_x();
-    group.bench_function("normalize", |b| b.iter(|| x.normalize()));
+    group.bench_function("normalize", |b| b.iter(|| black_box(x).normalize()));
 }
 
 fn bench_field_element_mul<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let x = test_field_element_x();
     let y = test_field_element_y();
-    group.bench_function("mul", |b| b.iter(|| &x * &y));
+    group.bench_function("mul", |b| b.iter(|| &black_box(x) * &black_box(y)));
 }
 
 fn bench_field_element_square<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let x = test_field_element_x();
-    group.bench_function("square", |b| b.iter(|| x.square()));
+    group.bench_function("square", |b| b.iter(|| black_box(x).square()));
 }
 
 fn bench_field_element_sqrt<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let x = test_field_element_x();
-    group.bench_function("sqrt", |b| b.iter(|| x.sqrt()));
+    group.bench_function("sqrt", |b| b.iter(|| black_box(x).sqrt()));
 }
 
 fn bench_field_element_invert<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let x = test_field_element_x();
-    group.bench_function("invert", |b| b.iter(|| x.invert()));
+    group.bench_function("invert", |b| b.iter(|| black_box(x).invert()));
 }
 
 fn bench_field_element(c: &mut Criterion) {

--- a/k256/benches/scalar.rs
+++ b/k256/benches/scalar.rs
@@ -36,14 +36,6 @@ fn bench_point_mul<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     group.bench_function("point-scalar mul", |b| {
         b.iter(|| &black_box(p) * &black_box(s))
     });
-
-    #[inline(never)]
-    fn mul_with_diff_scalars_in_same_fn(p: &ProjectivePoint, s1: &Scalar, s2: &Scalar) -> ProjectivePoint {
-        p * s1 + p * s2 + p.double()
-    }
-    group.bench_function("point mul with different scalars in same fn", |b| {
-        b.iter(|| mul_with_diff_scalars_in_same_fn(&black_box(p), &black_box(s), &black_box(s)))
-    });
 }
 
 fn bench_point_lincomb<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {

--- a/k256/benches/scalar.rs
+++ b/k256/benches/scalar.rs
@@ -36,6 +36,14 @@ fn bench_point_mul<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     group.bench_function("point-scalar mul", |b| {
         b.iter(|| &black_box(p) * &black_box(s))
     });
+
+    #[inline(never)]
+    fn mul_with_diff_scalars_in_same_fn(p: &ProjectivePoint, s1: &Scalar, s2: &Scalar) -> ProjectivePoint {
+        p * s1 + p * s2 + p.double()
+    }
+    group.bench_function("point mul with different scalars in same fn", |b| {
+        b.iter(|| mul_with_diff_scalars_in_same_fn(&black_box(p), &black_box(s), &black_box(s)))
+    });
 }
 
 fn bench_point_lincomb<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {

--- a/k256/benches/scalar.rs
+++ b/k256/benches/scalar.rs
@@ -1,7 +1,7 @@
 //! secp256k1 scalar arithmetic benchmarks
 
 use criterion::{
-    criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, Criterion,
+    black_box, criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, Criterion,
 };
 use hex_literal::hex;
 use k256::{
@@ -33,16 +33,22 @@ fn bench_point_mul<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let p = ProjectivePoint::GENERATOR;
     let m = hex!("AA5E28D6A97A2479A65527F7290311A3624D4CC0FA1578598EE3C2613BF99522");
     let s = Scalar::from_repr(m.into()).unwrap();
-    group.bench_function("point-scalar mul", |b| b.iter(|| &p * &s));
+    group.bench_function("point-scalar mul", |b| {
+        b.iter(|| &black_box(p) * &black_box(s))
+    });
 }
 
 fn bench_point_lincomb<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let p = ProjectivePoint::GENERATOR;
     let m = hex!("AA5E28D6A97A2479A65527F7290311A3624D4CC0FA1578598EE3C2613BF99522");
     let s = Scalar::from_repr(m.into()).unwrap();
-    group.bench_function("lincomb via mul+add", |b| b.iter(|| &p * &s + &p * &s));
+    group.bench_function("lincomb via mul+add", |b| {
+        b.iter(|| &black_box(p) * &black_box(s) + &black_box(p) * &black_box(s))
+    });
     group.bench_function("lincomb()", |b| {
-        b.iter(|| ProjectivePoint::lincomb(&p, &s, &p, &s))
+        b.iter(|| {
+            ProjectivePoint::lincomb(&black_box(p), &black_box(s), &black_box(p), &black_box(s))
+        })
     });
 }
 
@@ -50,10 +56,12 @@ fn bench_point_mul_by_generator<'a, M: Measurement>(group: &mut BenchmarkGroup<'
     let p = ProjectivePoint::GENERATOR;
     let x = test_scalar_x();
 
-    group.bench_function("mul_by_generator naive", |b| b.iter(|| &p * &x));
+    group.bench_function("mul_by_generator naive", |b| {
+        b.iter(|| &black_box(p) * &black_box(x))
+    });
 
     group.bench_function("mul_by_generator precomputed", |b| {
-        b.iter(|| ProjectivePoint::mul_by_generator(&x))
+        b.iter(|| ProjectivePoint::mul_by_generator(&black_box(x)))
     });
 }
 
@@ -68,29 +76,29 @@ fn bench_high_level(c: &mut Criterion) {
 fn bench_scalar_sub<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let x = test_scalar_x();
     let y = test_scalar_y();
-    group.bench_function("sub", |b| b.iter(|| &x - &y));
+    group.bench_function("sub", |b| b.iter(|| &black_box(x) - &black_box(y)));
 }
 
 fn bench_scalar_add<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let x = test_scalar_x();
     let y = test_scalar_y();
-    group.bench_function("add", |b| b.iter(|| &x + &y));
+    group.bench_function("add", |b| b.iter(|| &black_box(x) + &black_box(y)));
 }
 
 fn bench_scalar_mul<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let x = test_scalar_x();
     let y = test_scalar_y();
-    group.bench_function("mul", |b| b.iter(|| &x * &y));
+    group.bench_function("mul", |b| b.iter(|| &black_box(x) * &black_box(y)));
 }
 
 fn bench_scalar_negate<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let x = test_scalar_x();
-    group.bench_function("negate", |b| b.iter(|| -x));
+    group.bench_function("negate", |b| b.iter(|| -black_box(x)));
 }
 
 fn bench_scalar_invert<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let x = test_scalar_x();
-    group.bench_function("invert", |b| b.iter(|| x.invert()));
+    group.bench_function("invert", |b| b.iter(|| black_box(x).invert()));
 }
 
 fn bench_scalar(c: &mut Criterion) {

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -120,7 +120,6 @@ impl AffineCoordinates for AffinePoint {
 }
 
 impl ConditionallySelectable for AffinePoint {
-    #[inline(always)]
     fn conditional_select(a: &AffinePoint, b: &AffinePoint, choice: Choice) -> AffinePoint {
         AffinePoint {
             x: FieldElement::conditional_select(&a.x, &b.x, choice),
@@ -131,7 +130,6 @@ impl ConditionallySelectable for AffinePoint {
 }
 
 impl ConstantTimeEq for AffinePoint {
-    #[inline(always)]
     fn ct_eq(&self, other: &AffinePoint) -> Choice {
         (self.x.negate(1) + &other.x).normalizes_to_zero()
             & (self.y.negate(1) + &other.y).normalizes_to_zero()
@@ -148,7 +146,6 @@ impl Default for AffinePoint {
 impl DefaultIsZeroes for AffinePoint {}
 
 impl PartialEq for AffinePoint {
-    #[inline(always)]
     fn eq(&self, other: &AffinePoint) -> bool {
         self.ct_eq(other).into()
     }
@@ -159,7 +156,6 @@ impl Eq for AffinePoint {}
 impl Mul<Scalar> for AffinePoint {
     type Output = ProjectivePoint;
 
-    #[inline(always)]
     fn mul(self, scalar: Scalar) -> ProjectivePoint {
         ProjectivePoint::from(self) * scalar
     }
@@ -168,7 +164,6 @@ impl Mul<Scalar> for AffinePoint {
 impl Mul<&Scalar> for AffinePoint {
     type Output = ProjectivePoint;
 
-    #[inline(always)]
     fn mul(self, scalar: &Scalar) -> ProjectivePoint {
         ProjectivePoint::from(self) * scalar
     }
@@ -177,7 +172,6 @@ impl Mul<&Scalar> for AffinePoint {
 impl Neg for AffinePoint {
     type Output = AffinePoint;
 
-    #[inline(always)]
     fn neg(self) -> Self::Output {
         AffinePoint {
             x: self.x,
@@ -188,7 +182,6 @@ impl Neg for AffinePoint {
 }
 
 impl DecompressPoint<Secp256k1> for AffinePoint {
-    #[inline(always)]
     fn decompress(x_bytes: &FieldBytes, y_is_odd: Choice) -> CtOption<Self> {
         FieldElement::from_bytes(x_bytes).and_then(|x| {
             let alpha = (x * &x * &x) + &CURVE_EQUATION_B;
@@ -212,7 +205,6 @@ impl DecompressPoint<Secp256k1> for AffinePoint {
 ///
 /// [BIP 340]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 impl DecompactPoint<Secp256k1> for AffinePoint {
-    #[inline(always)]
     fn decompact(x_bytes: &FieldBytes) -> CtOption<Self> {
         Self::decompress(x_bytes, Choice::from(0))
     }
@@ -221,7 +213,6 @@ impl DecompactPoint<Secp256k1> for AffinePoint {
 impl GroupEncoding for AffinePoint {
     type Repr = CompressedPoint;
 
-    #[inline(always)]
     fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
         EncodedPoint::from_bytes(bytes)
             .map(|point| CtOption::new(point, Choice::from(1)))
@@ -234,13 +225,11 @@ impl GroupEncoding for AffinePoint {
             .and_then(|point| Self::from_encoded_point(&point))
     }
 
-    #[inline(always)]
     fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
         // No unchecked conversion possible for compressed points
         Self::from_bytes(bytes)
     }
 
-    #[inline(always)]
     fn to_bytes(&self) -> Self::Repr {
         let encoded = self.to_encoded_point(true);
         let mut result = CompressedPoint::default();
@@ -255,7 +244,6 @@ impl FromEncodedPoint<Secp256k1> for AffinePoint {
     /// # Returns
     ///
     /// `None` value if `encoded_point` is not on the secp256k1 curve.
-    #[inline(always)]
     fn from_encoded_point(encoded_point: &EncodedPoint) -> CtOption<Self> {
         match encoded_point.coordinates() {
             sec1::Coordinates::Identity => CtOption::new(Self::IDENTITY, 1.into()),
@@ -282,7 +270,6 @@ impl FromEncodedPoint<Secp256k1> for AffinePoint {
 }
 
 impl ToEncodedPoint<Secp256k1> for AffinePoint {
-    #[inline(always)]
     fn to_encoded_point(&self, compress: bool) -> EncodedPoint {
         EncodedPoint::conditional_select(
             &EncodedPoint::from_affine_coordinates(

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -120,6 +120,7 @@ impl AffineCoordinates for AffinePoint {
 }
 
 impl ConditionallySelectable for AffinePoint {
+    #[inline(always)]
     fn conditional_select(a: &AffinePoint, b: &AffinePoint, choice: Choice) -> AffinePoint {
         AffinePoint {
             x: FieldElement::conditional_select(&a.x, &b.x, choice),
@@ -130,6 +131,7 @@ impl ConditionallySelectable for AffinePoint {
 }
 
 impl ConstantTimeEq for AffinePoint {
+    #[inline(always)]
     fn ct_eq(&self, other: &AffinePoint) -> Choice {
         (self.x.negate(1) + &other.x).normalizes_to_zero()
             & (self.y.negate(1) + &other.y).normalizes_to_zero()
@@ -146,6 +148,7 @@ impl Default for AffinePoint {
 impl DefaultIsZeroes for AffinePoint {}
 
 impl PartialEq for AffinePoint {
+    #[inline(always)]
     fn eq(&self, other: &AffinePoint) -> bool {
         self.ct_eq(other).into()
     }
@@ -156,6 +159,7 @@ impl Eq for AffinePoint {}
 impl Mul<Scalar> for AffinePoint {
     type Output = ProjectivePoint;
 
+    #[inline(always)]
     fn mul(self, scalar: Scalar) -> ProjectivePoint {
         ProjectivePoint::from(self) * scalar
     }
@@ -164,6 +168,7 @@ impl Mul<Scalar> for AffinePoint {
 impl Mul<&Scalar> for AffinePoint {
     type Output = ProjectivePoint;
 
+    #[inline(always)]
     fn mul(self, scalar: &Scalar) -> ProjectivePoint {
         ProjectivePoint::from(self) * scalar
     }
@@ -172,6 +177,7 @@ impl Mul<&Scalar> for AffinePoint {
 impl Neg for AffinePoint {
     type Output = AffinePoint;
 
+    #[inline(always)]
     fn neg(self) -> Self::Output {
         AffinePoint {
             x: self.x,
@@ -182,6 +188,7 @@ impl Neg for AffinePoint {
 }
 
 impl DecompressPoint<Secp256k1> for AffinePoint {
+    #[inline(always)]
     fn decompress(x_bytes: &FieldBytes, y_is_odd: Choice) -> CtOption<Self> {
         FieldElement::from_bytes(x_bytes).and_then(|x| {
             let alpha = (x * &x * &x) + &CURVE_EQUATION_B;
@@ -205,6 +212,7 @@ impl DecompressPoint<Secp256k1> for AffinePoint {
 ///
 /// [BIP 340]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 impl DecompactPoint<Secp256k1> for AffinePoint {
+    #[inline(always)]
     fn decompact(x_bytes: &FieldBytes) -> CtOption<Self> {
         Self::decompress(x_bytes, Choice::from(0))
     }
@@ -213,6 +221,7 @@ impl DecompactPoint<Secp256k1> for AffinePoint {
 impl GroupEncoding for AffinePoint {
     type Repr = CompressedPoint;
 
+    #[inline(always)]
     fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
         EncodedPoint::from_bytes(bytes)
             .map(|point| CtOption::new(point, Choice::from(1)))
@@ -225,11 +234,13 @@ impl GroupEncoding for AffinePoint {
             .and_then(|point| Self::from_encoded_point(&point))
     }
 
+    #[inline(always)]
     fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
         // No unchecked conversion possible for compressed points
         Self::from_bytes(bytes)
     }
 
+    #[inline(always)]
     fn to_bytes(&self) -> Self::Repr {
         let encoded = self.to_encoded_point(true);
         let mut result = CompressedPoint::default();
@@ -244,6 +255,7 @@ impl FromEncodedPoint<Secp256k1> for AffinePoint {
     /// # Returns
     ///
     /// `None` value if `encoded_point` is not on the secp256k1 curve.
+    #[inline(always)]
     fn from_encoded_point(encoded_point: &EncodedPoint) -> CtOption<Self> {
         match encoded_point.coordinates() {
             sec1::Coordinates::Identity => CtOption::new(Self::IDENTITY, 1.into()),
@@ -270,6 +282,7 @@ impl FromEncodedPoint<Secp256k1> for AffinePoint {
 }
 
 impl ToEncodedPoint<Secp256k1> for AffinePoint {
+    #[inline(always)]
     fn to_encoded_point(&self, compress: bool) -> EncodedPoint {
         EncodedPoint::conditional_select(
             &EncodedPoint::from_affine_coordinates(

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -63,7 +63,6 @@ impl FieldElement {
     /// # Returns
     ///
     /// If zero, return `Choice(1)`.  Otherwise, return `Choice(0)`.
-    #[inline(always)]
     pub fn is_zero(&self) -> Choice {
         self.0.is_zero()
     }
@@ -73,7 +72,6 @@ impl FieldElement {
     /// # Returns
     ///
     /// If even, return `Choice(1)`.  Otherwise, return `Choice(0)`.
-    #[inline(always)]
     pub fn is_even(&self) -> Choice {
         !self.0.is_odd()
     }
@@ -83,14 +81,12 @@ impl FieldElement {
     /// # Returns
     ///
     /// If odd, return `Choice(1)`.  Otherwise, return `Choice(0)`.
-    #[inline(always)]
     pub fn is_odd(&self) -> Choice {
         self.0.is_odd()
     }
 
     /// Attempts to parse the given byte array as an SEC1-encoded field element.
     /// Does not check the result for being in the correct range.
-    #[inline(always)]
     pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         Self(FieldElementImpl::from_bytes_unchecked(bytes))
     }
@@ -99,60 +95,51 @@ impl FieldElement {
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
-    #[inline(always)]
     pub fn from_bytes(bytes: &FieldBytes) -> CtOption<Self> {
         FieldElementImpl::from_bytes(bytes).map(Self)
     }
 
     /// Convert a `u64` to a field element.
-    #[inline(always)]
     pub const fn from_u64(w: u64) -> Self {
         Self(FieldElementImpl::from_u64(w))
     }
 
     /// Returns the SEC1 encoding of this field element.
-    #[inline(always)]
     pub fn to_bytes(self) -> FieldBytes {
         self.0.normalize().to_bytes()
     }
 
     /// Returns -self, treating it as a value of given magnitude.
     /// The provided magnitude must be equal or greater than the actual magnitude of `self`.
-    #[inline(always)]
     pub fn negate(&self, magnitude: u32) -> Self {
         Self(self.0.negate(magnitude))
     }
 
     /// Fully normalizes the field element.
     /// Brings the magnitude to 1 and modulo reduces the value.
-    #[inline(always)]
     pub fn normalize(&self) -> Self {
         Self(self.0.normalize())
     }
 
     /// Weakly normalizes the field element.
     /// Brings the magnitude to 1, but does not guarantee the value to be less than the modulus.
-    #[inline(always)]
     pub fn normalize_weak(&self) -> Self {
         Self(self.0.normalize_weak())
     }
 
     /// Checks if the field element becomes zero if normalized.
-    #[inline(always)]
     pub fn normalizes_to_zero(&self) -> Choice {
         self.0.normalizes_to_zero()
     }
 
     /// Multiplies by a single-limb integer.
     /// Multiplies the magnitude by the same value.
-    #[inline(always)]
     pub fn mul_single(&self, rhs: u32) -> Self {
         Self(self.0.mul_single(rhs))
     }
 
     /// Returns 2*self.
     /// Doubles the magnitude.
-    #[inline(always)]
     pub fn double(&self) -> Self {
         Self(self.0.add(&(self.0)))
     }
@@ -160,7 +147,6 @@ impl FieldElement {
     /// Returns self * rhs mod p
     /// Brings the magnitude to 1 (but doesn't normalize the result).
     /// The magnitudes of arguments should be <= 8.
-    #[inline(always)]
     pub fn mul(&self, rhs: &Self) -> Self {
         Self(self.0.mul(&(rhs.0)))
     }
@@ -169,13 +155,11 @@ impl FieldElement {
     ///
     /// Brings the magnitude to 1 (but doesn't normalize the result).
     /// The magnitudes of arguments should be <= 8.
-    #[inline(always)]
     pub fn square(&self) -> Self {
         Self(self.0.square())
     }
 
     /// Raises the scalar to the power `2^k`
-    #[inline(always)]
     fn pow2k(&self, k: usize) -> Self {
         let mut x = *self;
         for _j in 0..k {
@@ -186,7 +170,6 @@ impl FieldElement {
 
     /// Returns the multiplicative inverse of self, if self is non-zero.
     /// The result has magnitude 1, but is not normalized.
-    #[inline(always)]
     pub fn invert(&self) -> CtOption<Self> {
         // The binary representation of (p - 2) has 5 blocks of 1s, with lengths in
         // { 1, 2, 22, 223 }. Use an addition chain to calculate 2^n - 1 for each block:
@@ -220,7 +203,6 @@ impl FieldElement {
 
     /// Returns the square root of self mod p, or `None` if no square root exists.
     /// The result has magnitude 1, but is not normalized.
-    #[inline(always)]
     pub fn sqrt(&self) -> CtOption<Self> {
         /*
         Given that p is congruent to 3 mod 4, we can compute the square root of
@@ -267,7 +249,6 @@ impl FieldElement {
 impl Invert for FieldElement {
     type Output = CtOption<Self>;
 
-    #[inline(always)]
     fn invert(&self) -> CtOption<Self> {
         self.invert()
     }
@@ -277,7 +258,6 @@ impl Field for FieldElement {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    #[inline(always)]
     fn random(mut rng: impl RngCore) -> Self {
         let mut bytes = FieldBytes::default();
 
@@ -290,28 +270,23 @@ impl Field for FieldElement {
     }
 
     #[must_use]
-    #[inline(always)]
     fn square(&self) -> Self {
         self.square()
     }
 
     #[must_use]
-    #[inline(always)]
     fn double(&self) -> Self {
         self.double()
     }
 
-    #[inline(always)]
     fn invert(&self) -> CtOption<Self> {
         self.invert()
     }
 
-    #[inline(always)]
     fn sqrt(&self) -> CtOption<Self> {
         self.sqrt()
     }
 
-    #[inline(always)]
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
         ff::helpers::sqrt_ratio_generic(num, div)
     }
@@ -343,17 +318,14 @@ impl PrimeField for FieldElement {
     ]));
     const DELTA: Self = Self::from_u64(9);
 
-    #[inline(always)]
     fn from_repr(repr: Self::Repr) -> CtOption<Self> {
         Self::from_bytes(&repr)
     }
 
-    #[inline(always)]
     fn to_repr(&self) -> Self::Repr {
         self.to_bytes()
     }
 
-    #[inline(always)]
     fn is_odd(&self) -> Choice {
         self.is_odd()
     }
@@ -367,14 +339,12 @@ impl ConditionallySelectable for FieldElement {
 }
 
 impl ConstantTimeEq for FieldElement {
-    #[inline(always)]
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&(other.0))
     }
 }
 
 impl Default for FieldElement {
-    #[inline(always)]
     fn default() -> Self {
         Self::ZERO
     }
@@ -385,14 +355,12 @@ impl DefaultIsZeroes for FieldElement {}
 impl Eq for FieldElement {}
 
 impl From<u64> for FieldElement {
-    #[inline(always)]
     fn from(k: u64) -> Self {
         Self(FieldElementImpl::from_u64(k))
     }
 }
 
 impl PartialEq for FieldElement {
-    #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         self.0.ct_eq(&(other.0)).into()
     }
@@ -401,7 +369,6 @@ impl PartialEq for FieldElement {
 impl Add<FieldElement> for FieldElement {
     type Output = FieldElement;
 
-    #[inline(always)]
     fn add(self, other: FieldElement) -> FieldElement {
         FieldElement(self.0.add(&(other.0)))
     }
@@ -410,7 +377,6 @@ impl Add<FieldElement> for FieldElement {
 impl Add<&FieldElement> for FieldElement {
     type Output = FieldElement;
 
-    #[inline(always)]
     fn add(self, other: &FieldElement) -> FieldElement {
         FieldElement(self.0.add(&(other.0)))
     }
@@ -419,21 +385,18 @@ impl Add<&FieldElement> for FieldElement {
 impl Add<&FieldElement> for &FieldElement {
     type Output = FieldElement;
 
-    #[inline(always)]
     fn add(self, other: &FieldElement) -> FieldElement {
         FieldElement(self.0.add(&(other.0)))
     }
 }
 
 impl AddAssign<FieldElement> for FieldElement {
-    #[inline(always)]
     fn add_assign(&mut self, other: FieldElement) {
         *self = *self + &other;
     }
 }
 
 impl AddAssign<&FieldElement> for FieldElement {
-    #[inline(always)]
     fn add_assign(&mut self, other: &FieldElement) {
         *self = *self + other;
     }
@@ -442,7 +405,6 @@ impl AddAssign<&FieldElement> for FieldElement {
 impl Sub<FieldElement> for FieldElement {
     type Output = FieldElement;
 
-    #[inline(always)]
     fn sub(self, other: FieldElement) -> FieldElement {
         self + -other
     }
@@ -451,7 +413,6 @@ impl Sub<FieldElement> for FieldElement {
 impl Sub<&FieldElement> for FieldElement {
     type Output = FieldElement;
 
-    #[inline(always)]
     fn sub(self, other: &FieldElement) -> FieldElement {
         self + -other
     }
@@ -464,7 +425,6 @@ impl SubAssign<FieldElement> for FieldElement {
 }
 
 impl SubAssign<&FieldElement> for FieldElement {
-    #[inline(always)]
     fn sub_assign(&mut self, other: &FieldElement) {
         *self = *self + -other;
     }
@@ -473,7 +433,6 @@ impl SubAssign<&FieldElement> for FieldElement {
 impl Mul<FieldElement> for FieldElement {
     type Output = FieldElement;
 
-    #[inline(always)]
     fn mul(self, other: FieldElement) -> FieldElement {
         FieldElement(self.0.mul(&(other.0)))
     }
@@ -482,7 +441,6 @@ impl Mul<FieldElement> for FieldElement {
 impl Mul<&FieldElement> for FieldElement {
     type Output = FieldElement;
 
-    #[inline(always)]
     fn mul(self, other: &FieldElement) -> FieldElement {
         FieldElement(self.0.mul(&(other.0)))
     }
@@ -491,21 +449,18 @@ impl Mul<&FieldElement> for FieldElement {
 impl Mul<&FieldElement> for &FieldElement {
     type Output = FieldElement;
 
-    #[inline(always)]
     fn mul(self, other: &FieldElement) -> FieldElement {
         FieldElement(self.0.mul(&(other.0)))
     }
 }
 
 impl MulAssign<FieldElement> for FieldElement {
-    #[inline(always)]
     fn mul_assign(&mut self, rhs: FieldElement) {
         *self = *self * &rhs;
     }
 }
 
 impl MulAssign<&FieldElement> for FieldElement {
-    #[inline(always)]
     fn mul_assign(&mut self, rhs: &FieldElement) {
         *self = *self * rhs;
     }
@@ -514,7 +469,6 @@ impl MulAssign<&FieldElement> for FieldElement {
 impl Neg for FieldElement {
     type Output = FieldElement;
 
-    #[inline(always)]
     fn neg(self) -> FieldElement {
         self.negate(1)
     }
@@ -523,35 +477,30 @@ impl Neg for FieldElement {
 impl Neg for &FieldElement {
     type Output = FieldElement;
 
-    #[inline(always)]
     fn neg(self) -> FieldElement {
         self.negate(1)
     }
 }
 
 impl Sum for FieldElement {
-    #[inline(always)]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.reduce(core::ops::Add::add).unwrap_or(Self::ZERO)
     }
 }
 
 impl<'a> Sum<&'a FieldElement> for FieldElement {
-    #[inline(always)]
     fn sum<I: Iterator<Item = &'a FieldElement>>(iter: I) -> Self {
         iter.copied().sum()
     }
 }
 
 impl Product for FieldElement {
-    #[inline(always)]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.reduce(core::ops::Mul::mul).unwrap_or(Self::ONE)
     }
 }
 
 impl<'a> Product<&'a FieldElement> for FieldElement {
-    #[inline(always)]
     fn product<I: Iterator<Item = &'a FieldElement>>(iter: I) -> Self {
         iter.copied().product()
     }

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -63,6 +63,7 @@ impl FieldElement {
     /// # Returns
     ///
     /// If zero, return `Choice(1)`.  Otherwise, return `Choice(0)`.
+    #[inline(always)]
     pub fn is_zero(&self) -> Choice {
         self.0.is_zero()
     }
@@ -72,6 +73,7 @@ impl FieldElement {
     /// # Returns
     ///
     /// If even, return `Choice(1)`.  Otherwise, return `Choice(0)`.
+    #[inline(always)]
     pub fn is_even(&self) -> Choice {
         !self.0.is_odd()
     }
@@ -81,12 +83,14 @@ impl FieldElement {
     /// # Returns
     ///
     /// If odd, return `Choice(1)`.  Otherwise, return `Choice(0)`.
+    #[inline(always)]
     pub fn is_odd(&self) -> Choice {
         self.0.is_odd()
     }
 
     /// Attempts to parse the given byte array as an SEC1-encoded field element.
     /// Does not check the result for being in the correct range.
+    #[inline(always)]
     pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         Self(FieldElementImpl::from_bytes_unchecked(bytes))
     }
@@ -95,51 +99,60 @@ impl FieldElement {
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
+    #[inline(always)]
     pub fn from_bytes(bytes: &FieldBytes) -> CtOption<Self> {
         FieldElementImpl::from_bytes(bytes).map(Self)
     }
 
     /// Convert a `u64` to a field element.
+    #[inline(always)]
     pub const fn from_u64(w: u64) -> Self {
         Self(FieldElementImpl::from_u64(w))
     }
 
     /// Returns the SEC1 encoding of this field element.
+    #[inline(always)]
     pub fn to_bytes(self) -> FieldBytes {
         self.0.normalize().to_bytes()
     }
 
     /// Returns -self, treating it as a value of given magnitude.
     /// The provided magnitude must be equal or greater than the actual magnitude of `self`.
+    #[inline(always)]
     pub fn negate(&self, magnitude: u32) -> Self {
         Self(self.0.negate(magnitude))
     }
 
     /// Fully normalizes the field element.
     /// Brings the magnitude to 1 and modulo reduces the value.
+    #[inline(always)]
     pub fn normalize(&self) -> Self {
         Self(self.0.normalize())
     }
 
     /// Weakly normalizes the field element.
     /// Brings the magnitude to 1, but does not guarantee the value to be less than the modulus.
+    #[inline(always)]
     pub fn normalize_weak(&self) -> Self {
         Self(self.0.normalize_weak())
     }
 
     /// Checks if the field element becomes zero if normalized.
+    #[inline(always)]
     pub fn normalizes_to_zero(&self) -> Choice {
         self.0.normalizes_to_zero()
     }
 
     /// Multiplies by a single-limb integer.
     /// Multiplies the magnitude by the same value.
+    #[inline(always)]
     pub fn mul_single(&self, rhs: u32) -> Self {
         Self(self.0.mul_single(rhs))
     }
 
     /// Returns 2*self.
     /// Doubles the magnitude.
+    #[inline(always)]
     pub fn double(&self) -> Self {
         Self(self.0.add(&(self.0)))
     }
@@ -147,6 +160,7 @@ impl FieldElement {
     /// Returns self * rhs mod p
     /// Brings the magnitude to 1 (but doesn't normalize the result).
     /// The magnitudes of arguments should be <= 8.
+    #[inline(always)]
     pub fn mul(&self, rhs: &Self) -> Self {
         Self(self.0.mul(&(rhs.0)))
     }
@@ -155,11 +169,13 @@ impl FieldElement {
     ///
     /// Brings the magnitude to 1 (but doesn't normalize the result).
     /// The magnitudes of arguments should be <= 8.
+    #[inline(always)]
     pub fn square(&self) -> Self {
         Self(self.0.square())
     }
 
     /// Raises the scalar to the power `2^k`
+    #[inline(always)]
     fn pow2k(&self, k: usize) -> Self {
         let mut x = *self;
         for _j in 0..k {
@@ -170,6 +186,7 @@ impl FieldElement {
 
     /// Returns the multiplicative inverse of self, if self is non-zero.
     /// The result has magnitude 1, but is not normalized.
+    #[inline(always)]
     pub fn invert(&self) -> CtOption<Self> {
         // The binary representation of (p - 2) has 5 blocks of 1s, with lengths in
         // { 1, 2, 22, 223 }. Use an addition chain to calculate 2^n - 1 for each block:
@@ -203,6 +220,7 @@ impl FieldElement {
 
     /// Returns the square root of self mod p, or `None` if no square root exists.
     /// The result has magnitude 1, but is not normalized.
+    #[inline(always)]
     pub fn sqrt(&self) -> CtOption<Self> {
         /*
         Given that p is congruent to 3 mod 4, we can compute the square root of
@@ -249,6 +267,7 @@ impl FieldElement {
 impl Invert for FieldElement {
     type Output = CtOption<Self>;
 
+    #[inline(always)]
     fn invert(&self) -> CtOption<Self> {
         self.invert()
     }
@@ -258,6 +277,7 @@ impl Field for FieldElement {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
+    #[inline(always)]
     fn random(mut rng: impl RngCore) -> Self {
         let mut bytes = FieldBytes::default();
 
@@ -270,23 +290,28 @@ impl Field for FieldElement {
     }
 
     #[must_use]
+    #[inline(always)]
     fn square(&self) -> Self {
         self.square()
     }
 
     #[must_use]
+    #[inline(always)]
     fn double(&self) -> Self {
         self.double()
     }
 
+    #[inline(always)]
     fn invert(&self) -> CtOption<Self> {
         self.invert()
     }
 
+    #[inline(always)]
     fn sqrt(&self) -> CtOption<Self> {
         self.sqrt()
     }
 
+    #[inline(always)]
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
         ff::helpers::sqrt_ratio_generic(num, div)
     }
@@ -318,14 +343,17 @@ impl PrimeField for FieldElement {
     ]));
     const DELTA: Self = Self::from_u64(9);
 
+    #[inline(always)]
     fn from_repr(repr: Self::Repr) -> CtOption<Self> {
         Self::from_bytes(&repr)
     }
 
+    #[inline(always)]
     fn to_repr(&self) -> Self::Repr {
         self.to_bytes()
     }
 
+    #[inline(always)]
     fn is_odd(&self) -> Choice {
         self.is_odd()
     }
@@ -339,12 +367,14 @@ impl ConditionallySelectable for FieldElement {
 }
 
 impl ConstantTimeEq for FieldElement {
+    #[inline(always)]
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&(other.0))
     }
 }
 
 impl Default for FieldElement {
+    #[inline(always)]
     fn default() -> Self {
         Self::ZERO
     }
@@ -355,12 +385,14 @@ impl DefaultIsZeroes for FieldElement {}
 impl Eq for FieldElement {}
 
 impl From<u64> for FieldElement {
+    #[inline(always)]
     fn from(k: u64) -> Self {
         Self(FieldElementImpl::from_u64(k))
     }
 }
 
 impl PartialEq for FieldElement {
+    #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         self.0.ct_eq(&(other.0)).into()
     }
@@ -369,6 +401,7 @@ impl PartialEq for FieldElement {
 impl Add<FieldElement> for FieldElement {
     type Output = FieldElement;
 
+    #[inline(always)]
     fn add(self, other: FieldElement) -> FieldElement {
         FieldElement(self.0.add(&(other.0)))
     }
@@ -377,6 +410,7 @@ impl Add<FieldElement> for FieldElement {
 impl Add<&FieldElement> for FieldElement {
     type Output = FieldElement;
 
+    #[inline(always)]
     fn add(self, other: &FieldElement) -> FieldElement {
         FieldElement(self.0.add(&(other.0)))
     }
@@ -385,18 +419,21 @@ impl Add<&FieldElement> for FieldElement {
 impl Add<&FieldElement> for &FieldElement {
     type Output = FieldElement;
 
+    #[inline(always)]
     fn add(self, other: &FieldElement) -> FieldElement {
         FieldElement(self.0.add(&(other.0)))
     }
 }
 
 impl AddAssign<FieldElement> for FieldElement {
+    #[inline(always)]
     fn add_assign(&mut self, other: FieldElement) {
         *self = *self + &other;
     }
 }
 
 impl AddAssign<&FieldElement> for FieldElement {
+    #[inline(always)]
     fn add_assign(&mut self, other: &FieldElement) {
         *self = *self + other;
     }
@@ -405,6 +442,7 @@ impl AddAssign<&FieldElement> for FieldElement {
 impl Sub<FieldElement> for FieldElement {
     type Output = FieldElement;
 
+    #[inline(always)]
     fn sub(self, other: FieldElement) -> FieldElement {
         self + -other
     }
@@ -413,6 +451,7 @@ impl Sub<FieldElement> for FieldElement {
 impl Sub<&FieldElement> for FieldElement {
     type Output = FieldElement;
 
+    #[inline(always)]
     fn sub(self, other: &FieldElement) -> FieldElement {
         self + -other
     }
@@ -425,6 +464,7 @@ impl SubAssign<FieldElement> for FieldElement {
 }
 
 impl SubAssign<&FieldElement> for FieldElement {
+    #[inline(always)]
     fn sub_assign(&mut self, other: &FieldElement) {
         *self = *self + -other;
     }
@@ -433,6 +473,7 @@ impl SubAssign<&FieldElement> for FieldElement {
 impl Mul<FieldElement> for FieldElement {
     type Output = FieldElement;
 
+    #[inline(always)]
     fn mul(self, other: FieldElement) -> FieldElement {
         FieldElement(self.0.mul(&(other.0)))
     }
@@ -441,6 +482,7 @@ impl Mul<FieldElement> for FieldElement {
 impl Mul<&FieldElement> for FieldElement {
     type Output = FieldElement;
 
+    #[inline(always)]
     fn mul(self, other: &FieldElement) -> FieldElement {
         FieldElement(self.0.mul(&(other.0)))
     }
@@ -449,18 +491,21 @@ impl Mul<&FieldElement> for FieldElement {
 impl Mul<&FieldElement> for &FieldElement {
     type Output = FieldElement;
 
+    #[inline(always)]
     fn mul(self, other: &FieldElement) -> FieldElement {
         FieldElement(self.0.mul(&(other.0)))
     }
 }
 
 impl MulAssign<FieldElement> for FieldElement {
+    #[inline(always)]
     fn mul_assign(&mut self, rhs: FieldElement) {
         *self = *self * &rhs;
     }
 }
 
 impl MulAssign<&FieldElement> for FieldElement {
+    #[inline(always)]
     fn mul_assign(&mut self, rhs: &FieldElement) {
         *self = *self * rhs;
     }
@@ -469,6 +514,7 @@ impl MulAssign<&FieldElement> for FieldElement {
 impl Neg for FieldElement {
     type Output = FieldElement;
 
+    #[inline(always)]
     fn neg(self) -> FieldElement {
         self.negate(1)
     }
@@ -477,30 +523,35 @@ impl Neg for FieldElement {
 impl Neg for &FieldElement {
     type Output = FieldElement;
 
+    #[inline(always)]
     fn neg(self) -> FieldElement {
         self.negate(1)
     }
 }
 
 impl Sum for FieldElement {
+    #[inline(always)]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.reduce(core::ops::Add::add).unwrap_or(Self::ZERO)
     }
 }
 
 impl<'a> Sum<&'a FieldElement> for FieldElement {
+    #[inline(always)]
     fn sum<I: Iterator<Item = &'a FieldElement>>(iter: I) -> Self {
         iter.copied().sum()
     }
 }
 
 impl Product for FieldElement {
+    #[inline(always)]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.reduce(core::ops::Mul::mul).unwrap_or(Self::ONE)
     }
 }
 
 impl<'a> Product<&'a FieldElement> for FieldElement {
+    #[inline(always)]
     fn product<I: Iterator<Item = &'a FieldElement>>(iter: I) -> Self {
         iter.copied().product()
     }

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -441,6 +441,7 @@ impl Mul<FieldElement> for FieldElement {
 impl Mul<&FieldElement> for FieldElement {
     type Output = FieldElement;
 
+    #[inline(always)]
     fn mul(self, other: &FieldElement) -> FieldElement {
         FieldElement(self.0.mul(&(other.0)))
     }
@@ -489,6 +490,7 @@ impl Sum for FieldElement {
 }
 
 impl<'a> Sum<&'a FieldElement> for FieldElement {
+    #[inline(always)]
     fn sum<I: Iterator<Item = &'a FieldElement>>(iter: I) -> Self {
         iter.copied().sum()
     }

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -490,7 +490,7 @@ impl Sum for FieldElement {
 }
 
 impl<'a> Sum<&'a FieldElement> for FieldElement {
-    #[inline(always)]
+    #[inline]
     fn sum<I: Iterator<Item = &'a FieldElement>>(iter: I) -> Self {
         iter.copied().sum()
     }

--- a/k256/src/arithmetic/field/field_5x52.rs
+++ b/k256/src/arithmetic/field/field_5x52.rs
@@ -71,7 +71,7 @@ impl FieldElement5x52 {
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
-    #[inline(always)]
+    #[inline]
     pub fn from_bytes(bytes: &FieldBytes) -> CtOption<Self> {
         let res = Self::from_bytes_unchecked(bytes.as_ref());
         let overflow = res.get_overflow();

--- a/k256/src/arithmetic/field/field_5x52.rs
+++ b/k256/src/arithmetic/field/field_5x52.rs
@@ -24,7 +24,6 @@ impl FieldElement5x52 {
 
     /// Attempts to parse the given byte array as an SEC1-encoded field element.
     /// Does not check the result for being in the correct range.
-    #[inline(always)]
     pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         let w0 = (bytes[31] as u64)
             | ((bytes[30] as u64) << 8)
@@ -72,14 +71,12 @@ impl FieldElement5x52 {
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
-    #[inline(always)]
     pub fn from_bytes(bytes: &FieldBytes) -> CtOption<Self> {
         let res = Self::from_bytes_unchecked(bytes.as_ref());
         let overflow = res.get_overflow();
         CtOption::new(res, !overflow)
     }
 
-    #[inline(always)]
     pub const fn from_u64(val: u64) -> Self {
         let w0 = val & 0xFFFFFFFFFFFFF;
         let w1 = val >> 52;
@@ -87,7 +84,6 @@ impl FieldElement5x52 {
     }
 
     /// Returns the SEC1 encoding of this field element.
-    #[inline(always)]
     pub fn to_bytes(self) -> FieldBytes {
         let mut ret = FieldBytes::default();
         ret[0] = (self.0[4] >> 40) as u8;
@@ -126,7 +122,6 @@ impl FieldElement5x52 {
     }
 
     /// Adds `x * (2^256 - modulus)`.
-    #[inline(always)]
     fn add_modulus_correction(&self, x: u64) -> Self {
         // add (2^256 - modulus) * x to the first limb
         let t0 = self.0[0] + x * 0x1000003D1u64;
@@ -149,7 +144,6 @@ impl FieldElement5x52 {
 
     /// Subtracts the overflow in the last limb and return it with the new field element.
     /// Equivalent to subtracting a multiple of 2^256.
-    #[inline(always)]
     fn subtract_modulus_approximation(&self) -> (Self, u64) {
         let x = self.0[4] >> 48;
         let t4 = self.0[4] & 0x0FFFFFFFFFFFFu64; // equivalent to self -= 2^256 * x
@@ -157,7 +151,6 @@ impl FieldElement5x52 {
     }
 
     /// Checks if the field element is greater or equal to the modulus.
-    #[inline(always)]
     fn get_overflow(&self) -> Choice {
         let m = self.0[1] & self.0[2] & self.0[3];
         let x = (self.0[4] >> 48 != 0)
@@ -168,7 +161,6 @@ impl FieldElement5x52 {
     }
 
     /// Brings the field element's magnitude to 1, but does not necessarily normalize it.
-    #[inline(always)]
     pub fn normalize_weak(&self) -> Self {
         // Reduce t4 at the start so there will be at most a single carry from the first pass
         let (t, x) = self.subtract_modulus_approximation();
@@ -185,7 +177,6 @@ impl FieldElement5x52 {
     /// Fully normalizes the field element.
     /// That is, first four limbs are at most 52 bit large, the last limb is at most 48 bit large,
     /// and the value is less than the modulus.
-    #[inline(always)]
     pub fn normalize(&self) -> Self {
         let res = self.normalize_weak();
 
@@ -206,7 +197,6 @@ impl FieldElement5x52 {
     }
 
     /// Checks if the field element becomes zero if normalized.
-    #[inline(always)]
     pub fn normalizes_to_zero(&self) -> Choice {
         let res = self.normalize_weak();
 
@@ -228,7 +218,6 @@ impl FieldElement5x52 {
     /// # Returns
     ///
     /// If zero, return `Choice(1)`.  Otherwise, return `Choice(0)`.
-    #[inline(always)]
     pub fn is_zero(&self) -> Choice {
         Choice::from(((self.0[0] | self.0[1] | self.0[2] | self.0[3] | self.0[4]) == 0) as u8)
     }
@@ -238,7 +227,6 @@ impl FieldElement5x52 {
     /// # Returns
     ///
     /// If odd, return `Choice(1)`.  Otherwise, return `Choice(0)`.
-    #[inline(always)]
     pub fn is_odd(&self) -> Choice {
         (self.0[0] as u8 & 1).into()
     }
@@ -252,7 +240,6 @@ impl FieldElement5x52 {
     /// Returns -self, treating it as a value of given magnitude.
     /// The provided magnitude must be equal or greater than the actual magnitude of `self`.
     /// Raises the magnitude by 1.
-    #[inline(always)]
     pub const fn negate(&self, magnitude: u32) -> Self {
         let m = (magnitude + 1) as u64;
         let r0 = 0xFFFFEFFFFFC2Fu64 * 2 * m - self.0[0];
@@ -265,7 +252,6 @@ impl FieldElement5x52 {
 
     /// Returns self + rhs mod p.
     /// Sums the magnitudes.
-    #[inline(always)]
     pub const fn add(&self, rhs: &Self) -> Self {
         Self([
             self.0[0] + rhs.0[0],
@@ -278,7 +264,6 @@ impl FieldElement5x52 {
 
     /// Multiplies by a single-limb integer.
     /// Multiplies the magnitude by the same value.
-    #[inline(always)]
     pub const fn mul_single(&self, rhs: u32) -> Self {
         let rhs_u64 = rhs as u64;
         Self([
@@ -457,7 +442,6 @@ impl FieldElement5x52 {
     /// Returns self * rhs mod p
     /// Brings the magnitude to 1 (but doesn't normalize the result).
     /// The magnitudes of arguments should be <= 8.
-    #[inline(always)]
     pub fn mul(&self, rhs: &Self) -> Self {
         self.mul_inner(rhs)
     }
@@ -465,7 +449,6 @@ impl FieldElement5x52 {
     /// Returns self * self
     /// Brings the magnitude to 1 (but doesn't normalize the result).
     /// The magnitudes of arguments should be <= 8.
-    #[inline(always)]
     pub fn square(&self) -> Self {
         self.mul_inner(self)
     }
@@ -495,7 +478,6 @@ impl ConditionallySelectable for FieldElement5x52 {
 }
 
 impl ConstantTimeEq for FieldElement5x52 {
-    #[inline(always)]
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0[0].ct_eq(&other.0[0])
             & self.0[1].ct_eq(&other.0[1])
@@ -506,7 +488,6 @@ impl ConstantTimeEq for FieldElement5x52 {
 }
 
 impl Zeroize for FieldElement5x52 {
-    #[inline(always)]
     fn zeroize(&mut self) {
         self.0.zeroize();
     }

--- a/k256/src/arithmetic/field/field_5x52.rs
+++ b/k256/src/arithmetic/field/field_5x52.rs
@@ -71,6 +71,7 @@ impl FieldElement5x52 {
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
+    #[inline(always)]
     pub fn from_bytes(bytes: &FieldBytes) -> CtOption<Self> {
         let res = Self::from_bytes_unchecked(bytes.as_ref());
         let overflow = res.get_overflow();
@@ -442,6 +443,7 @@ impl FieldElement5x52 {
     /// Returns self * rhs mod p
     /// Brings the magnitude to 1 (but doesn't normalize the result).
     /// The magnitudes of arguments should be <= 8.
+    #[inline(always)]
     pub fn mul(&self, rhs: &Self) -> Self {
         self.mul_inner(rhs)
     }

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -575,7 +575,7 @@ impl Add<&Scalar> for Scalar {
 }
 
 impl AddAssign<Scalar> for Scalar {
-    #[inline(always)]
+    #[inline]
     fn add_assign(&mut self, rhs: Scalar) {
         *self = Scalar::add(self, &rhs);
     }

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -575,6 +575,7 @@ impl Add<&Scalar> for Scalar {
 }
 
 impl AddAssign<Scalar> for Scalar {
+    #[inline(always)]
     fn add_assign(&mut self, rhs: Scalar) {
         *self = Scalar::add(self, &rhs);
     }

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -83,31 +83,26 @@ impl Scalar {
     pub const ONE: Self = Self(U256::ONE);
 
     /// Checks if the scalar is zero.
-    #[inline(always)]
     pub fn is_zero(&self) -> Choice {
         self.0.is_zero()
     }
 
     /// Returns the SEC1 encoding of this scalar.
-    #[inline(always)]
     pub fn to_bytes(&self) -> FieldBytes {
         self.0.to_be_byte_array()
     }
 
     /// Negates the scalar.
-    #[inline(always)]
     pub const fn negate(&self) -> Self {
         Self(self.0.neg_mod(&ORDER))
     }
 
     /// Returns self + rhs mod n.
-    #[inline(always)]
     pub const fn add(&self, rhs: &Self) -> Self {
         Self(self.0.add_mod(&rhs.0, &ORDER))
     }
 
     /// Returns self - rhs mod n.
-    #[inline(always)]
     pub const fn sub(&self, rhs: &Self) -> Self {
         Self(self.0.sub_mod(&rhs.0, &ORDER))
     }
@@ -118,7 +113,6 @@ impl Scalar {
     }
 
     /// Modulo squares the scalar.
-    #[inline(always)]
     pub fn square(&self) -> Self {
         self.mul(self)
     }
@@ -126,7 +120,6 @@ impl Scalar {
     /// Right shifts the scalar.
     ///
     /// Note: not constant-time with respect to the `shift` parameter.
-    #[inline(always)]
     pub fn shr_vartime(&self, shift: usize) -> Scalar {
         Self(self.0.shr_vartime(shift))
     }
@@ -189,7 +182,6 @@ impl Scalar {
     }
 
     /// Returns a (nearly) uniformly-random scalar, generated in constant time.
-    #[inline(always)]
     pub fn generate_biased(rng: &mut impl CryptoRngCore) -> Self {
         // We reduce a random 512-bit value into a 256-bit field, which results in a
         // negligible bias from the uniform distribution, but the process is constant-time.
@@ -200,7 +192,6 @@ impl Scalar {
 
     /// Returns a uniformly-random scalar, generated using rejection sampling.
     // TODO(tarcieri): make this a `CryptoRng` when `ff` allows it
-    #[inline(always)]
     pub fn generate_vartime(rng: &mut impl RngCore) -> Self {
         let mut bytes = FieldBytes::default();
 
@@ -215,13 +206,11 @@ impl Scalar {
 
     /// Attempts to parse the given byte array as a scalar.
     /// Does not check the result for being in the correct range.
-    #[inline(always)]
     pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
         Self(U256::from_be_slice(bytes))
     }
 
     /// Raises the scalar to the power `2^k`.
-    #[inline(always)]
     fn pow2k(&self, k: usize) -> Self {
         let mut x = *self;
         for _j in 0..k {
@@ -235,7 +224,6 @@ impl Field for Scalar {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    #[inline(always)]
     fn random(mut rng: impl RngCore) -> Self {
         // Uses rejection sampling as the default random generation method,
         // which produces a uniformly random distribution of scalars.
@@ -250,18 +238,15 @@ impl Field for Scalar {
     }
 
     #[must_use]
-    #[inline(always)]
     fn square(&self) -> Self {
         Scalar::square(self)
     }
 
     #[must_use]
-    #[inline(always)]
     fn double(&self) -> Self {
         self.add(self)
     }
 
-    #[inline(always)]
     fn invert(&self) -> CtOption<Self> {
         Scalar::invert(self)
     }
@@ -269,7 +254,6 @@ impl Field for Scalar {
     /// Tonelli-Shank's algorithm for q mod 16 = 1
     /// <https://eprint.iacr.org/2012/685.pdf> (page 12, algorithm 5)
     #[allow(clippy::many_single_char_names)]
-    #[inline(always)]
     fn sqrt(&self) -> CtOption<Self> {
         // Note: `pow_vartime` is constant-time with respect to `self`
         let w = self.pow_vartime([
@@ -423,7 +407,6 @@ impl From<&Scalar> for ScalarPrimitive<Secp256k1> {
 impl FromUintUnchecked for Scalar {
     type Uint = U256;
 
-    #[inline(always)]
     fn from_uint_unchecked(uint: Self::Uint) -> Self {
         Self(uint)
     }
@@ -448,7 +431,6 @@ impl Invert for Scalar {
     /// variable-time operation can potentially leak secrets through
     /// sidechannels.
     #[allow(non_snake_case)]
-    #[inline(always)]
     fn invert_vartime(&self) -> CtOption<Self> {
         let mut u = *self;
         let mut v = Self::from_uint_unchecked(Secp256k1::ORDER);
@@ -497,7 +479,6 @@ impl Invert for Scalar {
 }
 
 impl IsHigh for Scalar {
-    #[inline(always)]
     fn is_high(&self) -> Choice {
         self.0.ct_gt(&FRAC_MODULUS_2)
     }
@@ -506,7 +487,6 @@ impl IsHigh for Scalar {
 impl Shr<usize> for Scalar {
     type Output = Self;
 
-    #[inline(always)]
     fn shr(self, rhs: usize) -> Self::Output {
         self.shr_vartime(rhs)
     }
@@ -515,35 +495,30 @@ impl Shr<usize> for Scalar {
 impl Shr<usize> for &Scalar {
     type Output = Scalar;
 
-    #[inline(always)]
     fn shr(self, rhs: usize) -> Self::Output {
         self.shr_vartime(rhs)
     }
 }
 
 impl ShrAssign<usize> for Scalar {
-    #[inline(always)]
     fn shr_assign(&mut self, rhs: usize) {
         *self = *self >> rhs;
     }
 }
 
 impl ConditionallySelectable for Scalar {
-    #[inline(always)]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self(U256::conditional_select(&a.0, &b.0, choice))
     }
 }
 
 impl ConstantTimeEq for Scalar {
-    #[inline(always)]
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&(other.0))
     }
 }
 
 impl PartialEq for Scalar {
-    #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         self.ct_eq(other).into()
     }
@@ -554,7 +529,6 @@ impl Eq for Scalar {}
 impl Neg for Scalar {
     type Output = Scalar;
 
-    #[inline(always)]
     fn neg(self) -> Scalar {
         self.negate()
     }
@@ -571,7 +545,6 @@ impl Neg for &Scalar {
 impl Add<Scalar> for Scalar {
     type Output = Scalar;
 
-    #[inline(always)]
     fn add(self, other: Scalar) -> Scalar {
         Scalar::add(&self, &other)
     }
@@ -580,7 +553,6 @@ impl Add<Scalar> for Scalar {
 impl Add<&Scalar> for &Scalar {
     type Output = Scalar;
 
-    #[inline(always)]
     fn add(self, other: &Scalar) -> Scalar {
         Scalar::add(self, other)
     }
@@ -589,7 +561,6 @@ impl Add<&Scalar> for &Scalar {
 impl Add<Scalar> for &Scalar {
     type Output = Scalar;
 
-    #[inline(always)]
     fn add(self, other: Scalar) -> Scalar {
         Scalar::add(self, &other)
     }
@@ -604,14 +575,12 @@ impl Add<&Scalar> for Scalar {
 }
 
 impl AddAssign<Scalar> for Scalar {
-    #[inline(always)]
     fn add_assign(&mut self, rhs: Scalar) {
         *self = Scalar::add(self, &rhs);
     }
 }
 
 impl AddAssign<&Scalar> for Scalar {
-    #[inline(always)]
     fn add_assign(&mut self, rhs: &Scalar) {
         *self = Scalar::add(self, rhs);
     }
@@ -620,7 +589,6 @@ impl AddAssign<&Scalar> for Scalar {
 impl Sub<Scalar> for Scalar {
     type Output = Scalar;
 
-    #[inline(always)]
     fn sub(self, other: Scalar) -> Scalar {
         Scalar::sub(&self, &other)
     }
@@ -629,7 +597,6 @@ impl Sub<Scalar> for Scalar {
 impl Sub<&Scalar> for &Scalar {
     type Output = Scalar;
 
-    #[inline(always)]
     fn sub(self, other: &Scalar) -> Scalar {
         Scalar::sub(self, other)
     }
@@ -638,21 +605,18 @@ impl Sub<&Scalar> for &Scalar {
 impl Sub<&Scalar> for Scalar {
     type Output = Scalar;
 
-    #[inline(always)]
     fn sub(self, other: &Scalar) -> Scalar {
         Scalar::sub(&self, other)
     }
 }
 
 impl SubAssign<Scalar> for Scalar {
-    #[inline(always)]
     fn sub_assign(&mut self, rhs: Scalar) {
         *self = Scalar::sub(self, &rhs);
     }
 }
 
 impl SubAssign<&Scalar> for Scalar {
-    #[inline(always)]
     fn sub_assign(&mut self, rhs: &Scalar) {
         *self = Scalar::sub(self, rhs);
     }
@@ -661,7 +625,6 @@ impl SubAssign<&Scalar> for Scalar {
 impl Mul<Scalar> for Scalar {
     type Output = Scalar;
 
-    #[inline(always)]
     fn mul(self, other: Scalar) -> Scalar {
         Scalar::mul(&self, &other)
     }
@@ -670,7 +633,6 @@ impl Mul<Scalar> for Scalar {
 impl Mul<&Scalar> for &Scalar {
     type Output = Scalar;
 
-    #[inline(always)]
     fn mul(self, other: &Scalar) -> Scalar {
         Scalar::mul(self, other)
     }
@@ -679,21 +641,18 @@ impl Mul<&Scalar> for &Scalar {
 impl Mul<&Scalar> for Scalar {
     type Output = Scalar;
 
-    #[inline(always)]
     fn mul(self, other: &Scalar) -> Scalar {
         Scalar::mul(&self, other)
     }
 }
 
 impl MulAssign<Scalar> for Scalar {
-    #[inline(always)]
     fn mul_assign(&mut self, rhs: Scalar) {
         *self = Scalar::mul(self, &rhs);
     }
 }
 
 impl MulAssign<&Scalar> for Scalar {
-    #[inline(always)]
     fn mul_assign(&mut self, rhs: &Scalar) {
         *self = Scalar::mul(self, rhs);
     }
@@ -702,7 +661,6 @@ impl MulAssign<&Scalar> for Scalar {
 impl Reduce<U256> for Scalar {
     type Bytes = FieldBytes;
 
-    #[inline(always)]
     fn reduce(w: U256) -> Self {
         let (r, underflow) = w.sbb(&ORDER, Limb::ZERO);
         let underflow = Choice::from((underflow.0 >> (Limb::BITS - 1)) as u8);
@@ -718,12 +676,10 @@ impl Reduce<U256> for Scalar {
 impl Reduce<U512> for Scalar {
     type Bytes = WideBytes;
 
-    #[inline(always)]
     fn reduce(w: U512) -> Self {
         WideScalar(w).reduce()
     }
 
-    #[inline(always)]
     fn reduce_bytes(bytes: &WideBytes) -> Self {
         Self::reduce(U512::from_be_byte_array(*bytes))
     }
@@ -755,28 +711,24 @@ impl ReduceNonZero<U512> for Scalar {
 }
 
 impl Sum for Scalar {
-    #[inline(always)]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.reduce(core::ops::Add::add).unwrap_or(Self::ZERO)
     }
 }
 
 impl<'a> Sum<&'a Scalar> for Scalar {
-    #[inline(always)]
     fn sum<I: Iterator<Item = &'a Scalar>>(iter: I) -> Self {
         iter.copied().sum()
     }
 }
 
 impl Product for Scalar {
-    #[inline(always)]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.reduce(core::ops::Mul::mul).unwrap_or(Self::ONE)
     }
 }
 
 impl<'a> Product<&'a Scalar> for Scalar {
-    #[inline(always)]
     fn product<I: Iterator<Item = &'a Scalar>>(iter: I) -> Self {
         iter.copied().product()
     }


### PR DESCRIPTION
If I add more `inline`s, the performance in most current benchmarks improves on my machine (AMD EPYC 7302). Benchmarks were run as `RUSTFLAGS='-C target-cpu=native' cargo bench --features expose-field`.

```
    Running benches/ecdsa.rs
ecdsa/try_sign_prehashed
                        time:   [48.866 µs 48.901 µs 48.944 µs]
                        change: [-10.073% -8.5345% -6.8744%] (p = 0.00 < 0.05)
ecdsa/verify_prehashed  
                        time:   [103.95 µs 104.43 µs 105.00 µs]
                        change: [-12.366% -11.807% -11.312%] (p = 0.00 < 0.05)

     Running benches/field.rs
field element operations/normalize_weak
                        time:   [3.1100 ns 3.1228 ns 3.1391 ns]
                        change: [-44.824% -44.193% -43.486%] (p = 0.00 < 0.05)
field element operations/normalize
                        time:   [10.600 ns 10.665 ns 10.757 ns]
                        change: [-25.955% -25.278% -24.669%] (p = 0.00 < 0.05)
field element operations/mul
                        time:   [22.809 ns 22.943 ns 23.120 ns]
                        change: [-22.698% -22.031% -21.383%] (p = 0.00 < 0.05)
field element operations/square
                        time:   [17.109 ns 17.158 ns 17.223 ns]
                        change: [-24.579% -24.168% -23.815%] (p = 0.00 < 0.05)
field element operations/invert
                        time:   [4.8184 µs 4.8271 µs 4.8384 µs]
                        change: [-26.792% -26.425% -26.113%] (p = 0.00 < 0.05)
field element operations/sqrt
                        time:   [4.9200 µs 4.9255 µs 4.9332 µs]
                        change: [-24.270% -23.922% -23.657%] (p = 0.00 < 0.05)

     Running benches/scalar.rs
high-level operations/point-scalar mul
                        time:   [56.610 µs 56.936 µs 57.360 µs]
                        change: [-11.544% -10.793% -10.106%] (p = 0.00 < 0.05)
high-level operations/mul_by_generator naive
                        time:   [56.326 µs 56.422 µs 56.535 µs]
                        change: [-11.644% -11.084% -10.507%] (p = 0.00 < 0.05)
high-level operations/mul_by_generator precomputed
                        time:   [27.987 µs 28.020 µs 28.066 µs]
                        change: [-9.8668% -8.9146% -8.1681%] (p = 0.00 < 0.05)
high-level operations/lincomb via mul+add
                        time:   [112.67 µs 113.36 µs 114.37 µs]
                        change: [-9.3266% -8.7609% -8.0640%] (p = 0.00 < 0.05)
high-level operations/lincomb()
                        time:   [89.727 µs 90.030 µs 90.401 µs]
                        change: [-9.4576% -8.5924% -7.8728%] (p = 0.00 < 0.05)
scalar operations/sub   
                        time:   [6.2334 ns 6.2527 ns 6.2782 ns]
                        change: [-18.510% -17.243% -16.189%] (p = 0.00 < 0.05)
scalar operations/add   
                        time:   [8.1355 ns 8.1517 ns 8.1712 ns]
                        change: [-20.691% -19.968% -19.352%] (p = 0.00 < 0.05)
scalar operations/mul   
                        time:   [46.323 ns 46.443 ns 46.596 ns]
                        change: [-0.6997% -0.1909% +0.2646%] (p = 0.46 > 0.05)
scalar operations/negate
                        time:   [7.6674 ns 7.6991 ns 7.7444 ns]
                        change: [-19.449% -19.121% -18.801%] (p = 0.00 < 0.05)
scalar operations/invert
                        time:   [15.156 µs 15.167 µs 15.180 µs]
                        change: [-1.0203% -0.4949% -0.1341%] (p = 0.01 < 0.05)
```

This PR also adds `criterion::black_box()` to the input variables in benchmarks s.t. they are not optimized away.