### PR TITLE
chore: fix cargo clippy warning

### DIFF
--- a/sm2/src/pke/decrypting.rs
+++ b/sm2/src/pke/decrypting.rs
@@ -160,7 +160,7 @@ fn decrypt(
     cipher: &[u8],
 ) -> Result<Vec<u8>> {
     let q = U256::from_be_hex(FieldElement::MODULUS);
-    let c1_len = (q.bits() + 7) / 8 * 2 + 1;
+    let c1_len = q.bits().div_ceil(8) * 2 + 1;
 
     // B1: get 𝐶1 from 𝐶
     let (c1, c) = cipher.split_at(c1_len as usize);

--- a/sm2/src/pke/encrypting.rs
+++ b/sm2/src/pke/encrypting.rs
@@ -152,7 +152,7 @@ fn encrypt<R: TryCryptoRng + ?Sized>(
     digest: &mut dyn DynDigest,
     msg: &[u8],
 ) -> Result<Vec<u8>> {
-    const N_BYTES: u32 = (Sm2::ORDER.bits() + 7) / 8;
+    const N_BYTES: u32 = Sm2::ORDER.bits().div_ceil(8);
     let mut c1 = vec![0; (N_BYTES * 2 + 1) as usize];
     let mut c2 = msg.to_owned();
     let mut hpb: AffinePoint;


### PR DESCRIPTION
Running cargo clippy reports the following error.

```shell
warning: manually reimplementing `div_ceil`
   --> sm2/src/pke/decrypting.rs:163:18
    |
163 |     let c1_len = (q.bits() + 7) / 8 * 2 + 1;
    |                  ^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `q.bits().div_ceil(8)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_div_ceil
    = note: `#[warn(clippy::manual_div_ceil)]` on by default

warning: manually reimplementing `div_ceil`
   --> sm2/src/pke/encrypting.rs:155:26
    |
155 |     const N_BYTES: u32 = (Sm2::ORDER.bits() + 7) / 8;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `Sm2::ORDER.bits().div_ceil(8)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_div_ceil

warning: `sm2` (lib) generated 2 warnings (run `cargo clippy --fix --lib -p sm2` to apply 2 suggestions)
```

This commit resolves the issue.



