### PR TITLE
Fix typo in point compatibility description in CHANGELOG.md

### DIFF
--- a/p384/CHANGELOG.md
+++ b/p384/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `primeorder` dependency to v0.13 ([#777])
 
 ### Fixed
-- Point compactabtility check ([#772])
+- Point compatibility check ([#772])
 
 [#730]: https://github.com/RustCrypto/elliptic-curves/pull/730
 [#732]: https://github.com/RustCrypto/elliptic-curves/pull/732


### PR DESCRIPTION
**Title:**
"Fix typo in CHANGELOG.md"

**Description:**
"Corrected a typo in the 'Fixed' section of CHANGELOG.md: replaced 'compactability' with 'compatibility'. This update clarifies the context of the point compatibility check."
