### PR TITLE
primefield v0.14.0-pre.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-pre.3"
+version = "0.14.0-pre.4"
 dependencies = [
  "blobby",
  "cfg-if",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-pre.3"
+version = "0.14.0-pre.4"
 dependencies = [
  "blobby",
  "criterion",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-pre.3"
+version = "0.14.0-pre.4"
 dependencies = [
  "blobby",
  "criterion",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-pre.3"
+version = "0.14.0-pre.4"
 dependencies = [
  "base16ct",
  "blobby",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-pre.1"
+version = "0.14.0-pre.2"
 dependencies = [
  "crypto-bigint",
  "ff",

--- a/bign256/Cargo.toml
+++ b/bign256/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.2", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.3", features = ["sec1"] }
 
 # optional dependencies
 belt-hash = { version = "0.2.0-rc.0", optional = true, default-features = false }
@@ -30,7 +30,7 @@ hmac = { version = "0.13.0-rc.0", optional = true }
 rand_core = "0.9"
 rfc6979 = { version = "0.5.0-rc.0", optional = true }
 pkcs8 = { version = "0.11.0-rc.3", optional = true }
-primefield = { version = "=0.14.0-pre.1", optional = true, path = "../primefield" }
+primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
 sec1 = { version = "0.8.0-rc.1", optional = true }
 signature = { version = "3.0.0-pre.0", optional = true }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,11 +14,11 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.0", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "=0.14.0-pre.1", optional = true, path = "../primefield" }
+primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,11 +14,11 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.0", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "=0.14.0-pre.1", optional = true, path = "../primefield" }
+primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.14.0-pre.3"
+version = "0.14.0-pre.4"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification/public-key recovery, Taproot Schnorr signatures (BIP340),
@@ -20,7 +20,7 @@ rust-version = "1.85"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 once_cell = { version = "1.21", optional = true, default-features = false }

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -17,13 +17,13 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features = ["sec1"] }
 sec1 = { version = "0.8.0-rc.1", default-features = false }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.1", optional = true, path = "../primefield" }
+primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
 serdect = { version = "0.3", optional = true, default-features = false }
 

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,12 +17,12 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.1", optional = true, path = "../primefield" }
+primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
 serdect = { version = "0.3", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256"
-version = "0.14.0-pre.3"
+version = "0.14.0-pre.4"
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve as defined in SP 800-186, with support for ECDH, ECDSA
@@ -18,12 +18,12 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.1", optional = true, path = "../primefield" }
+primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
 serdect = { version = "0.3", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
@@ -33,7 +33,7 @@ blobby = "0.3"
 criterion = "0.6"
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primefield = { version = "=0.14.0-pre.1", path = "../primefield" }
+primefield = { version = "=0.14.0-pre.2", path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.3", features = ["dev"], path = "../primeorder" }
 proptest = "1"
 rand_core = { version = "0.9", features = ["os_rng"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p384"
-version = "0.14.0-pre.3"
+version = "0.14.0-pre.4"
 description = """
 Pure Rust implementation of the NIST P-384 (a.k.a. secp384r1) elliptic curve
 as defined in SP 800-186 with support for ECDH, ECDSA signing/verification,
@@ -18,12 +18,12 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.1", optional = true, path = "../primefield" }
+primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
 serdect = { version = "0.3", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p521"
-version = "0.14.0-pre.3"
+version = "0.14.0-pre.4"
 description = """
 Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve
 as defined in SP 800-186
@@ -18,12 +18,12 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "0.2"
-elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.1", optional = true, path = "../primefield" }
+primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
 rand_core = { version = "0.9", optional = true, default-features = false }
 serdect = { version = "0.3", optional = true, default-features = false }

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primefield"
-version = "0.14.0-pre.1"
+version = "0.14.0-pre.2"
 description = "Macros for generating prime field implementations"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.3", optional = true, default-features = false }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -18,11 +18,11 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features = ["sec1"] }
 rand_core = { version = "0.9", default-features = false }
 
 # optional dependencies
-primefield = { version = "=0.14.0-pre.1", optional = true, path = "../primefield" }
+primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
 primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
 rfc6979 = { version = "0.5.0-rc.0", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false }


### PR DESCRIPTION
Also cuts releases of: `k256`, `p256`, `p384`, `p521`