### PR TITLE
Bump `digest` dependency to v0.11.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,8 +60,9 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes.git#d9ad085ed12dba58d2a6d75d76a17a1b2706c4c7"
+version = "0.2.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb51c5f2d38f4751a11964ac3988a05812fdec736b15bc0424f2cec697a85728"
 dependencies = [
  "belt-block",
  "digest",
@@ -330,8 +331,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/RustCrypto/traits.git#e728ece19cb5df8d8a7f575c4676a323d449a885"
+version = "0.2.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a23fa214dea9efd4dacee5a5614646b30216ae0f05d4bb51bafb50e9da1c5be"
 dependencies = [
  "hybrid-array",
 ]
@@ -349,8 +351,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.10"
-source = "git+https://github.com/RustCrypto/traits.git#4de33de9409d6534501c3d390a3051618482a419"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460dd7f37e4950526b54a5a6b1f41b6c8e763c58eb9a8fc8fc05ba5c2f44ca7b"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -360,8 +363,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-pre.9"
-source = "git+https://github.com/RustCrypto/signatures.git#132a6b1b38d055caa548a095e6342d58d2bc3f3c"
+version = "0.17.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abbc927a7e946a78fbff19c283bc5d4f8960d9000049a7e2b0d84cb2730613c4"
 dependencies = [
  "der",
  "digest",
@@ -381,8 +385,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.1"
-source = "git+https://github.com/RustCrypto/traits.git#e728ece19cb5df8d8a7f575c4676a323d449a885"
+version = "0.14.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1786d08ca7d401fcc540b2fab11ec37b224ced5a0455c451656f83d80e681ddb"
 dependencies = [
  "base16ct",
  "base64ct",
@@ -516,16 +521,18 @@ checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hkdf"
-version = "0.13.0-pre.5"
-source = "git+https://github.com/RustCrypto/KDFs.git#651abc90e35ef90bfcf799124459b239c0811334"
+version = "0.13.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6738bc5110ee31b066339f0c9454db29a93db3b0484bbf2afa8a7e9cebc62141"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.13.0-pre.5"
-source = "git+https://github.com/RustCrypto/MACs.git#22dff974b3f921e6aa09c6067d96659cf1cb9753"
+version = "0.13.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc6a2fcc35ab09136c6df2cdf9ca49790701420a3a6b5db0987dddbabc79b21"
 dependencies = [
  "digest",
 ]
@@ -1000,8 +1007,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-pre.4"
-source = "git+https://github.com/RustCrypto/signatures.git#132a6b1b38d055caa548a095e6342d58d2bc3f3c"
+version = "0.5.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f53f124bf3ec90be84ae97d7f52175ba938898525554c13c9017eb8f0a604146"
 dependencies = [
  "hmac",
  "subtle",
@@ -1112,8 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes.git#d9ad085ed12dba58d2a6d75d76a17a1b2706c4c7"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1d2e6b3cc4e43a8258a9a3b17aa5dfd2cc5186c7024bba8a64aa65b2c71a59"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1122,8 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes.git#d9ad085ed12dba58d2a6d75d76a17a1b2706c4c7"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e6a92fd180fd205defdc0b78288ce847c7309d329fd6647a814567e67db50e"
 dependencies = [
  "digest",
  "keccak",
@@ -1131,8 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#4de33de9409d6534501c3d390a3051618482a419"
+version = "3.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ae074ff622614874804868b07d9cb786223082c9fe726a6653608f32f37b02"
 dependencies = [
  "digest",
  "rand_core 0.9.3",
@@ -1156,8 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "sm3"
-version = "0.5.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes.git#d9ad085ed12dba58d2a6d75d76a17a1b2706c4c7"
+version = "0.5.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd4150a9ed499352d8c4da088deb0c3348b18d3df054e529868e3290f4dd1be6"
 dependencies = [
  "digest",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,26 +17,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-belt-hash = { git = "https://github.com/RustCrypto/hashes.git" }
-sha2 = { git = "https://github.com/RustCrypto/hashes.git" }
-sha3 = { git = "https://github.com/RustCrypto/hashes.git" }
-sm3 = { git = "https://github.com/RustCrypto/hashes.git" }
-
-hkdf = { git = "https://github.com/RustCrypto/KDFs.git" }
-
-hmac = { git = "https://github.com/RustCrypto/MACs.git" }
-
-# https://github.com/RustCrypto/signatures/pull/913
-# https://github.com/RustCrypto/signatures/pull/940
-# https://github.com/RustCrypto/signatures/pull/955
-ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
-rfc6979 = { git = "https://github.com/RustCrypto/signatures.git" }
-
-# https://github.com/RustCrypto/traits/pull/1777
-# https://github.com/RustCrypto/traits/pull/1845
-digest = { git = "https://github.com/RustCrypto/traits.git" }
-elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
-signature = { git = "https://github.com/RustCrypto/traits.git" }
-

--- a/bign256/Cargo.toml
+++ b/bign256/Cargo.toml
@@ -18,22 +18,22 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.0", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.2", features = ["sec1"] }
 
 # optional dependencies
-belt-hash = { version = "=0.2.0-pre.5", optional = true, default-features = false }
+belt-hash = { version = "0.2.0-rc.0", optional = true, default-features = false }
 der = { version = "0.8.0-rc.0" }
-digest = { version = "=0.11.0-pre.10", optional = true }
+digest = { version = "0.11.0-rc.0", optional = true }
 hex-literal = { version = "1", optional = true }
-hkdf = { version = "=0.13.0-pre.5", optional = true }
-hmac = { version = "=0.13.0-pre.5", optional = true }
+hkdf = { version = "0.13.0-rc.0", optional = true }
+hmac = { version = "0.13.0-rc.0", optional = true }
 rand_core = "0.9"
-rfc6979 = { version = "=0.5.0-pre.4", optional = true }
+rfc6979 = { version = "0.5.0-rc.0", optional = true }
 pkcs8 = { version = "0.11.0-rc.3", optional = true }
 primefield = { version = "=0.14.0-pre.0", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.2", optional = true, path = "../primeorder" }
 sec1 = { version = "0.8.0-rc.1", optional = true }
-signature = { version = "=3.0.0-pre", optional = true }
+signature = { version = "3.0.0-pre.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.6"

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,13 +14,13 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.0", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "=0.17.0-pre.9", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.0", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "=0.14.0-pre.0", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.2", optional = true, path = "../primeorder" }
-sha2 = { version = "=0.11.0-pre.5", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,13 +14,13 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.0", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "=0.17.0-pre.9", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.0", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "=0.14.0-pre.0", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.2", optional = true, path = "../primeorder" }
-sha2 = { version = "=0.11.0-pre.5", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
 [features]
 default = ["pkcs8", "std"]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,27 +20,27 @@ rust-version = "1.85"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "0.14.0-rc.0", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 once_cell = { version = "1.21", optional = true, default-features = false }
-ecdsa-core = { version = "=0.17.0-pre.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.5", optional = true, default-features = false }
-signature = { version = "=3.0.0-pre", optional = true }
+sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
+signature = { version = "3.0.0-rc.0", optional = true }
 
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.6"
-ecdsa-core = { version = "=0.17.0-pre.9", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4.3"
 hex-literal = "1"
 num-bigint = "0.4"
 num-traits = "0.2"
 proptest = "1.5"
 rand_core = { version = "0.9", features = ["os_rng"] }
-sha3 = { version = "=0.11.0-pre.5", default-features = false }
+sha3 = { version = "0.11.0-rc.0", default-features = false }
 
 [features]
 default = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "schnorr", "std"]

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -17,18 +17,18 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.0", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
 sec1 = { version = "0.8.0-rc.1", default-features = false }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.0", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.2", optional = true, path = "../primeorder" }
 serdect = { version = "0.3", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "=0.17.0-pre.9", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "=0.14.0-pre.2", features = ["dev"], path = "../primeorder" }
 

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,19 +17,19 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.0", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.0", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.2", optional = true, path = "../primeorder" }
 serdect = { version = "0.3", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.5", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
-ecdsa-core = { version = "=0.17.0-pre.9", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "=0.14.0-pre.2", features = ["dev"], path = "../primeorder" }
 rand_core = { version = "0.9", features = ["os_rng"] }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,20 +18,20 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.0", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.0", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.2", optional = true, path = "../primeorder" }
 serdect = { version = "0.3", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.5", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.6"
-ecdsa-core = { version = "=0.17.0-pre.9", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primefield = { version = "=0.14.0-pre.0", path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.2", features = ["dev"], path = "../primeorder" }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,20 +18,20 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.0", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.0", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.2", optional = true, path = "../primeorder" }
 serdect = { version = "0.3", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.5", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.6"
-ecdsa-core = { version = "=0.17.0-pre.9", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "=0.14.0-pre.2", features = ["dev"], path = "../primeorder" }
 proptest = "1.5"

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -18,21 +18,21 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "0.2"
-elliptic-curve = { version = "0.14.0-rc.0", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "=0.17.0-pre.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.0", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.2", optional = true, path = "../primeorder" }
 rand_core = { version = "0.9", optional = true, default-features = false }
 serdect = { version = "0.3", optional = true, default-features = false }
-sha2 = { version = "=0.11.0-pre.5", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.6"
-ecdsa-core = { version = "=0.17.0-pre.9", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "=0.14.0-pre.2", features = ["dev"], path = "../primeorder" }
 proptest = "1.5"

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.0", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.3", optional = true, default-features = false }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -18,16 +18,16 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.0", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
 rand_core = { version = "0.9", default-features = false }
 
 # optional dependencies
 primefield = { version = "=0.14.0-pre.0", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.2", optional = true, path = "../primeorder" }
-rfc6979 = { version = "=0.5.0-pre.4", optional = true }
+rfc6979 = { version = "0.5.0-rc.0", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false }
-signature = { version = "=3.0.0-pre", optional = true, features = ["rand_core"] }
-sm3 = { version = "=0.5.0-pre.5", optional = true, default-features = false }
+signature = { version = "3.0.0-rc.0", optional = true, features = ["rand_core"] }
+sm3 = { version = "0.5.0-rc.0", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"


### PR DESCRIPTION
Also bumps:
- `ecdsa` v0.17.0-rc.0
- `elliptic-curve` v0.14.0-rc.2
- `signature` v3.0.0-rc.0