### PR TITLE
Implement `TryFrom<Scalar/Projective/AffinePoint>` for `NonIdentity/ZeroScalar`

### DIFF
--- a/bign256/src/arithmetic/scalar.rs
+++ b/bign256/src/arithmetic/scalar.rs
@@ -223,6 +223,7 @@ impl From<&SecretKey> for Scalar {
     }
 }
 
+/// The constant-time alternative is available at [`NonZeroScalar::new()`].
 impl TryFrom<Scalar> for NonZeroScalar {
     type Error = Error;
 

--- a/bign256/src/arithmetic/scalar.rs
+++ b/bign256/src/arithmetic/scalar.rs
@@ -223,6 +223,14 @@ impl From<&SecretKey> for Scalar {
     }
 }
 
+impl TryFrom<Scalar> for NonZeroScalar {
+    type Error = Error;
+
+    fn try_from(scalar: Scalar) -> Result<Self> {
+        NonZeroScalar::new(scalar).into_option().ok_or(Error)
+    }
+}
+
 impl TryFrom<U256> for Scalar {
     type Error = Error;
 

--- a/bp256/src/r1/arithmetic.rs
+++ b/bp256/src/r1/arithmetic.rs
@@ -77,6 +77,7 @@ impl From<&Scalar> for ScalarPrimitive {
     }
 }
 
