### PR TITLE
primeorder: add `scalar_mul_impls!` macro

### DIFF
--- a/bign256/src/arithmetic/scalar.rs
+++ b/bign256/src/arithmetic/scalar.rs
@@ -88,6 +88,8 @@ primefield::fiat_field_arithmetic!(
     fiat_bign256_scalar_selectznz
 );
 
+primeorder::scalar_mul_impls!(BignP256, Scalar);
+
 impl Scalar {
     /// Returns the square root of self mod p, or `None` if no square root
     /// exists.

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -15,7 +15,7 @@
 mod scalar_impl;
 
 use self::scalar_impl::*;
-use crate::{FieldBytes, ORDER, ORDER_HEX, U256};
+use crate::{BrainpoolP256r1, BrainpoolP256t1, FieldBytes, ORDER, ORDER_HEX, U256};
 use elliptic_curve::{
     Error, Result,
     bigint::{ArrayEncoding, Limb},
@@ -59,6 +59,9 @@ primefield::fiat_field_arithmetic!(
     fiat_bp256_scalar_msat,
     fiat_bp256_scalar_selectznz
 );
+
+primeorder::scalar_mul_impls!(BrainpoolP256r1, Scalar);
+primeorder::scalar_mul_impls!(BrainpoolP256t1, Scalar);
 
 impl Scalar {
     /// Returns the square root of self mod n, or `None` if no square root

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -15,7 +15,7 @@
 mod scalar_impl;
 
 use self::scalar_impl::*;
-use crate::{FieldBytes, ORDER, ORDER_HEX, U384};
+use crate::{BrainpoolP384r1, BrainpoolP384t1, FieldBytes, ORDER, ORDER_HEX, U384};
 use elliptic_curve::{
     Error, Result,
     bigint::{ArrayEncoding, Limb},
@@ -59,6 +59,9 @@ primefield::fiat_field_arithmetic!(
     fiat_bp384_scalar_msat,
     fiat_bp384_scalar_selectznz
 );
+
+primeorder::scalar_mul_impls!(BrainpoolP384r1, Scalar);
+primeorder::scalar_mul_impls!(BrainpoolP384t1, Scalar);
 
 impl Scalar {
     /// Atkin algorithm for q mod 8 = 5

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -6,7 +6,10 @@ mod wide;
 
 pub(crate) use self::wide::WideScalar;
 
-use crate::{FieldBytes, NonZeroScalar, ORDER, ORDER_HEX, Secp256k1, WideBytes};
+use crate::{
+    FieldBytes, NonZeroScalar, ORDER, ORDER_HEX, Secp256k1, WideBytes,
+    arithmetic::{AffinePoint, ProjectivePoint},
+};
 use core::{
     iter::{Product, Sum},
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, ShrAssign, Sub, SubAssign},
@@ -653,6 +656,78 @@ impl Mul<&Scalar> for Scalar {
 
     fn mul(self, other: &Scalar) -> Scalar {
         Scalar::mul(&self, other)
+    }
+}
+
+impl Mul<AffinePoint> for Scalar {
+    type Output = ProjectivePoint;
+
+    #[inline]
+    fn mul(self, rhs: AffinePoint) -> ProjectivePoint {
+        rhs * self
+    }
+}
+
+impl Mul<&AffinePoint> for Scalar {
+    type Output = ProjectivePoint;
+
+    #[inline]
+    fn mul(self, rhs: &AffinePoint) -> ProjectivePoint {
+        *rhs * self
+    }
+}
+
+impl Mul<AffinePoint> for &Scalar {
+    type Output = ProjectivePoint;
+
+    #[inline]
+    fn mul(self, rhs: AffinePoint) -> ProjectivePoint {
+        rhs * self
+    }
+}
+
+impl Mul<&AffinePoint> for &Scalar {
+    type Output = ProjectivePoint;
+
+    #[inline]
+    fn mul(self, rhs: &AffinePoint) -> ProjectivePoint {
+        *rhs * self
+    }
+}
+
+impl Mul<ProjectivePoint> for Scalar {
+    type Output = ProjectivePoint;
+
+    #[inline]
+    fn mul(self, rhs: ProjectivePoint) -> ProjectivePoint {
+        rhs * self
+    }
+}
+
+impl Mul<&ProjectivePoint> for Scalar {
+    type Output = ProjectivePoint;
+
+    #[inline]
+    fn mul(self, rhs: &ProjectivePoint) -> ProjectivePoint {
+        rhs * &self
+    }
+}
+
+impl Mul<ProjectivePoint> for &Scalar {
+    type Output = ProjectivePoint;
+
+    #[inline]
+    fn mul(self, rhs: ProjectivePoint) -> ProjectivePoint {
+        rhs * self
+    }
+}
+
+impl Mul<&ProjectivePoint> for &Scalar {
+    type Output = ProjectivePoint;
+
+    #[inline]
+    fn mul(self, rhs: &ProjectivePoint) -> ProjectivePoint {
+        rhs * self
     }
 }
 

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -98,6 +98,8 @@ primefield::fiat_field_arithmetic!(
     fiat_p192_scalar_selectznz
 );
 
+primeorder::scalar_mul_impls!(NistP192, Scalar);
+
 impl Scalar {
     /// Tonelli-Shank's algorithm for q mod 16 = 1
     /// <https://eprint.iacr.org/2012/685.pdf> (page 12, algorithm 5)

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -106,6 +106,8 @@ primefield::fiat_field_arithmetic!(
     fiat_p224_scalar_selectznz
 );
 
+primeorder::scalar_mul_impls!(NistP224, Scalar);
+
 impl Scalar {
     /// Atkin algorithm for q mod 8 = 5
     /// <https://eips.ethereum.org/assets/eip-3068/2012-685_Square_Root_Even_Ext.pdf>

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -605,6 +605,8 @@ impl SubAssign<&Scalar> for Scalar {
     }
 }
 
+primeorder::scalar_mul_impls!(NistP256, Scalar);
+
 impl Mul<Scalar> for Scalar {
     type Output = Scalar;
 

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -106,6 +106,8 @@ primefield::fiat_field_arithmetic!(
     fiat_p384_scalar_selectznz
 );
 
+primeorder::scalar_mul_impls!(NistP384, Scalar);
+
 impl Scalar {
     /// Compute modular square root.
     pub fn sqrt(&self) -> CtOption<Self> {

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -442,6 +442,7 @@ impl Field for Scalar {
 primefield::field_op!(Scalar, Add, add, add);
 primefield::field_op!(Scalar, Sub, sub, sub);
 primefield::field_op!(Scalar, Mul, mul, multiply);
+primeorder::scalar_mul_impls!(NistP521, Scalar);
 
 impl AddAssign<Scalar> for Scalar {
     #[inline]

--- a/primefield/src/lib.rs
+++ b/primefield/src/lib.rs
@@ -74,14 +74,7 @@ macro_rules! field_element_type {
         $decode_uint:path,
         $encode_uint:path
     ) => {
-        primefield::field_element_type_core!(
-            $fe,
-            $bytes,
-            $uint,
-            $modulus,
-            $decode_uint,
-            $encode_uint
-        );
+        $crate::field_element_type_core!($fe, $bytes, $uint, $modulus, $decode_uint, $encode_uint);
 
         $crate::field_op!($fe, Add, add, add);
         $crate::field_op!($fe, Sub, sub, sub);

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -429,6 +429,21 @@ where
 {
     type Output = ProjectivePoint<C>;
 
+    #[inline]
+    fn mul(self, scalar: S) -> ProjectivePoint<C> {
+        ProjectivePoint::<C>::from(self) * scalar
+    }
+}
+
+impl<C, S> Mul<S> for &AffinePoint<C>
+where
+    C: PrimeCurveParams,
+    S: Borrow<Scalar<C>>,
+    ProjectivePoint<C>: Double,
+{
+    type Output = ProjectivePoint<C>;
+
+    #[inline]
     fn mul(self, scalar: S) -> ProjectivePoint<C> {
         ProjectivePoint::<C>::from(self) * scalar
     }
@@ -440,6 +455,7 @@ where
 {
     type Output = Self;
 
+    #[inline]
     fn neg(self) -> Self {
         AffinePoint {
             x: self.x,
@@ -455,6 +471,7 @@ where
 {
     type Output = AffinePoint<C>;
 
+    #[inline]
     fn neg(self) -> AffinePoint<C> {
         -(*self)
     }

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -17,14 +17,13 @@ pub mod point_arithmetic;
 mod affine;
 #[cfg(feature = "dev")]
 mod dev;
+mod macros;
 mod projective;
 
 pub use crate::{affine::AffinePoint, projective::ProjectivePoint};
 pub use elliptic_curve::{self, Field, FieldBytes, PrimeCurve, PrimeField, array, point::Double};
 
-use elliptic_curve::CurveArithmetic;
-use elliptic_curve::ops::Invert;
-use elliptic_curve::subtle::CtOption;
+use elliptic_curve::{CurveArithmetic, ops::Invert, subtle::CtOption};
 
 /// Parameters for elliptic curves of prime order which can be described by the
 /// short Weierstrass equation.

--- a/primeorder/src/macros.rs
+++ b/primeorder/src/macros.rs
@@ -1,0 +1,103 @@
+//! Macros for writing common patterns that interact with this crate.
+
+/// Writes a series of `Mul` impls for an elliptic curve's scalar field
+#[macro_export]
+macro_rules! scalar_mul_impls {
+    ($curve:path, $scalar:ty) => {
+        impl ::core::ops::Mul<$crate::elliptic_curve::AffinePoint<$curve>> for $scalar {
+            type Output = $crate::elliptic_curve::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(
+                self,
+                rhs: $crate::elliptic_curve::AffinePoint<$curve>,
+            ) -> $crate::elliptic_curve::ProjectivePoint<$curve> {
+                rhs * self
+            }
+        }
+
+        impl ::core::ops::Mul<&$crate::elliptic_curve::AffinePoint<$curve>> for $scalar {
+            type Output = $crate::elliptic_curve::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(
+                self,
+                rhs: &$crate::elliptic_curve::AffinePoint<$curve>,
+            ) -> $crate::elliptic_curve::ProjectivePoint<$curve> {
+                *rhs * self
+            }
+        }
+
+        impl ::core::ops::Mul<$crate::elliptic_curve::AffinePoint<$curve>> for &$scalar {
+            type Output = $crate::elliptic_curve::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(
+                self,
+                rhs: $crate::elliptic_curve::AffinePoint<$curve>,
+            ) -> $crate::elliptic_curve::ProjectivePoint<$curve> {
+                rhs * self
+            }
+        }
+
+        impl ::core::ops::Mul<&$crate::elliptic_curve::AffinePoint<$curve>> for &$scalar {
+            type Output = $crate::elliptic_curve::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(
+                self,
+                rhs: &$crate::elliptic_curve::AffinePoint<$curve>,
+            ) -> $crate::elliptic_curve::ProjectivePoint<$curve> {
+                *rhs * self
+            }
+        }
+
+        impl ::core::ops::Mul<$crate::elliptic_curve::ProjectivePoint<$curve>> for $scalar {
+            type Output = $crate::elliptic_curve::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(
+                self,
+                rhs: $crate::elliptic_curve::ProjectivePoint<$curve>,
+            ) -> $crate::elliptic_curve::ProjectivePoint<$curve> {
+                rhs * self
+            }
+        }
+
+        impl ::core::ops::Mul<&$crate::elliptic_curve::ProjectivePoint<$curve>> for $scalar {
+            type Output = $crate::elliptic_curve::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(
+                self,
+                rhs: &$crate::elliptic_curve::ProjectivePoint<$curve>,
+            ) -> $crate::elliptic_curve::ProjectivePoint<$curve> {
+                rhs * &self
+            }
+        }
+
+        impl ::core::ops::Mul<$crate::elliptic_curve::ProjectivePoint<$curve>> for &$scalar {
+            type Output = $crate::elliptic_curve::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(
+                self,
+                rhs: $crate::elliptic_curve::ProjectivePoint<$curve>,
+            ) -> $crate::elliptic_curve::ProjectivePoint<$curve> {
+                rhs * self
+            }
+        }
+
+        impl ::core::ops::Mul<&$crate::elliptic_curve::ProjectivePoint<$curve>> for &$scalar {
+            type Output = $crate::elliptic_curve::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(
+                self,
+                rhs: &$crate::elliptic_curve::ProjectivePoint<$curve>,
+            ) -> $crate::elliptic_curve::ProjectivePoint<$curve> {
+                rhs * self
+            }
+        }
+    };
+}

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -738,6 +738,19 @@ where
     }
 }
 
+impl<C, S> Mul<S> for &ProjectivePoint<C>
+where
+    Self: Double,
+    C: PrimeCurveParams,
+    S: Borrow<Scalar<C>>,
+{
+    type Output = ProjectivePoint<C>;
+
+    fn mul(self, scalar: S) -> ProjectivePoint<C> {
+        ProjectivePoint::mul(self, scalar.borrow())
+    }
+}
+
 impl<C> Mul<&Scalar<C>> for &ProjectivePoint<C>
 where
     C: PrimeCurveParams,

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -100,6 +100,8 @@ primefield::fiat_field_arithmetic!(
     fiat_sm2_scalar_selectznz
 );
 
+primeorder::scalar_mul_impls!(Sm2, Scalar);
+
 impl Scalar {
     /// Returns the square root of self mod n, or `None` if no square root
     /// exists.


### PR DESCRIPTION
Adds a macro which writes a series of `Mul` impls for `Scalar` types for both `AffinePoint` and `ProjectivePoint` as operands (and various combinations of references thereof).

See also: RustCrypto/traits#1854