### PR TITLE
p256: remove unnecessary sub in scalar Barrett reduction

### DIFF
--- a/p256/src/arithmetic/scalar/scalar32.rs
+++ b/p256/src/arithmetic/scalar/scalar32.rs
@@ -79,7 +79,6 @@ pub(super) const fn barrett_reduce(lo: U256, hi: U256) -> U256 {
     // Result is in range (0, 3*n - 1),
     // and 90% of the time, no subtraction will be needed.
     let r = subtract_n_if_necessary(r);
-    let r = subtract_n_if_necessary(r);
 
     U256::new([r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7]])
 }

--- a/p256/src/arithmetic/scalar/scalar64.rs
+++ b/p256/src/arithmetic/scalar/scalar64.rs
@@ -65,7 +65,6 @@ pub(super) const fn barrett_reduce(lo: U256, hi: U256) -> U256 {
     // Result is in range (0, 3*n - 1),
     // and 90% of the time, no subtraction will be needed.
     let r = subtract_n_if_necessary(r);
-    let r = subtract_n_if_necessary(r);
     U256::new([r[0], r[1], r[2], r[3]])
 }
 


### PR DESCRIPTION
Based on the following Barrett reduction bound analysis:

https://reports.zksecurity.xyz/reports/near-p256/#analysis-of-the-bound-of-barrett-reduction

...the duplicate subtractions are unnecessary, and it was recommended to remove them:

https://reports.zksecurity.xyz/reports/near-p256/#finding-barrett-second-sub

This results in the following performance improvements:

        scalar operations/mul   time:   [38.900 ns 38.957 ns 39.026 ns]
                                change: [-14.379% -14.052% -13.734%] (p = 0.00 < 0.05)
                                Performance has improved.
        scalar operations/invert
                                time:   [20.716 µs 20.758 µs 20.823 µs]
                                change: [-14.817% -14.331% -13.969%] (p = 0.00 < 0.05)
                                Performance has improved.