### PR TITLE
ed448-goldilocks: reuse types from `ed448`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,9 +378,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed448"
+version = "0.5.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f3621b15eb4095d0e7c2502abd44291413b8a638f88dc08f1188993143332b"
+dependencies = [
+ "pkcs8",
+ "serde",
+ "serde_bytes",
+ "signature",
+]
+
+[[package]]
 name = "ed448-goldilocks"
 version = "0.14.0-pre.0"
 dependencies = [
+ "ed448",
  "elliptic-curve",
  "hex",
  "hex-literal",
@@ -1123,6 +1136,15 @@ name = "serde_bare"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
 dependencies = [
  "serde",
 ]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -18,6 +18,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 [dependencies]
 crypto_signature = { version = "3.0.0-rc.0", default-features = false, features = ["digest", "rand_core"], optional = true, package = "signature" }
 elliptic-curve = { version = "0.14.0-rc.5", features = ["arithmetic", "hash2curve", "pkcs8"] }
+ed448 = { version = "=0.5.0-pre.0", default-features = false, optional = true }
 rand_core = { version = "0.9", default-features = false }
 serdect = { version = "0.3.0", optional = true }
 sha3 = { version = "0.11.0-rc.0", default-features = false }
@@ -25,13 +26,12 @@ subtle = { version = "2.6", default-features = false }
 
 [features]
 default = ["std", "signing", "pkcs8"]
-alloc = ["crypto_signature/alloc", "elliptic-curve/alloc", "serdect/alloc"]
+alloc = ["crypto_signature/alloc", "ed448?/alloc", "elliptic-curve/alloc", "serdect/alloc"]
 std = ["alloc"]
-
 bits = ["elliptic-curve/bits"]
-pkcs8 = ["elliptic-curve/pkcs8"]
-signing = ["dep:crypto_signature"]
-serde = ["dep:serdect"]
+pkcs8 = ["ed448?/pkcs8", "elliptic-curve/pkcs8"]
+signing = ["dep:crypto_signature", "ed448"]
+serde = ["dep:serdect", "ed448?/serde_bytes"]
 
 [dev-dependencies]
 hex-literal = "1"

--- a/ed448-goldilocks/src/curve/edwards/extended.rs
+++ b/ed448-goldilocks/src/curve/edwards/extended.rs
@@ -148,7 +148,7 @@ impl TryFrom<&[u8]> for CompressedEdwardsY {
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         let bytes = <PointBytes>::try_from(value).map_err(|_| "Invalid length")?;
-        Self::try_from(&bytes)
+        Ok(CompressedEdwardsY(bytes))
     }
 }
 
@@ -173,24 +173,6 @@ impl From<&CompressedEdwardsY> for PointBytes {
     }
 }
 
-impl TryFrom<PointBytes> for CompressedEdwardsY {
-    type Error = &'static str;
-
-    fn try_from(value: PointBytes) -> Result<Self, Self::Error> {
-        let pt = CompressedEdwardsY(value);
-        let _ = Option::<EdwardsPoint>::from(pt.decompress()).ok_or("Invalid point")?;
-        Ok(pt)
-    }
-}
-
-impl TryFrom<&PointBytes> for CompressedEdwardsY {
-    type Error = &'static str;
-
-    fn try_from(value: &PointBytes) -> Result<Self, Self::Error> {
-        Self::try_from(*value)
-    }
-}
-
 #[cfg(feature = "serde")]
 impl serdect::serde::Serialize for CompressedEdwardsY {
     fn serialize<S: serdect::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
@@ -207,6 +189,12 @@ impl<'de> serdect::serde::Deserialize<'de> for CompressedEdwardsY {
         let mut arr = [0u8; 57];
         serdect::array::deserialize_hex_or_bin(&mut arr, d)?;
         Ok(CompressedEdwardsY(arr))
+    }
+}
+
+impl From<PointBytes> for CompressedEdwardsY {
+    fn from(point: PointBytes) -> Self {
+        Self(point)
     }
 }
 

--- a/ed448-goldilocks/src/sign/signature.rs
+++ b/ed448-goldilocks/src/sign/signature.rs
@@ -1,160 +1,24 @@
 use crate::*;
