### PR TITLE
p256: use `primefield` macros

### DIFF
--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -7,17 +7,12 @@
 mod field_impl;
 
 use crate::{FieldBytes, NistP256};
-use core::{
-    iter::{Product, Sum},
-    ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
-};
-use elliptic_curve::ops::Invert;
+use core::ops::Mul;
 use elliptic_curve::{
     FieldBytesEncoding,
     bigint::U256,
     ff::PrimeField,
-    subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
-    zeroize::DefaultIsZeroes,
+    subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
 const MODULUS_HEX: &str = "ffffffff00000001000000000000000000000000ffffffffffffffffffffffff";
@@ -35,10 +30,10 @@ const R2: FieldElement = FieldElement(U256::from_be_hex(
 ///
 /// The internal representation is in little-endian order. Elements are always in
 /// Montgomery form; i.e., FieldElement(a) = aR mod p, with R = 2^256.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct FieldElement(pub(crate) U256);
 
-primefield::field_element_type_core!(
+primefield::field_element_type!(
     FieldElement,
     FieldBytes,
     U256,
@@ -194,197 +189,6 @@ impl PrimeField for FieldElement {
 
     fn is_odd(&self) -> Choice {
         self.is_odd()
-    }
-}
-
-impl ConditionallySelectable for FieldElement {
-    #[inline(always)]
-    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        Self(U256::conditional_select(&a.0, &b.0, choice))
-    }
-}
-
-impl ConstantTimeEq for FieldElement {
-    fn ct_eq(&self, other: &Self) -> Choice {
-        self.0.ct_eq(&other.0)
-    }
-}
-
-impl Default for FieldElement {
-    fn default() -> Self {
-        FieldElement::ZERO
-    }
-}
-
-impl DefaultIsZeroes for FieldElement {}
-
-impl Eq for FieldElement {}
-
-impl From<u64> for FieldElement {
-    fn from(n: u64) -> FieldElement {
-        Self::from_uint_unchecked(U256::from(n))
-    }
-}
-
-impl PartialEq for FieldElement {
-    fn eq(&self, other: &Self) -> bool {
-        self.ct_eq(other).into()
-    }
-}
-
-impl Invert for FieldElement {
-    type Output = CtOption<Self>;
-
-    fn invert(&self) -> CtOption<Self> {
-        self.invert()
-    }
-}
-
-impl Add<FieldElement> for FieldElement {
-    type Output = FieldElement;
-
-    fn add(self, other: FieldElement) -> FieldElement {
-        FieldElement::add(&self, &other)
-    }
-}
-
-impl Add<&FieldElement> for FieldElement {
-    type Output = FieldElement;
-
-    fn add(self, other: &FieldElement) -> FieldElement {
-        FieldElement::add(&self, other)
-    }
-}
-
-impl Add<&FieldElement> for &FieldElement {
-    type Output = FieldElement;
-
-    fn add(self, other: &FieldElement) -> FieldElement {
-        FieldElement::add(self, other)
-    }
-}
-
-impl AddAssign<FieldElement> for FieldElement {
-    fn add_assign(&mut self, other: FieldElement) {
-        *self = FieldElement::add(self, &other);
-    }
-}
-
-impl AddAssign<&FieldElement> for FieldElement {
-    fn add_assign(&mut self, other: &FieldElement) {
-        *self = FieldElement::add(self, other);
-    }
-}
-
-impl Sub<FieldElement> for FieldElement {
-    type Output = FieldElement;
-
-    fn sub(self, other: FieldElement) -> FieldElement {
-        FieldElement::sub(&self, &other)
-    }
-}
-
-impl Sub<&FieldElement> for FieldElement {
-    type Output = FieldElement;
-
-    fn sub(self, other: &FieldElement) -> FieldElement {
-        FieldElement::sub(&self, other)
-    }
-}
-
-impl Sub<&FieldElement> for &FieldElement {
-    type Output = FieldElement;
-
-    fn sub(self, other: &FieldElement) -> FieldElement {
-        FieldElement::sub(self, other)
-    }
-}
-
-impl SubAssign<FieldElement> for FieldElement {
-    fn sub_assign(&mut self, other: FieldElement) {
-        *self = FieldElement::sub(self, &other);
-    }
-}
-
-impl SubAssign<&FieldElement> for FieldElement {
-    fn sub_assign(&mut self, other: &FieldElement) {
-        *self = FieldElement::sub(self, other);
-    }
-}
-
-impl Mul<FieldElement> for FieldElement {
-    type Output = FieldElement;
-
-    fn mul(self, other: FieldElement) -> FieldElement {
-        FieldElement::multiply(&self, &other)
-    }
-}
-
-impl Mul<&FieldElement> for FieldElement {
-    type Output = FieldElement;
-
-    fn mul(self, other: &FieldElement) -> FieldElement {
-        FieldElement::multiply(&self, other)
-    }
-}
-
-impl Mul<&FieldElement> for &FieldElement {
-    type Output = FieldElement;
-
-    fn mul(self, other: &FieldElement) -> FieldElement {
-        FieldElement::multiply(self, other)
-    }
-}
-
-impl MulAssign<FieldElement> for FieldElement {
-    fn mul_assign(&mut self, other: FieldElement) {
-        *self = FieldElement::multiply(self, &other);
-    }
-}
-
-impl MulAssign<&FieldElement> for FieldElement {
-    fn mul_assign(&mut self, other: &FieldElement) {
-        *self = FieldElement::multiply(self, other);
-    }
-}
-
-impl Neg for FieldElement {
-    type Output = FieldElement;
-
-    fn neg(self) -> FieldElement {
-        FieldElement::ZERO - &self
-    }
-}
-
-impl Neg for &FieldElement {
-    type Output = FieldElement;
-
-    fn neg(self) -> FieldElement {
-        FieldElement::ZERO - self
-    }
-}
-
-impl Sum for FieldElement {
-    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(Add::add).unwrap_or(Self::ZERO)
-    }
-}
-
-impl<'a> Sum<&'a FieldElement> for FieldElement {
-    fn sum<I: Iterator<Item = &'a FieldElement>>(iter: I) -> Self {
-        iter.copied().sum()
-    }
-}
-
-impl Product for FieldElement {
-    fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(Mul::mul).unwrap_or(Self::ONE)
-    }
-}
-
-impl<'a> Product<&'a FieldElement> for FieldElement {
-    fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
-        iter.copied().product()
     }
 }
 

