### PR TITLE
Add core::fmt::Debug constraint to PrimeCurveParams::FieldElement

### DIFF
--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -37,7 +37,8 @@ pub trait PrimeCurveParams:
 {
     /// Base field element type.
     type FieldElement: PrimeField<Repr = FieldBytes<Self>>
-        + Invert<Output = CtOption<Self::FieldElement>>;
+        + Invert<Output = CtOption<Self::FieldElement>>
+        + core::fmt::Debug;
 
     /// [Point arithmetic](point_arithmetic) implementation, might be optimized for this specific curve
     type PointArithmetic: point_arithmetic::PointArithmetic<Self>;


### PR DESCRIPTION
Building with master causes the below error depending on usage.

```
error[E0277]: `<C as PrimeCurveParams>::FieldElement` doesn't implement `Debug`
   --> /home/coder0xff/Dropbox/Documents/Projects/Community/src/community/elliptic-curves/primeorder/src/affine.rs:290:30
    |
290 | impl<C> PrimeCurveAffine for AffinePoint<C>
    |                              ^^^^^^^^^^^^^^ `<C as PrimeCurveParams>::FieldElement` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = help: the trait `Debug` is not implemented for `<C as PrimeCurveParams>::FieldElement`
note: required for `AffinePoint<C>` to implement `Debug`
   --> /home/coder0xff/Dropbox/Documents/Projects/Community/src/community/elliptic-curves/primeorder/src/affine.rs:28:23
    |
28  | #[derive(Clone, Copy, Debug)]
    |                       ^^^^^ unsatisfied trait bound introduced in this `derive` macro
note: required by a bound in `PrimeCurveAffine`
   --> /home/coder0xff/.cargo/registry/src/index.crates.io-6f17d22bba15001f/group-0.13.0/src/prime.rs:27:7
    |
21  | pub trait PrimeCurveAffine: GroupEncoding
    |           ---------------- required by a bound in this trait
...
27  |     + fmt::Debug
    |       ^^^^^^^^^^ required by this bound in `PrimeCurveAffine`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider further restricting the associated type
    |
298 |     <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy, <C as PrimeCurveParams>::FieldElement: Debug
    |                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```