### PR TITLE
p256: begin using `primefield`

### DIFF
--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -23,6 +23,7 @@ elliptic-curve = { version = "0.14.0-rc.0", default-features = false, features =
 # optional dependencies
 ecdsa-core = { version = "=0.17.0-pre.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
+primefield = { version = "=0.14.0-pre.0", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.2", optional = true, path = "../primeorder" }
 serdect = { version = "0.3", optional = true, default-features = false }
 sha2 = { version = "=0.11.0-pre.5", optional = true, default-features = false }
@@ -42,7 +43,7 @@ default = ["arithmetic", "ecdsa", "pem", "std"]
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std"]
 
-arithmetic = ["dep:primeorder", "elliptic-curve/arithmetic"]
+arithmetic = ["dep:primefield", "dep:primeorder", "elliptic-curve/arithmetic"]
 bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]

--- a/p256/benches/field.rs
+++ b/p256/benches/field.rs
@@ -8,14 +8,14 @@ use p256::FieldElement;
 
 fn test_field_element_x() -> FieldElement {
     FieldElement::from_bytes(
-        hex!("1ccbe91c075fc7f4f033bfa248db8fccd3565de94bbfb12f3c59ff46c271bf83").into(),
+        hex!("1ccbe91c075fc7f4f033bfa248db8fccd3565de94bbfb12f3c59ff46c271bf83").as_ref(),
     )
     .unwrap()
 }
 
 fn test_field_element_y() -> FieldElement {
     FieldElement::from_bytes(
-        hex!("ce4014c68811f9a21a1fdb2c0e6113e06db7ca93b7404e78dc7ccd5ca89a4ca9").into(),
+        hex!("ce4014c68811f9a21a1fdb2c0e6113e06db7ca93b7404e78dc7ccd5ca89a4ca9").as_ref(),
     )
     .unwrap()
 }

--- a/p256/src/arithmetic/field/field32.rs
+++ b/p256/src/arithmetic/field/field32.rs
@@ -1,7 +1,7 @@
 //! 32-bit secp256r1 field element algorithms.
 
 use super::MODULUS;
-use elliptic_curve::bigint::{Limb, U256, U512};
+use elliptic_curve::bigint::{Limb, U256};
 
 pub(super) const fn add(a: U256, b: U256) -> U256 {
     let a = a.as_limbs();
@@ -55,18 +55,6 @@ pub(super) const fn sub(a: U256, b: U256) -> U256 {
 #[inline]
 pub(super) const fn to_canonical(a: U256) -> U256 {
     montgomery_reduce(a, U256::ZERO)
-}
-
-pub(super) fn from_bytes_wide(a: U512) -> U256 {
-    let words = a.to_limbs();
-    montgomery_reduce(
-        U256::new([
-            words[8], words[9], words[10], words[11], words[12], words[13], words[14], words[15],
-        ]),
-        U256::new([
-            words[0], words[1], words[2], words[3], words[4], words[5], words[6], words[7],
-        ]),
-    )
 }
 
 /// Montgomery Reduction

--- a/p256/src/arithmetic/field/field64.rs
+++ b/p256/src/arithmetic/field/field64.rs
@@ -1,7 +1,7 @@
 //! 64-bit secp256r1 field element algorithms.
 
 use super::MODULUS;
-use elliptic_curve::bigint::{Limb, U256, U512};
+use elliptic_curve::bigint::{Limb, U256};
 
 pub(super) const fn add(a: U256, b: U256) -> U256 {
     let a = a.as_limbs();
@@ -41,14 +41,6 @@ pub(super) const fn sub(a: U256, b: U256) -> U256 {
 #[inline]
 pub(super) const fn to_canonical(a: U256) -> U256 {
     montgomery_reduce(a, U256::ZERO)
-}
-
-pub(super) fn from_bytes_wide(a: U512) -> U256 {
-    let words = a.to_limbs();
-    montgomery_reduce(
-        U256::new([words[4], words[5], words[6], words[7]]),
-        U256::new([words[0], words[1], words[2], words[3]]),
-    )
 }
 
 /// Montgomery Reduction


### PR DESCRIPTION
This represents an initial attempt to convert some of the functionality of `FieldElement` to using macros from the `primefield` crate.

Changes have been made carefully and minimally along with benchmarking to ensure this does not impact performance (unlike the last attempt to do this, see #885)

Trying to use the full `field_element_type!` did appear to result in a benchmark regression, so this instead extracts a
`field_element_type_core!` macro (again) and begins to use it in `p256`, ensuring that there are no benchmark regressions.