### PR TITLE
p256: use `U256` for `MODULUS` of `FieldElement`

### DIFF
--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -24,7 +24,7 @@ const MODULUS_HEX: &str = "ffffffff00000001000000000000000000000000fffffffffffff
 
 /// Constant representing the modulus
 /// p = 2^{224}(2^{32} − 1) + 2^{192} + 2^{96} − 1
-pub const MODULUS: FieldElement = FieldElement(U256::from_be_hex(MODULUS_HEX));
+pub const MODULUS: U256 = U256::from_be_hex(MODULUS_HEX);
 
 /// R = 2^256 mod p
 const R: FieldElement = FieldElement(U256::from_be_hex(
@@ -69,7 +69,7 @@ impl FieldElement {
     /// w * R^2 * R^-1 mod p = wR mod p
     /// ```
     pub fn from_uint(uint: U256) -> CtOption<Self> {
-        let is_some = uint.ct_lt(&MODULUS.0);
+        let is_some = uint.ct_lt(&MODULUS);
         CtOption::new(Self::from_uint_unchecked(uint), is_some)
     }
 

--- a/p256/src/arithmetic/field/field32.rs
+++ b/p256/src/arithmetic/field/field32.rs
@@ -18,7 +18,7 @@ pub(super) const fn add(a: U256, b: U256) -> U256 {
     let (w6, carry) = a[6].adc(b[6], carry);
     let (w7, w8) = a[7].adc(b[7], carry);
     // Attempt to subtract the modulus, to ensure the result is in the field.
-    let modulus = MODULUS.0.as_limbs();
+    let modulus = MODULUS.as_limbs();
 
     let (result, _) = sub_inner(
         [w0, w1, w2, w3, w4, w5, w6, w7, w8],
@@ -138,7 +138,7 @@ pub(super) const fn montgomery_reduce(lo: U256, hi: U256) -> U256 {
     let a14 = hi[6];
     let a15 = hi[7];
 
-    let modulus = MODULUS.0.as_limbs();
+    let modulus = MODULUS.as_limbs();
 
     /*
      * let (a0, c) = (0, a0);
@@ -249,7 +249,7 @@ const fn sub_inner(l: [Limb; 9], r: [Limb; 9]) -> ([Limb; 8], Limb) {
     // borrow = 0x000...000. Thus, we use it as a mask to conditionally add
     // the modulus.
 
-    let modulus = MODULUS.0.as_limbs();
+    let modulus = MODULUS.as_limbs();
 
     let (w0, carry) = w0.adc(modulus[0].bitand(borrow), Limb::ZERO);
     let (w1, carry) = w1.adc(modulus[1].bitand(borrow), carry);

--- a/p256/src/arithmetic/field/field64.rs
+++ b/p256/src/arithmetic/field/field64.rs
@@ -18,7 +18,7 @@ pub(super) const fn add(a: U256, b: U256) -> U256 {
     // let (w3, w4) = adc(a[3], b[3], carry);
 
     // Attempt to subtract the modulus, to ensure the result is in the field
-    let modulus = MODULUS.0.as_limbs();
+    let modulus = MODULUS.as_limbs();
 
     let (result, _) = sub_inner(
         [w0, w1, w2, w3, w4],
@@ -106,7 +106,7 @@ pub(super) const fn montgomery_reduce(lo: U256, hi: U256) -> U256 {
     let a6 = hi[2];
     let a7 = hi[3];
 
-    let modulus = MODULUS.0.as_limbs();
+    let modulus = MODULUS.as_limbs();
 
     /*
     let (a1, carry) = mac(a1, a0, modulus[1], a0);
@@ -179,7 +179,7 @@ const fn sub_inner(l: [Limb; 5], r: [Limb; 5]) -> ([Limb; 4], Limb) {
     // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
     // modulus.
 
-    let modulus = MODULUS.0.as_limbs();
+    let modulus = MODULUS.as_limbs();
 
     /*
     let (w0, carry) = adc(w0, modulus[0] & borrow, 0);

--- a/p256/src/arithmetic/hash2curve.rs
+++ b/p256/src/arithmetic/hash2curve.rs
@@ -112,7 +112,7 @@ mod tests {
     fn params() {
         let params = <FieldElement as OsswuMap>::PARAMS;
 
-        let c1 = MODULUS.0.checked_sub(&U256::from_u8(3)).unwrap()
+        let c1 = MODULUS.checked_sub(&U256::from_u8(3)).unwrap()
             / NonZero::new(U256::from_u8(4)).unwrap();
         assert_eq!(
             Array::from_iter(params.c1.iter().rev().flat_map(|v| v.to_be_bytes())),


### PR DESCRIPTION
Previously `FieldElement` was used, however `MODULUS` itself is not a valid field element.

Originally suggested here: https://reports.zksecurity.xyz/reports/near-p256/#finding-mix-type