### PR TITLE
 Fix documentation formatting and link issues

### DIFF
--- a/bp256/README.md
+++ b/bp256/README.md
@@ -14,7 +14,7 @@ implemented in terms of traits from the [`elliptic-curve`] crate.
 
 ## Minimum Supported Rust Version
 
-Rust **1.81* or higher.
+Rust **1.81** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.

--- a/primeorder/README.md
+++ b/primeorder/README.md
@@ -92,5 +92,5 @@ dual licensed as above, without any additional terms or conditions.
 [`p224`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p224
 [`p256`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p256
 [`p384`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p384
-[`p521`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p384
+[`p521`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p521
 [`sm2`]: https://github.com/RustCrypto/elliptic-curves/tree/master/sm2


### PR DESCRIPTION

1. bp256/README.md:
Old: `Rust **1.81* or higher.`
New: `Rust **1.81** or higher.`
Reason: Fixes incorrect Markdown bold text formatting by adding the missing closing asterisk. This ensures proper rendering of the minimum Rust version requirement.

2. primeorder/README.md:
Old: [`p521`]: `https://github.com/RustCrypto/elliptic-curves/tree/master/p384`
New: [`p521`]: `https://github.com/RustCrypto/elliptic-curves/tree/master/p521`
Reason: Corrects the incorrect URL path for the p521 documentation link. The original link incorrectly pointed to p384 instead of p521, which could confuse users looking for p521 documentation.

Before:
![image](https://github.com/user-attachments/assets/fef158ee-e835-4b78-b939-30e23e7699c9)


After:
![image](https://github.com/user-attachments/assets/619a1bbf-5ed6-4739-b5e2-dc3a993104fa)


These changes improve documentation accuracy and ensure proper navigation within the project documentation.

Testing:
- Verified Markdown formatting renders correctly
- Confirmed the p521 link points to the correct directory