### PR TITLE
bp256+bp384: `arithmetic` feature

### DIFF
--- a/.github/workflows/bp256.yml
+++ b/.github/workflows/bp256.yml
@@ -37,6 +37,7 @@ jobs:
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
@@ -52,14 +53,14 @@ jobs:
           - 1.85.0 # MSRV
           - stable
     steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ matrix.rust }}
-    - run: cargo check --all-features
-    - run: cargo test --no-default-features
-    - run: cargo test
-    - run: cargo test --all-features
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo check --all-features
+      - run: cargo test --no-default-features
+      - run: cargo test
+      - run: cargo test --all-features
 
   doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/bp384.yml
+++ b/.github/workflows/bp384.yml
@@ -37,6 +37,7 @@ jobs:
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
@@ -52,14 +53,14 @@ jobs:
           - 1.85.0 # MSRV
           - stable
     steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ matrix.rust }}
-    - run: cargo check --all-features
-    - run: cargo test --no-default-features
-    - run: cargo test
-    - run: cargo test --all-features
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo check --all-features
+      - run: cargo test --no-default-features
+      - run: cargo test
+      - run: cargo test --all-features
 
   doc:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ NOTE: Most crates have field/point arithmetic implementations gated under the
 | Name      | Curve              | `arithmetic`? | Crates.io                                                                                 | Documentation                                                              | Build Status                                                                                               |
 |-----------|--------------------|---------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
 | [`bign256`] | bign-curve256v1  | ✅             | [![crates.io](https://img.shields.io/crates/v/bign256.svg)](https://crates.io/crates/bign256) | [![Documentation](https://docs.rs/bign256/badge.svg)](https://docs.rs/bign256) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/bign256/badge.svg?branch=master&event=push) |
-| [`bp256`] | brainpoolP256r1/t1 | 🚧            | [![crates.io](https://img.shields.io/crates/v/bp256.svg)](https://crates.io/crates/bp256) | [![Documentation](https://docs.rs/bp256/badge.svg)](https://docs.rs/bp256) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/bp256/badge.svg?branch=master&event=push) |
-| [`bp384`] | brainpoolP384r1/t1 | 🚧            | [![crates.io](https://img.shields.io/crates/v/bp384.svg)](https://crates.io/crates/bp384) | [![Documentation](https://docs.rs/bp384/badge.svg)](https://docs.rs/bp384) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/bp384/badge.svg?branch=master&event=push) |
+| [`bp256`] | brainpoolP256r1/t1 | ✅             | [![crates.io](https://img.shields.io/crates/v/bp256.svg)](https://crates.io/crates/bp256) | [![Documentation](https://docs.rs/bp256/badge.svg)](https://docs.rs/bp256) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/bp256/badge.svg?branch=master&event=push) |
+| [`bp384`] | brainpoolP384r1/t1 | ✅             | [![crates.io](https://img.shields.io/crates/v/bp384.svg)](https://crates.io/crates/bp384) | [![Documentation](https://docs.rs/bp384/badge.svg)](https://docs.rs/bp384) | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/bp384/badge.svg?branch=master&event=push) |
 | [`k256`]  | [secp256k1]        | ✅             | [![crates.io](https://img.shields.io/crates/v/k256.svg)](https://crates.io/crates/k256)   | [![Documentation](https://docs.rs/k256/badge.svg)](https://docs.rs/k256)   | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/k256/badge.svg?branch=master&event=push)  |
 | [`p192`]  | [NIST P-192]       | ✅             | [![crates.io](https://img.shields.io/crates/v/p192.svg)](https://crates.io/crates/p192)   | [![Documentation](https://docs.rs/p192/badge.svg)](https://docs.rs/p192)   | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/p192/badge.svg?branch=master&event=push)  |
 | [`p224`]  | [NIST P-224]       | ✅             | [![crates.io](https://img.shields.io/crates/v/p224.svg)](https://crates.io/crates/p224)   | [![Documentation](https://docs.rs/p224/badge.svg)](https://docs.rs/p224)   | ![build](https://github.com/RustCrypto/elliptic-curves/workflows/p224/badge.svg?branch=master&event=push)  |
@@ -35,7 +35,7 @@ if you are interested in curves beyond the ones listed here.
 
 ## Minimum Supported Rust Version
 
-All crates in this repository support Rust **1.81** or higher.
+All crates in this repository support Rust **1.85** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -57,7 +57,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[rustc-image]: https://img.shields.io/badge/rustc-1.81+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [deps-image]: https://deps.rs/repo/github/RustCrypto/elliptic-curves/status.svg

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -31,7 +31,7 @@ pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa/serde", "elliptic-curve/serde"]
 sha256 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
-wip-arithmetic-do-not-use = ["dep:primefield", "dep:primeorder"]
+arithmetic = ["dep:primefield", "dep:primeorder"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/bp256/src/lib.rs
+++ b/bp256/src/lib.rs
@@ -18,19 +18,19 @@
 pub mod r1;
 pub mod t1;
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 mod arithmetic;
 
 pub use crate::{r1::BrainpoolP256r1, t1::BrainpoolP256t1};
 pub use elliptic_curve::{self, bigint::U256};
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 pub use crate::arithmetic::scalar::Scalar;
 
 #[cfg(feature = "pkcs8")]
 pub use elliptic_curve::pkcs8;
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 pub(crate) use crate::arithmetic::field::FieldElement;
 use elliptic_curve::array::{Array, typenum::U32};
 use elliptic_curve::bigint::ArrayEncoding;

--- a/bp256/src/r1.rs
+++ b/bp256/src/r1.rs
@@ -3,10 +3,10 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 mod arithmetic;
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 pub use {
     self::arithmetic::{AffinePoint, ProjectivePoint},
     crate::Scalar,
@@ -66,5 +66,5 @@ impl FieldBytesEncoding<BrainpoolP256r1> for U256 {
 /// brainpoolP256r1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP256r1>;
 
-#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
+#[cfg(not(feature = "arithmetic"))]
 impl elliptic_curve::sec1::ValidatePublicKey for BrainpoolP256r1 {}

--- a/bp256/src/t1.rs
+++ b/bp256/src/t1.rs
@@ -3,10 +3,10 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 mod arithmetic;
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 pub use {
     self::arithmetic::{AffinePoint, ProjectivePoint},
     crate::Scalar,
@@ -66,5 +66,5 @@ impl FieldBytesEncoding<BrainpoolP256t1> for U256 {
 /// brainpoolP256t1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP256t1>;
 
-#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
+#[cfg(not(feature = "arithmetic"))]
 impl elliptic_curve::sec1::ValidatePublicKey for BrainpoolP256t1 {}

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -31,7 +31,7 @@ pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa/serde", "elliptic-curve/serde"]
 sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
-wip-arithmetic-do-not-use = ["dep:primefield", "dep:primeorder"]
+arithmetic = ["dep:primefield", "dep:primeorder"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/bp384/src/lib.rs
+++ b/bp384/src/lib.rs
@@ -18,7 +18,7 @@
 pub mod r1;
 pub mod t1;
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 mod arithmetic;
 
 pub use crate::{r1::BrainpoolP384r1, t1::BrainpoolP384t1};
@@ -27,13 +27,13 @@ pub use elliptic_curve::{
     bigint::{ArrayEncoding, U384},
 };
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 pub use crate::arithmetic::scalar::Scalar;
 
 #[cfg(feature = "pkcs8")]
 pub use elliptic_curve::pkcs8;
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 pub(crate) use crate::arithmetic::field::FieldElement;
 use elliptic_curve::array::{Array, typenum::U48};
 

--- a/bp384/src/r1.rs
+++ b/bp384/src/r1.rs
@@ -3,10 +3,10 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 mod arithmetic;
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 pub use {
     self::arithmetic::{AffinePoint, ProjectivePoint},
     crate::Scalar,
@@ -66,5 +66,5 @@ impl FieldBytesEncoding<BrainpoolP384r1> for U384 {
 /// brainpoolP384r1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP384r1>;
 
-#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
+#[cfg(not(feature = "arithmetic"))]
 impl elliptic_curve::sec1::ValidatePublicKey for BrainpoolP384r1 {}

--- a/bp384/src/t1.rs
+++ b/bp384/src/t1.rs
@@ -3,10 +3,10 @@
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 mod arithmetic;
 
-#[cfg(feature = "wip-arithmetic-do-not-use")]
+#[cfg(feature = "arithmetic")]
 pub use {
     self::arithmetic::{AffinePoint, ProjectivePoint},
     crate::Scalar,
@@ -66,5 +66,5 @@ impl FieldBytesEncoding<BrainpoolP384t1> for U384 {
 /// brainpoolP384t1 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<BrainpoolP384t1>;
 
-#[cfg(not(feature = "wip-arithmetic-do-not-use"))]
+#[cfg(not(feature = "arithmetic"))]
 impl elliptic_curve::sec1::ValidatePublicKey for BrainpoolP384t1 {}


### PR DESCRIPTION
Promotes the previous `wip-arithmetic-do-not-use` feature to a proper `arithmetic` feature.

The previous bugs were in the field implementation. The `bp*` crates now use the `primefield` crate to write their field implementations with macros as opposed to the previous copy/pasted code.