### PR TITLE
Implement `De/Serialize` for `ProjectivePoint`

### DIFF
--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -21,6 +21,7 @@
 //! `Deserialize` are impl'd for the following types:
 //!
 //! - [`AffinePoint`]
+//! - [`ProjectivePoint`]
 //! - [`Scalar`]
 //! - [`ecdsa::VerifyingKey`]
 //!

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -14,6 +14,7 @@
 //! `Deserialize` are impl'd for the following types:
 //!
 //! - [`AffinePoint`]
+//! - [`ProjectivePoint`]
 //! - [`Scalar`]
 //! - [`ecdsa::VerifyingKey`]
 //!

--- a/p521/src/lib.rs
+++ b/p521/src/lib.rs
@@ -21,6 +21,7 @@
 //! `Deserialize` are impl'd for the following types:
 //!
 //! - [`AffinePoint`]
+//! - [`ProjectivePoint`]
 //! - [`Scalar`]
 //!
 //! Please see type-specific documentation for more information.


### PR DESCRIPTION
I'm not sure if this was *not* implemented on purpose; let me know.

For context:

This makes it possible for crates which are generic over different curves to require `De/Serialize` on a generic point.

```rust
trait Group {
    type Point;
}

impl Group for NistP256 {
    type Point = ProjectivePoint<NistP256>;
}

struct BlindedElement<G: Group>(G::Point);

impl<G: Group> Serialize for BlindedElement<G> where G::Point: Serialize {
    ...
}
```