### PR TITLE
Revert "primeorder: remove `Invert` bounds on `FieldElement` (#985)"

### DIFF
--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -23,6 +23,8 @@ mod projective;
 pub use crate::{affine::AffinePoint, projective::ProjectivePoint};
 pub use elliptic_curve::{self, array, point::Double, Field, FieldBytes, PrimeCurve, PrimeField};
 
+use elliptic_curve::ops::Invert;
+use elliptic_curve::subtle::CtOption;
 use elliptic_curve::CurveArithmetic;
 
 /// Parameters for elliptic curves of prime order which can be described by the
@@ -34,8 +36,8 @@ pub trait PrimeCurveParams:
     + CurveArithmetic<ProjectivePoint = ProjectivePoint<Self>>
 {
     /// Base field element type.
-    // TODO(tarcieri): add `Invert` bound
-    type FieldElement: PrimeField<Repr = FieldBytes<Self>>;
+    type FieldElement: PrimeField<Repr = FieldBytes<Self>>
+        + Invert<Output = CtOption<Self::FieldElement>>;
 
     /// [Point arithmetic](point_arithmetic) implementation, might be optimized for this specific curve
     type PointArithmetic: point_arithmetic::PointArithmetic<Self>;

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -17,7 +17,7 @@ use elliptic_curve::{
         prime::{PrimeCurve, PrimeGroup},
         Group, GroupEncoding,
     },
-    ops::{BatchInvert, Invert, LinearCombination, MulByGenerator},
+    ops::{BatchInvert, LinearCombination, MulByGenerator},
     point::Double,
     rand_core::RngCore,
     sec1::{
@@ -334,21 +334,19 @@ where
         ProjectivePoint::to_affine(self)
     }
 
-    // TODO(tarcieri): re-enable when we can add `Invert` bounds on `FieldElement`
-    // #[cfg(feature = "alloc")]
-    // #[inline]
-    // fn batch_normalize(projective: &[Self], affine: &mut [Self::AffineRepr]) {
-    //     assert_eq!(projective.len(), affine.len());
-    //     let mut zs = vec![C::FieldElement::ONE; projective.len()];
-    //     batch_normalize_generic(projective, zs.as_mut_slice(), affine);
-    // }
+    #[cfg(feature = "alloc")]
+    #[inline]
+    fn batch_normalize(projective: &[Self], affine: &mut [Self::AffineRepr]) {
+        assert_eq!(projective.len(), affine.len());
+        let mut zs = vec![C::FieldElement::ONE; projective.len()];
+        batch_normalize_generic(projective, zs.as_mut_slice(), affine);
+    }
 }
 
 impl<const N: usize, C> BatchNormalize<[ProjectivePoint<C>; N]> for ProjectivePoint<C>
 where
     Self: Double,
     C: PrimeCurveParams,
-    C::FieldElement: Invert<Output = CtOption<C::FieldElement>>,
 {
     type Output = [Self::AffineRepr; N];
 
@@ -366,7 +364,6 @@ impl<C> BatchNormalize<[ProjectivePoint<C>]> for ProjectivePoint<C>
 where
     Self: Double,
     C: PrimeCurveParams,
-    C::FieldElement: Invert<Output = CtOption<C::FieldElement>>,
 {
     type Output = Vec<Self::AffineRepr>;
 


### PR DESCRIPTION
This reverts commit 33af0a62bb83ed28dfca1266840b779a4136e4d1.

We can now make breaking changes again