### PR TITLE
p256: inline inner functions of Barrett reduction

### DIFF
--- a/p256/src/arithmetic/scalar/scalar32.rs
+++ b/p256/src/arithmetic/scalar/scalar32.rs
@@ -83,6 +83,7 @@ pub(super) const fn barrett_reduce(lo: U256, hi: U256) -> U256 {
     U256::new([r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7]])
 }
 
+#[inline]
 const fn q1_times_mu_shift_nine(q1: &[Limb; 9]) -> [Limb; 9] {
     // Schoolbook multiplication
 
@@ -202,6 +203,7 @@ const fn q1_times_mu_shift_nine(q1: &[Limb; 9]) -> [Limb; 9] {
     [w9, w10, w11, w12, w13, w14, w15, w16, w17]
 }
 
+#[inline]
 const fn q3_times_n_keep_nine(q3: &[Limb; 9]) -> [Limb; 9] {
     // Schoolbook multiplication
 

--- a/p256/src/arithmetic/scalar/scalar64.rs
+++ b/p256/src/arithmetic/scalar/scalar64.rs
@@ -68,6 +68,7 @@ pub(super) const fn barrett_reduce(lo: U256, hi: U256) -> U256 {
     U256::new([r[0], r[1], r[2], r[3]])
 }
 
+#[inline]
 const fn q1_times_mu_shift_five(q1: &[Limb; 5]) -> [Limb; 5] {
     // Schoolbook multiplication
 
@@ -111,6 +112,7 @@ const fn q1_times_mu_shift_five(q1: &[Limb; 5]) -> [Limb; 5] {
     [w5, w6, w7, w8, w9]
 }
 
+#[inline]
 const fn q3_times_n_keep_five(q3: &[Limb; 5]) -> [Limb; 5] {
     // Schoolbook multiplication.
 


### PR DESCRIPTION
This results in a 15%-20% speedup:

    scalar operations/invert
                            time:   [16.393 µs 16.500 µs 16.600 µs]
                            change: [-15.781% -15.313% -14.861%] (p = 0.00 < 0.05)
                            Performance has improved.