+/// The constant-time alternative is available at [`NonZeroScalar::new()`].
 impl TryFrom<Scalar> for NonZeroScalar {
     type Error = Error;
 

--- a/bp256/src/r1/arithmetic.rs
+++ b/bp256/src/r1/arithmetic.rs
@@ -2,7 +2,7 @@
 
 use super::BrainpoolP256r1;
 use crate::{FieldElement, Scalar};
-use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use elliptic_curve::{CurveArithmetic, Error, PrimeCurveArithmetic};
 use primeorder::{PrimeCurveParams, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -74,5 +74,13 @@ impl From<Scalar> for ScalarPrimitive {
 impl From<&Scalar> for ScalarPrimitive {
     fn from(scalar: &Scalar) -> ScalarPrimitive {
         ScalarPrimitive::new(scalar.into()).unwrap()
+    }
+}
+
+impl TryFrom<Scalar> for NonZeroScalar {
+    type Error = Error;
+
+    fn try_from(scalar: Scalar) -> Result<Self, Error> {
+        NonZeroScalar::new(scalar).into_option().ok_or(Error)
     }
 }

--- a/bp256/src/t1/arithmetic.rs
+++ b/bp256/src/t1/arithmetic.rs
@@ -77,6 +77,7 @@ impl From<&Scalar> for ScalarPrimitive {
     }
 }
 
+/// The constant-time alternative is available at [`NonZeroScalar::new()`].
 impl TryFrom<Scalar> for NonZeroScalar {
     type Error = Error;
 

--- a/bp256/src/t1/arithmetic.rs
+++ b/bp256/src/t1/arithmetic.rs
@@ -2,7 +2,7 @@
 
 use super::BrainpoolP256t1;
 use crate::{FieldElement, Scalar};
-use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use elliptic_curve::{CurveArithmetic, Error, PrimeCurveArithmetic};
 use primeorder::{PrimeCurveParams, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -74,5 +74,13 @@ impl From<Scalar> for ScalarPrimitive {
 impl From<&Scalar> for ScalarPrimitive {
     fn from(scalar: &Scalar) -> ScalarPrimitive {
         ScalarPrimitive::new(scalar.into()).unwrap()
+    }
+}
+
+impl TryFrom<Scalar> for NonZeroScalar {
+    type Error = Error;
+
+    fn try_from(scalar: Scalar) -> Result<Self, Error> {
+        NonZeroScalar::new(scalar).into_option().ok_or(Error)
     }
 }

--- a/bp384/src/r1/arithmetic.rs
+++ b/bp384/src/r1/arithmetic.rs
@@ -83,6 +83,7 @@ impl From<&Scalar> for ScalarPrimitive {
     }
 }
 
+/// The constant-time alternative is available at [`NonZeroScalar::new()`].
 impl TryFrom<Scalar> for NonZeroScalar {
     type Error = Error;
 

--- a/bp384/src/r1/arithmetic.rs
+++ b/bp384/src/r1/arithmetic.rs
@@ -2,7 +2,7 @@
 
 use super::BrainpoolP384r1;
 use crate::{FieldElement, Scalar};
-use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use elliptic_curve::{CurveArithmetic, Error, PrimeCurveArithmetic};
 use primeorder::{PrimeCurveParams, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -80,5 +80,13 @@ impl From<Scalar> for ScalarPrimitive {
 impl From<&Scalar> for ScalarPrimitive {
     fn from(scalar: &Scalar) -> ScalarPrimitive {
         ScalarPrimitive::new(scalar.into()).unwrap()
+    }
+}
+
+impl TryFrom<Scalar> for NonZeroScalar {
+    type Error = Error;
+
+    fn try_from(scalar: Scalar) -> Result<Self, Error> {
+        NonZeroScalar::new(scalar).into_option().ok_or(Error)
     }
 }

--- a/bp384/src/t1/arithmetic.rs
+++ b/bp384/src/t1/arithmetic.rs
@@ -83,6 +83,7 @@ impl From<&Scalar> for ScalarPrimitive {
     }
 }
 
+/// The constant-time alternative is available at [`NonZeroScalar::new()`].
 impl TryFrom<Scalar> for NonZeroScalar {
     type Error = Error;
 

--- a/bp384/src/t1/arithmetic.rs
+++ b/bp384/src/t1/arithmetic.rs
@@ -2,7 +2,7 @@
 
 use super::BrainpoolP384t1;
 use crate::{FieldElement, Scalar};
-use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use elliptic_curve::{CurveArithmetic, Error, PrimeCurveArithmetic};
 use primeorder::{PrimeCurveParams, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -80,5 +80,13 @@ impl From<Scalar> for ScalarPrimitive {
 impl From<&Scalar> for ScalarPrimitive {
     fn from(scalar: &Scalar) -> ScalarPrimitive {
         ScalarPrimitive::new(scalar.into()).unwrap()
+    }
+}
+
+impl TryFrom<Scalar> for NonZeroScalar {
+    type Error = Error;
+
+    fn try_from(scalar: Scalar) -> Result<Self, Error> {
+        NonZeroScalar::new(scalar).into_option().ok_or(Error)
     }
 }

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -329,6 +329,7 @@ impl From<&PublicKey> for AffinePoint {
     }
 }
 
+/// The constant-time alternative is available at [`NonIdentity::new()`].
 impl TryFrom<AffinePoint> for NonIdentity<AffinePoint> {
     type Error = Error;
 

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -329,6 +329,14 @@ impl From<&PublicKey> for AffinePoint {
     }
 }
 
+impl TryFrom<AffinePoint> for NonIdentity<AffinePoint> {
+    type Error = Error;
+
+    fn try_from(affine_point: AffinePoint) -> Result<Self> {
+        NonIdentity::new(affine_point).into_option().ok_or(Error)
+    }
+}
+
 impl TryFrom<AffinePoint> for PublicKey {
     type Error = Error;
 

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -664,6 +664,14 @@ impl From<&PublicKey> for ProjectivePoint {
     }
 }
 
+impl TryFrom<ProjectivePoint> for NonIdentity<ProjectivePoint> {
+    type Error = Error;
+
+    fn try_from(point: ProjectivePoint) -> Result<Self> {
+        NonIdentity::new(point).into_option().ok_or(Error)
+    }
+}
+
 impl TryFrom<ProjectivePoint> for PublicKey {
     type Error = Error;
 

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -664,6 +664,7 @@ impl From<&PublicKey> for ProjectivePoint {
     }
 }
 
+/// The constant-time alternative is available at [`NonIdentity::new()`].
 impl TryFrom<ProjectivePoint> for NonIdentity<ProjectivePoint> {
     type Error = Error;
 

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -413,6 +413,7 @@ impl From<&Scalar> for ScalarPrimitive<Secp256k1> {
     }
 }
 
+/// The constant-time alternative is available at [`NonZeroScalar::new()`].
 impl TryFrom<Scalar> for NonZeroScalar {
     type Error = Error;
 

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -12,7 +12,7 @@ use core::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, ShrAssign, Sub, SubAssign},
 };
 use elliptic_curve::{
-    Curve, ScalarPrimitive,
+    Curve, Error, ScalarPrimitive,
     bigint::{Limb, U256, U512, Word, prelude::*},
     ff::{self, Field, PrimeField},
     ops::{Invert, Reduce, ReduceNonZero},
@@ -410,6 +410,14 @@ impl From<Scalar> for ScalarPrimitive<Secp256k1> {
 impl From<&Scalar> for ScalarPrimitive<Secp256k1> {
     fn from(scalar: &Scalar) -> ScalarPrimitive<Secp256k1> {
         ScalarPrimitive::new(scalar.0).unwrap()
+    }
+}
+
+impl TryFrom<Scalar> for NonZeroScalar {
+    type Error = Error;
+
+    fn try_from(scalar: Scalar) -> Result<Self, Error> {
+        NonZeroScalar::new(scalar).into_option().ok_or(Error)
     }
 }
 

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -253,6 +253,7 @@ impl From<&Scalar> for ScalarPrimitive<NistP192> {
     }
 }
 
+/// The constant-time alternative is available at [`NonZeroScalar::new()`].
 impl TryFrom<Scalar> for NonZeroScalar {
     type Error = Error;
 

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -253,6 +253,14 @@ impl From<&Scalar> for ScalarPrimitive<NistP192> {
     }
 }
 
+impl TryFrom<Scalar> for NonZeroScalar {
+    type Error = Error;
+
+    fn try_from(scalar: Scalar) -> Result<Self> {
+        NonZeroScalar::new(scalar).into_option().ok_or(Error)
+    }
+}
+
 impl TryFrom<U192> for Scalar {
     type Error = Error;
 

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -254,6 +254,7 @@ impl From<&SecretKey> for Scalar {
     }
 }
 
+/// The constant-time alternative is available at [`NonZeroScalar::new()`].
 impl TryFrom<Scalar> for NonZeroScalar {
     type Error = Error;
 

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -254,6 +254,14 @@ impl From<&SecretKey> for Scalar {
     }
 }
 
+impl TryFrom<Scalar> for NonZeroScalar {
+    type Error = Error;
+
+    fn try_from(scalar: Scalar) -> Result<Self> {
+        NonZeroScalar::new(scalar).into_option().ok_or(Error)
+    }
+}
+
 impl TryFrom<Uint> for Scalar {
     type Error = Error;
 

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -533,6 +533,7 @@ impl From<&Scalar> for ScalarBits {
     }
 }
 
+/// The constant-time alternative is available at [`NonZeroScalar::new()`].
 impl TryFrom<Scalar> for NonZeroScalar {
     type Error = Error;
 

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -12,7 +12,7 @@ use core::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, ShrAssign, Sub, SubAssign},
 };
 use elliptic_curve::{
-    Curve, ScalarPrimitive,
+    Curve, Error, ScalarPrimitive,
     bigint::{Limb, U256, prelude::*},
     group::ff::{self, Field, PrimeField},
     ops::{Invert, Reduce, ReduceNonZero},
@@ -530,6 +530,14 @@ impl From<&Scalar> for U256 {
 impl From<&Scalar> for ScalarBits {
     fn from(scalar: &Scalar) -> ScalarBits {
         scalar.0.to_words().into()
+    }
+}
+
+impl TryFrom<Scalar> for NonZeroScalar {
+    type Error = Error;
+
+    fn try_from(scalar: Scalar) -> Result<Self, Error> {
+        NonZeroScalar::new(scalar).into_option().ok_or(Error)
     }
 }
 

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -292,6 +292,7 @@ impl From<&SecretKey> for Scalar {
     }
 }
 
+/// The constant-time alternative is available at [`NonZeroScalar::new()`].
 impl TryFrom<Scalar> for NonZeroScalar {
     type Error = Error;
 

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -292,6 +292,14 @@ impl From<&SecretKey> for Scalar {
     }
 }
 
+impl TryFrom<Scalar> for NonZeroScalar {
+    type Error = Error;
+
+    fn try_from(scalar: Scalar) -> Result<Self> {
+        NonZeroScalar::new(scalar).into_option().ok_or(Error)
+    }
+}
+
 impl TryFrom<U384> for Scalar {
     type Error = Error;
 

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -698,6 +698,7 @@ impl From<&SecretKey> for Scalar {
     }
 }
 
+/// The constant-time alternative is available at [`NonZeroScalar::new()`].
 impl TryFrom<Scalar> for NonZeroScalar {
     type Error = Error;
 

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -698,6 +698,14 @@ impl From<&SecretKey> for Scalar {
     }
 }
 
+impl TryFrom<Scalar> for NonZeroScalar {
+    type Error = Error;
+
+    fn try_from(scalar: Scalar) -> Result<Self> {
+        NonZeroScalar::new(scalar).into_option().ok_or(Error)
+    }
+}
+
 impl TryFrom<U576> for Scalar {
     type Error = Error;
 

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -367,6 +367,7 @@ where
     }
 }
 
+/// The constant-time alternative is available at [`NonIdentity::new()`].
 impl<C> TryFrom<AffinePoint<C>> for NonIdentity<AffinePoint<C>>
 where
     C: PrimeCurveParams,

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -367,6 +367,17 @@ where
     }
 }
 
+impl<C> TryFrom<AffinePoint<C>> for NonIdentity<AffinePoint<C>>
+where
+    C: PrimeCurveParams,
+{
+    type Error = Error;
+
+    fn try_from(affine_point: AffinePoint<C>) -> Result<Self> {
+        NonIdentity::new(affine_point).into_option().ok_or(Error)
+    }
+}
+
 impl<C> TryFrom<EncodedPoint<C>> for AffinePoint<C>
 where
     C: PrimeCurveParams,

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -477,6 +477,17 @@ where
     }
 }
 
+impl<C> TryFrom<ProjectivePoint<C>> for NonIdentity<ProjectivePoint<C>>
+where
+    C: PrimeCurveParams,
+{
+    type Error = Error;
+
+    fn try_from(point: ProjectivePoint<C>) -> Result<Self> {
+        NonIdentity::new(point).into_option().ok_or(Error)
+    }
+}
+
 impl<C> TryFrom<ProjectivePoint<C>> for PublicKey<C>
 where
     C: PrimeCurveParams,

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -477,6 +477,7 @@ where
     }
 }
 
+/// The constant-time alternative is available at [`NonIdentity::new()`].
 impl<C> TryFrom<ProjectivePoint<C>> for NonIdentity<ProjectivePoint<C>>
 where
     C: PrimeCurveParams,

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -238,6 +238,7 @@ impl From<&SecretKey> for Scalar {
     }
 }
 
+/// The constant-time alternative is available at [`NonZeroScalar::new()`].
 impl TryFrom<Scalar> for NonZeroScalar {
     type Error = Error;
 

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -238,6 +238,14 @@ impl From<&SecretKey> for Scalar {
     }
 }
 
+impl TryFrom<Scalar> for NonZeroScalar {
+    type Error = Error;
+
+    fn try_from(scalar: Scalar) -> Result<Self> {
+        NonZeroScalar::new(scalar).into_option().ok_or(Error)
+    }
+}
+
 impl TryFrom<U256> for Scalar {
     type Error = Error;
 


### PR DESCRIPTION
This implement `TryFrom<Scalar> for NonZeroScalar`, `TryFrom<ProjectivePoint> for NonIdentity<ProjectivePoint>` and `TryFrom<AffinePoint> for NonIdentity<AffinePoint>` in the same spirit as #1188 and #1190.