--- a/primefield/src/fiat.rs
+++ b/primefield/src/fiat.rs
@@ -148,15 +148,6 @@ macro_rules! fiat_field_arithmetic {
                 Self(<$uint>::from_words(words))
             }
         }
-
-        impl ::core::ops::Neg for $fe {
-            type Output = $fe;
-
-            #[inline]
-            fn neg(self) -> $fe {
-                <$fe>::neg(&self)
-            }
-        }
     };
 }
 

--- a/primefield/src/lib.rs
+++ b/primefield/src/lib.rs
@@ -129,6 +129,24 @@ macro_rules! field_element_type {
             }
         }
 
+        impl ::core::ops::Neg for $fe {
+            type Output = $fe;
+
+            #[inline]
+            fn neg(self) -> $fe {
+                <$fe>::neg(&self)
+            }
+        }
+
+        impl ::core::ops::Neg for &$fe {
+            type Output = $fe;
+
+            #[inline]
+            fn neg(self) -> $fe {
+                <$fe>::neg(self)
+            }
+        }
+
         impl ::core::ops::Shr<u32> for $fe {
             type Output = Self;
 


### PR DESCRIPTION
Write most of the `FieldElement` implementation in `p256` using the same macros we're applying to other crates.

This somewhat mysteriously seems to cause the following performance regression on a macOS/M2 target:

    point operations/point-scalar mul
                        time:   [155.25 µs 155.60 µs 156.13 µs]
                        change: [+2.3080% +2.7473% +3.4111%] (p = 0.00 < 0.05)
                        Performance has regressed.

Drilling down on the issue, it seems related to the `#[inline]` directives on the core arithmetic trait impls:

https://github.com/RustCrypto/elliptic-curves/blob/f259ec4/primefield/src/lib.rs#L511-L529

It would be good to confirm this is a real issue, possibly through detailed codegen examination, though the total size of involved code is relatively large.

However, the change is small enough to be within a range that is difficult to benchmark, and it's not yet clear how other changes (e.g. switching to a `crypto-bigint` backend) will impact performance.

So this commit accepts this performance regression for now with a note to follow up on potentially switching inlining off on the `core::ops` impls to see if that addresses the issue if other code changes don't make this irrelevant.