### PR TITLE
primeorder: remove unnecessary `must_use`

### DIFF
--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -291,7 +291,6 @@ where
         self.ct_eq(&Self::IDENTITY)
     }
 
-    #[must_use]
     fn double(&self) -> Self {
         Double::double(self)
     }


### PR DESCRIPTION
    warning: `#[must_use]` has no effect when applied to a provided trait
    method
       --> primeorder/src/projective.rs:294:5
           |
       294 |     #[must_use]
           |     ^^^^^^^^^^^