### PR TITLE
primeorder: rename `test_projective_arithmetic!` macro

### DIFF
--- a/bign256/tests/projective.rs
+++ b/bign256/tests/projective.rs
@@ -10,9 +10,9 @@ use elliptic_curve::{
     group::{GroupEncoding, ff::PrimeField},
     sec1::{self, ToEncodedPoint},
 };
-use primeorder::{Double, impl_projective_arithmetic_tests};
+use primeorder::{Double, test_projective_arithmetic};
 
-impl_projective_arithmetic_tests!(
+test_projective_arithmetic!(
     AffinePoint,
     ProjectivePoint,
     Scalar,

--- a/p192/tests/projective.rs
+++ b/p192/tests/projective.rs
@@ -10,9 +10,9 @@ use p192::{
     AffinePoint, ProjectivePoint, Scalar,
     test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
 };
-use primeorder::{Double, impl_projective_arithmetic_tests};
+use primeorder::{Double, test_projective_arithmetic};
 
-impl_projective_arithmetic_tests!(
+test_projective_arithmetic!(
     AffinePoint,
     ProjectivePoint,
     Scalar,

--- a/p224/tests/projective.rs
+++ b/p224/tests/projective.rs
@@ -10,9 +10,9 @@ use p224::{
     AffinePoint, ProjectivePoint, Scalar,
     test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
 };
-use primeorder::{Double, impl_projective_arithmetic_tests};
+use primeorder::{Double, test_projective_arithmetic};
 
-impl_projective_arithmetic_tests!(
+test_projective_arithmetic!(
     AffinePoint,
     ProjectivePoint,
     Scalar,

--- a/p256/tests/projective.rs
+++ b/p256/tests/projective.rs
@@ -10,9 +10,9 @@ use p256::{
     AffinePoint, ProjectivePoint, Scalar,
     test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
 };
-use primeorder::{Double, impl_projective_arithmetic_tests};
+use primeorder::{Double, test_projective_arithmetic};
 
-impl_projective_arithmetic_tests!(
+test_projective_arithmetic!(
     AffinePoint,
     ProjectivePoint,
     Scalar,

--- a/p384/tests/projective.rs
+++ b/p384/tests/projective.rs
@@ -10,9 +10,9 @@ use p384::{
     AffinePoint, ProjectivePoint, Scalar,
     test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
 };
-use primeorder::{Double, impl_projective_arithmetic_tests};
+use primeorder::{Double, test_projective_arithmetic};
 
-impl_projective_arithmetic_tests!(
+test_projective_arithmetic!(
     AffinePoint,
     ProjectivePoint,
     Scalar,

--- a/p521/tests/projective.rs
+++ b/p521/tests/projective.rs
@@ -10,9 +10,9 @@ use p521::{
     AffinePoint, ProjectivePoint, Scalar,
     test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
 };
-use primeorder::{Double, impl_projective_arithmetic_tests};
+use primeorder::{Double, test_projective_arithmetic};
 
-impl_projective_arithmetic_tests!(
+test_projective_arithmetic!(
     AffinePoint,
     ProjectivePoint,
     Scalar,

--- a/primeorder/src/dev.rs
+++ b/primeorder/src/dev.rs
@@ -1,10 +1,8 @@
 //! Development-related functionality.
 
-// TODO(tarcieri): move all development-related macros into this module
-
 /// Implement projective arithmetic tests.
 #[macro_export]
-macro_rules! impl_projective_arithmetic_tests {
+macro_rules! test_projective_arithmetic {
     (
         $affine:tt,
         $projective:tt,


### PR DESCRIPTION
It was previously the more verbose `impl_projective_arithmetic_tests!`.

This follows the convention in the `primefield` crate.