### PR TITLE
Bump `elliptic-curve` pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.1"
-source = "git+https://github.com/RustCrypto/traits.git#2744cdb79cee28069755a870ab700e3827be8c07"
+source = "git+https://github.com/RustCrypto/traits.git#915474f1ed5be0a19fd102d5f75ef8e04c765416"
 dependencies = [
  "base16ct",
  "base64ct",
@@ -1139,7 +1139,7 @@ dependencies = [
 [[package]]
 name = "signature"
 version = "3.0.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#2744cdb79cee28069755a870ab700e3827be8c07"
+source = "git+https://github.com/RustCrypto/traits.git#915474f1ed5be0a19fd102d5f75ef8e04c765416"
 dependencies = [
  "digest",
  "rand_core 0.9.3",


### PR DESCRIPTION
Ensure we're compatible with the latest upstream changes to the `elliptic-curve` crate