### PR TITLE
p384: remove default `ecdh` feature

### DIFF
--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -37,7 +37,7 @@ proptest = "1.5"
 rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
-default = ["arithmetic", "ecdh", "ecdsa", "pem", "std"]
+default = ["arithmetic", "ecdsa", "pem", "std"]
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std"]
 


### PR DESCRIPTION
This default feature is inconsistent with all of the other curve implementations in this repo, which don't enable the `ecdh` feature by default.

We could go either way, enabling it in all the other curves, or just disabling it here. This PR opts to do the latter, as it's simpler.

Closes #1047