### PR TITLE
k256: update `Signature::normalize_s` usages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
  "primeorder",
  "proptest",
  "rand_core",
- "rfc6979",
+ "rfc6979 0.5.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "signature",
 ]
 
@@ -362,13 +362,12 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.17.0-pre.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae8ed6f5c6fcb637533628167d436653c3045721175741f2bf201ac6fbe3270"
+source = "git+https://github.com/RustCrypto/signatures.git#32edd0d6309e63b6d1a9afcf062dc2c3f5f73b46"
 dependencies = [
  "der",
  "digest",
  "elliptic-curve",
- "rfc6979",
+ "rfc6979 0.5.0-pre.1 (git+https://github.com/RustCrypto/signatures.git)",
  "serdect 0.2.0",
  "signature",
  "spki",
@@ -1031,6 +1030,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.5.0-pre.1"
+source = "git+https://github.com/RustCrypto/signatures.git#32edd0d6309e63b6d1a9afcf062dc2c3f5f73b46"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,7 +1205,7 @@ dependencies = [
  "primeorder",
  "proptest",
  "rand_core",
- "rfc6979",
+ "rfc6979 0.5.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serdect 0.2.0",
  "signature",
  "sm3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ members = [
 [profile.dev]
 opt-level = 2
 
-[patch.crates-io.crypto-bigint]
-git = "https://github.com/RustCrypto/crypto-bigint.git"
+[patch.crates-io]
+crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint.git" }
+ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -191,9 +191,8 @@ impl SignPrimitive<Secp256k1> for Scalar {
     {
         let (sig, recid) = hazmat::sign_prehashed::<Secp256k1, K>(self, k, z)?;
         let is_y_odd = recid.is_y_odd() ^ bool::from(sig.s().is_high());
-        let sig_low = sig.normalize_s().unwrap_or(sig);
         let recid = RecoveryId::new(is_y_odd, recid.is_x_reduced());
-        Ok((sig_low, Some(recid)))
+        Ok((sig.normalize_s(), Some(recid)))
     }
 }
 
@@ -239,7 +238,7 @@ mod tests {
                 0xfb, 0x42, 0xef, 0x20, 0xe3, 0xc6, 0xad, 0xb2,
             ].as_slice()).unwrap();
 
-            let sig_normalized = sig_hi.normalize_s().unwrap();
+            let sig_normalized = sig_hi.normalize_s();
             assert_eq!(sig_lo, sig_normalized);
         }
 
@@ -253,7 +252,7 @@ mod tests {
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             ].as_slice()).unwrap();
 
-            assert_eq!(sig.normalize_s(), None);
+            assert_eq!(sig.normalize_s(), sig);
         }
     }
 
@@ -386,7 +385,7 @@ mod tests {
                     ecdsa_core::VerifyingKey::from_encoded_point(&q_encoded).unwrap();
 
                 let sig = match Signature::<Secp256k1>::from_der(sig) {
-                    Ok(s) => s.normalize_s().unwrap_or(s),
+                    Ok(s) => s.normalize_s(),
                     Err(_) if !pass => return None,
                     Err(_) => return Some("failed to parse signature ASN.1"),
                 };


### PR DESCRIPTION
It's now infallible and always returns a normalized signature regardless of if the original one was normalized or not:

https://github.com/RustCrypto/signatures/pull/780