### PR TITLE
Feature/add sm2 pke tests

### DIFF
--- a/sm2/tests/dsa_extended.rs
+++ b/sm2/tests/dsa_extended.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "dsa")]
 
-use elliptic_curve::{ops::Reduce, SecretKey};
+use elliptic_curve::ops::Reduce;
 use proptest::prelude::*;
 use sm2::{
     dsa::{

--- a/sm2/tests/dsa_extended.rs
+++ b/sm2/tests/dsa_extended.rs
@@ -3,11 +3,11 @@
 use elliptic_curve::ops::Reduce;
 use proptest::prelude::*;
 use sm2::{
-    dsa::{
-        signature::{Signer, Verifier},
-        Signature, SigningKey,
-    },
     NonZeroScalar, Scalar, U256,
+    dsa::{
+        Signature, SigningKey,
+        signature::{Signer, Verifier},
+    },
 };
 
 const IDENTITY: &str = "test@rustcrypto.org";
@@ -25,7 +25,7 @@ fn create_test_signing_key() -> SigningKey {
 fn test_varying_message_lengths() {
     let sk = create_test_signing_key();
     let test_messages = vec![
-        vec![],           // Empty message
+        vec![],          // Empty message
         vec![1u8; 1],    // 1 byte
         vec![2u8; 32],   // 32 bytes
         vec![3u8; 1024], // 1KB

--- a/sm2/tests/dsa_extended.rs
+++ b/sm2/tests/dsa_extended.rs
@@ -1,21 +1,18 @@
 #![cfg(feature = "dsa")]
 
-use elliptic_curve::{
-    ops::Reduce,
-    SecretKey,
-};
+use elliptic_curve::{ops::Reduce, SecretKey};
 use proptest::prelude::*;
 use sm2::{
-    NonZeroScalar, Scalar, U256,
     dsa::{
-        Signature, SigningKey,
         signature::{Signer, Verifier},
+        Signature, SigningKey,
     },
+    NonZeroScalar, Scalar, U256,
 };
 
 const IDENTITY: &str = "test@rustcrypto.org";
 
-// Helper function to create a signing key from test data
+/// Helper function to create a signing key from test data
 fn create_test_signing_key() -> SigningKey {
     // Use a fixed test key for deterministic testing
     let test_key = [42u8; 32];
@@ -24,15 +21,14 @@ fn create_test_signing_key() -> SigningKey {
     SigningKey::from_nonzero_scalar(IDENTITY.into(), scalar).unwrap()
 }
 
-// Test vectors for different message lengths
 #[test]
 fn test_varying_message_lengths() {
     let sk = create_test_signing_key();
     let test_messages = vec![
-        vec![],                // Empty message
-        vec![1u8; 1],         // 1 byte
-        vec![2u8; 32],        // 32 bytes
-        vec![3u8; 1024],      // 1KB
+        vec![],           // Empty message
+        vec![1u8; 1],    // 1 byte
+        vec![2u8; 32],   // 32 bytes
+        vec![3u8; 1024], // 1KB
     ];
 
     for msg in test_messages {
@@ -41,7 +37,6 @@ fn test_varying_message_lengths() {
     }
 }
 
-// Test signature tampering detection
 #[test]
 fn test_signature_tampering() {
     let sk = create_test_signing_key();
@@ -54,18 +49,17 @@ fn test_signature_tampering() {
         tampered_sig[i] ^= 1;
         let invalid_sig = Signature::from_bytes(&tampered_sig).unwrap();
         assert!(sk.verifying_key().verify(msg, &invalid_sig).is_err());
-        tampered_sig[i] ^= 1;  // Restore
+        tampered_sig[i] ^= 1; // Restore
     }
 }
 
-// Test edge cases with special messages
 #[test]
 fn test_special_messages() {
     let sk = create_test_signing_key();
     let special_msgs = vec![
-        vec![0u8; 32],        // All zeros
-        vec![255u8; 32],      // All ones
-        b"\n\r\t".to_vec(),   // Control chars
+        vec![0u8; 32],      // All zeros
+        vec![255u8; 32],    // All ones
+        b"\n\r\t".to_vec(), // Control chars
     ];
 
     for msg in special_msgs {
@@ -74,7 +68,6 @@ fn test_special_messages() {
     }
 }
 
-// Property-based test for signature consistency
 proptest! {
     #[test]
     fn test_signature_consistency(
@@ -83,8 +76,8 @@ proptest! {
     ) {
         let sk = create_test_signing_key();
         let sig1 = sk.sign(&msg1);
-        let sig2 = sk.sign(&msg1);  // Same message
-        let sig3 = sk.sign(&msg2);  // Different message
+        let sig2 = sk.sign(&msg1); // Same message
+        let sig3 = sk.sign(&msg2); // Different message
 
         // Same message should verify with both signatures
         prop_assert!(sk.verifying_key().verify(&msg1, &sig1).is_ok());
@@ -95,4 +88,4 @@ proptest! {
             prop_assert_ne!(sig1.to_bytes(), sig3.to_bytes());
         }
     }
-} 
+}

--- a/sm2/tests/dsa_extended.rs
+++ b/sm2/tests/dsa_extended.rs
@@ -1,0 +1,98 @@
+#![cfg(feature = "dsa")]
+
+use elliptic_curve::{
+    ops::Reduce,
+    SecretKey,
+};
+use proptest::prelude::*;
+use sm2::{
+    NonZeroScalar, Scalar, U256,
+    dsa::{
+        Signature, SigningKey,
+        signature::{Signer, Verifier},
+    },
+};
+
+const IDENTITY: &str = "test@rustcrypto.org";
+
+// Helper function to create a signing key from test data
+fn create_test_signing_key() -> SigningKey {
+    // Use a fixed test key for deterministic testing
+    let test_key = [42u8; 32];
+    let scalar = <Scalar as Reduce<U256>>::reduce_bytes(&test_key.into());
+    let scalar = NonZeroScalar::new(scalar).unwrap();
+    SigningKey::from_nonzero_scalar(IDENTITY.into(), scalar).unwrap()
+}
+
+// Test vectors for different message lengths
+#[test]
+fn test_varying_message_lengths() {
+    let sk = create_test_signing_key();
+    let test_messages = vec![
+        vec![],                // Empty message
+        vec![1u8; 1],         // 1 byte
+        vec![2u8; 32],        // 32 bytes
+        vec![3u8; 1024],      // 1KB
+    ];
+
+    for msg in test_messages {
+        let sig = sk.sign(&msg);
+        assert!(sk.verifying_key().verify(&msg, &sig).is_ok());
+    }
+}
+
+// Test signature tampering detection
+#[test]
+fn test_signature_tampering() {
+    let sk = create_test_signing_key();
+    let msg = b"test message";
+    let sig = sk.sign(msg);
+    let mut tampered_sig = sig.to_bytes();
+
+    // Modify each byte of signature
+    for i in 0..64 {
+        tampered_sig[i] ^= 1;
+        let invalid_sig = Signature::from_bytes(&tampered_sig).unwrap();
+        assert!(sk.verifying_key().verify(msg, &invalid_sig).is_err());
+        tampered_sig[i] ^= 1;  // Restore
+    }
+}
+
+// Test edge cases with special messages
+#[test]
+fn test_special_messages() {
+    let sk = create_test_signing_key();
+    let special_msgs = vec![
+        vec![0u8; 32],        // All zeros
+        vec![255u8; 32],      // All ones
+        b"\n\r\t".to_vec(),   // Control chars
+    ];
+
+    for msg in special_msgs {
+        let sig = sk.sign(&msg);
+        assert!(sk.verifying_key().verify(&msg, &sig).is_ok());
+    }
+}
+
+// Property-based test for signature consistency
+proptest! {
+    #[test]
+    fn test_signature_consistency(
+        msg1 in any::<Vec<u8>>(),
+        msg2 in any::<Vec<u8>>()
+    ) {
+        let sk = create_test_signing_key();
+        let sig1 = sk.sign(&msg1);
+        let sig2 = sk.sign(&msg1);  // Same message
+        let sig3 = sk.sign(&msg2);  // Different message
+
+        // Same message should verify with both signatures
+        prop_assert!(sk.verifying_key().verify(&msg1, &sig1).is_ok());
+        prop_assert!(sk.verifying_key().verify(&msg1, &sig2).is_ok());
+
+        // Different messages should have different signatures
+        if msg1 != msg2 {
+            prop_assert_ne!(sig1.to_bytes(), sig3.to_bytes());
+        }
+    }
+} 

--- a/sm2/tests/pke_extended.rs
+++ b/sm2/tests/pke_extended.rs
@@ -116,4 +116,4 @@ proptest! {
             prop_assert_ne!(dk.decrypt(&cipher1).unwrap(), dk.decrypt(&cipher3).unwrap());
         }
     }
-} 
+}

--- a/sm2/tests/pke_extended.rs
+++ b/sm2/tests/pke_extended.rs
@@ -1,0 +1,119 @@
+#![cfg(feature = "pke")]
+
+use elliptic_curve::ops::Reduce;
+use proptest::prelude::*;
+use sm2::{
+    NonZeroScalar, Scalar, U256,
+    pke::{DecryptingKey, EncryptingKey, Mode},
+};
+
+/// Helper function to create a decrypting key from test data
+fn create_test_key() -> DecryptingKey {
+    // Use a fixed test key for deterministic testing
+    let test_key = [42u8; 32];
+    let scalar = <Scalar as Reduce<U256>>::reduce_bytes(&test_key.into());
+    let scalar = NonZeroScalar::new(scalar).unwrap();
+    DecryptingKey::from_nonzero_scalar(scalar).unwrap()
+}
+
+#[test]
+fn test_varying_plaintext_lengths() {
+    let dk = create_test_key();
+    let ek = dk.encrypting_key();
+    let test_plaintexts = vec![
+        vec![],          // Empty message
+        vec![1u8; 1],    // 1 byte
+        vec![2u8; 32],   // 32 bytes
+        vec![3u8; 256],  // 256 bytes
+    ];
+
+    for plaintext in test_plaintexts {
+        let ciphertext = ek.encrypt(&mut rand_core::OsRng, &plaintext).unwrap();
+        let decrypted = dk.decrypt(&ciphertext).unwrap();
+        assert_eq!(plaintext, decrypted);
+    }
+}
+
+#[test]
+fn test_ciphertext_tampering() {
+    let dk = create_test_key();
+    let ek = dk.encrypting_key();
+    let plaintext = b"test message";
+    let ciphertext = ek.encrypt(&mut rand_core::OsRng, plaintext).unwrap();
+
+    // Test tampering with each byte
+    for i in 0..ciphertext.len() {
+        let mut tampered = ciphertext.clone();
+        tampered[i] ^= 1;
+        assert!(dk.decrypt(&tampered).is_err());
+    }
+}
+
+#[test]
+fn test_special_plaintexts() {
+    let dk = create_test_key();
+    let ek = dk.encrypting_key();
+    let special_plaintexts = vec![
+        vec![0u8; 32],      // All zeros
+        vec![255u8; 32],    // All ones
+        b"\n\r\t".to_vec(), // Control chars
+        vec![0xF0, 0x9F, 0x98, 0x81], // UTF-8 emoji
+    ];
+
+    for plaintext in special_plaintexts {
+        let ciphertext = ek.encrypt(&mut rand_core::OsRng, &plaintext).unwrap();
+        let decrypted = dk.decrypt(&ciphertext).unwrap();
+        assert_eq!(plaintext, decrypted);
+    }
+}
+
+#[test]
+fn test_encryption_modes() {
+    let plaintext = b"test message";
+    
+    // Test C1C3C2 mode (default)
+    let dk_default = create_test_key();
+    let ek_default = dk_default.encrypting_key();
+    let cipher_default = ek_default.encrypt(&mut rand_core::OsRng, plaintext).unwrap();
+    assert_eq!(plaintext[..], dk_default.decrypt(&cipher_default).unwrap());
+
+    // Test C1C2C3 mode
+    let dk_c1c2c3 = DecryptingKey::new_with_mode(
+        NonZeroScalar::new(Scalar::ONE).unwrap(),
+        Mode::C1C2C3,
+    );
+    let ek_c1c2c3 = dk_c1c2c3.encrypting_key();
+    let cipher_c1c2c3 = ek_c1c2c3.encrypt(&mut rand_core::OsRng, plaintext).unwrap();
+    assert_eq!(plaintext[..], dk_c1c2c3.decrypt(&cipher_c1c2c3).unwrap());
+
+    // Verify that different modes produce different ciphertexts
+    assert_ne!(cipher_default, cipher_c1c2c3);
+}
+
+proptest! {
+    #[test]
+    fn test_encryption_consistency(
+        plaintext1 in any::<Vec<u8>>(),
+        plaintext2 in any::<Vec<u8>>()
+    ) {
+        let dk = create_test_key();
+        let ek = dk.encrypting_key();
+
+        // Same plaintext should decrypt correctly with different randomness
+        let cipher1 = ek.encrypt(&mut rand_core::OsRng, &plaintext1).unwrap();
+        let cipher2 = ek.encrypt(&mut rand_core::OsRng, &plaintext1).unwrap();
+        
+        // Different ciphertexts for same plaintext (due to randomness)
+        prop_assert_ne!(cipher1, cipher2);
+        
+        // Both should decrypt to original plaintext
+        prop_assert_eq!(dk.decrypt(&cipher1).unwrap(), plaintext1);
+        prop_assert_eq!(dk.decrypt(&cipher2).unwrap(), plaintext1);
+
+        // Different plaintexts should produce different ciphertexts
+        if plaintext1 != plaintext2 {
+            let cipher3 = ek.encrypt(&mut rand_core::OsRng, &plaintext2).unwrap();
+            prop_assert_ne!(dk.decrypt(&cipher1).unwrap(), dk.decrypt(&cipher3).unwrap());
+        }
+    }
+} 

--- a/sm2/tests/pke_extended.rs
+++ b/sm2/tests/pke_extended.rs
@@ -21,10 +21,10 @@ fn test_varying_plaintext_lengths() {
     let dk = create_test_key();
     let ek = dk.encrypting_key();
     let test_plaintexts = vec![
-        vec![],          // Empty message
-        vec![1u8; 1],    // 1 byte
-        vec![2u8; 32],   // 32 bytes
-        vec![3u8; 256],  // 256 bytes
+        vec![],         // Empty message
+        vec![1u8; 1],   // 1 byte
+        vec![2u8; 32],  // 32 bytes
+        vec![3u8; 256], // 256 bytes
     ];
 
     for plaintext in test_plaintexts {
@@ -54,9 +54,9 @@ fn test_special_plaintexts() {
     let dk = create_test_key();
     let ek = dk.encrypting_key();
     let special_plaintexts = vec![
-        vec![0u8; 32],      // All zeros
-        vec![255u8; 32],    // All ones
-        b"\n\r\t".to_vec(), // Control chars
+        vec![0u8; 32],                // All zeros
+        vec![255u8; 32],              // All ones
+        b"\n\r\t".to_vec(),           // Control chars
         vec![0xF0, 0x9F, 0x98, 0x81], // UTF-8 emoji
     ];
 
@@ -70,18 +70,18 @@ fn test_special_plaintexts() {
 #[test]
 fn test_encryption_modes() {
     let plaintext = b"test message";
-    
+
     // Test C1C3C2 mode (default)
     let dk_default = create_test_key();
     let ek_default = dk_default.encrypting_key();
-    let cipher_default = ek_default.encrypt(&mut rand_core::OsRng, plaintext).unwrap();
+    let cipher_default = ek_default
+        .encrypt(&mut rand_core::OsRng, plaintext)
+        .unwrap();
     assert_eq!(plaintext[..], dk_default.decrypt(&cipher_default).unwrap());
 
     // Test C1C2C3 mode
-    let dk_c1c2c3 = DecryptingKey::new_with_mode(
-        NonZeroScalar::new(Scalar::ONE).unwrap(),
-        Mode::C1C2C3,
-    );
+    let dk_c1c2c3 =
+        DecryptingKey::new_with_mode(NonZeroScalar::new(Scalar::ONE).unwrap(), Mode::C1C2C3);
     let ek_c1c2c3 = dk_c1c2c3.encrypting_key();
     let cipher_c1c2c3 = ek_c1c2c3.encrypt(&mut rand_core::OsRng, plaintext).unwrap();
     assert_eq!(plaintext[..], dk_c1c2c3.decrypt(&cipher_c1c2c3).unwrap());
@@ -102,10 +102,10 @@ proptest! {
         // Same plaintext should decrypt correctly with different randomness
         let cipher1 = ek.encrypt(&mut rand_core::OsRng, &plaintext1).unwrap();
         let cipher2 = ek.encrypt(&mut rand_core::OsRng, &plaintext1).unwrap();
-        
+
         // Different ciphertexts for same plaintext (due to randomness)
         prop_assert_ne!(cipher1, cipher2);
-        
+
         // Both should decrypt to original plaintext
         prop_assert_eq!(dk.decrypt(&cipher1).unwrap(), plaintext1);
         prop_assert_eq!(dk.decrypt(&cipher2).unwrap(), plaintext1);


### PR DESCRIPTION
# Description

Add comprehensive test suite for SM2 PKE (Public Key Encryption) implementation.

## Changes

Added new test file `pke_extended.rs` with the following test cases:

- Test vectors for different plaintext lengths (empty, 1 byte, 32 bytes, 256 bytes)
- Ciphertext tampering detection tests
- Special plaintext cases (all zeros, all ones, control characters, UTF-8)
- Encryption mode tests (C1C3C2 and C1C2C3)
- Property-based tests for encryption consistency

## Testing

All tests pass successfully. The new tests provide better coverage for:
- Edge cases
- Security properties
- Encryption modes
- Randomness properties
- Error handling

## Related Issues

N/A

## Checklist

- [x] Tests added
- [x] All tests passing
- [x] No unsafe code
- [x] Documentation comments in English