### PR TITLE
primefield: decouple from `elliptic-curve`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,6 +846,7 @@ dependencies = [
 name = "primefield"
 version = "0.14.0-pre.0"
 dependencies = [
+ "crypto-bigint",
  "ff",
  "rand_core 0.9.3",
  "subtle",

--- a/bign256/src/arithmetic/field.rs
+++ b/bign256/src/arithmetic/field.rs
@@ -32,6 +32,7 @@ mod field_impl;
 use self::field_impl::*;
 use crate::{BignP256, FieldBytes, U256};
 use elliptic_curve::{
+    FieldBytesEncoding,
     ff::PrimeField,
     ops::Invert,
     subtle::{Choice, ConstantTimeEq, CtOption},
@@ -46,7 +47,14 @@ pub(crate) const MODULUS: U256 =
 #[derive(Clone, Copy)]
 pub struct FieldElement(pub(super) U256);
 
-primefield::field_element_type!(BignP256, FieldElement, FieldBytes, U256, MODULUS);
+primefield::field_element_type!(
+    FieldElement,
+    FieldBytes,
+    U256,
+    MODULUS,
+    FieldBytesEncoding::<BignP256>::decode_field_bytes,
+    FieldBytesEncoding::<BignP256>::encode_field_bytes
+);
 
 primefield::fiat_field_arithmetic!(
     FieldElement,

--- a/bign256/src/arithmetic/scalar.rs
+++ b/bign256/src/arithmetic/scalar.rs
@@ -15,10 +15,10 @@
 mod scalar_impl;
 
 use self::scalar_impl::*;
-use crate::{BignP256, FieldBytes, FieldBytesEncoding, ORDER_HEX, SecretKey, U256};
+use crate::{BignP256, FieldBytes, ORDER_HEX, SecretKey, U256};
 use core::ops::{Shr, ShrAssign};
 use elliptic_curve::{
-    Curve as _, Error, Result, ScalarPrimitive,
+    Curve as _, Error, FieldBytesEncoding, Result, ScalarPrimitive,
     bigint::Limb,
     ff::PrimeField,
     ops::{Invert, Reduce},
@@ -61,7 +61,14 @@ use core::ops::{Add, Mul, Neg, Sub};
 #[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(pub U256);
 
-primefield::field_element_type!(BignP256, Scalar, FieldBytes, U256, BignP256::ORDER);
+primefield::field_element_type!(
+    Scalar,
+    FieldBytes,
+    U256,
+    BignP256::ORDER,
+    FieldBytesEncoding::<BignP256>::decode_field_bytes,
+    FieldBytesEncoding::<BignP256>::encode_field_bytes
+);
 
 primefield::fiat_field_arithmetic!(
     Scalar,

--- a/bign256/src/ecdsa/signing.rs
+++ b/bign256/src/ecdsa/signing.rs
@@ -134,7 +134,7 @@ impl PrehashSigner<Signature> for SigningKey {
         s0[16..].fill(0x00);
         s0.reverse();
 
-        let s0_scalar = Scalar::from_slice(&s0).map_err(|_| Error::new())?;
+        let s0_scalar = Scalar::from_slice(&s0).ok_or_else(Error::new)?;
 
         let right = s0_scalar
             .add(&Scalar::from_u64(2).pow([128, 0, 0, 0]))

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -26,6 +26,7 @@ mod field_impl;
 use self::field_impl::*;
 use crate::{FieldBytes, NistP384};
 use elliptic_curve::{
+    FieldBytesEncoding,
     bigint::U384,
     ff::PrimeField,
     ops::Invert,
@@ -40,7 +41,14 @@ pub(crate) const MODULUS: U384 = U384::from_be_hex(FieldElement::MODULUS);
 #[derive(Clone, Copy)]
 pub struct FieldElement(pub(super) U384);
 
-primefield::field_element_type!(NistP384, FieldElement, FieldBytes, U384, MODULUS);
+primefield::field_element_type!(
+    FieldElement,
+    FieldBytes,
+    U384,
+    MODULUS,
+    FieldBytesEncoding::<NistP384>::decode_field_bytes,
+    FieldBytesEncoding::<NistP384>::encode_field_bytes
+);
 
 primefield::fiat_field_arithmetic!(
     FieldElement,

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -25,7 +25,7 @@ use self::scalar_impl::*;
 use crate::{FieldBytes, NistP384, ORDER_HEX, SecretKey, U384};
 use core::ops::{Shr, ShrAssign};
 use elliptic_curve::{
-    Curve as _, Error, Result, ScalarPrimitive,
+    Curve as _, Error, FieldBytesEncoding, Result, ScalarPrimitive,
     bigint::{ArrayEncoding, Limb},
     ff::PrimeField,
     ops::{Invert, Reduce, ReduceNonZero},
@@ -79,7 +79,14 @@ use core::ops::{Add, Mul, Neg, Sub};
 #[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(U384);
 
-primefield::field_element_type!(NistP384, Scalar, FieldBytes, U384, NistP384::ORDER);
+primefield::field_element_type!(
+    Scalar,
+    FieldBytes,
+    U384,
+    NistP384::ORDER,
+    FieldBytesEncoding::<NistP384>::decode_field_bytes,
+    FieldBytesEncoding::<NistP384>::encode_field_bytes
+);
 
 primefield::fiat_field_arithmetic!(
     Scalar,

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
+bigint = { package = "crypto-bigint", version = "=0.7.0-pre.1", default-features = false }
 ff = { version = "=0.14.0-pre.0", default-features = false }
 subtle = { version = "2.6", default-features = false }
 rand_core = { version = "0.9", default-features = false }

--- a/primefield/src/fiat.rs
+++ b/primefield/src/fiat.rs
@@ -127,7 +127,7 @@ macro_rules! fiat_field_arithmetic {
                     &$mont_type(Self::ONE.0.to_words()),
                     <$uint>::BITS as usize,
                     <$uint>::LIMBS,
-                    ::elliptic_curve::bigint::Word, // TODO(tarcieri): source from `crypto-bigint` directly?
+                    $crate::bigint::Word,
                     $non_mont_type,
                     $mont_type,
                     $from_mont,


### PR DESCRIPTION
This commit removes the last pieces coupling `primefield` and `elliptic-curve`.

Since an elliptic curve is over a finite field, it doesn't make sense for the dependency to go the other way.