### PR TITLE
Fixed `to_bytes` function

### DIFF
--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -95,7 +95,7 @@ impl FieldElement {
 
     /// Returns the big-endian encoding of this [`FieldElement`].
     pub fn to_bytes(self) -> FieldBytes {
-        self.0.to_be_byte_array()
+        self.to_canonical().to_be_byte_array()
     }
 
     /// Translate [`FieldElement`] out of the Montgomery domain, returning a


### PR DESCRIPTION
When searching for the "broken backend" of the bp256 crate, it turned out that  `FieldElement::to_bytes` misses a conversion from Montgomery form to canonical form and thus whenever this function is used in computations, it yields nonsensical results.

Test vectors for the arithmetic on the level of field elements, scalars and curve points  will follow. At this point, we were not able to find any problems with the implementation.