### PR TITLE
Bump `elliptic-curve` to v0.14.0-pre.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0625acf009be193873699e396d2e83db1d92717b4d3de4ce48aa2e04348ed5b5"
+checksum = "dc652cc2553b19afcdcb890c9fa22e315f759d87b195fe1924f97692fd20ecce"
 dependencies = [
  "belt-block",
  "digest",
@@ -60,7 +60,7 @@ dependencies = [
  "primeorder",
  "proptest",
  "rand_core",
- "rfc6979 0.5.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rfc6979",
  "signature",
 ]
 
@@ -317,8 +317,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.6.0-pre.10"
-source = "git+https://github.com/RustCrypto/crypto-bigint.git#313505f9e748ad462033c957bf0cdad1715934b8"
+version = "0.6.0-pre.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1943d7beadd9ce2b25f3bae73b9e9336fccc1edf38bdec1ed58d3aa183989e11"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -349,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.4"
+version = "0.11.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b429fb535b92bad18c86f1d7ee7584a175c2810800c7ac5b75b9408b13981979"
+checksum = "957713a19ffdda287c63772e607f848512f67ba948f17d8e42cb8d50fd98a786"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -361,13 +362,14 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-pre.2"
-source = "git+https://github.com/RustCrypto/signatures.git#55e4450a65eb47c74620ef11698618035faca985"
+version = "0.17.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f2dfabe05b5b067c9ee2b158f1892379d676ed5032fba27567990f709f3bda"
 dependencies = [
  "der",
  "digest",
  "elliptic-curve",
- "rfc6979 0.5.0-pre.1 (git+https://github.com/RustCrypto/signatures.git)",
+ "rfc6979",
  "serdect 0.2.0",
  "signature",
  "spki",
@@ -381,9 +383,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-pre.2"
+version = "0.14.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c5ff6cab3de51acc7aa1b7ed79e85d4ac92dc718f18899d7622cf9dc0fae94"
+checksum = "b5a28b26e8b4a94186ac649acffa41ba13ca853bd33e44b00fc1c3bd30bfeebe"
 dependencies = [
  "base16ct",
  "base64ct",
@@ -515,27 +517,27 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hkdf"
-version = "0.13.0-pre.1"
+version = "0.13.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8030479f3be0f2d183d7fcb5a8bb3c08c31ba40c49a1af5780544272ab8494fb"
+checksum = "c524b31a8b37d9561e29293b5931461f0bb72a75101f3916e1480525113da8e9"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.13.0-pre.1"
+version = "0.13.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad9bdb2c4daa57033321e5e64c7a8cab02086ee130f8702f72b5c164893026a"
+checksum = "1fac01891f12d968a2737928c9af2532abdc750e56a890fdbcafdfff17017678"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c5517ac29f08e88170b9647d85cc5f21c2596de177b4867232e20b214b8da1"
+checksum = "7b700a69c9d992339e82b6cda619873ee17768be06e80ed5ef07c50c50d499ab"
 dependencies = [
  "typenum",
  "zeroize",
@@ -619,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.4"
+version = "0.2.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
 dependencies = [
  "cpufeatures",
 ]
@@ -1021,18 +1023,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-pre.1"
+version = "0.5.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f74fe2f5245b7dcff4f1c633a5dcc1fb54dbb0e4b1fa569ab60863806229d54f"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.5.0-pre.1"
-source = "git+https://github.com/RustCrypto/signatures.git#55e4450a65eb47c74620ef11698618035faca985"
+checksum = "5ca433f6da88ec508578cac524a1602a437964cf049ffb39f1509e8696d43e79"
 dependencies = [
  "hmac",
  "subtle",
@@ -1167,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9daa731ca112bb569b34b41775363a461422813d8ed1ea6dba352eb58ec4e684"
+checksum = "e18b939d4051b69874cbdb8f55de6a14ae44b357ccb94bdbd0a2122f8f875a46"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1178,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f5da8ebbbfc6bd857bb4d209bb42109772703b118ea137d57352c2a95b3322"
+checksum = "9cecb44e361133b3304a1b3e325a1d8c999339fec8c19762b55e1509a17d6806"
 dependencies = [
  "digest",
  "keccak",
@@ -1188,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.3.0-pre.1"
+version = "2.3.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40c007df8d40a44d464726cc639e1b48c1894ad074eb4168ff91e62d94b53a"
+checksum = "017ea2f120415e4bf9c6177425b40386f207284147564e19d196c7bc90483c08"
 dependencies = [
  "digest",
  "rand_core",
@@ -1205,7 +1198,7 @@ dependencies = [
  "primeorder",
  "proptest",
  "rand_core",
- "rfc6979 0.5.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rfc6979",
  "serdect 0.2.0",
  "signature",
  "sm3",
@@ -1213,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "sm3"
-version = "0.5.0-pre.1"
+version = "0.5.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b6ef3d77873a42e29556a31c798acde8010117e79817bcebacbd536be772dd"
+checksum = "2321118e4564a21e290428343d8cb9ae4728fbd837fed928ab990a595b1f545b"
 dependencies = [
  "digest",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint.git" }
-ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }

--- a/bign256/Cargo.toml
+++ b/bign256/Cargo.toml
@@ -17,13 +17,13 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.2", features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.3", features = ["hazmat", "sec1"] }
 
 # optional dependencies
 primeorder = { version = "=0.14.0-pre", optional = true, path = "../primeorder" }
-signature = { version = "=2.3.0-pre.1", optional = true }
-belt-hash = { version = "=0.2.0-pre.1", optional = true, default-features = false }
-rfc6979 = { version = "=0.5.0-pre.1", optional = true }
+signature = { version = "=2.3.0-pre.2", optional = true }
+belt-hash = { version = "=0.2.0-pre.2", optional = true, default-features = false }
+rfc6979 = { version = "=0.5.0-pre.2", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -13,12 +13,12 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa = { version = "=0.17.0-pre.2", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.17.0-pre.3", optional = true, default-features = false, features = ["der"] }
 primeorder = { version = "=0.14.0-pre", optional = true, path = "../primeorder" }
-sha2 = { version = "=0.11.0-pre.1", optional = true, default-features = false }
+sha2 = { version = "=0.11.0-pre.2", optional = true, default-features = false }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -13,12 +13,12 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa = { version = "=0.17.0-pre.2", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.17.0-pre.3", optional = true, default-features = false, features = ["der"] }
 primeorder = { version = "=0.14.0-pre", optional = true, path = "../primeorder" }
-sha2 = { version = "=0.11.0-pre.1", optional = true, default-features = false }
+sha2 = { version = "=0.11.0-pre.2", optional = true, default-features = false }
 
 [features]
 default = ["pkcs8", "std"]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -19,26 +19,26 @@ rust-version = "1.73"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "=0.14.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
 once_cell = { version = "1.19", optional = true, default-features = false }
-ecdsa-core = { version = "=0.17.0-pre.2", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.17.0-pre.3", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 serdect = { version = "0.2", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.1", optional = true, default-features = false }
-signature = { version = "=2.3.0-pre.1", optional = true }
+sha2 = { version = "=0.11.0-pre.2", optional = true, default-features = false }
+signature = { version = "=2.3.0-pre.2", optional = true }
 
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.5"
-ecdsa-core = { version = "=0.17.0-pre.2", package = "ecdsa", default-features = false, features = ["dev"] } 
+ecdsa-core = { version = "=0.17.0-pre.3", package = "ecdsa", default-features = false, features = ["dev"] } 
 hex-literal = "0.4"
 num-bigint = "0.4"
 num-traits = "0.2"
 proptest = "1.4"
 rand_core = { version = "0.6", features = ["getrandom"] }
-sha3 = { version = "=0.11.0-pre.1", default-features = false }
+sha3 = { version = "=0.11.0-pre.2", default-features = false }
 
 [features]
 default = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "schnorr", "std"]

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -16,17 +16,17 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 sec1 = { version = "=0.8.0-pre.1", default-features = false }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.2", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.17.0-pre.3", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primeorder = { version = "=0.14.0-pre", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "=0.17.0-pre.2", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.17.0-pre.3", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "=0.14.0-pre", features = ["dev"], path = "../primeorder" }
 

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -16,18 +16,18 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.2", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.17.0-pre.3", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primeorder = { version = "=0.14.0-pre", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.1", optional = true, default-features = false }
+sha2 = { version = "=0.11.0-pre.2", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
-ecdsa-core = { version = "=0.17.0-pre.2", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.17.0-pre.3", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "=0.14.0-pre", features = ["dev"], path = "../primeorder" }
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -17,19 +17,19 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.2", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.17.0-pre.3", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primeorder = { version = "=0.14.0-pre", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.1", optional = true, default-features = false }
+sha2 = { version = "=0.11.0-pre.2", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.5"
-ecdsa-core = { version = "=0.17.0-pre.2", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.17.0-pre.3", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "=0.14.0-pre", features = ["dev"], path = "../primeorder" }
 proptest = "1"

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -17,19 +17,19 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.2", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.17.0-pre.3", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primeorder = { version = "=0.14.0-pre", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.1", optional = true, default-features = false }
+sha2 = { version = "=0.11.0-pre.2", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.5"
-ecdsa-core = { version = "=0.17.0-pre.2", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.17.0-pre.3", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "=0.14.0-pre", features = ["dev"], path = "../primeorder" }
 proptest = "1.4"

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -17,20 +17,20 @@ rust-version = "1.73"
 
 [dependencies]
 base16ct = "0.2"
-elliptic-curve = { version = "=0.14.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.2", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.17.0-pre.3", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primefield = { version = "=0.14.0-pre", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre", optional = true, path = "../primeorder" }
 rand_core = { version = "0.6", optional = true, default-features = false }
 serdect = { version = "0.2", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.1", optional = true, default-features = false }
+sha2 = { version = "=0.11.0-pre.2", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
-ecdsa-core = { version = "=0.17.0-pre.2", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.17.0-pre.3", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "=0.14.0-pre", features = ["dev"], path = "../primeorder" }
 proptest = "1.4"

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.2", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.3", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.2", optional = true, default-features = false }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -17,14 +17,14 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.2", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.3", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
 primeorder = { version = "=0.14.0-pre", optional = true, path = "../primeorder" }
-rfc6979 = { version = "=0.5.0-pre.1", optional = true }
+rfc6979 = { version = "=0.5.0-pre.2", optional = true }
 serdect = { version = "0.2", optional = true, default-features = false }
-signature = { version = "=2.3.0-pre.1", optional = true, features = ["rand_core"] }
-sm3 = { version = "=0.5.0-pre.1", optional = true, default-features = false }
+signature = { version = "=2.3.0-pre.2", optional = true, features = ["rand_core"] }
+sm3 = { version = "=0.5.0-pre.2", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"


### PR DESCRIPTION
Also bumps `ecdsa` to v0.17.0-pre.3