### PR TITLE
Bump dependencies to new prerelease/RC crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-pre.3"
+version = "0.2.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f27c3b1a850b9948ab73e1f8064ac701716cad53259d43d173017f7dd4b0ec6"
+checksum = "ee5982dbf7d2f719b4237cd796ee600e9dcbef1eef460ece65380f9192a54ab5"
 dependencies = [
  "belt-block",
  "digest",
@@ -117,9 +117,9 @@ checksum = "847495c209977a90e8aad588b959d0ca9f5dc228096d29a6bd3defd53f35eaec"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ded684142010808eb980d9974ef794da2bcf97d13396143b1515e9f0fb4a10e"
+checksum = "17092d478f4fadfb35a7e082f62e49f0907fdf048801d9d706277e34f9df8a78"
 dependencies = [
  "crypto-common",
 ]
@@ -223,9 +223,9 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "const-oid"
-version = "0.10.0-pre.2"
+version = "0.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e3352a27098ba6b09546e5f13b15165e6a88b5c2723afecb3ea9576b27e3ea"
+checksum = "9adcf94f05e094fca3005698822ec791cb4433ced416afda1c5ca3b8dfc05a2f"
 
 [[package]]
 name = "cpufeatures"
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.6.0-pre.12"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1943d7beadd9ce2b25f3bae73b9e9336fccc1edf38bdec1ed58d3aa183989e11"
+checksum = "e43027691f1c055da3da4f7d96af09fcec420d435d5616e51f29afd0811c56a7"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -336,18 +336,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-pre.5"
+version = "0.2.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
+checksum = "8c070b79a496dccd931229780ad5bbedd535ceff6c3565605a8e440e18e1aa2b"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "der"
-version = "0.8.0-pre.0"
+version = "0.8.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b489fd2221710c1dd46637d66b984161fb66134f81437a8489800306bcc2ecea"
+checksum = "05d9c07d3bd80cf0935ce478d07edf7e7a5b158446757f988f3e62082227b700"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.8"
+version = "0.11.0-pre.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065d93ead7c220b85d5b4be4795d8398eac4ff68b5ee63895de0a3c1fb6edf25"
+checksum = "cf2e3d6615d99707295a9673e889bf363a04b2a466bd320c65a72536f7577379"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-pre.5"
+version = "0.17.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e045ee5c360512162782f3d4cb07d2f4ce8c4ef9bf7c77ec16d1cf60b3d5ca"
+checksum = "fad051af2b2d2f356d716138c76775929be913deb5b4ea217cd2613535936bef"
 dependencies = [
  "der",
  "digest",
@@ -389,9 +389,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-pre.5"
+version = "0.14.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1775af172997a40c14854c3a9fde9e03e5772084b334b6a0bb18bf7f93ac16"
+checksum = "4ed8e96bb573517f42470775f8ef1b9cd7595de52ba7a8e19c48325a92c8fe4f"
 dependencies = [
  "base16ct",
  "base64ct",
@@ -523,27 +523,27 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hkdf"
-version = "0.13.0-pre.3"
+version = "0.13.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5d615ab5c462f96c309b3a00b19f373025a4981312f717f9df5bbd0201530c"
+checksum = "00176ff81091018d42ff82e8324f8e5adb0b7e0468d1358f653972562dbff031"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.13.0-pre.3"
+version = "0.13.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd790a0795ee332ed3e8959e5b177beb70d7112eb7d345428ec17427897d5ce"
+checksum = "e4b1fb14e4df79f9406b434b60acef9f45c26c50062cccf1346c6103b8c47d58"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.8"
+version = "0.2.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53668f5da5a41d9eaf4bf7064be46d1ebe6a4e1ceed817f387587b18f2b51047"
+checksum = "4d306b679262030ad8813a82d4915fc04efff97776e4db7f8eb5137039d56400"
 dependencies = [
  "typenum",
  "zeroize",
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -816,18 +816,18 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "1.0.0-pre.0"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a65e1c27d1680f8805b3f8c9949f08d6aa5d6cbd088c9896e64a53821dc27d"
+checksum = "b2b24c1c4a3b352d47de5ec824193e68317dc0ce041f6279a4771eb550ab7f8c"
 dependencies = [
  "base64ct",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-pre.0"
+version = "0.11.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935c09e0aecb0cb8f8907b57438b19a068cb74a25189b06724f061170b2465ff"
+checksum = "66180445f1dce533620a7743467ef85fe1c5e80cdaf7c7053609d7a2fbcdae20"
 dependencies = [
  "der",
  "spki",
@@ -1028,9 +1028,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-pre.3"
+version = "0.5.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045972f2f66b9467a2f6834b7fd0f9b23ca214b4a8700b880c36edb726e96da6"
+checksum = "871ee76a3eee98b0f805e5d1caf26929f4565073c580c053a55f886fc15dea49"
 dependencies = [
  "hmac",
  "subtle",
@@ -1099,9 +1099,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sec1"
-version = "0.8.0-pre.1"
+version = "0.8.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dc081ed777a3bab68583b52ffb8221677b6e90d483b320963a247e2c07f328"
+checksum = "32c98827dc6ed0ea1707286a3d14b4ad4e25e2643169cbf111568a46ff5b09f5"
 dependencies = [
  "base16ct",
  "der",
@@ -1134,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f33549bf3064b62478926aa89cbfc7c109aab66ae8f0d5d2ef839e482cc30d6"
+checksum = "540c0893cce56cdbcfebcec191ec8e0f470dd1889b6e7a0b503e310a94a168f5"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1176,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f32c02b9987a647a3d6af14c3e88df86594e4283050d9d8ee3a035df247785b9"
+checksum = "e485881f388c2818d709796dc883c1ffcadde9d1f0e054f3a5c14974185261a6"
 dependencies = [
  "digest",
  "keccak",
@@ -1186,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.3.0-pre.3"
+version = "2.3.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1700c22ba9ce32c7b0a1495068a906c3552e7db386af7cf865162e0dea498523"
+checksum = "054d71959c7051b9042c26af337f05cc930575ed2604d7d3ced3158383e59734"
 dependencies = [
  "digest",
  "rand_core",
@@ -1211,18 +1211,18 @@ dependencies = [
 
 [[package]]
 name = "sm3"
-version = "0.5.0-pre.3"
+version = "0.5.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f18e1b896a93beea148524bdfd4b7c58034de3b3edcacc6be1bec9d9fe043d"
+checksum = "07f9b2bb2253fa784d673b18790bafaa35f5757b27e6616b01f09417dd0003f9"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "spki"
-version = "0.8.0-pre.0"
+version = "0.8.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb2b56670f5ef52934c97efad30bf42585de0c33ec3e2a886e38b80d2db67243"
+checksum = "ee3fb1c675852398475928637b3ebbdd7e1d0cc24d27b3bbc81788b4eb51e310"
 dependencies = [
  "base64ct",
  "der",
@@ -1230,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1582,6 +1582,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/bign256/Cargo.toml
+++ b/bign256/Cargo.toml
@@ -18,21 +18,21 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.5", features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.6", features = ["sec1"] }
 
 # optional dependencies
-belt-hash = { version = "=0.2.0-pre.3", optional = true, default-features = false }
-der = { version = "0.8.0-pre.0" }
-digest = { version = "0.11.0-pre.8", optional = true }
+belt-hash = { version = "=0.2.0-pre.4", optional = true, default-features = false }
+der = { version = "0.8.0-rc.0" }
+digest = { version = "=0.11.0-pre.9", optional = true }
 hex-literal = { version = "0.4", optional = true }
-hkdf = { version = "0.13.0-pre.3", optional = true }
-hmac = { version = "0.13.0-pre.3", optional = true }
+hkdf = { version = "=0.13.0-pre.4", optional = true }
+hmac = { version = "=0.13.0-pre.4", optional = true }
 rand_core = "0.6.4"
-rfc6979 = { version = "=0.5.0-pre.3", optional = true }
-pkcs8 = { version = "0.11.0-pre.0", optional = true }
+rfc6979 = { version = "=0.5.0-pre.4", optional = true }
+pkcs8 = { version = "0.11.0-rc.0", optional = true }
 primeorder = { version = "=0.14.0-pre.0", optional = true, path = "../primeorder" }
-sec1 = { version = "0.8.0-pre.1", optional = true }
-signature = { version = "=2.3.0-pre.3", optional = true }
+sec1 = { version = "0.8.0-rc.0", optional = true }
+signature = { version = "=2.3.0-pre.4", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/bign256/src/ecdsa/signing.rs
+++ b/bign256/src/ecdsa/signing.rs
@@ -101,6 +101,7 @@ impl SigningKey {
 //
 
 impl PrehashSigner<Signature> for SigningKey {
+    #[allow(deprecated)] // clone_from_slice
     fn sign_prehash(&self, prehash: &[u8]) -> Result<Signature> {
         if prehash.len() != <BignP256 as Curve>::FieldBytesSize::USIZE {
             return Err(Error::new());

--- a/bign256/src/ecdsa/verifying.rs
+++ b/bign256/src/ecdsa/verifying.rs
@@ -107,6 +107,7 @@ impl VerifyingKey {
 // `*Verifier` trait impls
 //
 impl PrehashVerifier<Signature> for VerifyingKey {
+    #[allow(deprecated)] // clone_from_slice
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature) -> Result<()> {
         // 1. If |𝑆| != 3𝑙, return NO.
         if prehash.len() != <BignP256 as Curve>::FieldBytesSize::USIZE {

--- a/bign256/src/public_key.rs
+++ b/bign256/src/public_key.rs
@@ -57,7 +57,8 @@ impl PublicKey {
 
     /// Get [`PublicKey`] from bytes
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let mut bytes = Array::clone_from_slice(bytes);
+        let mut bytes = Array::try_from(bytes).map_err(|_| Error)?;
+
         // It is because public_key in little endian
         bytes[..32].reverse();
         bytes[32..].reverse();

--- a/bign256/src/secret_key.rs
+++ b/bign256/src/secret_key.rs
@@ -78,6 +78,7 @@ impl SecretKey {
     /// sidechannel, always ensure that the input has been pre-padded to `C::FieldBytesSize`.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
         if slice.len() == <BignP256 as elliptic_curve::Curve>::FieldBytesSize::USIZE {
+            #[allow(deprecated)]
             Self::from_bytes(FieldBytes::from_slice(slice))
         } else if (Self::MIN_SIZE..<BignP256 as elliptic_curve::Curve>::FieldBytesSize::USIZE)
             .contains(&slice.len())

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,12 +14,12 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.6", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "=0.17.0-pre.5", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.17.0-pre.7", optional = true, default-features = false, features = ["der"] }
 primeorder = { version = "=0.14.0-pre.0", optional = true, path = "../primeorder" }
-sha2 = { version = "=0.11.0-pre.3", optional = true, default-features = false }
+sha2 = { version = "=0.11.0-pre.4", optional = true, default-features = false }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -52,11 +52,8 @@ impl FieldElement {
 
     /// Decode [`FieldElement`] from a big endian byte slice.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
-        if slice.len() == 32 {
-            Option::from(Self::from_bytes(FieldBytes::from_slice(slice))).ok_or(Error)
-        } else {
-            Err(Error)
-        }
+        let field_bytes = FieldBytes::try_from(slice).map_err(|_| Error)?;
+        Self::from_bytes(&field_bytes).into_option().ok_or(Error)
     }
 
     /// Decode [`FieldElement`] from [`U256`] converting it into Montgomery form:

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -54,11 +54,8 @@ impl Scalar {
 
     /// Decode [`Scalar`] from a big endian byte slice.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
-        if slice.len() == 32 {
-            Option::from(Self::from_bytes(FieldBytes::from_slice(slice))).ok_or(Error)
-        } else {
-            Err(Error)
-        }
+        let field_bytes = FieldBytes::try_from(slice).map_err(|_| Error)?;
+        Self::from_bytes(&field_bytes).into_option().ok_or(Error)
     }
 
     /// Decode [`Scalar`] from [`U256`] converting it into Montgomery form:

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,12 +14,12 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.6", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "=0.17.0-pre.5", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "=0.17.0-pre.7", optional = true, default-features = false, features = ["der"] }
 primeorder = { version = "=0.14.0-pre.0", optional = true, path = "../primeorder" }
-sha2 = { version = "=0.11.0-pre.3", optional = true, default-features = false }
+sha2 = { version = "=0.11.0-pre.4", optional = true, default-features = false }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -52,11 +52,8 @@ impl FieldElement {
 
     /// Decode [`FieldElement`] from a big endian byte slice.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
-        if slice.len() == 48 {
-            Option::from(Self::from_bytes(FieldBytes::from_slice(slice))).ok_or(Error)
-        } else {
-            Err(Error)
-        }
+        let field_bytes = FieldBytes::try_from(slice).map_err(|_| Error)?;
+        Self::from_bytes(&field_bytes).into_option().ok_or(Error)
     }
 
     /// Decode [`FieldElement`] from [`U384`] converting it into Montgomery form:

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -54,11 +54,8 @@ impl Scalar {
 
     /// Decode [`Scalar`] from a big endian byte slice.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
-        if slice.len() == 32 {
-            Option::from(Self::from_bytes(FieldBytes::from_slice(slice))).ok_or(Error)
-        } else {
-            Err(Error)
-        }
+        let field_bytes = FieldBytes::try_from(slice).map_err(|_| Error)?;
+        Self::from_bytes(&field_bytes).into_option().ok_or(Error)
     }
 
     /// Decode [`Scalar`] from [`U384`] converting it into Montgomery form:

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,27 +20,27 @@ rust-version = "1.73"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "=0.14.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.6", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 once_cell = { version = "1.19", optional = true, default-features = false }
-ecdsa-core = { version = "=0.17.0-pre.5", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.17.0-pre.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 serdect = { version = "0.2", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.3", optional = true, default-features = false }
-signature = { version = "=2.3.0-pre.3", optional = true }
+sha2 = { version = "=0.11.0-pre.4", optional = true, default-features = false }
+signature = { version = "=2.3.0-pre.4", optional = true }
 
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.5"
-ecdsa-core = { version = "=0.17.0-pre.5", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.17.0-pre.7", package = "ecdsa", default-features = false, features = ["dev"] }
+hex = "0.4.3"
 hex-literal = "0.4"
 num-bigint = "0.4"
 num-traits = "0.2"
 proptest = "1.5"
 rand_core = { version = "0.6", features = ["getrandom"] }
-sha3 = { version = "=0.11.0-pre.3", default-features = false }
-hex = "0.4.3"
+sha3 = { version = "=0.11.0-pre.4", default-features = false }
 
 [features]
 default = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "schnorr", "std"]

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -1038,7 +1038,7 @@ mod tests {
         let m = Scalar::modulus_as_biguint();
 
         fn reduce<T: Reduce<U256, Bytes = FieldBytes>>(arr: &[u8]) -> T {
-            T::reduce_bytes(Array::from_slice(arr))
+            T::reduce_bytes(&Array::try_from(arr).unwrap())
         }
 
         // Regular reduction

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -279,7 +279,8 @@ mod tests {
                     for v in data.iter().take(offset) {
                         assert_eq!(*v, 0, "EcdsaVerifier: point too large");
                     }
-                    elliptic_curve::FieldBytes::<C>::clone_from_slice(&data[offset..])
+                    elliptic_curve::FieldBytes::<C>::try_from(&data[offset..])
+                        .expect("length mismatch")
                 } else {
                     let mut point = elliptic_curve::FieldBytes::<C>::default();
                     let offset = point_len - data.len();

--- a/k256/src/schnorr/verifying.rs
+++ b/k256/src/schnorr/verifying.rs
@@ -75,7 +75,8 @@ impl VerifyingKey {
 
     /// Parse verifying key from big endian-encoded x-coordinate.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        let maybe_affine_point = AffinePoint::decompact(FieldBytes::from_slice(bytes));
+        let field_bytes = FieldBytes::try_from(bytes).map_err(|_| Error::new())?;
+        let maybe_affine_point = AffinePoint::decompact(&field_bytes);
         let affine_point = Option::from(maybe_affine_point).ok_or_else(Error::new)?;
         PublicKey::from_affine(affine_point)
             .map_err(|_| Error::new())?

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
-sec1 = { version = "=0.8.0-pre.1", default-features = false }
+elliptic-curve = { version = "=0.14.0-pre.6", default-features = false, features = ["sec1"] }
+sec1 = { version = "0.8.0-rc.0", default-features = false }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.5", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.17.0-pre.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primeorder = { version = "=0.14.0-pre.0", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "=0.17.0-pre.5", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.17.0-pre.7", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "=0.14.0-pre.0", features = ["dev"], path = "../primeorder" }
 

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,18 +17,18 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.6", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.5", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.17.0-pre.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primeorder = { version = "=0.14.0-pre.0", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.3", optional = true, default-features = false }
+sha2 = { version = "=0.11.0-pre.4", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
-ecdsa-core = { version = "=0.17.0-pre.5", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.17.0-pre.7", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "=0.14.0-pre.0", features = ["dev"], path = "../primeorder" }
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,19 +18,19 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.6", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.5", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.17.0-pre.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primeorder = { version = "=0.14.0-pre.0", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.3", optional = true, default-features = false }
+sha2 = { version = "=0.11.0-pre.4", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.5"
-ecdsa-core = { version = "=0.17.0-pre.5", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.17.0-pre.7", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "=0.14.0-pre.0", features = ["dev"], path = "../primeorder" }
 proptest = "1"

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -76,7 +76,7 @@ mod tests {
         },
         AffinePoint, EncodedPoint,
     };
-    use elliptic_curve::{array::Array, sec1::FromEncodedPoint};
+    use elliptic_curve::sec1::FromEncodedPoint;
     use hex_literal::hex;
     use sha2::Digest;
 
@@ -128,24 +128,16 @@ mod tests {
         // <https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/digital-signatures>
         let verifier = VerifyingKey::from_affine(
             AffinePoint::from_encoded_point(&EncodedPoint::from_affine_coordinates(
-                Array::from_slice(&hex!(
-                    "e0e7b99bc62d8dd67883e39ed9fa0657789c5ff556cc1fd8dd1e2a55e9e3f243"
-                )),
-                Array::from_slice(&hex!(
-                    "63fbfd0232b95578075c903a4dbf85ad58f8350516e1ec89b0ee1f5e1362da69"
-                )),
+                &hex!("e0e7b99bc62d8dd67883e39ed9fa0657789c5ff556cc1fd8dd1e2a55e9e3f243").into(),
+                &hex!("63fbfd0232b95578075c903a4dbf85ad58f8350516e1ec89b0ee1f5e1362da69").into(),
                 false,
             ))
             .unwrap(),
         )
         .unwrap();
         let signature = Signature::from_scalars(
-            Array::clone_from_slice(&hex!(
-                "f5087878e212b703578f5c66f434883f3ef414dc23e2e8d8ab6a8d159ed5ad83"
-            )),
-            Array::clone_from_slice(&hex!(
-                "306b4c6c20213707982dffbb30fba99b96e792163dd59dbe606e734328dd7c8a"
-            )),
+            hex!("f5087878e212b703578f5c66f434883f3ef414dc23e2e8d8ab6a8d159ed5ad83"),
+            hex!("306b4c6c20213707982dffbb30fba99b96e792163dd59dbe606e734328dd7c8a"),
         )
         .unwrap();
         let result = verifier.verify_prehash(

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,19 +18,19 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.6", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.5", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.17.0-pre.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primeorder = { version = "=0.14.0-pre.0", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.3", optional = true, default-features = false }
+sha2 = { version = "=0.11.0-pre.4", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.5"
-ecdsa-core = { version = "=0.17.0-pre.5", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.17.0-pre.7", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "=0.14.0-pre.0", features = ["dev"], path = "../primeorder" }
 proptest = "1.5"

--- a/p384/src/ecdsa.rs
+++ b/p384/src/ecdsa.rs
@@ -76,7 +76,7 @@ mod tests {
         AffinePoint, EncodedPoint, SecretKey,
     };
 
-    use elliptic_curve::{array::Array, sec1::FromEncodedPoint};
+    use elliptic_curve::sec1::FromEncodedPoint;
     use hex_literal::hex;
     use sha2::Digest;
 
@@ -130,17 +130,15 @@ mod tests {
         let verifier = VerifyingKey::from_affine(
             AffinePoint::from_encoded_point(
                 &EncodedPoint::from_affine_coordinates(
-                    Array::from_slice(&hex!
-                    ("0400193b21f07cd059826e9453d3e96dd145041c97d49ff6b7047f86bb0b0439e909274cb9c282bfab88674c0765bc75")),
-                    Array::from_slice(&hex!
-                    ("f70d89c52acbc70468d2c5ae75c76d7f69b76af62dcf95e99eba5dd11adf8f42ec9a425b0c5ec98e2f234a926b82a147")),
+                    &hex!("0400193b21f07cd059826e9453d3e96dd145041c97d49ff6b7047f86bb0b0439e909274cb9c282bfab88674c0765bc75").into(),
+                    &hex! ("f70d89c52acbc70468d2c5ae75c76d7f69b76af62dcf95e99eba5dd11adf8f42ec9a425b0c5ec98e2f234a926b82a147").into(),
                     false,
                 ),
             ).unwrap()
         ).unwrap();
         let signature = Signature::from_scalars(
-            Array::clone_from_slice(&hex!("b11db00cdaf53286d4483f38cd02785948477ed7ebc2ad609054551da0ab0359978c61851788aa2ec3267946d440e878")),
-            Array::clone_from_slice(&hex!("16007873c5b0604ce68112a8fee973e8e2b6e3319c683a762ff5065a076512d7c98b27e74b7887671048ac027df8cbf2")),
+            hex!("b11db00cdaf53286d4483f38cd02785948477ed7ebc2ad609054551da0ab0359978c61851788aa2ec3267946d440e878"),
+            hex!("16007873c5b0604ce68112a8fee973e8e2b6e3319c683a762ff5065a076512d7c98b27e74b7887671048ac027df8cbf2"),
         ).unwrap();
         let result = verifier.verify_prehash(
             &hex!("bbbd0a5f645d3fda10e288d172b299455f9dff00e0fbc2833e18cd017d7f3ed1"),

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -18,20 +18,20 @@ rust-version = "1.73"
 
 [dependencies]
 base16ct = "0.2"
-elliptic-curve = { version = "=0.14.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.6", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.5", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "=0.17.0-pre.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primefield = { version = "=0.14.0-pre.0", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.0", optional = true, path = "../primeorder" }
 rand_core = { version = "0.6", optional = true, default-features = false }
 serdect = { version = "0.2", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.3", optional = true, default-features = false }
+sha2 = { version = "=0.11.0-pre.4", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
-ecdsa-core = { version = "=0.17.0-pre.5", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "=0.17.0-pre.7", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "=0.14.0-pre.0", features = ["dev"], path = "../primeorder" }
 proptest = "1.5"

--- a/p521/benches/field.rs
+++ b/p521/benches/field.rs
@@ -4,18 +4,18 @@ use criterion::{
     black_box, criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, Criterion,
 };
 use hex_literal::hex;
-use p521::{FieldBytes, FieldElement};
+use p521::FieldElement;
 
 fn test_field_element_x() -> FieldElement {
     black_box(FieldElement::from_bytes(
-        &FieldBytes::clone_from_slice(&hex!("01a7596d38aac7868327ddc1ef5e8178cf052b7ebc512828e8a45955d85bef49494d15278198bbcc5454358c12a2af9a3874e7002e1a2f02fcb36ff3e3b4bc0c69e7"))
+        hex!("01a7596d38aac7868327ddc1ef5e8178cf052b7ebc512828e8a45955d85bef49494d15278198bbcc5454358c12a2af9a3874e7002e1a2f02fcb36ff3e3b4bc0c69e7").as_ref()
     )
     .unwrap())
 }
 
 fn test_field_element_y() -> FieldElement {
     black_box(FieldElement::from_bytes(
-        &FieldBytes::clone_from_slice(&hex!("0184902e515982bb225b8c84f245e61b327c08e94d41c07d0b4101a963e02fe52f6a9f33e8b1de2394e0cb74c40790b4e489b5500e6804cabed0fe8c192443d4027b"))
+        hex!("0184902e515982bb225b8c84f245e61b327c08e94d41c07d0b4101a963e02fe52f6a9f33e8b1de2394e0cb74c40790b4e489b5500e6804cabed0fe8c192443d4027b").as_ref()
     )
     .unwrap())
 }

--- a/p521/benches/scalar.rs
+++ b/p521/benches/scalar.rs
@@ -4,17 +4,17 @@ use criterion::{
     black_box, criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, Criterion,
 };
 use hex_literal::hex;
-use p521::{elliptic_curve::group::ff::PrimeField, FieldBytes, ProjectivePoint, Scalar};
+use p521::{elliptic_curve::group::ff::PrimeField, ProjectivePoint, Scalar};
 
 fn test_scalar_x() -> Scalar {
     black_box(Scalar::from_repr(
-        FieldBytes::clone_from_slice(&hex!("01d7bb864c5b5ecae019296cf9b5c63a166f5f1113942819b1933d889a96d12245777a99428f93de4fc9a18d709bf91889d7f8dddd522b4c364aeae13c983e9fae46"))
+        hex!("01d7bb864c5b5ecae019296cf9b5c63a166f5f1113942819b1933d889a96d12245777a99428f93de4fc9a18d709bf91889d7f8dddd522b4c364aeae13c983e9fae46").into()
     ).unwrap())
 }
 
 fn test_scalar_y() -> Scalar {
     black_box(Scalar::from_repr(
-        FieldBytes::clone_from_slice(&hex!("017e49b8ea8f9d1b7c0378e378a7a42e68e12cf78779ed41dcd29a090ae7e0f883b0d0f2cbc8f0473c0ad6732bea40d371a7f363bc6537d075bd1a4c23e558b0bc73"))
+        hex!("017e49b8ea8f9d1b7c0378e378a7a42e68e12cf78779ed41dcd29a090ae7e0f883b0d0f2cbc8f0473c0ad6732bea40d371a7f363bc6537d075bd1a4c23e558b0bc73").into()
     ).unwrap())
 }
 

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -21,7 +21,6 @@ use core::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, ShrAssign, SubAssign},
 };
 use elliptic_curve::{
-    array::Array,
     bigint::{self, Integer},
     ff::{self, Field, PrimeField},
     ops::{Invert, Reduce},
@@ -78,9 +77,6 @@ impl Scalar {
     /// Multiplicative identity.
     pub const ONE: Self = Self::from_u64(1);
 
-    /// Number of bytes in the serialized representation.
-    const BYTES: usize = 66;
-
     /// Create a [`Scalar`] from a canonical big-endian representation.
     pub fn from_bytes(repr: &FieldBytes) -> CtOption<Self> {
         Self::from_uint(FieldBytesEncoding::<NistP521>::decode_field_bytes(repr))
@@ -88,11 +84,8 @@ impl Scalar {
 
     /// Decode [`Scalar`] from a big endian byte slice.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
-        if slice.len() != Self::BYTES {
-            return Err(Error);
-        }
-
-        Option::from(Self::from_bytes(Array::from_slice(slice))).ok_or(Error)
+        let field_bytes = FieldBytes::try_from(slice).map_err(|_| Error)?;
+        Self::from_bytes(&field_bytes).into_option().ok_or(Error)
     }
 
     /// Decode [`Scalar`] from [`U576`] converting it into Montgomery form:

--- a/primefield/src/lib.rs
+++ b/primefield/src/lib.rs
@@ -96,7 +96,7 @@ macro_rules! impl_mont_field_element {
                     return Err($crate::elliptic_curve::Error);
                 }
 
-                Option::from(Self::from_bytes(Array::from_slice(slice)))
+                Option::from(Self::from_bytes(&Array::try_from(slice).unwrap()))
                     .ok_or($crate::elliptic_curve::Error)
             }
 

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.5", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.6", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.2", optional = true, default-features = false }

--- a/primeorder/src/dev.rs
+++ b/primeorder/src/dev.rs
@@ -139,12 +139,12 @@ macro_rules! impl_projective_arithmetic_tests {
                 .iter()
                 .enumerate()
                 .map(|(k, coords)| (<$scalar>::from(k as u64 + 1), *coords))
-                .chain($mul_vectors.iter().cloned().map(|(k, x, y)| {
-                    (
-                        <$scalar>::from_repr($crate::array::Array::clone_from_slice(&k)).unwrap(),
-                        (x, y),
-                    )
-                }))
+                .chain(
+                    $mul_vectors
+                        .iter()
+                        .cloned()
+                        .map(|(k, x, y)| (<$scalar>::from_repr(k.into()).unwrap(), (x, y))),
+                )
             {
                 let p = generator * &k;
                 assert_point_eq!(p, coords);

--- a/primeorder/src/field.rs
+++ b/primeorder/src/field.rs
@@ -86,7 +86,7 @@ macro_rules! impl_mont_field_element {
                     return Err($crate::elliptic_curve::Error);
                 }
 
-                Option::from(Self::from_bytes(Array::from_slice(slice)))
+                Option::from(Self::from_bytes(&Array::try_from(slice).unwrap()))
                     .ok_or($crate::elliptic_curve::Error)
             }
 

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -18,14 +18,14 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.5", default-features = false, features = ["hazmat", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.6", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 primeorder = { version = "=0.14.0-pre.0", optional = true, path = "../primeorder" }
-rfc6979 = { version = "=0.5.0-pre.3", optional = true }
+rfc6979 = { version = "=0.5.0-pre.4", optional = true }
 serdect = { version = "0.2", optional = true, default-features = false }
-signature = { version = "=2.3.0-pre.3", optional = true, features = ["rand_core"] }
-sm3 = { version = "=0.5.0-pre.3", optional = true, default-features = false }
+signature = { version = "=2.3.0-pre.4", optional = true, features = ["rand_core"] }
+sm3 = { version = "=0.5.0-pre.4", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"

--- a/sm2/src/dsa/signing.rs
+++ b/sm2/src/dsa/signing.rs
@@ -189,6 +189,7 @@ fn sign_prehash_rfc6979(secret_scalar: &Scalar, prehash: &[u8], data: &[u8]) -> 
     }
 
     // A2: calculate e=Hv(M~)
+    #[allow(deprecated)] // from_slice
     let e = Scalar::reduce_bytes(FieldBytes::from_slice(prehash));
 
     // A3: pick a random number k in [1, n-1] via a random number generator

--- a/sm2/src/dsa/verifying.rs
+++ b/sm2/src/dsa/verifying.rs
@@ -140,6 +140,7 @@ impl PrehashVerifier<Signature> for VerifyingKey {
         let s = signature.s(); // NonZeroScalar checked at signature parse time
 
         // B4: calculate e'=Hv(M'~)
+        #[allow(deprecated)] // from_slice
         let e = Scalar::reduce_bytes(FieldBytes::from_slice(prehash));
 
         // B5: calculate t = (r' + s') modn, verification failed if t=0


### PR DESCRIPTION
Bumps the following:

- `belt-hash` v0.2.0-pre.4
- `ecdsa` v0.17.0-pre.7
- `elliptic-curve` v0.14.0-pre.6
- `hybrid-array` v0.2.0-rc.9
- `pkcs8` v0.11.0-rc.0
- `sha2` v0.11.0-pre.4
- `signature` v2.3.0-pre.4
- `sm3` v0.5.0-pre.4