### PR TITLE
Update to `ExpandMsg` changes

### DIFF
--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -44,12 +44,12 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features hash2curve
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features jwk
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features oprf
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha256
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features voprf
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,bits,ecdh,ecdsa,hash2curve,jwk,pem,pkcs8,serde,sha256,voprf
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,bits,ecdh,ecdsa,hash2curve,jwk,oprf,pem,pkcs8,serde,sha256
 
   benches:
     runs-on: ubuntu-latest

--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -41,12 +41,12 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa-core
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features hash2curve
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features jwk
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features oprf
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha384
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features voprf
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa-core,hash2curve,jwk,pem,pkcs8,serde,sha384,voprf
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa-core,hash2curve,jwk,oprf,pem,pkcs8,serde,sha384
 
   benches:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
 [[package]]
 name = "crypto-common"
 version = "0.2.0-rc.2"
-source = "git+https://github.com/RustCrypto/traits.git#4de33de9409d6534501c3d390a3051618482a419"
+source = "git+https://github.com/RustCrypto/traits.git#e728ece19cb5df8d8a7f575c4676a323d449a885"
 dependencies = [
  "hybrid-array",
 ]
@@ -382,7 +382,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.1"
-source = "git+https://github.com/RustCrypto/traits.git#4de33de9409d6534501c3d390a3051618482a419"
+source = "git+https://github.com/RustCrypto/traits.git#e728ece19cb5df8d8a7f575c4676a323d449a885"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/k256/src/arithmetic/hash2curve.rs
+++ b/k256/src/arithmetic/hash2curve.rs
@@ -355,7 +355,8 @@ mod tests {
             // in parts
             let mut u = [FieldElement::default(), FieldElement::default()];
             hash2curve::hash_to_field::<
-                ExpandMsgXmd<Sha256, <Secp256k1 as GroupDigest>::K>,
+                ExpandMsgXmd<Sha256>,
+                <Secp256k1 as GroupDigest>::K,
                 FieldElement,
             >(&[test_vector.msg], &[DST], &mut u)
             .unwrap();
@@ -378,10 +379,8 @@ mod tests {
             assert_eq!(ap.y.to_bytes().as_slice(), test_vector.p_y);
 
             // complete run
-            let pt = Secp256k1::hash_from_bytes::<
-                ExpandMsgXmd<Sha256, <Secp256k1 as GroupDigest>::K>,
-            >(&[test_vector.msg], &[DST])
-            .unwrap();
+            let pt = Secp256k1::hash_from_bytes::<ExpandMsgXmd<Sha256>>(&[test_vector.msg], &[DST])
+                .unwrap();
             let apt = pt.to_affine();
             assert_eq!(apt.x.to_bytes().as_slice(), test_vector.p_x);
             assert_eq!(apt.y.to_bytes().as_slice(), test_vector.p_y);

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -51,12 +51,12 @@ ecdsa = ["arithmetic", "ecdsa-core/signing", "ecdsa-core/verifying", "sha256"]
 expose-field = ["arithmetic"]
 hash2curve = ["arithmetic", "elliptic-curve/hash2curve"]
 jwk = ["elliptic-curve/jwk"]
+oprf = ["hash2curve", "elliptic-curve/oprf", "sha2"]
 pem = ["elliptic-curve/pem", "ecdsa-core/pem", "pkcs8"]
 pkcs8 = ["ecdsa-core?/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa-core?/serde", "elliptic-curve/serde", "primeorder?/serde", "serdect"]
 sha256 = ["digest", "sha2"]
 test-vectors = ["dep:hex-literal"]
-voprf = ["hash2curve", "elliptic-curve/voprf", "sha2"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/p256/src/arithmetic/hash2curve.rs
+++ b/p256/src/arithmetic/hash2curve.rs
@@ -206,7 +206,8 @@ mod tests {
             // in parts
             let mut u = [FieldElement::default(), FieldElement::default()];
             hash2curve::hash_to_field::<
-                ExpandMsgXmd<Sha256, <NistP256 as GroupDigest>::K>,
+                ExpandMsgXmd<Sha256>,
+                <NistP256 as GroupDigest>::K,
                 FieldElement,
             >(&[test_vector.msg], &[DST], &mut u)
             .unwrap();
@@ -239,11 +240,7 @@ mod tests {
             assert_point_eq!(p, test_vector.p_x, test_vector.p_y);
 
             // complete run
-            let pt =
-                NistP256::hash_from_bytes::<ExpandMsgXmd<Sha256, <NistP256 as GroupDigest>::K>>(
-                    &[test_vector.msg],
-                    &[DST],
-                )
+            let pt = NistP256::hash_from_bytes::<ExpandMsgXmd<Sha256>>(&[test_vector.msg], &[DST])
                 .unwrap();
             assert_point_eq!(pt, test_vector.p_x, test_vector.p_y);
         }
@@ -286,17 +283,16 @@ mod tests {
                 .to_be_bytes();
 
             for counter in 0_u8..=u8::MAX {
-                let scalar =
-                    NistP256::hash_to_scalar::<ExpandMsgXmd<Sha256, <NistP256 as GroupDigest>::K>>(
-                        &[
-                            test_vector.seed,
-                            &key_info_len,
-                            test_vector.key_info,
-                            &counter.to_be_bytes(),
-                        ],
-                        &[test_vector.dst],
-                    )
-                    .unwrap();
+                let scalar = NistP256::hash_to_scalar::<ExpandMsgXmd<Sha256>>(
+                    &[
+                        test_vector.seed,
+                        &key_info_len,
+                        test_vector.key_info,
+                        &counter.to_be_bytes(),
+                    ],
+                    &[test_vector.dst],
+                )
+                .unwrap();
 
                 if !bool::from(scalar.is_zero()) {
                     assert_eq!(scalar.to_bytes().as_slice(), test_vector.sk_sm);

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -171,18 +171,15 @@ impl elliptic_curve::sec1::ValidatePublicKey for NistP256 {}
 #[cfg(feature = "bits")]
 pub type ScalarBits = elliptic_curve::scalar::ScalarBits<NistP256>;
 
-#[cfg(feature = "voprf")]
-impl elliptic_curve::VoprfParameters for NistP256 {
+#[cfg(feature = "oprf")]
+impl elliptic_curve::OprfParameters for NistP256 {
     /// See <https://www.rfc-editor.org/rfc/rfc9497.html#section-4.3-1>.
-    const ID: &'static str = "P256-SHA256";
+    const ID: &'static [u8] = b"P256-SHA256";
 
     /// See <https://www.rfc-editor.org/rfc/rfc9497.html#section-4.3-2.4>.
     type Hash = sha2::Sha256;
 
     /// See <https://www.rfc-editor.org/rfc/rfc9497.html#section-4.3-2.2.2.10>
     /// and <https://www.rfc-editor.org/rfc/rfc9497.html#section-4.3-2.2.2.12>.
-    type ExpandMsg = elliptic_curve::hash2curve::ExpandMsgXmd<
-        sha2::Sha256,
-        <Self as elliptic_curve::hash2curve::GroupDigest>::K,
-    >;
+    type ExpandMsg = elliptic_curve::hash2curve::ExpandMsgXmd<sha2::Sha256>;
 }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -55,12 +55,12 @@ ecdsa = ["arithmetic", "ecdsa-core/signing", "ecdsa-core/verifying", "sha384"]
 expose-field = ["arithmetic"]
 hash2curve = ["arithmetic", "elliptic-curve/hash2curve"]
 jwk = ["elliptic-curve/jwk"]
+oprf = ["hash2curve", "elliptic-curve/oprf", "sha2"]
 pem = ["elliptic-curve/pem", "ecdsa-core/pem", "pkcs8"]
 pkcs8 = ["ecdsa-core/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa-core?/serde", "elliptic-curve/serde", "primeorder?/serde", "serdect"]
 sha384 = ["digest", "sha2"]
 test-vectors = ["hex-literal"]
-voprf = ["hash2curve", "elliptic-curve/voprf", "sha2"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/p384/src/arithmetic/hash2curve.rs
+++ b/p384/src/arithmetic/hash2curve.rs
@@ -211,7 +211,8 @@ mod tests {
             // in parts
             let mut u = [FieldElement::default(), FieldElement::default()];
             hash2curve::hash_to_field::<
-                ExpandMsgXmd<Sha384, <NistP384 as GroupDigest>::K>,
+                ExpandMsgXmd<Sha384>,
+                <NistP384 as GroupDigest>::K,
                 FieldElement,
             >(&[test_vector.msg], &[DST], &mut u)
             .unwrap();
@@ -244,11 +245,7 @@ mod tests {
             assert_point_eq!(p, test_vector.p_x, test_vector.p_y);
 
             // complete run
-            let pt =
-                NistP384::hash_from_bytes::<ExpandMsgXmd<Sha384, <NistP384 as GroupDigest>::K>>(
-                    &[test_vector.msg],
-                    &[DST],
-                )
+            let pt = NistP384::hash_from_bytes::<ExpandMsgXmd<Sha384>>(&[test_vector.msg], &[DST])
                 .unwrap();
             assert_point_eq!(pt, test_vector.p_x, test_vector.p_y);
         }
@@ -297,17 +294,16 @@ mod tests {
                 .to_be_bytes();
 
             for counter in 0_u8..=u8::MAX {
-                let scalar =
-                    NistP384::hash_to_scalar::<ExpandMsgXmd<Sha384, <NistP384 as GroupDigest>::K>>(
-                        &[
-                            test_vector.seed,
-                            &key_info_len,
-                            test_vector.key_info,
-                            &counter.to_be_bytes(),
-                        ],
-                        &[test_vector.dst],
-                    )
-                    .unwrap();
+                let scalar = NistP384::hash_to_scalar::<ExpandMsgXmd<Sha384>>(
+                    &[
+                        test_vector.seed,
+                        &key_info_len,
+                        test_vector.key_info,
+                        &counter.to_be_bytes(),
+                    ],
+                    &[test_vector.dst],
+                )
+                .unwrap();
 
                 if !bool::from(scalar.is_zero()) {
                     assert_eq!(scalar.to_bytes().as_slice(), test_vector.sk_sm);

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -124,18 +124,15 @@ impl elliptic_curve::sec1::ValidatePublicKey for NistP384 {}
 #[cfg(feature = "bits")]
 pub type ScalarBits = elliptic_curve::scalar::ScalarBits<NistP384>;
 
-#[cfg(feature = "voprf")]
-impl elliptic_curve::VoprfParameters for NistP384 {
+#[cfg(feature = "oprf")]
+impl elliptic_curve::OprfParameters for NistP384 {
     /// See <https://www.rfc-editor.org/rfc/rfc9497.html#section-4.4-1>.
-    const ID: &'static str = "P384-SHA384";
+    const ID: &'static [u8] = b"P384-SHA384";
 
     /// See <https://www.rfc-editor.org/rfc/rfc9497.html#section-4.4-2.4>.
     type Hash = sha2::Sha384;
 
     /// See <https://www.rfc-editor.org/rfc/rfc9497.html#section-4.4-2.2.2.10>
     /// and <https://www.rfc-editor.org/rfc/rfc9497.html#section-4.4-2.2.2.12>.
-    type ExpandMsg = elliptic_curve::hash2curve::ExpandMsgXmd<
-        sha2::Sha384,
-        <Self as elliptic_curve::hash2curve::GroupDigest>::K,
-    >;
+    type ExpandMsg = elliptic_curve::hash2curve::ExpandMsgXmd<sha2::Sha384>;
 }

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -51,12 +51,12 @@ expose-field = ["arithmetic"]
 getrandom = ["rand_core/os_rng"]
 hash2curve = ["arithmetic", "elliptic-curve/hash2curve"]
 jwk = ["elliptic-curve/jwk"]
+oprf = ["hash2curve", "elliptic-curve/oprf", "dep:sha2"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa-core?/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa-core?/serde", "elliptic-curve/serde", "primeorder?/serde", "serdect"]
 sha512 = ["digest", "dep:sha2"]
 test-vectors = ["dep:hex-literal"]
-voprf = ["hash2curve", "elliptic-curve/voprf", "dep:sha2"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/p521/src/arithmetic/hash2curve.rs
+++ b/p521/src/arithmetic/hash2curve.rs
@@ -214,7 +214,8 @@ mod tests {
             // in parts
             let mut u = [FieldElement::default(), FieldElement::default()];
             hash2curve::hash_to_field::<
-                ExpandMsgXmd<Sha512, <NistP521 as GroupDigest>::K>,
+                ExpandMsgXmd<Sha512>,
+                <NistP521 as GroupDigest>::K,
                 FieldElement,
             >(&[test_vector.msg], &[DST], &mut u)
             .unwrap();
@@ -247,11 +248,7 @@ mod tests {
             assert_point_eq!(p, test_vector.p_x, test_vector.p_y);
 
             // complete run
-            let pt =
-                NistP521::hash_from_bytes::<ExpandMsgXmd<Sha512, <NistP521 as GroupDigest>::K>>(
-                    &[test_vector.msg],
-                    &[DST],
-                )
+            let pt = NistP521::hash_from_bytes::<ExpandMsgXmd<Sha512>>(&[test_vector.msg], &[DST])
                 .unwrap();
             assert_point_eq!(pt, test_vector.p_x, test_vector.p_y);
         }
@@ -300,17 +297,16 @@ mod tests {
                 .to_be_bytes();
 
             for counter in 0_u8..=u8::MAX {
-                let scalar =
-                    NistP521::hash_to_scalar::<ExpandMsgXmd<Sha512, <NistP521 as GroupDigest>::K>>(
-                        &[
-                            test_vector.seed,
-                            &key_info_len,
-                            test_vector.key_info,
-                            &counter.to_be_bytes(),
-                        ],
-                        &[test_vector.dst],
-                    )
-                    .unwrap();
+                let scalar = NistP521::hash_to_scalar::<ExpandMsgXmd<Sha512>>(
+                    &[
+                        test_vector.seed,
+                        &key_info_len,
+                        test_vector.key_info,
+                        &counter.to_be_bytes(),
+                    ],
+                    &[test_vector.dst],
+                )
+                .unwrap();
 
                 if !bool::from(scalar.is_zero()) {
                     assert_eq!(scalar.to_bytes().as_slice(), test_vector.sk_sm);

--- a/p521/src/lib.rs
+++ b/p521/src/lib.rs
@@ -114,18 +114,15 @@ pub type PublicKey = elliptic_curve::PublicKey<NistP521>;
 /// NIST P-521 secret key.
 pub type SecretKey = elliptic_curve::SecretKey<NistP521>;
 
-#[cfg(feature = "voprf")]
-impl elliptic_curve::VoprfParameters for NistP521 {
+#[cfg(feature = "oprf")]
+impl elliptic_curve::OprfParameters for NistP521 {
     /// See <https://www.rfc-editor.org/rfc/rfc9497.html#section-4.5-1>.
-    const ID: &'static str = "P521-SHA512";
+    const ID: &'static [u8] = b"P521-SHA512";
 
     /// See <https://www.rfc-editor.org/rfc/rfc9497.html#section-4.5-2.4>.
     type Hash = sha2::Sha512;
 
     /// See <https://www.rfc-editor.org/rfc/rfc9497.html#section-4.5-2.2.2.10>
     /// and <https://www.rfc-editor.org/rfc/rfc9497.html#section-4.5-2.2.2.12>.
-    type ExpandMsg = elliptic_curve::hash2curve::ExpandMsgXmd<
-        sha2::Sha512,
-        <Self as elliptic_curve::hash2curve::GroupDigest>::K,
-    >;
+    type ExpandMsg = elliptic_curve::hash2curve::ExpandMsgXmd<sha2::Sha512>;
 }


### PR DESCRIPTION
Updates to the changes introduced in https://github.com/RustCrypto/traits/pull/1862.

Requires https://github.com/RustCrypto/traits/pull/1862.