### PR TITLE
primefield: add `test_primefield!` macro

### DIFF
--- a/bign256/src/arithmetic/field.rs
+++ b/bign256/src/arithmetic/field.rs
@@ -124,11 +124,6 @@ impl PrimeField for FieldElement {
 #[cfg(test)]
 mod tests {
     use super::FieldElement;
-    use elliptic_curve::ff::PrimeField;
-    use primeorder::{
-        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
-        impl_primefield_tests,
-    };
 
     // t = (modulus - 1) >> S
     const T: [u64; 4] = [
@@ -138,8 +133,5 @@ mod tests {
         0x7fffffffffffffff,
     ];
 
-    impl_field_identity_tests!(FieldElement);
-    impl_field_invert_tests!(FieldElement);
-    impl_field_sqrt_tests!(FieldElement);
-    impl_primefield_tests!(FieldElement, T);
+    primefield::test_primefield!(FieldElement, T);
 }

--- a/bign256/src/arithmetic/scalar.rs
+++ b/bign256/src/arithmetic/scalar.rs
@@ -246,11 +246,6 @@ impl TryFrom<U256> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::Scalar;
-    use elliptic_curve::ff::PrimeField;
-    use primeorder::{
-        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
-        impl_primefield_tests,
-    };
 
     // t = (modulus - 1) >> S
     const T: [u64; 4] = [
@@ -260,8 +255,5 @@ mod tests {
         0x7fffffffffffffff,
     ];
 
-    impl_field_identity_tests!(Scalar);
-    impl_field_invert_tests!(Scalar);
-    impl_field_sqrt_tests!(Scalar);
-    impl_primefield_tests!(Scalar, T);
+    primefield::test_primefield!(Scalar, T);
 }

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -108,11 +108,6 @@ impl PrimeField for FieldElement {
 #[cfg(test)]
 mod tests {
     use super::FieldElement;
-    use elliptic_curve::ff::PrimeField;
-    use primeorder::{
-        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
-        impl_primefield_tests,
-    };
 
     /// t = (modulus - 1) >> S
     /// 0x54fdabedd0f754de1f3305484ec1c6b9371dfb11ea9310141009a40e8fb729bb
@@ -123,8 +118,5 @@ mod tests {
         0x54fdabedd0f754de,
     ];
 
-    impl_field_identity_tests!(FieldElement);
-    impl_field_invert_tests!(FieldElement);
-    impl_field_sqrt_tests!(FieldElement);
-    impl_primefield_tests!(FieldElement, T);
+    primefield::test_primefield!(FieldElement, T);
 }

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -178,11 +178,6 @@ impl TryFrom<U256> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::Scalar;
-    use elliptic_curve::ff::PrimeField;
-    use primeorder::{
-        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
-        impl_primefield_tests,
-    };
 
     /// t = (modulus - 1) >> S
     /// 0x54fdabedd0f754de1f3305484ec1c6b8c61cbd51dab0d37bc80f07414ba42b53
@@ -193,8 +188,5 @@ mod tests {
         0x54fdabedd0f754de,
     ];
 
-    impl_field_identity_tests!(Scalar);
-    impl_field_invert_tests!(Scalar);
-    impl_field_sqrt_tests!(Scalar);
-    impl_primefield_tests!(Scalar, T);
+    primefield::test_primefield!(Scalar, T);
 }

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -111,11 +111,6 @@ impl PrimeField for FieldElement {
 #[cfg(test)]
 mod tests {
     use super::FieldElement;
-    use elliptic_curve::ff::PrimeField;
-    use primeorder::{
-        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
-        impl_primefield_tests,
-    };
 
     /// t = (modulus - 1) >> S
     /// 0x465c8f41519c369407aeb7bf287320ef8a97b884f6aa2b5a0958ed0cbfdb8891d669d394c80e8d38c3a380099883f629
@@ -128,8 +123,5 @@ mod tests {
         0x465c8f41519c3694,
     ];
 
-    impl_field_identity_tests!(FieldElement);
-    impl_field_invert_tests!(FieldElement);
-    impl_field_sqrt_tests!(FieldElement);
-    impl_primefield_tests!(FieldElement, T);
+    primefield::test_primefield!(FieldElement, T);
 }

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -186,11 +186,6 @@ impl TryFrom<U384> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::Scalar;
-    use elliptic_curve::ff::PrimeField;
-    use primeorder::{
-        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
-        impl_primefield_tests,
-    };
 
     /// t = (modulus - 1) >> S
     /// 0x232e47a0a8ce1b4a03d75bdf94399077c54bdc427b5515acc7c59b9b2b010969f3ceadabdadff0c40ee20c80ba411959
@@ -203,8 +198,5 @@ mod tests {
         0x232e47a0a8ce1b4a,
     ];
 
-    impl_field_identity_tests!(Scalar);
-    impl_field_invert_tests!(Scalar);
-    impl_field_sqrt_tests!(Scalar);
-    impl_primefield_tests!(Scalar, T);
+    primefield::test_primefield!(Scalar, T);
 }

--- a/p192/src/arithmetic/field.rs
+++ b/p192/src/arithmetic/field.rs
@@ -113,17 +113,9 @@ impl PrimeField for FieldElement {
 #[cfg(test)]
 mod tests {
     use super::FieldElement;
-    use elliptic_curve::ff::PrimeField;
-    use primeorder::{
-        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
-        impl_primefield_tests,
-    };
 
     /// t = (modulus - 1) >> S
     const T: [u64; 3] = [0x7fffffffffffffff, 0xffffffffffffffff, 0x7fffffffffffffff];
 
-    impl_field_identity_tests!(FieldElement);
-    impl_field_invert_tests!(FieldElement);
-    impl_field_sqrt_tests!(FieldElement);
-    impl_primefield_tests!(FieldElement, T);
+    primefield::test_primefield!(FieldElement, T);
 }

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -296,18 +296,10 @@ impl<'de> Deserialize<'de> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::Scalar;
-    use elliptic_curve::ff::PrimeField;
-    use primeorder::{
-        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
-        impl_primefield_tests,
-    };
 
     /// t = (modulus - 1) >> S
     /// 0xffffffffffffffffffffffff99def836146bc9b1b4d2283
     const T: [u64; 3] = [0x6146bc9b1b4d2283, 0xfffffffff99def83, 0x0fffffffffffffff];
 
-    impl_field_identity_tests!(Scalar);
-    impl_field_invert_tests!(Scalar);
-    impl_field_sqrt_tests!(Scalar);
-    impl_primefield_tests!(Scalar, T);
+    primefield::test_primefield!(Scalar, T);
 }

--- a/p224/src/arithmetic/field.rs
+++ b/p224/src/arithmetic/field.rs
@@ -333,11 +333,6 @@ impl PrimeField for FieldElement {
 #[cfg(test)]
 mod tests {
     use super::FieldElement;
-    use elliptic_curve::ff::PrimeField;
-    use primeorder::{
-        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
-        impl_primefield_tests,
-    };
 
     /// t = (modulus - 1) >> S
     const T: [u64; 4] = [
@@ -347,8 +342,5 @@ mod tests {
         0x0000000000000000,
     ];
 
-    impl_field_identity_tests!(FieldElement);
-    impl_field_invert_tests!(FieldElement);
-    impl_field_sqrt_tests!(FieldElement);
-    impl_primefield_tests!(FieldElement, T);
+    primefield::test_primefield!(FieldElement, T);
 }

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -322,11 +322,6 @@ impl<'de> Deserialize<'de> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::Scalar;
-    use elliptic_curve::PrimeField;
-    use primeorder::{
-        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
-        impl_primefield_tests,
-    };
 
     /// t = (modulus - 1) >> S
     const T: [u64; 4] = [
@@ -336,8 +331,5 @@ mod tests {
         0x000000003fffffff,
     ];
 
-    impl_field_identity_tests!(Scalar);
-    impl_field_invert_tests!(Scalar);
-    impl_field_sqrt_tests!(Scalar);
-    impl_primefield_tests!(Scalar, T);
+    primefield::test_primefield!(Scalar, T);
 }

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -139,7 +139,6 @@ impl PrimeField for FieldElement {
 #[cfg(test)]
 mod tests {
     use super::FieldElement;
-    use elliptic_curve::ff::PrimeField;
 
     /// t = (modulus - 1) >> S
     const T: [u64; 6] = [
@@ -151,8 +150,5 @@ mod tests {
         0x7fffffffffffffff,
     ];
 
-    primefield::test_field_constants!(FieldElement, T);
-    primefield::test_field_identity!(FieldElement);
-    primefield::test_field_invert!(FieldElement);
-    primefield::test_field_sqrt!(FieldElement);
+    primefield::test_primefield!(FieldElement, T);
 }

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -336,14 +336,7 @@ impl<'de> Deserialize<'de> for Scalar {
 mod tests {
     use super::{Scalar, U384};
     use crate::{FieldBytes, NistP384};
-    use elliptic_curve::Curve;
-    use elliptic_curve::array::Array;
-    use elliptic_curve::ff::PrimeField;
-    use elliptic_curve::ops::ReduceNonZero;
-    use primeorder::{
-        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
-        impl_primefield_tests,
-    };
+    use elliptic_curve::{Curve, array::Array, ff::PrimeField, ops::ReduceNonZero};
 
     /// t = (modulus - 1) >> S
     const T: [u64; 6] = [
@@ -355,10 +348,7 @@ mod tests {
         0x7fffffffffffffff,
     ];
 
-    impl_field_identity_tests!(Scalar);
-    impl_field_invert_tests!(Scalar);
-    impl_field_sqrt_tests!(Scalar);
-    impl_primefield_tests!(Scalar, T);
+    primefield::test_primefield!(Scalar, T);
 
     #[test]
     fn from_to_bytes_roundtrip() {

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -670,7 +670,6 @@ impl Invert for FieldElement {
 #[cfg(test)]
 mod tests {
     use super::FieldElement;
-    use elliptic_curve::ff::PrimeField;
     use hex_literal::hex;
 
     /// t = (modulus - 1) >> S
@@ -686,10 +685,7 @@ mod tests {
         0x00000000000000ff,
     ];
 
-    primefield::test_field_constants!(FieldElement, T);
-    primefield::test_field_identity!(FieldElement);
-    primefield::test_field_invert!(FieldElement);
-    primefield::test_field_sqrt!(FieldElement);
+    primefield::test_primefield!(FieldElement, T);
 
     /// Regression test for RustCrypto/elliptic-curves#965
     #[test]

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -721,9 +721,7 @@ mod tests {
     use crate::NistP521;
 
     use super::{Scalar, U576};
-    use elliptic_curve::array::Array;
-    use elliptic_curve::ops::ReduceNonZero;
-    use elliptic_curve::{Curve, PrimeField};
+    use elliptic_curve::{Curve, array::Array, ops::ReduceNonZero};
 
     /// t = (modulus - 1) >> S
     const T: [u64; 9] = [
@@ -738,7 +736,7 @@ mod tests {
         0x000000000000003f,
     ];
 
-    primefield::test_field_constants!(Scalar, T);
+    primefield::test_primefield_constants!(Scalar, T);
     primefield::test_field_identity!(Scalar);
     primefield::test_field_invert!(Scalar);
     //primefield::test_field_sqrt!(Scalar); // TODO(tarcieri): impl this

--- a/primefield/src/lib.rs
+++ b/primefield/src/lib.rs
@@ -488,6 +488,67 @@ macro_rules! field_op {
     };
 }
 
+/// Implement all tests for a type which impls the `PrimeField` trait.
+#[macro_export]
+macro_rules! test_primefield {
+    ($fe:tt, $t:expr) => {
+        $crate::test_primefield_constants!($fe, $t);
+        $crate::test_field_identity!($fe);
+        $crate::test_field_invert!($fe);
+        $crate::test_field_sqrt!($fe);
+    };
+}
+
+/// Implement tests for constants defined by the `PrimeField` trait.
+#[macro_export]
+macro_rules! test_primefield_constants {
+    ($fe:tt, $t:expr) => {
+        #[test]
+        fn two_inv_constant() {
+            use $crate::ff::PrimeField;
+            assert_eq!($fe::from(2u32) * $fe::TWO_INV, $fe::ONE);
+        }
+
+        #[test]
+        fn root_of_unity_constant() {
+            use $crate::ff::PrimeField;
+            assert!($fe::S < 128);
+            let two_to_s = 1u128 << $fe::S;
+
+            // ROOT_OF_UNITY^{2^s} mod m == 1
+            assert_eq!(
+                $fe::ROOT_OF_UNITY.pow_vartime(&[
+                    (two_to_s & 0xFFFFFFFFFFFFFFFF) as u64,
+                    (two_to_s >> 64) as u64,
+                    0,
+                    0
+                ]),
+                $fe::ONE
+            );
+
+            // MULTIPLICATIVE_GENERATOR^{t} mod m == ROOT_OF_UNITY
+            assert_eq!(
+                $fe::MULTIPLICATIVE_GENERATOR.pow_vartime(&$t),
+                $fe::ROOT_OF_UNITY
+            )
+        }
+
+        #[test]
+        fn root_of_unity_inv_constant() {
+            use $crate::ff::PrimeField;
+            assert_eq!($fe::ROOT_OF_UNITY * $fe::ROOT_OF_UNITY_INV, $fe::ONE);
+        }
+
+        #[test]
+        fn delta_constant() {
+            use $crate::ff::PrimeField;
+
+            // DELTA^{t} mod m == 1
+            assert_eq!($fe::DELTA.pow_vartime(&$t), $fe::ONE);
+        }
+    };
+}
+
 /// Implement field element identity tests.
 #[macro_export]
 macro_rules! test_field_identity {
@@ -540,51 +601,6 @@ macro_rules! test_field_sqrt {
                 let sqrt = fe.sqrt().unwrap();
                 assert_eq!(sqrt.square(), fe);
             }
-        }
-    };
-}
-
-/// Implement tests for constants defined by the `PrimeField` trait.
-#[macro_export]
-macro_rules! test_field_constants {
-    ($fe:tt, $t:expr) => {
-        #[test]
-        fn two_inv_constant() {
-            assert_eq!($fe::from(2u32) * $fe::TWO_INV, $fe::ONE);
-        }
-
-        #[test]
-        fn root_of_unity_constant() {
-            assert!($fe::S < 128);
-            let two_to_s = 1u128 << $fe::S;
-
-            // ROOT_OF_UNITY^{2^s} mod m == 1
-            assert_eq!(
-                $fe::ROOT_OF_UNITY.pow_vartime(&[
-                    (two_to_s & 0xFFFFFFFFFFFFFFFF) as u64,
-                    (two_to_s >> 64) as u64,
-                    0,
-                    0
-                ]),
-                $fe::ONE
-            );
-
-            // MULTIPLICATIVE_GENERATOR^{t} mod m == ROOT_OF_UNITY
-            assert_eq!(
-                $fe::MULTIPLICATIVE_GENERATOR.pow_vartime(&$t),
-                $fe::ROOT_OF_UNITY
-            )
-        }
-
-        #[test]
-        fn root_of_unity_inv_constant() {
-            assert_eq!($fe::ROOT_OF_UNITY * $fe::ROOT_OF_UNITY_INV, $fe::ONE);
-        }
-
-        #[test]
-        fn delta_constant() {
-            // DELTA^{t} mod m == 1
-            assert_eq!($fe::DELTA.pow_vartime(&$t), $fe::ONE);
         }
     };
 }

--- a/sm2/src/arithmetic/field.rs
+++ b/sm2/src/arithmetic/field.rs
@@ -121,11 +121,6 @@ impl PrimeField for FieldElement {
 #[cfg(test)]
 mod tests {
     use super::FieldElement;
-    use elliptic_curve::ff::PrimeField;
-    use primeorder::{
-        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
-        impl_primefield_tests,
-    };
 
     /// t = (modulus - 1) >> S
     /// 0x7fffffff7fffffffffffffffffffffffffffffff800000007fffffffffffffff
@@ -136,8 +131,5 @@ mod tests {
         0x7fffffff7fffffff,
     ];
 
-    impl_field_identity_tests!(FieldElement);
-    impl_field_invert_tests!(FieldElement);
-    impl_field_sqrt_tests!(FieldElement);
-    impl_primefield_tests!(FieldElement, T);
+    primefield::test_primefield!(FieldElement, T);
 }

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -281,11 +281,6 @@ impl<'de> Deserialize<'de> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::Scalar;
-    use elliptic_curve::ff::PrimeField;
-    use primeorder::{
-        impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
-        impl_primefield_tests,
-    };
 
     /// t = (modulus - 1) >> S
     /// 0x7fffffff7fffffffffffffffffffffffb901efb590e30295a9ddfa049ceaa091
@@ -296,8 +291,5 @@ mod tests {
         0x7fffffff7fffffff,
     ];
 
-    impl_field_identity_tests!(Scalar);
-    impl_field_invert_tests!(Scalar);
-    impl_field_sqrt_tests!(Scalar);
-    impl_primefield_tests!(Scalar, T);
+    primefield::test_primefield!(Scalar, T);
 }


### PR DESCRIPTION
Adds a macro which writes all of the currently provided macro-based tests for types which impl `PrimeField`.