### PR TITLE
primefield: move more `From` impls into `field_element_type!`

### DIFF
--- a/bign256/src/arithmetic/scalar.rs
+++ b/bign256/src/arithmetic/scalar.rs
@@ -205,30 +205,6 @@ impl From<&Scalar> for ScalarPrimitive<BignP256> {
     }
 }
 
-impl From<Scalar> for FieldBytes {
-    fn from(scalar: Scalar) -> Self {
-        scalar.to_repr()
-    }
-}
-
-impl From<&Scalar> for FieldBytes {
-    fn from(scalar: &Scalar) -> Self {
-        scalar.to_repr()
-    }
-}
-
-impl From<Scalar> for U256 {
-    fn from(scalar: Scalar) -> U256 {
-        U256::from(&scalar)
-    }
-}
-
-impl From<&Scalar> for U256 {
-    fn from(scalar: &Scalar) -> U256 {
-        scalar.to_canonical()
-    }
-}
-
 impl From<&SecretKey> for Scalar {
     fn from(secret_key: &SecretKey) -> Scalar {
         *secret_key.to_nonzero_scalar()

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -143,30 +143,6 @@ impl Reduce<U256> for Scalar {
     }
 }
 
-impl From<Scalar> for FieldBytes {
-    fn from(scalar: Scalar) -> Self {
-        scalar.to_repr()
-    }
-}
-
-impl From<&Scalar> for FieldBytes {
-    fn from(scalar: &Scalar) -> Self {
-        scalar.to_repr()
-    }
-}
-
-impl From<Scalar> for U256 {
-    fn from(scalar: Scalar) -> U256 {
-        U256::from(&scalar)
-    }
-}
-
-impl From<&Scalar> for U256 {
-    fn from(scalar: &Scalar) -> U256 {
-        scalar.to_canonical()
-    }
-}
-
 impl TryFrom<U256> for Scalar {
     type Error = Error;
 

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -151,30 +151,6 @@ impl Reduce<U384> for Scalar {
     }
 }
 
-impl From<Scalar> for FieldBytes {
-    fn from(scalar: Scalar) -> Self {
-        scalar.to_repr()
-    }
-}
-
-impl From<&Scalar> for FieldBytes {
-    fn from(scalar: &Scalar) -> Self {
-        scalar.to_repr()
-    }
-}
-
-impl From<Scalar> for U384 {
-    fn from(scalar: Scalar) -> U384 {
-        U384::from(&scalar)
-    }
-}
-
-impl From<&Scalar> for U384 {
-    fn from(scalar: &Scalar) -> U384 {
-        scalar.to_canonical()
-    }
-}
-
 impl TryFrom<U384> for Scalar {
     type Error = Error;
 

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -241,30 +241,6 @@ impl From<&Scalar> for ScalarPrimitive<NistP192> {
     }
 }
 
-impl From<Scalar> for FieldBytes {
-    fn from(scalar: Scalar) -> Self {
-        scalar.to_repr()
-    }
-}
-
-impl From<&Scalar> for FieldBytes {
-    fn from(scalar: &Scalar) -> Self {
-        scalar.to_repr()
-    }
-}
-
-impl From<Scalar> for U192 {
-    fn from(scalar: Scalar) -> U192 {
-        U192::from(&scalar)
-    }
-}
-
-impl From<&Scalar> for U192 {
-    fn from(scalar: &Scalar) -> U192 {
-        scalar.to_canonical()
-    }
-}
-
 impl TryFrom<U192> for Scalar {
     type Error = Error;
 

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -236,30 +236,6 @@ impl From<&Scalar> for ScalarPrimitive<NistP224> {
     }
 }
 
-impl From<Scalar> for FieldBytes {
-    fn from(scalar: Scalar) -> Self {
-        scalar.to_repr()
-    }
-}
-
-impl From<&Scalar> for FieldBytes {
-    fn from(scalar: &Scalar) -> Self {
-        scalar.to_repr()
-    }
-}
-
-impl From<Scalar> for Uint {
-    fn from(scalar: Scalar) -> Uint {
-        Uint::from(&scalar)
-    }
-}
-
-impl From<&Scalar> for Uint {
-    fn from(scalar: &Scalar) -> Uint {
-        scalar.to_canonical()
-    }
-}
-
 impl From<&SecretKey> for Scalar {
     fn from(secret_key: &SecretKey) -> Scalar {
         *secret_key.to_nonzero_scalar()

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -274,30 +274,6 @@ impl From<&Scalar> for ScalarPrimitive<NistP384> {
     }
 }
 
-impl From<Scalar> for FieldBytes {
-    fn from(scalar: Scalar) -> Self {
-        scalar.to_repr()
-    }
-}
-
-impl From<&Scalar> for FieldBytes {
-    fn from(scalar: &Scalar) -> Self {
-        scalar.to_repr()
-    }
-}
-
-impl From<Scalar> for U384 {
-    fn from(scalar: Scalar) -> U384 {
-        U384::from(&scalar)
-    }
-}
-
-impl From<&Scalar> for U384 {
-    fn from(scalar: &Scalar) -> U384 {
-        scalar.to_canonical()
-    }
-}
-
 impl From<&SecretKey> for Scalar {
     fn from(secret_key: &SecretKey) -> Scalar {
         *secret_key.to_nonzero_scalar()

--- a/primefield/src/lib.rs
+++ b/primefield/src/lib.rs
@@ -392,6 +392,30 @@ macro_rules! field_element_type {
             }
         }
 
+        impl From<$fe> for $bytes {
+            fn from(fe: $fe) -> Self {
+                <$bytes>::from(&fe)
+            }
+        }
+
+        impl From<&$fe> for $bytes {
+            fn from(fe: &$fe) -> Self {
+                fe.to_repr()
+            }
+        }
+
+        impl From<$fe> for $uint {
+            fn from(fe: $fe) -> $uint {
+                <$uint>::from(&fe)
+            }
+        }
+
+        impl From<&$fe> for $uint {
+            fn from(fe: &$fe) -> $uint {
+                fe.to_canonical()
+            }
+        }
+
         impl ::core::iter::Sum for $fe {
             #[allow(unused_qualifications)]
             fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -220,30 +220,6 @@ impl From<&Scalar> for ScalarPrimitive<Sm2> {
     }
 }
 
-impl From<Scalar> for FieldBytes {
-    fn from(scalar: Scalar) -> Self {
-        scalar.to_repr()
-    }
-}
-
-impl From<&Scalar> for FieldBytes {
-    fn from(scalar: &Scalar) -> Self {
-        scalar.to_repr()
-    }
-}
-
-impl From<Scalar> for U256 {
-    fn from(scalar: Scalar) -> U256 {
-        U256::from(&scalar)
-    }
-}
-
-impl From<&Scalar> for U256 {
-    fn from(scalar: &Scalar) -> U256 {
-        scalar.to_canonical()
-    }
-}
-
 impl From<&SecretKey> for Scalar {
     fn from(secret_key: &SecretKey) -> Scalar {
         *secret_key.to_nonzero_scalar()


### PR DESCRIPTION
More boilerplate in the macro is less copy/paste