### PR TITLE
Implement `From<NonIdentity>` for `Projective/AffinePoint`

### DIFF
--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -8,7 +8,7 @@ use core::ops::{Mul, Neg};
 use elliptic_curve::{
     Error, Result,
     group::{GroupEncoding, prime::PrimeCurveAffine},
-    point::{AffineCoordinates, DecompactPoint, DecompressPoint},
+    point::{AffineCoordinates, DecompactPoint, DecompressPoint, NonIdentity},
     sec1::{self, FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
@@ -308,6 +308,12 @@ impl From<AffinePoint> for EncodedPoint {
 impl From<&AffinePoint> for EncodedPoint {
     fn from(affine_point: &AffinePoint) -> EncodedPoint {
         affine_point.to_encoded_point(true)
+    }
+}
+
+impl From<NonIdentity<AffinePoint>> for AffinePoint {
+    fn from(affine_point: NonIdentity<AffinePoint>) -> Self {
+        affine_point.to_point()
     }
 }
 

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -8,7 +8,6 @@ use core::{
     iter::Sum,
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
 };
-use elliptic_curve::ops::BatchInvert;
 use elliptic_curve::{
     BatchNormalize, Error, Result,
     group::{
@@ -21,6 +20,7 @@ use elliptic_curve::{
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
 };
+use elliptic_curve::{ops::BatchInvert, point::NonIdentity};
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -315,6 +315,12 @@ where
 impl From<&AffinePoint> for ProjectivePoint {
     fn from(p: &AffinePoint) -> Self {
         Self::from(*p)
+    }
+}
+
+impl From<NonIdentity<ProjectivePoint>> for ProjectivePoint {
+    fn from(p: NonIdentity<ProjectivePoint>) -> Self {
+        p.to_point()
     }
 }
 

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -12,7 +12,7 @@ use elliptic_curve::{
     array::ArraySize,
     ff::{Field, PrimeField},
     group::{GroupEncoding, prime::PrimeCurveAffine},
-    point::{AffineCoordinates, DecompactPoint, DecompressPoint, Double},
+    point::{AffineCoordinates, DecompactPoint, DecompressPoint, Double, NonIdentity},
     sec1::{
         self, CompressedPoint, EncodedPoint, FromEncodedPoint, ModulusSize, ToCompactEncodedPoint,
         ToEncodedPoint, UncompressedPointSize,
@@ -191,6 +191,15 @@ where
                 })
             }
         }
+    }
+}
+
+impl<C> From<NonIdentity<AffinePoint<C>>> for AffinePoint<C>
+where
+    C: PrimeCurveParams,
+{
+    fn from(affine: NonIdentity<AffinePoint<C>>) -> Self {
+        affine.to_point()
     }
 }
 

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -18,7 +18,7 @@ use elliptic_curve::{
         prime::{PrimeCurve, PrimeGroup},
     },
     ops::{BatchInvert, LinearCombination},
-    point::Double,
+    point::{Double, NonIdentity},
     rand_core::TryRngCore,
     sec1::{
         CompressedPoint, EncodedPoint, FromEncodedPoint, ModulusSize, ToEncodedPoint,
@@ -235,6 +235,15 @@ where
 {
     fn from(p: &AffinePoint<C>) -> Self {
         Self::from(*p)
+    }
+}
+
+impl<C> From<NonIdentity<ProjectivePoint<C>>> for ProjectivePoint<C>
+where
+    C: PrimeCurveParams,
+{
+    fn from(p: NonIdentity<ProjectivePoint<C>>) -> Self {
+        p.to_point()
     }
 }
 


### PR DESCRIPTION
This is the equivalent of #1188 for `ProjectivePoint` and `AffinePoint`.