-use elliptic_curve::Group;
+use elliptic_curve::array::Array;
 
-/// Ed448 signature as defined in [RFC8032 § 5.2.5]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct Signature {
-    pub(crate) r: CompressedEdwardsY,
-    pub(crate) s: [u8; 57],
-}
-
-impl Default for Signature {
-    fn default() -> Self {
-        Self {
-            r: CompressedEdwardsY::default(),
-            s: [0u8; 57],
-        }
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl TryFrom<Vec<u8>> for Signature {
-    type Error = SigningError;
-
-    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_slice())
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl TryFrom<&Vec<u8>> for Signature {
-    type Error = SigningError;
-
-    fn try_from(value: &Vec<u8>) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_slice())
-    }
-}
-
-impl TryFrom<&[u8]> for Signature {
-    type Error = SigningError;
-
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        if value.len() != SIGNATURE_LENGTH {
-            return Err(SigningError::InvalidSignatureLength);
-        }
-
-        let mut bytes = [0u8; SIGNATURE_LENGTH];
-        bytes.copy_from_slice(value);
-        Self::from_bytes(&bytes)
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl TryFrom<Box<[u8]>> for Signature {
-    type Error = SigningError;
-
-    fn try_from(value: Box<[u8]>) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_ref())
-    }
-}
-
-#[cfg(feature = "serde")]
-impl serdect::serde::Serialize for Signature {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: serdect::serde::Serializer,
-    {
-        serdect::array::serialize_hex_lower_or_bin(&self.to_bytes(), s)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> serdect::serde::Deserialize<'de> for Signature {
-    fn deserialize<D>(d: D) -> Result<Self, D::Error>
-    where
-        D: serdect::serde::Deserializer<'de>,
-    {
-        let mut bytes = [0u8; SIGNATURE_LENGTH];
-        serdect::array::deserialize_hex_or_bin(&mut bytes, d)?;
-        Signature::from_bytes(&bytes).map_err(serdect::serde::de::Error::custom)
-    }
-}
-
-impl Signature {
-    /// Converts [`Signature`] to a byte array.
-    pub fn to_bytes(&self) -> [u8; SIGNATURE_LENGTH] {
-        let mut bytes = [0u8; SIGNATURE_LENGTH];
-        bytes[..57].copy_from_slice(self.r.as_bytes());
-        bytes[57..].copy_from_slice(&self.s);
-        bytes
-    }
-
-    /// Converts a byte array to a [`Signature`].
-    pub fn from_bytes(bytes: &[u8; SIGNATURE_LENGTH]) -> Result<Self, SigningError> {
-        let mut r = [0u8; SECRET_KEY_LENGTH];
-        r.copy_from_slice(&bytes[..SECRET_KEY_LENGTH]);
-        let mut s = [0u8; SECRET_KEY_LENGTH];
-        s.copy_from_slice(&bytes[SECRET_KEY_LENGTH..]);
-
-        let r = CompressedEdwardsY(r);
-
-        let big_r = r.decompress();
-        if big_r.is_none().into() {
-            return Err(SigningError::InvalidSignatureRComponent);
-        }
-
-        let big_r = big_r.expect("big_r is not none");
-        if big_r.is_identity().into() {
-            return Err(SigningError::InvalidSignatureRComponent);
-        }
-
-        if s[56] != 0x00 {
-            return Err(SigningError::InvalidSignatureSComponent);
-        }
-        let s_bytes = ScalarBytes::from(s);
-        let ss = Scalar::from_canonical_bytes(&s_bytes);
-
-        if ss.is_none().into() {
-            return Err(SigningError::InvalidSignatureSComponent);
-        }
-        let sc = ss.expect("ss is not none");
-        if sc.is_zero().into() {
-            return Err(SigningError::InvalidSignatureSComponent);
-        }
-
-        Ok(Self { r, s })
-    }
-
-    /// The `r` value of the signature.
-    pub fn r(&self) -> CompressedEdwardsY {
-        self.r
-    }
-
-    /// The `s` value of the signature.
-    pub fn s(&self) -> &[u8; SECRET_KEY_LENGTH] {
-        &self.s
-    }
-}
+pub use ed448::Signature;
 
 impl From<InnerSignature> for Signature {
     fn from(inner: InnerSignature) -> Self {
         let mut s = [0u8; SECRET_KEY_LENGTH];
         s.copy_from_slice(&inner.s.to_bytes_rfc_8032());
-        Self {
-            r: inner.r.compress(),
-            s,
-        }
+        Self::from_components(inner.r.compress(), s)
     }
 }
 
-impl TryFrom<Signature> for InnerSignature {
+impl TryFrom<&Signature> for InnerSignature {
     type Error = SigningError;
 
-    fn try_from(signature: Signature) -> Result<Self, Self::Error> {
-        let s_bytes = ScalarBytes::try_from(&signature.s[..]).expect("invalid length");
-        let s = Option::from(Scalar::from_canonical_bytes(&s_bytes))
+    fn try_from(signature: &Signature) -> Result<Self, Self::Error> {
+        let s_bytes: &Array<u8, _> = (signature.s_bytes()).into();
+        let s = Option::from(Scalar::from_canonical_bytes(s_bytes))
             .ok_or(SigningError::InvalidSignatureSComponent)?;
-        let r = Option::from(signature.r.decompress())
+        let r = Option::from(CompressedEdwardsY::from(*signature.r_bytes()).decompress())
             .ok_or(SigningError::InvalidSignatureRComponent)?;
         Ok(Self { r, s })
     }
@@ -165,21 +29,10 @@ pub(crate) struct InnerSignature {
     pub(crate) s: Scalar,
 }
 
-#[cfg(feature = "serde")]
-#[test]
-fn serialization() {
-    use rand_chacha::ChaCha8Rng;
-    use rand_core::SeedableRng;
+impl TryFrom<Signature> for InnerSignature {
+    type Error = SigningError;
 
-    let mut rng = ChaCha8Rng::from_seed([0u8; 32]);
-    let signing_key = super::SigningKey::generate(&mut rng);
-    let signature = signing_key.sign_raw(b"Hello, World!");
-
-    let bytes = serde_bare::to_vec(&signature).unwrap();
-    let signature2: Signature = serde_bare::from_slice(&bytes).unwrap();
-    assert_eq!(signature, signature2);
-
-    let string = serde_json::to_string(&signature).unwrap();
-    let signature3: Signature = serde_json::from_str(&string).unwrap();
-    assert_eq!(signature, signature3);
+    fn try_from(signature: Signature) -> Result<Self, Self::Error> {
+        Self::try_from(&signature)
+    }
 }

--- a/ed448-goldilocks/src/sign/verifying_key.rs
+++ b/ed448-goldilocks/src/sign/verifying_key.rs
@@ -2,14 +2,15 @@
 //! and adapted to mirror `ed25519-dalek`'s API.
 
 use crate::curve::edwards::extended::PointBytes;
-use crate::sign::HASH_HEAD;
+use crate::sign::{HASH_HEAD, InnerSignature};
 use crate::{
-    CompressedEdwardsY, Context, EdwardsPoint, PreHash, Scalar, ScalarBytes, Signature,
-    SigningError, WideScalarBytes,
+    CompressedEdwardsY, Context, EdwardsPoint, PreHash, Scalar, Signature, SigningError,
+    WideScalarBytes,
 };
 
-#[cfg(any(feature = "pkcs8", feature = "serde"))]
+#[cfg(feature = "serde")]
 use crate::PUBLIC_KEY_LENGTH;
+
 #[cfg(feature = "pkcs8")]
 use elliptic_curve::pkcs8;
 
@@ -91,9 +92,7 @@ where
 }
 
 #[cfg(feature = "pkcs8")]
-/// This type is primarily useful for decoding/encoding SPKI public key files (either DER or PEM)
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub struct PublicKeyBytes(pub [u8; PUBLIC_KEY_LENGTH]);
+pub use ed448::pkcs8::PublicKeyBytes;
 
 #[cfg(feature = "pkcs8")]
 impl TryFrom<PublicKeyBytes> for VerifyingKey {
@@ -117,38 +116,6 @@ impl TryFrom<&PublicKeyBytes> for VerifyingKey {
 impl From<VerifyingKey> for PublicKeyBytes {
     fn from(key: VerifyingKey) -> Self {
         Self(key.compressed.to_bytes())
-    }
-}
-
-#[cfg(all(feature = "pkcs8", feature = "alloc"))]
-impl pkcs8::EncodePublicKey for PublicKeyBytes {
-    fn to_public_key_der(&self) -> pkcs8::spki::Result<pkcs8::Document> {
-        pkcs8::SubjectPublicKeyInfoRef {
-            algorithm: super::ALGORITHM_ID,
-            subject_public_key: pkcs8::der::asn1::BitStringRef::new(0, &self.0)?,
-        }
-        .try_into()
-    }
-}
-
-#[cfg(feature = "pkcs8")]
-impl TryFrom<pkcs8::spki::SubjectPublicKeyInfoRef<'_>> for PublicKeyBytes {
-    type Error = pkcs8::spki::Error;
-
-    fn try_from(value: pkcs8::spki::SubjectPublicKeyInfoRef<'_>) -> Result<Self, Self::Error> {
-        value.algorithm.assert_algorithm_oid(super::ALGORITHM_OID)?;
-
-        if value.algorithm.parameters.is_some() {
-            return Err(pkcs8::spki::Error::KeyMalformed);
-        }
-
-        value
-            .subject_public_key
-            .as_bytes()
-            .ok_or(pkcs8::spki::Error::KeyMalformed)?
-            .try_into()
-            .map(Self)
-            .map_err(|_| pkcs8::spki::Error::KeyMalformed)
     }
 }
 
@@ -293,24 +260,19 @@ impl VerifyingKey {
         // `signature` should already be valid but check to make sure
         // Note that the scalar itself uses only 56 bytes; the extra
         // 57th byte must be 0x00.
-        if signature.s[56] != 0x00 {
+        if signature.s_bytes()[56] != 0x00 {
             return Err(SigningError::InvalidSignatureSComponent.into());
         }
         if self.point.is_identity().into() {
             return Err(SigningError::InvalidPublicKeyBytes.into());
         }
 
-        let r = Option::<EdwardsPoint>::from(signature.r.decompress())
-            .ok_or(SigningError::InvalidSignatureRComponent)?;
-        if r.is_identity().into() {
+        let inner_signature = InnerSignature::try_from(signature)?;
+        if inner_signature.r.is_identity().into() {
             return Err(SigningError::InvalidSignatureRComponent.into());
         }
 
-        let s_bytes = ScalarBytes::try_from(&signature.s[..]).expect("signature.s is 57 bytes");
-        let s = Option::<Scalar>::from(Scalar::from_canonical_bytes(&s_bytes))
-            .ok_or(SigningError::InvalidSignatureSComponent)?;
-
-        if s.is_zero().into() {
+        if inner_signature.s.is_zero().into() {
             return Err(SigningError::InvalidSignatureSComponent.into());
         }
 
@@ -322,15 +284,15 @@ impl VerifyingKey {
             .chain([phflag])
             .chain([clen])
             .chain(ctx)
-            .chain(signature.r.as_bytes())
+            .chain(signature.r_bytes())
             .chain(self.compressed.as_bytes())
             .chain(m)
             .finalize_xof();
         reader.read(&mut bytes);
         let k = Scalar::from_bytes_mod_order_wide(&bytes);
         // Check the verification equation [S]B = R + [k]A.
-        let lhs = EdwardsPoint::GENERATOR * s;
-        let rhs = r + (self.point * k);
+        let lhs = EdwardsPoint::GENERATOR * inner_signature.s;
+        let rhs = inner_signature.r + (self.point * k);
         if lhs == rhs {
             Ok(())
         } else {


### PR DESCRIPTION
Depends:
 - https://github.com/RustCrypto/elliptic-curves/pull/1219
 - https://github.com/RustCrypto/signatures/pull/983
 

This is a followup to #1219 