### PR TITLE
p256: use of `DigestSigner` with a shorter hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ dependencies = [
  "proptest",
  "rand_core 0.9.3",
  "serdect",
+ "sha1",
  "sha2",
 ]
 
@@ -1109,6 +1110,17 @@ checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f44e40722caefdd99383c25d3ae52a1094a1951215ae76f68837ece4e7f566"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -35,6 +35,7 @@ hex-literal = "1"
 primeorder = { version = "=0.14.0-pre.2", features = ["dev"], path = "../primeorder" }
 proptest = "1"
 rand_core = { version = "0.9", features = ["os_rng"] }
+sha1 = { version = "=0.11.0-pre.5", default-features = false }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]


### PR DESCRIPTION
This showcases the use of `DigestSigner` with a shorter hash than what p256 is usually used with.