### PR TITLE
Add `EcdsaCurve` trait impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
  "primeorder",
  "proptest",
  "rand_core",
- "rfc6979",
+ "rfc6979 0.5.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "signature",
 ]
 
@@ -363,13 +363,12 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.17.0-pre.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f2dfabe05b5b067c9ee2b158f1892379d676ed5032fba27567990f709f3bda"
+source = "git+https://github.com/rustcrypto/signatures.git#56b8b7acdf6d76291f8cbff56241fb15063befd3"
 dependencies = [
  "der",
  "digest",
  "elliptic-curve",
- "rfc6979",
+ "rfc6979 0.5.0-pre.2 (git+https://github.com/rustcrypto/signatures.git)",
  "serdect 0.2.0",
  "signature",
  "spki",
@@ -1032,6 +1031,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.5.0-pre.2"
+source = "git+https://github.com/rustcrypto/signatures.git#56b8b7acdf6d76291f8cbff56241fb15063befd3"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,7 +1206,7 @@ dependencies = [
  "primeorder",
  "proptest",
  "rand_core",
- "rfc6979",
+ "rfc6979 0.5.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serdect 0.2.0",
  "signature",
  "sm3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io.ecdsa]
+git = "https://github.com/rustcrypto/signatures.git"

--- a/bp256/src/r1/ecdsa.rs
+++ b/bp256/src/r1/ecdsa.rs
@@ -8,6 +8,10 @@ pub type Signature = ecdsa::Signature<BrainpoolP256r1>;
 /// ECDSA/brainpoolP256r1 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa::der::Signature<BrainpoolP256r1>;
 
+impl ecdsa::EcdsaCurve for BrainpoolP256r1 {
+    const NORMALIZE_S: bool = false;
+}
+
 #[cfg(feature = "sha256")]
 impl ecdsa::hazmat::DigestPrimitive for BrainpoolP256r1 {
     type Digest = sha2::Sha256;

--- a/bp256/src/t1/ecdsa.rs
+++ b/bp256/src/t1/ecdsa.rs
@@ -8,6 +8,10 @@ pub type Signature = ecdsa::Signature<BrainpoolP256t1>;
 /// ECDSA/brainpoolP256t1 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa::der::Signature<BrainpoolP256t1>;
 
+impl ecdsa::EcdsaCurve for BrainpoolP256t1 {
+    const NORMALIZE_S: bool = false;
+}
+
 #[cfg(feature = "sha256")]
 impl ecdsa::hazmat::DigestPrimitive for BrainpoolP256t1 {
     type Digest = sha2::Sha256;

--- a/bp384/src/r1/ecdsa.rs
+++ b/bp384/src/r1/ecdsa.rs
@@ -8,6 +8,10 @@ pub type Signature = ecdsa::Signature<BrainpoolP384r1>;
 /// ECDSA/brainpoolP384r1 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa::der::Signature<BrainpoolP384r1>;
 
+impl ecdsa::EcdsaCurve for BrainpoolP384r1 {
+    const NORMALIZE_S: bool = false;
+}
+
 #[cfg(feature = "sha384")]
 impl ecdsa::hazmat::DigestPrimitive for BrainpoolP384r1 {
     type Digest = sha2::Sha384;

--- a/bp384/src/t1/ecdsa.rs
+++ b/bp384/src/t1/ecdsa.rs
@@ -8,6 +8,10 @@ pub type Signature = ecdsa::Signature<BrainpoolP384t1>;
 /// ECDSA/brainpoolP384t1 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa::der::Signature<BrainpoolP384t1>;
 
+impl ecdsa::EcdsaCurve for BrainpoolP384t1 {
+    const NORMALIZE_S: bool = false;
+}
+
 #[cfg(feature = "sha384")]
 impl ecdsa::hazmat::DigestPrimitive for BrainpoolP384t1 {
     type Digest = sha2::Sha384;

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -144,7 +144,7 @@
 
 pub use ecdsa_core::{
     signature::{self, Error},
-    RecoveryId,
+    EcdsaCurve, RecoveryId,
 };
 
 #[cfg(any(feature = "ecdsa", feature = "sha256"))]
@@ -164,6 +164,10 @@ pub type Signature = ecdsa_core::Signature<Secp256k1>;
 
 /// ECDSA/secp256k1 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa_core::der::Signature<Secp256k1>;
+
+impl EcdsaCurve for Secp256k1 {
+    const NORMALIZE_S: bool = true;
+}
 
 /// ECDSA/secp256k1 signing key
 #[cfg(feature = "ecdsa")]

--- a/p192/src/ecdsa.rs
+++ b/p192/src/ecdsa.rs
@@ -32,16 +32,22 @@
 //! [NIST Special Publication 800-131A Revision 2]: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf
 
 pub use ecdsa_core::signature::{self, Error};
-#[cfg(feature = "ecdsa")]
-use {crate::AffinePoint, ecdsa_core::hazmat::VerifyPrimitive};
 
 use super::NistP192;
+use ecdsa_core::EcdsaCurve;
+
+#[cfg(feature = "ecdsa")]
+use {crate::AffinePoint, ecdsa_core::hazmat::VerifyPrimitive};
 
 /// ECDSA/P-192 signature (fixed-size)
 pub type Signature = ecdsa_core::Signature<NistP192>;
 
 /// ECDSA/P-192 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa_core::der::Signature<NistP192>;
+
+impl EcdsaCurve for NistP192 {
+    const NORMALIZE_S: bool = false;
+}
 
 /// ECDSA/P-192 verification key (i.e. public key)
 #[cfg(feature = "ecdsa")]

--- a/p224/src/ecdsa.rs
+++ b/p224/src/ecdsa.rs
@@ -38,19 +38,25 @@
 //! ```
 
 pub use ecdsa_core::signature::{self, Error};
+
+use super::NistP224;
+use ecdsa_core::EcdsaCurve;
+
 #[cfg(feature = "ecdsa")]
 use {
     crate::{AffinePoint, Scalar},
     ecdsa_core::hazmat::{SignPrimitive, VerifyPrimitive},
 };
 
-use super::NistP224;
-
 /// ECDSA/P-224 signature (fixed-size)
 pub type Signature = ecdsa_core::Signature<NistP224>;
 
 /// ECDSA/P-224 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa_core::der::Signature<NistP224>;
+
+impl EcdsaCurve for NistP224 {
+    const NORMALIZE_S: bool = false;
+}
 
 /// ECDSA/P-224 signing key
 #[cfg(feature = "ecdsa")]

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -42,6 +42,7 @@
 pub use ecdsa_core::signature::{self, Error};
 
 use super::NistP256;
+use ecdsa_core::EcdsaCurve;
 
 #[cfg(feature = "ecdsa")]
 use {
@@ -54,6 +55,10 @@ pub type Signature = ecdsa_core::Signature<NistP256>;
 
 /// ECDSA/P-256 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa_core::der::Signature<NistP256>;
+
+impl EcdsaCurve for NistP256 {
+    const NORMALIZE_S: bool = false;
+}
 
 /// ECDSA/P-256 signing key
 #[cfg(feature = "ecdsa")]

--- a/p384/src/ecdsa.rs
+++ b/p384/src/ecdsa.rs
@@ -38,19 +38,25 @@
 //! ```
 
 pub use ecdsa_core::signature::{self, Error};
+
+use super::NistP384;
+use ecdsa_core::EcdsaCurve;
+
 #[cfg(feature = "ecdsa")]
 use {
     crate::{AffinePoint, Scalar},
     ecdsa_core::hazmat::{SignPrimitive, VerifyPrimitive},
 };
 
-use super::NistP384;
-
 /// ECDSA/P-384 signature (fixed-size)
 pub type Signature = ecdsa_core::Signature<NistP384>;
 
 /// ECDSA/P-384 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa_core::der::Signature<NistP384>;
+
+impl EcdsaCurve for NistP384 {
+    const NORMALIZE_S: bool = false;
+}
 
 /// ECDSA/P-384 signing key
 #[cfg(feature = "ecdsa")]

--- a/p521/src/ecdsa.rs
+++ b/p521/src/ecdsa.rs
@@ -38,19 +38,25 @@
 //! ```
 
 pub use ecdsa_core::signature::{self, Error};
+
+use super::NistP521;
+use ecdsa_core::EcdsaCurve;
+
 #[cfg(feature = "ecdsa")]
 use {
     crate::{AffinePoint, Scalar},
     ecdsa_core::hazmat::{SignPrimitive, VerifyPrimitive},
 };
 
-use super::NistP521;
-
 /// ECDSA/P-521 signature (fixed-size)
 pub type Signature = ecdsa_core::Signature<NistP521>;
 
 /// ECDSA/P-521 signature (ASN.1 DER encoded)
 pub type DerSignature = ecdsa_core::der::Signature<NistP521>;
+
+impl EcdsaCurve for NistP521 {
+    const NORMALIZE_S: bool = false;
+}
 
 /// ECDSA/P-521 signing key
 #[cfg(feature = "ecdsa")]


### PR DESCRIPTION
This is a marker trait added in RustCrypto/signatures#787 which marks an elliptic curve as being intended for use with ECDSA.

It's the intended successor of the `SignPrimitive` and `VerifyPrimitive` traits, carrying with it the one bit of information needed to eliminate the need for custom impls: a flag for low-S normalization.

`bp256`, `bp384`, `k256`, `p192`, `p224`, `p256`, `p384`, and `p521` have all received trait impls.

Of those, only `k256` has the `NORMALIZE_S` flag set to `true`.