### PR TITLE
Prevent panic when creating a Schnorr from slice

### DIFF
--- a/k256/src/schnorr.rs
+++ b/k256/src/schnorr.rs
@@ -509,4 +509,12 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn try_from() {
+        // Pass an invalid signature (shorter than Self::BYTES / 2) and make sure
+        // it does not panic, but return Err
+        let invalid_signature = [111; 24];
+        assert_eq!(Signature::try_from(&invalid_signature[..]).is_err(), true);
+    }
 }

--- a/k256/src/schnorr.rs
+++ b/k256/src/schnorr.rs
@@ -117,6 +117,31 @@ impl Signature {
     fn split(&self) -> (&FieldElement, &NonZeroScalar) {
         (self.r(), self.s())
     }
+
+    /// Parse a Secp256k1 signature from a byte array.
+    pub fn from_bytes(bytes: &SignatureBytes) -> Result<Self> {
+        let (r_bytes, s_bytes) = bytes.split_at(Self::BYTE_SIZE / 2);
+
+        let r: FieldElement =
+            Option::from(FieldElement::from_bytes(FieldBytes::from_slice(r_bytes)))
+                .ok_or_else(Error::new)?;
+
+        // one of the rules for valid signatures: !is_infinite(R);
+        if r.is_zero().into() {
+            return Err(Error::new());
+        }
+
+        let s = NonZeroScalar::try_from(s_bytes).map_err(|_| Error::new())?;
+
+        Ok(Self { r, s })
+    }
+
+    /// Parse a Secp256k1 signature from a byte slice.
+    pub fn from_slice(bytes: &[u8]) -> Result<Self> {
+        SignatureBytes::try_from(bytes)
+            .map_err(|_| Error::new())?
+            .try_into()
+    }
 }
 
 impl Eq for Signature {}
@@ -139,24 +164,27 @@ impl PartialEq for Signature {
     }
 }
 
+impl TryFrom<SignatureBytes> for Signature {
+    type Error = Error;
+
+    fn try_from(signature: SignatureBytes) -> Result<Signature> {
+        Signature::from_bytes(&signature)
+    }
+}
+
+impl TryFrom<&SignatureBytes> for Signature {
+    type Error = Error;
+
+    fn try_from(signature: &SignatureBytes) -> Result<Signature> {
+        Signature::from_bytes(signature)
+    }
+}
+
 impl TryFrom<&[u8]> for Signature {
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Signature> {
-        let (r_bytes, s_bytes) = bytes.split_at(Self::BYTE_SIZE / 2);
-
-        let r: FieldElement =
-            Option::from(FieldElement::from_bytes(FieldBytes::from_slice(r_bytes)))
-                .ok_or_else(Error::new)?;
-
-        // one of the rules for valid signatures: !is_infinite(R);
-        if r.is_zero().into() {
-            return Err(Error::new());
-        }
-
-        let s = NonZeroScalar::try_from(s_bytes).map_err(|_| Error::new())?;
-
-        Ok(Self { r, s })
+        Signature::from_slice(bytes)
     }
 }
 


### PR DESCRIPTION
If you pass a byte slice shorter than 32 bytes to Schnorr's Signature::try_from, it panics.

There is a unit test as first commit to test behaviour before and after the fix.

An easy fix would have been to check in `try_from` if the slice was shorted than `Self::BYTES / 2` but this patch makes it more similar to `bign256` and `sm2`.