### PR TITLE
Implement `From<NonZeroScalar>` for `Scalar`

### DIFF
--- a/bign256/src/arithmetic/scalar.rs
+++ b/bign256/src/arithmetic/scalar.rs
@@ -15,7 +15,7 @@
 mod scalar_impl;
 
 use self::scalar_impl::*;
-use crate::{BignP256, FieldBytes, ORDER_HEX, SecretKey, U256};
+use crate::{BignP256, FieldBytes, NonZeroScalar, ORDER_HEX, SecretKey, U256};
 use elliptic_curve::{
     Curve as _, Error, FieldBytesEncoding, Result, ScalarPrimitive,
     bigint::Limb,
@@ -178,6 +178,18 @@ impl Reduce<U256> for Scalar {
     fn reduce_bytes(bytes: &FieldBytes) -> Self {
         let w = <U256 as FieldBytesEncoding<BignP256>>::decode_field_bytes(bytes);
         Self::reduce(w)
+    }
+}
+
+impl From<NonZeroScalar> for Scalar {
+    fn from(scalar: NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
+}
+
+impl From<&NonZeroScalar> for Scalar {
+    fn from(scalar: &NonZeroScalar) -> Self {
+        *scalar.as_ref()
     }
 }
 

--- a/bp256/src/r1/arithmetic.rs
+++ b/bp256/src/r1/arithmetic.rs
@@ -14,6 +14,9 @@ pub type ProjectivePoint = primeorder::ProjectivePoint<BrainpoolP256r1>;
 /// Primitive scalar type.
 pub type ScalarPrimitive = elliptic_curve::ScalarPrimitive<BrainpoolP256r1>;
 
+/// Non-zero scalar field element.
+pub type NonZeroScalar = elliptic_curve::NonZeroScalar<BrainpoolP256r1>;
+
 impl CurveArithmetic for BrainpoolP256r1 {
     type AffinePoint = AffinePoint;
     type ProjectivePoint = ProjectivePoint;
@@ -36,6 +39,18 @@ impl PrimeCurveParams for BrainpoolP256r1 {
         FieldElement::from_hex("8bd2aeb9cb7e57cb2c4b482ffc81b7afb9de27e1e3bd23c23a4453bd9ace3262"),
         FieldElement::from_hex("547ef835c3dac4fd97f8461a14611dc9c27745132ded8e545c1d54c72f046997"),
     );
+}
+
+impl From<NonZeroScalar> for Scalar {
+    fn from(scalar: NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
+}
+
+impl From<&NonZeroScalar> for Scalar {
+    fn from(scalar: &NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
 }
 
 impl From<ScalarPrimitive> for Scalar {

--- a/bp256/src/t1/arithmetic.rs
+++ b/bp256/src/t1/arithmetic.rs
@@ -14,6 +14,9 @@ pub type ProjectivePoint = primeorder::ProjectivePoint<BrainpoolP256t1>;
 /// Primitive scalar type.
 pub type ScalarPrimitive = elliptic_curve::ScalarPrimitive<BrainpoolP256t1>;
 
+/// Non-zero scalar field element.
+pub type NonZeroScalar = elliptic_curve::NonZeroScalar<BrainpoolP256t1>;
+
 impl CurveArithmetic for BrainpoolP256t1 {
     type AffinePoint = AffinePoint;
     type ProjectivePoint = ProjectivePoint;
@@ -36,6 +39,18 @@ impl PrimeCurveParams for BrainpoolP256t1 {
         FieldElement::from_hex("a3e8eb3cc1cfe7b7732213b23a656149afa142c47aafbc2b79a191562e1305f4"),
         FieldElement::from_hex("2d996c823439c56d7f7b22e14644417e69bcb6de39d027001dabe8f35b25c9be"),
     );
+}
+
+impl From<NonZeroScalar> for Scalar {
+    fn from(scalar: NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
+}
+
+impl From<&NonZeroScalar> for Scalar {
+    fn from(scalar: &NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
 }
 
 impl From<ScalarPrimitive> for Scalar {

--- a/bp384/src/r1/arithmetic.rs
+++ b/bp384/src/r1/arithmetic.rs
@@ -14,6 +14,9 @@ pub type ProjectivePoint = primeorder::ProjectivePoint<BrainpoolP384r1>;
 /// Primitive scalar type.
 pub type ScalarPrimitive = elliptic_curve::ScalarPrimitive<BrainpoolP384r1>;
 
+/// Non-zero scalar field element.
+pub type NonZeroScalar = elliptic_curve::NonZeroScalar<BrainpoolP384r1>;
+
 impl CurveArithmetic for BrainpoolP384r1 {
     type AffinePoint = AffinePoint;
     type ProjectivePoint = ProjectivePoint;
@@ -42,6 +45,18 @@ impl PrimeCurveParams for BrainpoolP384r1 {
             "8abe1d7520f9c2a45cb1eb8e95cfd55262b70b29feec5864e19c054ff99129280e4646217791811142820341263c5315",
         ),
     );
+}
+
+impl From<NonZeroScalar> for Scalar {
+    fn from(scalar: NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
+}
+
+impl From<&NonZeroScalar> for Scalar {
+    fn from(scalar: &NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
 }
 
 impl From<ScalarPrimitive> for Scalar {

--- a/bp384/src/t1/arithmetic.rs
+++ b/bp384/src/t1/arithmetic.rs
@@ -14,6 +14,9 @@ pub type ProjectivePoint = primeorder::ProjectivePoint<BrainpoolP384t1>;
 /// Primitive scalar type.
 pub type ScalarPrimitive = elliptic_curve::ScalarPrimitive<BrainpoolP384t1>;
 
+/// Non-zero scalar field element.
+pub type NonZeroScalar = elliptic_curve::NonZeroScalar<BrainpoolP384t1>;
+
 impl CurveArithmetic for BrainpoolP384t1 {
     type AffinePoint = AffinePoint;
     type ProjectivePoint = ProjectivePoint;
@@ -42,6 +45,18 @@ impl PrimeCurveParams for BrainpoolP384t1 {
             "25ab056962d30651a114afd2755ad336747f93475b7a1fca3b88f2b6a208ccfe469408584dc2b2912675bf5b9e582928",
         ),
     );
+}
+
+impl From<NonZeroScalar> for Scalar {
+    fn from(scalar: NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
+}
+
+impl From<&NonZeroScalar> for Scalar {
+    fn from(scalar: &NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
 }
 
 impl From<ScalarPrimitive> for Scalar {

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -6,7 +6,7 @@ mod wide;
 
 pub(crate) use self::wide::WideScalar;
 
-use crate::{FieldBytes, ORDER, ORDER_HEX, Secp256k1, WideBytes};
+use crate::{FieldBytes, NonZeroScalar, ORDER, ORDER_HEX, Secp256k1, WideBytes};
 use core::{
     iter::{Product, Sum},
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, ShrAssign, Sub, SubAssign},
@@ -376,6 +376,18 @@ impl From<u64> for Scalar {
 impl From<u128> for Scalar {
     fn from(k: u128) -> Self {
         Self(k.into())
+    }
+}
+
+impl From<NonZeroScalar> for Scalar {
+    fn from(scalar: NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
+}
+
+impl From<&NonZeroScalar> for Scalar {
+    fn from(scalar: &NonZeroScalar) -> Self {
+        *scalar.as_ref()
     }
 }
 

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -22,7 +22,7 @@
 mod scalar_impl;
 
 use self::scalar_impl::*;
-use crate::{FieldBytes, FieldBytesEncoding, NistP192, ORDER_HEX, U192};
+use crate::{FieldBytes, FieldBytesEncoding, NistP192, NonZeroScalar, ORDER_HEX, U192};
 use elliptic_curve::{
     Curve as _, Error, Result, ScalarPrimitive,
     bigint::Limb,
@@ -214,6 +214,18 @@ impl Reduce<U192> for Scalar {
     fn reduce_bytes(bytes: &FieldBytes) -> Self {
         let w = <U192 as FieldBytesEncoding<NistP192>>::decode_field_bytes(bytes);
         Self::reduce(w)
+    }
+}
+
+impl From<NonZeroScalar> for Scalar {
+    fn from(scalar: NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
+}
+
+impl From<&NonZeroScalar> for Scalar {
+    fn from(scalar: &NonZeroScalar) -> Self {
+        *scalar.as_ref()
     }
 }
 

--- a/p192/src/lib.rs
+++ b/p192/src/lib.rs
@@ -90,6 +90,10 @@ impl FieldBytesEncoding<NistP192> for U192 {
     }
 }
 
+/// Non-zero NIST P-192 scalar field element.
+#[cfg(feature = "arithmetic")]
+pub type NonZeroScalar = elliptic_curve::NonZeroScalar<NistP192>;
+
 #[cfg(not(feature = "arithmetic"))]
 impl elliptic_curve::sec1::ValidatePublicKey for NistP192 {}
 

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -22,7 +22,7 @@
 mod scalar_impl;
 
 use self::scalar_impl::*;
-use crate::{FieldBytes, FieldBytesEncoding, NistP224, ORDER_HEX, SecretKey, Uint};
+use crate::{FieldBytes, FieldBytesEncoding, NistP224, NonZeroScalar, ORDER_HEX, SecretKey, Uint};
 use elliptic_curve::{
     Curve as _, Error, Result, ScalarPrimitive,
     bigint::Limb,
@@ -209,6 +209,18 @@ impl Reduce<Uint> for Scalar {
     fn reduce_bytes(bytes: &FieldBytes) -> Self {
         let w = <Uint as FieldBytesEncoding<NistP224>>::decode_field_bytes(bytes);
         Self::reduce(w)
+    }
+}
+
+impl From<NonZeroScalar> for Scalar {
+    fn from(scalar: NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
+}
+
+impl From<&NonZeroScalar> for Scalar {
+    fn from(scalar: &NonZeroScalar) -> Self {
+        *scalar.as_ref()
     }
 }
 

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -5,7 +5,7 @@
 mod scalar_impl;
 
 use self::scalar_impl::barrett_reduce;
-use crate::{FieldBytes, NistP256, ORDER_HEX, SecretKey};
+use crate::{FieldBytes, NistP256, NonZeroScalar, ORDER_HEX, SecretKey};
 use core::{
     fmt::{self, Debug},
     iter::{Product, Sum},
@@ -471,6 +471,18 @@ impl From<Scalar> for FieldBytes {
 impl From<&Scalar> for FieldBytes {
     fn from(scalar: &Scalar) -> Self {
         scalar.to_bytes()
+    }
+}
+
+impl From<NonZeroScalar> for Scalar {
+    fn from(scalar: NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
+}
+
+impl From<&NonZeroScalar> for Scalar {
+    fn from(scalar: &NonZeroScalar) -> Self {
+        *scalar.as_ref()
     }
 }
 

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -22,7 +22,7 @@
 mod scalar_impl;
 
 use self::scalar_impl::*;
-use crate::{FieldBytes, NistP384, ORDER_HEX, SecretKey, U384};
+use crate::{FieldBytes, NistP384, NonZeroScalar, ORDER_HEX, SecretKey, U384};
 use elliptic_curve::{
     Curve as _, Error, FieldBytesEncoding, Result, ScalarPrimitive,
     bigint::{ArrayEncoding, Limb},
@@ -247,6 +247,18 @@ impl ReduceNonZero<U384> for Scalar {
 
     fn reduce_nonzero_bytes(bytes: &FieldBytes) -> Self {
         Self::reduce_nonzero(U384::from_be_byte_array(*bytes))
+    }
+}
+
+impl From<NonZeroScalar> for Scalar {
+    fn from(scalar: NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
+}
+
+impl From<&NonZeroScalar> for Scalar {
+    fn from(scalar: &NonZeroScalar) -> Self {
+        *scalar.as_ref()
     }
 }
 

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -15,7 +15,7 @@
 mod scalar_impl;
 
 use self::scalar_impl::*;
-use crate::{FieldBytes, NistP521, SecretKey, U576};
+use crate::{FieldBytes, NistP521, NonZeroScalar, SecretKey, U576};
 use core::{
     iter::{Product, Sum},
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, ShrAssign, SubAssign},
@@ -631,6 +631,18 @@ impl ReduceNonZero<U576> for Scalar {
     fn reduce_nonzero_bytes(bytes: &FieldBytes) -> Self {
         let w = <U576 as FieldBytesEncoding<NistP521>>::decode_field_bytes(bytes);
         Self::reduce_nonzero(w)
+    }
+}
+
+impl From<NonZeroScalar> for Scalar {
+    fn from(scalar: NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
+}
+
+impl From<&NonZeroScalar> for Scalar {
+    fn from(scalar: &NonZeroScalar) -> Self {
+        *scalar.as_ref()
     }
 }
 

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -24,7 +24,7 @@
 mod scalar_impl;
 
 use self::scalar_impl::*;
-use crate::{FieldBytes, FieldBytesEncoding, ORDER_HEX, SecretKey, Sm2, U256};
+use crate::{FieldBytes, FieldBytesEncoding, NonZeroScalar, ORDER_HEX, SecretKey, Sm2, U256};
 use elliptic_curve::{
     Curve as _, Error, Result, ScalarPrimitive,
     bigint::Limb,
@@ -193,6 +193,18 @@ impl Reduce<U256> for Scalar {
     fn reduce_bytes(bytes: &FieldBytes) -> Self {
         let w = <U256 as FieldBytesEncoding<Sm2>>::decode_field_bytes(bytes);
         Self::reduce(w)
+    }
+}
+
+impl From<NonZeroScalar> for Scalar {
+    fn from(scalar: NonZeroScalar) -> Self {
+        *scalar.as_ref()
+    }
+}
+
+impl From<&NonZeroScalar> for Scalar {
+    fn from(scalar: &NonZeroScalar) -> Self {
+        *scalar.as_ref()
     }
 }
 


### PR DESCRIPTION
This implements `From<NonZeroScalar>` for `Scalar`. Unfortunately this can't be implemented on `NonZeroScalar` directly because `elliptic_curve::Scalar` is just a type alias.

Companion PR: https://github.com/RustCrypto/traits/pull/1847.