### PR TITLE
Fix grammar and links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 
-All curves reside in the separate crates and implemented using traits from
+All curves reside in separate crates and are implemented using traits from
 the [`elliptic-curve`](https://docs.rs/elliptic-curve/) crate.
 
 Crates in this repo do not require the standard library (i.e. `no_std` capable)

--- a/bp256/README.md
+++ b/bp256/README.md
@@ -14,7 +14,7 @@ implemented in terms of traits from the [`elliptic-curve`] crate.
 
 ## Minimum Supported Rust Version
 
-Rust **1.81* or higher.
+Rust **1.81** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.

--- a/primeorder/README.md
+++ b/primeorder/README.md
@@ -92,5 +92,5 @@ dual licensed as above, without any additional terms or conditions.
 [`p224`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p224
 [`p256`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p256
 [`p384`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p384
-[`p521`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p384
+[`p521`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p521
 [`sm2`]: https://github.com/RustCrypto/elliptic-curves/tree/master/sm2


### PR DESCRIPTION
Changes Made

1. README.md
- All curves reside in the separate crates and implemented using traits from
+ All curves reside in separate crates and are implemented using traits from
Reason: Improved grammar by removing unnecessary article "the" and adding missing auxiliary verb "are" to make the sentence grammatically correct.

2. bp256/README.md
- Rust **1.81* or higher.
+ Rust **1.81** or higher.
Reason: Fixed Markdown formatting by adding missing asterisk for proper bold text rendering.

3. primeorder/README.md
- [`p521`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p384
+ [`p521`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p521
Reason: Corrected incorrect URL path that was pointing to p384 instead of p521, ensuring proper documentation linking.
