### PR TITLE
Fix warnings on Rust 1.87

### DIFF
--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -270,12 +270,10 @@ impl Field for FieldElement {
         }
     }
 
-    #[must_use]
     fn square(&self) -> Self {
         self.square()
     }
 
-    #[must_use]
     fn double(&self) -> Self {
         self.double()
     }

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -418,7 +418,6 @@ impl Group for ProjectivePoint {
         self.z.normalizes_to_zero()
     }
 
-    #[must_use]
     fn double(&self) -> Self {
         Self::double(self)
     }

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -236,12 +236,10 @@ impl Field for Scalar {
         }
     }
 
-    #[must_use]
     fn square(&self) -> Self {
         Scalar::square(self)
     }
 
-    #[must_use]
     fn double(&self) -> Self {
         self.add(self)
     }

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -209,12 +209,10 @@ impl Field for Scalar {
         }
     }
 
-    #[must_use]
     fn square(&self) -> Self {
         Scalar::square(self)
     }
 
-    #[must_use]
     fn double(&self) -> Self {
         self.add(self)
     }

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -441,12 +441,10 @@ impl Field for FieldElement {
         Self::ZERO.ct_eq(self)
     }
 
-    #[must_use]
     fn square(&self) -> Self {
         self.square()
     }
 
-    #[must_use]
     fn double(&self) -> Self {
         self.double()
     }

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -418,12 +418,10 @@ impl Field for Scalar {
         Self::ZERO.ct_eq(self)
     }
 
-    #[must_use]
     fn square(&self) -> Self {
         self.square()
     }
 
-    #[must_use]
     fn double(&self) -> Self {
         self.double()
     }


### PR DESCRIPTION
There were several new warnings of this nature:

```console
warning: `#[must_use]` has no effect when applied to a provided trait method
       --> k256/src/arithmetic/scalar.rs:239:5
        |
    239 |     #[must_use]
        |     ^^^^^^^^^^^
```