### PR TITLE
ecdsa: remove `SignPrimitive`/`VerifyPrimitive` traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.17.0-pre.3"
-source = "git+https://github.com/rustcrypto/signatures.git#56b8b7acdf6d76291f8cbff56241fb15063befd3"
+source = "git+https://github.com/rustcrypto/signatures.git#3ed9867409ddb392ddc6787168ca32150a897161"
 dependencies = [
  "der",
  "digest",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.5.0-pre.2"
-source = "git+https://github.com/rustcrypto/signatures.git#56b8b7acdf6d76291f8cbff56241fb15063befd3"
+source = "git+https://github.com/rustcrypto/signatures.git#3ed9867409ddb392ddc6787168ca32150a897161"
 dependencies = [
  "hmac",
  "subtle",

--- a/k256/benches/ecdsa.rs
+++ b/k256/benches/ecdsa.rs
@@ -1,32 +1,26 @@
 //! secp256k1 scalar arithmetic benchmarks
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ecdsa_core::{
-    elliptic_curve::group::prime::PrimeCurveAffine,
-    hazmat::{SignPrimitive, VerifyPrimitive},
+use k256::{
+    ecdsa::{
+        signature::hazmat::{PrehashSigner, PrehashVerifier},
+        Signature, SigningKey,
+    },
+    elliptic_curve::group::ff::PrimeField,
+    FieldBytes, NonZeroScalar, Scalar,
 };
-use k256::{elliptic_curve::group::ff::PrimeField, AffinePoint, FieldBytes, Scalar};
 
-fn test_scalar_d() -> Scalar {
-    Scalar::from_repr(
-        [
-            0xbb, 0x48, 0x8a, 0xef, 0x41, 0x6a, 0x41, 0xd7, 0x68, 0x0d, 0x1c, 0xf0, 0x1d, 0x70,
-            0xf5, 0x9b, 0x60, 0xd7, 0xf5, 0xf7, 0x7e, 0x30, 0xe7, 0x8b, 0x8b, 0xf9, 0xd2, 0xd8,
-            0x82, 0xf1, 0x56, 0xa6,
-        ]
-        .into(),
-    )
-    .unwrap()
-}
-
-fn test_scalar_k() -> Scalar {
-    Scalar::from_repr(
-        [
-            0x67, 0xe2, 0xf6, 0x80, 0x71, 0xed, 0x82, 0x81, 0xe8, 0xae, 0xd6, 0xbc, 0xf1, 0xc5,
-            0x20, 0x7c, 0x5e, 0x63, 0x37, 0x22, 0xd9, 0x20, 0xaf, 0xd6, 0xae, 0x22, 0xd0, 0x6e,
-            0xeb, 0x80, 0x35, 0xe3,
-        ]
-        .into(),
+fn test_scalar_d() -> NonZeroScalar {
+    NonZeroScalar::new(
+        Scalar::from_repr(
+            [
+                0xbb, 0x48, 0x8a, 0xef, 0x41, 0x6a, 0x41, 0xd7, 0x68, 0x0d, 0x1c, 0xf0, 0x1d, 0x70,
+                0xf5, 0x9b, 0x60, 0xd7, 0xf5, 0xf7, 0x7e, 0x30, 0xe7, 0x8b, 0x8b, 0xf9, 0xd2, 0xd8,
+                0x82, 0xf1, 0x56, 0xa6,
+            ]
+            .into(),
+        )
+        .unwrap(),
     )
     .unwrap()
 }
@@ -43,25 +37,22 @@ fn test_scalar_z() -> FieldBytes {
 fn bench_ecdsa(c: &mut Criterion) {
     let mut group = c.benchmark_group("ecdsa");
 
-    let d = test_scalar_d();
-    let k = test_scalar_k();
+    let d = SigningKey::from(test_scalar_d());
     let z = test_scalar_z();
 
     group.bench_function("try_sign_prehashed", |b| {
         b.iter(|| {
-            black_box(d)
-                .try_sign_prehashed(black_box(k), &black_box(z))
-                .unwrap()
+            let _: Signature = black_box(&d).sign_prehash(&black_box(z)).unwrap();
         })
     });
 
-    let q = (AffinePoint::generator() * d).to_affine();
-    let s = d.try_sign_prehashed(k, &z).unwrap().0;
+    let q = d.verifying_key();
+    let s: Signature = d.sign_prehash(&z).unwrap();
 
     group.bench_function("verify_prehashed", |b| {
         b.iter(|| {
             black_box(q)
-                .verify_prehashed(&black_box(z), &black_box(s))
+                .verify_prehash(&black_box(z), &black_box(s))
                 .unwrap()
         })
     });

--- a/p192/src/ecdsa.rs
+++ b/p192/src/ecdsa.rs
@@ -36,9 +36,6 @@ pub use ecdsa_core::signature::{self, Error};
 use super::NistP192;
 use ecdsa_core::EcdsaCurve;
 
-#[cfg(feature = "ecdsa")]
-use {crate::AffinePoint, ecdsa_core::hazmat::VerifyPrimitive};
-
 /// ECDSA/P-192 signature (fixed-size)
 pub type Signature = ecdsa_core::Signature<NistP192>;
 
@@ -52,9 +49,6 @@ impl EcdsaCurve for NistP192 {
 /// ECDSA/P-192 verification key (i.e. public key)
 #[cfg(feature = "ecdsa")]
 pub type VerifyingKey = ecdsa_core::VerifyingKey<NistP192>;
-
-#[cfg(feature = "ecdsa")]
-impl VerifyPrimitive<NistP192> for AffinePoint {}
 
 #[cfg(all(test, feature = "ecdsa"))]
 mod tests {

--- a/p224/src/ecdsa.rs
+++ b/p224/src/ecdsa.rs
@@ -42,12 +42,6 @@ pub use ecdsa_core::signature::{self, Error};
 use super::NistP224;
 use ecdsa_core::EcdsaCurve;
 
-#[cfg(feature = "ecdsa")]
-use {
-    crate::{AffinePoint, Scalar},
-    ecdsa_core::hazmat::{SignPrimitive, VerifyPrimitive},
-};
-
 /// ECDSA/P-224 signature (fixed-size)
 pub type Signature = ecdsa_core::Signature<NistP224>;
 
@@ -70,12 +64,6 @@ pub type VerifyingKey = ecdsa_core::VerifyingKey<NistP224>;
 impl ecdsa_core::hazmat::DigestPrimitive for NistP224 {
     type Digest = sha2::Sha224;
 }
-
-#[cfg(feature = "ecdsa")]
-impl SignPrimitive<NistP224> for Scalar {}
-
-#[cfg(feature = "ecdsa")]
-impl VerifyPrimitive<NistP224> for AffinePoint {}
 
 #[cfg(all(test, feature = "ecdsa"))]
 mod tests {

--- a/p384/src/ecdsa.rs
+++ b/p384/src/ecdsa.rs
@@ -42,12 +42,6 @@ pub use ecdsa_core::signature::{self, Error};
 use super::NistP384;
 use ecdsa_core::EcdsaCurve;
 
-#[cfg(feature = "ecdsa")]
-use {
-    crate::{AffinePoint, Scalar},
-    ecdsa_core::hazmat::{SignPrimitive, VerifyPrimitive},
-};
-
 /// ECDSA/P-384 signature (fixed-size)
 pub type Signature = ecdsa_core::Signature<NistP384>;
 
@@ -70,12 +64,6 @@ pub type VerifyingKey = ecdsa_core::VerifyingKey<NistP384>;
 impl ecdsa_core::hazmat::DigestPrimitive for NistP384 {
     type Digest = sha2::Sha384;
 }
-
-#[cfg(feature = "ecdsa")]
-impl SignPrimitive<NistP384> for Scalar {}
-
-#[cfg(feature = "ecdsa")]
-impl VerifyPrimitive<NistP384> for AffinePoint {}
 
 #[cfg(all(test, feature = "ecdsa"))]
 mod tests {

--- a/p521/src/ecdsa.rs
+++ b/p521/src/ecdsa.rs
@@ -42,12 +42,6 @@ pub use ecdsa_core::signature::{self, Error};
 use super::NistP521;
 use ecdsa_core::EcdsaCurve;
 
-#[cfg(feature = "ecdsa")]
-use {
-    crate::{AffinePoint, Scalar},
-    ecdsa_core::hazmat::{SignPrimitive, VerifyPrimitive},
-};
-
 /// ECDSA/P-521 signature (fixed-size)
 pub type Signature = ecdsa_core::Signature<NistP521>;
 
@@ -70,12 +64,6 @@ pub type VerifyingKey = ecdsa_core::VerifyingKey<NistP521>;
 impl ecdsa_core::hazmat::DigestPrimitive for NistP521 {
     type Digest = sha2::Sha512;
 }
-
-#[cfg(feature = "ecdsa")]
-impl SignPrimitive<NistP521> for Scalar {}
-
-#[cfg(feature = "ecdsa")]
-impl VerifyPrimitive<NistP521> for AffinePoint {}
 
 #[cfg(all(test, feature = "ecdsa"))]
 mod tests {


### PR DESCRIPTION
These were removed upstream in RustCrypto/signatures#793.

The ECDSA implementation is fully generic now. These traits were originally for per-curve implementations, but those are no-longer needed.

The upstream implementation now has native support for low-S normalization by way of `EcdsaCurve::NORMALIZE_S`.