### PR TITLE
Update for MapToCurve changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
 [[package]]
 name = "crypto-common"
 version = "0.2.0-rc.2"
-source = "git+https://github.com/RustCrypto/traits.git#857f6de047cffa855e6634e4fe61d3b023aca1fd"
+source = "git+https://github.com/RustCrypto/traits.git#4de33de9409d6534501c3d390a3051618482a419"
 dependencies = [
  "hybrid-array",
 ]
@@ -350,7 +350,7 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.11.0-pre.10"
-source = "git+https://github.com/RustCrypto/traits.git#1cae37d25c5bc6c59570d5136ccb710e1914b07a"
+source = "git+https://github.com/RustCrypto/traits.git#4de33de9409d6534501c3d390a3051618482a419"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -382,7 +382,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.1"
-source = "git+https://github.com/RustCrypto/traits.git#857f6de047cffa855e6634e4fe61d3b023aca1fd"
+source = "git+https://github.com/RustCrypto/traits.git#4de33de9409d6534501c3d390a3051618482a419"
 dependencies = [
  "base16ct",
  "base64ct",
@@ -1132,7 +1132,7 @@ dependencies = [
 [[package]]
 name = "signature"
 version = "3.0.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#1cae37d25c5bc6c59570d5136ccb710e1914b07a"
+source = "git+https://github.com/RustCrypto/traits.git#4de33de9409d6534501c3d390a3051618482a419"
 dependencies = [
  "digest",
  "rand_core 0.9.3",

--- a/p256/src/arithmetic/hash2curve.rs
+++ b/p256/src/arithmetic/hash2curve.rs
@@ -10,8 +10,6 @@ use elliptic_curve::{
 };
 
 impl GroupDigest for NistP256 {
-    type FieldElement = FieldElement;
-
     type K = U16;
 }
 
@@ -60,16 +58,21 @@ impl OsswuMap for FieldElement {
     };
 }
 
-impl MapToCurve for FieldElement {
-    type Output = ProjectivePoint;
+impl MapToCurve for NistP256 {
+    type CurvePoint = ProjectivePoint;
+    type FieldElement = FieldElement;
 
-    fn map_to_curve(&self) -> Self::Output {
-        let (qx, qy) = self.osswu();
+    fn map_to_curve(element: Self::FieldElement) -> Self::CurvePoint {
+        let (qx, qy) = element.osswu();
 
         // TODO(tarcieri): assert that `qy` is correct? less circuitous conversion?
         AffinePoint::decompress(&qx.to_bytes(), qy.is_odd())
             .unwrap()
             .into()
+    }
+
+    fn map_to_subgroup(point: Self::CurvePoint) -> ProjectivePoint {
+        point
     }
 }
 
@@ -102,7 +105,6 @@ mod tests {
         array::Array,
         bigint::{ArrayEncoding, CheckedSub, NonZero, U384},
         consts::U48,
-        group::cofactor::CofactorGroup,
         hash2curve::{self, ExpandMsgXmd, FromOkm, GroupDigest, MapToCurve, OsswuMap},
         sec1::{self, ToEncodedPoint},
     };
@@ -227,13 +229,13 @@ mod tests {
             assert_eq!(u[0].to_bytes().as_slice(), test_vector.u_0);
             assert_eq!(u[1].to_bytes().as_slice(), test_vector.u_1);
 
-            let q0 = u[0].map_to_curve();
+            let q0 = NistP256::map_to_curve(u[0]);
             assert_point_eq!(q0, test_vector.q0_x, test_vector.q0_y);
 
-            let q1 = u[1].map_to_curve();
+            let q1 = NistP256::map_to_curve(u[1]);
             assert_point_eq!(q1, test_vector.q1_x, test_vector.q1_y);
 
-            let p = q0.clear_cofactor() + q1.clear_cofactor();
+            let p = q0 + q1;
             assert_point_eq!(p, test_vector.p_x, test_vector.p_y);
 
             // complete run

--- a/p384/src/arithmetic/hash2curve.rs
+++ b/p384/src/arithmetic/hash2curve.rs
@@ -11,8 +11,6 @@ use elliptic_curve::{
 };
 
 impl GroupDigest for NistP384 {
-    type FieldElement = FieldElement;
-
     type K = U24;
 }
 
@@ -63,16 +61,21 @@ impl OsswuMap for FieldElement {
     };
 }
 
-impl MapToCurve for FieldElement {
-    type Output = ProjectivePoint;
+impl MapToCurve for NistP384 {
+    type CurvePoint = ProjectivePoint;
+    type FieldElement = FieldElement;
 
-    fn map_to_curve(&self) -> Self::Output {
-        let (qx, qy) = self.osswu();
+    fn map_to_curve(element: FieldElement) -> Self::CurvePoint {
+        let (qx, qy) = element.osswu();
 
         // TODO(tarcieri): assert that `qy` is correct? less circuitous conversion?
         AffinePoint::decompress(&qx.to_bytes(), qy.is_odd())
             .unwrap()
             .into()
+    }
+
+    fn map_to_subgroup(point: Self::CurvePoint) -> ProjectivePoint {
+        point
     }
 }
 
@@ -98,7 +101,10 @@ impl FromOkm for Scalar {
 
 #[cfg(test)]
 mod tests {
-    use crate::{FieldElement, NistP384, Scalar, arithmetic::field::MODULUS};
+    use crate::{
+        NistP384, Scalar,
+        arithmetic::field::{FieldElement, MODULUS},
+    };
     use elliptic_curve::{
         Curve,
         array::Array,
@@ -229,10 +235,10 @@ mod tests {
             assert_eq!(u[0].to_bytes().as_slice(), test_vector.u_0);
             assert_eq!(u[1].to_bytes().as_slice(), test_vector.u_1);
 
-            let q0 = u[0].map_to_curve();
+            let q0 = NistP384::map_to_curve(u[0]);
             assert_point_eq!(q0, test_vector.q0_x, test_vector.q0_y);
 
-            let q1 = u[1].map_to_curve();
+            let q1 = NistP384::map_to_curve(u[1]);
             assert_point_eq!(q1, test_vector.q1_x, test_vector.q1_y);
 
             let p = q0.clear_cofactor() + q1.clear_cofactor();

--- a/p384/src/arithmetic/hash2curve.rs
+++ b/p384/src/arithmetic/hash2curve.rs
@@ -110,7 +110,6 @@ mod tests {
         array::Array,
         bigint::{ArrayEncoding, CheckedSub, NonZero, U384, U576},
         consts::U72,
-        group::cofactor::CofactorGroup,
         hash2curve::{self, ExpandMsgXmd, FromOkm, GroupDigest, MapToCurve, OsswuMap},
         ops::Reduce,
         sec1::{self, ToEncodedPoint},
@@ -241,7 +240,7 @@ mod tests {
             let q1 = NistP384::map_to_curve(u[1]);
             assert_point_eq!(q1, test_vector.q1_x, test_vector.q1_y);
 
-            let p = q0.clear_cofactor() + q1.clear_cofactor();
+            let p = NistP384::add_and_map_to_subgroup(q0, q1);
             assert_point_eq!(p, test_vector.p_x, test_vector.p_y);
 
             // complete run

--- a/p521/src/arithmetic/hash2curve.rs
+++ b/p521/src/arithmetic/hash2curve.rs
@@ -11,8 +11,6 @@ use elliptic_curve::{
 };
 
 impl GroupDigest for NistP521 {
-    type FieldElement = FieldElement;
-
     type K = U32;
 }
 
@@ -66,16 +64,21 @@ impl OsswuMap for FieldElement {
     };
 }
 
-impl MapToCurve for FieldElement {
-    type Output = ProjectivePoint;
+impl MapToCurve for NistP521 {
+    type CurvePoint = ProjectivePoint;
+    type FieldElement = FieldElement;
 
-    fn map_to_curve(&self) -> Self::Output {
-        let (qx, qy) = self.osswu();
+    fn map_to_curve(element: FieldElement) -> Self::CurvePoint {
+        let (qx, qy) = element.osswu();
 
         // TODO(tarcieri): assert that `qy` is correct? less circuitous conversion?
         AffinePoint::decompress(&qx.to_bytes(), qy.is_odd())
             .unwrap()
             .into()
+    }
+
+    fn map_to_subgroup(point: Self::CurvePoint) -> ProjectivePoint {
+        point
     }
 }
 
@@ -235,10 +238,10 @@ mod tests {
             assert_eq!(u[0].to_bytes().as_slice(), test_vector.u_0);
             assert_eq!(u[1].to_bytes().as_slice(), test_vector.u_1);
 
-            let q0 = u[0].map_to_curve();
+            let q0 = NistP521::map_to_curve(u[0]);
             assert_point_eq!(q0, test_vector.q0_x, test_vector.q0_y);
 
-            let q1 = u[1].map_to_curve();
+            let q1 = NistP521::map_to_curve(u[1]);
             assert_point_eq!(q1, test_vector.q1_x, test_vector.q1_y);
 
             let p = q0.clear_cofactor() + q1.clear_cofactor();

--- a/p521/src/arithmetic/hash2curve.rs
+++ b/p521/src/arithmetic/hash2curve.rs
@@ -113,7 +113,6 @@ mod tests {
         array::Array,
         bigint::{ArrayEncoding, CheckedSub, NonZero, U576, U896},
         consts::U98,
-        group::cofactor::CofactorGroup,
         hash2curve::{self, ExpandMsgXmd, FromOkm, GroupDigest, MapToCurve, OsswuMap},
         ops::Reduce,
         sec1::{self, ToEncodedPoint},
@@ -244,7 +243,7 @@ mod tests {
             let q1 = NistP521::map_to_curve(u[1]);
             assert_point_eq!(q1, test_vector.q1_x, test_vector.q1_y);
 
-            let p = q0.clear_cofactor() + q1.clear_cofactor();
+            let p = NistP521::add_and_map_to_subgroup(q0, q1);
             assert_point_eq!(p, test_vector.p_x, test_vector.p_y);
 
             // complete run

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -14,7 +14,6 @@ use elliptic_curve::{
     bigint::ArrayEncoding,
     group::{
         self, Group, GroupEncoding,
-        cofactor::CofactorGroup,
         prime::{PrimeCurve, PrimeGroup},
     },
     ops::{BatchInvert, LinearCombination},
@@ -146,30 +145,6 @@ where
         }
 
         q
-    }
-}
-
-impl<C> CofactorGroup for ProjectivePoint<C>
-where
-    Self: Double,
-    C: PrimeCurveParams,
-    CompressedPoint<C>: Copy + Send + Sync,
-    FieldBytes<C>: Copy,
-    FieldBytesSize<C>: ModulusSize,
-    <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
-{
-    type Subgroup = Self;
-
-    fn clear_cofactor(&self) -> Self::Subgroup {
-        *self
-    }
-
-    fn into_subgroup(self) -> CtOption<Self> {
-        CtOption::new(self, 1.into())
-    }
-
-    fn is_torsion_free(&self) -> Choice {
-        1.into()
     }
 }
 


### PR DESCRIPTION
Updates to the changes introduced in https://github.com/RustCrypto/traits/pull/1866.

Requires https://github.com/RustCrypto/traits/pull/1866.

This removes the unnecessary implementations of `CofactorGroup`.