### PR TITLE
p256: oid feature

### DIFF
--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -17,10 +17,14 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-elliptic-curve = { version = "0.13.8", default-features = false, features = ["hazmat", "sec1"] }
-
+elliptic-curve = { version = "0.13.8", default-features = false, features = [
+    "hazmat",
+    "sec1"
+] }
 # optional dependencies
-ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = [
+    "der"
+] }
 hex-literal = { version = "0.4", optional = true }
 primeorder = { version = "0.13", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
@@ -29,7 +33,9 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.5"
-ecdsa-core = { version = "0.16", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.16", package = "ecdsa", default-features = false, features = [
+    "dev"
+] }
 hex-literal = "0.4"
 primeorder = { version = "0.13.5", features = ["dev"], path = "../primeorder" }
 proptest = "1"
@@ -39,7 +45,6 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 default = ["arithmetic", "ecdsa", "pem", "std"]
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std"]
-
 arithmetic = ["dep:primeorder", "elliptic-curve/arithmetic"]
 bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
@@ -50,10 +55,16 @@ hash2curve = ["arithmetic", "elliptic-curve/hash2curve"]
 jwk = ["elliptic-curve/jwk"]
 pem = ["elliptic-curve/pem", "ecdsa-core/pem", "pkcs8"]
 pkcs8 = ["ecdsa-core?/pkcs8", "elliptic-curve/pkcs8"]
-serde = ["ecdsa-core?/serde", "elliptic-curve/serde", "primeorder?/serde", "serdect"]
+serde = [
+    "ecdsa-core?/serde",
+    "elliptic-curve/serde",
+    "primeorder?/serde",
+    "serdect"
+]
 sha256 = ["digest", "sha2"]
 test-vectors = ["dep:hex-literal"]
 voprf = ["elliptic-curve/voprf", "sha2"]
+oid = ["sha2/oid"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
If Oid support is not added, SigningKey<NistP256> cannot be passed to CertificateBuilder::new as the cert_signer parameter