### PR TITLE
Fix typos

### DIFF
--- a/p192/src/test_vectors/ecdsa.rs
+++ b/p192/src/test_vectors/ecdsa.rs
@@ -9,7 +9,7 @@ use hex_literal::hex;
 /// (P-192, SHA-1, from `SigGen.txt` in `186-2ecdsatestvectors.zip`)
 /// <https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/digital-signatures>
 ///
-/// The `m` field contains a SHA-1 prehash of the `Msg` field in the
+/// The `m` field contains an SHA-1 prehash of the `Msg` field in the
 /// original `SigTen.txt`.
 
 pub const ECDSA_TEST_VECTORS: &[TestVector; 15] = &[

--- a/p224/src/test_vectors/ecdsa.rs
+++ b/p224/src/test_vectors/ecdsa.rs
@@ -9,7 +9,7 @@ use hex_literal::hex;
 /// (P-224, SHA-224, from `SigGen.txt` in `186-4ecdsatestvectors.zip`)
 /// <https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/digital-signatures>
 ///
-/// The `m` field contains a SHA-224 prehash of the `Msg` field in the
+/// The `m` field contains an SHA-224 prehash of the `Msg` field in the
 /// original `SigTen.txt`.
 
 pub const ECDSA_TEST_VECTORS: &[TestVector; 15] = &[

--- a/p384/src/test_vectors/ecdsa.rs
+++ b/p384/src/test_vectors/ecdsa.rs
@@ -9,7 +9,7 @@ use hex_literal::hex;
 /// (P-384, SHA-384, from `SigGen.txt` in `186-4ecdsatestvectors.zip`)
 /// <https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/digital-signatures>
 ///
-/// The `m` field contains a SHA-384 prehash of the `Msg` field in the
+/// The `m` field contains an SHA-384 prehash of the `Msg` field in the
 /// original `SigTen.txt`.
 pub const ECDSA_TEST_VECTORS: &[TestVector; 15] = &[
     TestVector {

--- a/p521/src/test_vectors/ecdsa.rs
+++ b/p521/src/test_vectors/ecdsa.rs
@@ -9,7 +9,7 @@ use hex_literal::hex;
 /// (P-521, SHA-521, from `SigGen.txt` in `186-4ecdsatestvectors.zip`)
 /// <https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/digital-signatures>
 ///
-/// The `m` field contains a SHA-512 prehash of the `Msg` field in the
+/// The `m` field contains an SHA-512 prehash of the `Msg` field in the
 /// original `SigTen.txt`.
 
 pub const ECDSA_TEST_VECTORS: &[TestVector] = &[


### PR DESCRIPTION
This pull request addresses grammatical errors in comments within multiple `ecdsa.rs` files across the repository. The phrase "a SHA" was replaced with "an SHA" to ensure grammatical correctness when referring to words beginning with a vowel sound.

### Files Updated

1. **p192/src/test_vectors/ecdsa.rs**
   - Corrected: `"a SHA-1"` → `"an SHA-1"`
2. **p224/src/test_vectors/ecdsa.rs**
   - Corrected: `"a SHA-224"` → `"an SHA-224"`
3. **p384/src/test_vectors/ecdsa.rs**
   - Corrected: `"a SHA-384"` → `"an SHA-384"`
4. **p521/src/test_vectors/ecdsa.rs**
   - Corrected: `"a SHA-512"` → `"an SHA-512"`
