### PR TITLE
workspace: avoid duplicates when pulling dependency from git

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+primefield = { path = "primefield" }
+primeorder = { path = "primeorder" }

--- a/bign256/Cargo.toml
+++ b/bign256/Cargo.toml
@@ -30,15 +30,15 @@ hmac = { version = "0.13.0-rc.0", optional = true }
 rand_core = "0.9"
 rfc6979 = { version = "0.5.0-rc.0", optional = true }
 pkcs8 = { version = "0.11.0-rc.3", optional = true }
-primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
-primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
+primefield = { version = "=0.14.0-pre.2", optional = true }
+primeorder = { version = "=0.14.0-pre.3", optional = true }
 sec1 = { version = "0.8.0-rc.1", optional = true }
 signature = { version = "3.0.0-pre.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.6"
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.3", features = ["dev"], path = "../primeorder" }
+primeorder = { version = "=0.14.0-pre.3", features = ["dev"] }
 proptest = "1"
 rand_core = { version = "0.9", features = ["os_rng"] }
 hex = { version = "0.4" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -18,8 +18,8 @@ elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features =
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.0", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
-primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
+primefield = { version = "=0.14.0-pre.2", optional = true }
+primeorder = { version = "=0.14.0-pre.3", optional = true }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
 [features]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -18,8 +18,8 @@ elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features =
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.0", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
-primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
+primefield = { version = "=0.14.0-pre.2", optional = true }
+primeorder = { version = "=0.14.0-pre.3", optional = true }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
 [features]

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -23,14 +23,14 @@ sec1 = { version = "0.8.0-rc.1", default-features = false }
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
-primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
+primefield = { version = "=0.14.0-pre.2", optional = true }
+primeorder = { version = "=0.14.0-pre.3", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false }
 
 [dev-dependencies]
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.3", features = ["dev"], path = "../primeorder" }
+primeorder = { version = "=0.14.0-pre.3", features = ["dev"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -22,8 +22,8 @@ elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features =
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
-primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
+primefield = { version = "=0.14.0-pre.2", optional = true }
+primeorder = { version = "=0.14.0-pre.3", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
@@ -31,7 +31,7 @@ sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 blobby = "0.3"
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.3", features = ["dev"], path = "../primeorder" }
+primeorder = { version = "=0.14.0-pre.3", features = ["dev"] }
 rand_core = { version = "0.9", features = ["os_rng"] }
 
 [features]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -23,8 +23,8 @@ elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features =
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
-primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
+primefield = { version = "=0.14.0-pre.2", optional = true }
+primeorder = { version = "=0.14.0-pre.3", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
@@ -33,8 +33,8 @@ blobby = "0.3"
 criterion = "0.6"
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primefield = { version = "=0.14.0-pre.2", path = "../primefield" }
-primeorder = { version = "=0.14.0-pre.3", features = ["dev"], path = "../primeorder" }
+primefield = { version = "=0.14.0-pre.2" }
+primeorder = { version = "=0.14.0-pre.3", features = ["dev"] }
 proptest = "1"
 rand_core = { version = "0.9", features = ["os_rng"] }
 

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -23,8 +23,8 @@ elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features =
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
-primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
+primefield = { version = "=0.14.0-pre.2", optional = true }
+primeorder = { version = "=0.14.0-pre.3", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
@@ -33,7 +33,7 @@ blobby = "0.3"
 criterion = "0.6"
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.3", features = ["dev"], path = "../primeorder" }
+primeorder = { version = "=0.14.0-pre.3", features = ["dev"] }
 proptest = "1.5"
 rand_core = { version = "0.9", features = ["os_rng"] }
 

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -23,8 +23,8 @@ elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features =
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
-primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
+primefield = { version = "=0.14.0-pre.2", optional = true }
+primeorder = { version = "=0.14.0-pre.3", optional = true }
 rand_core = { version = "0.9", optional = true, default-features = false }
 serdect = { version = "0.3", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
@@ -34,7 +34,7 @@ blobby = "0.3"
 criterion = "0.6"
 ecdsa-core = { version = "0.17.0-rc.0", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.3", features = ["dev"], path = "../primeorder" }
+primeorder = { version = "=0.14.0-pre.3", features = ["dev"] }
 proptest = "1.5"
 rand_core = { version = "0.9", features = ["os_rng"] }
 

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -22,8 +22,8 @@ elliptic-curve = { version = "0.14.0-rc.3", default-features = false, features =
 rand_core = { version = "0.9", default-features = false }
 
 # optional dependencies
-primefield = { version = "=0.14.0-pre.2", optional = true, path = "../primefield" }
-primeorder = { version = "=0.14.0-pre.3", optional = true, path = "../primeorder" }
+primefield = { version = "=0.14.0-pre.2", optional = true }
+primeorder = { version = "=0.14.0-pre.3", optional = true }
 rfc6979 = { version = "0.5.0-rc.0", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false }
 signature = { version = "3.0.0-rc.0", optional = true, features = ["rand_core"] }


### PR DESCRIPTION
When pulling dependencies using a `patch.crates-io` to a git dependency (for unreleased crates or ...):
```
[dependencies]
p224 = "0.14.0-pre"
p256 = "0.14.0-pre.4"

[patch.crates-io]
p224 = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
```

Cargo will duplicate the `primefield` and `primeorder` dependencies:
```
[[package]]
name = "p224"
version = "0.14.0-pre"
source = "git+https://github.com/RustCrypto/elliptic-curves.git#d0d84f5bcc0ed933d472548e3085f17fdea57f17"
dependencies = [
 "ecdsa",
 "elliptic-curve",
 "primefield 0.14.0-pre.2 (git+https://github.com/RustCrypto/elliptic-curves.git)",
 "primeorder 0.14.0-pre.3 (git+https://github.com/RustCrypto/elliptic-curves.git)",
 "sha2",
]

[[package]]
name = "p256"
version = "0.14.0-pre.4"
source = "registry+https://github.com/rust-lang/crates.io-index"
checksum = "635e1f1e5af6fc13e6c6a587fa1455e17fa7c8b54ba74093be5254819e34713f"
dependencies = [
 "ecdsa",
 "elliptic-curve",
 "primefield 0.14.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "primeorder 0.14.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "sha2",
]

[[package]]
name = "primefield"
version = "0.14.0-pre.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
checksum = "1bbeb92947a0d0d4b0cab5e2e6749acc44c81461eb3b1aff4dbb7acd0eb9f0ab"
dependencies = [
 "crypto-bigint",
 "ff",
 "rand_core",
 "subtle",
 "zeroize",
]

[[package]]
name = "primefield"
version = "0.14.0-pre.2"
source = "git+https://github.com/RustCrypto/elliptic-curves.git#d0d84f5bcc0ed933d472548e3085f17fdea57f17"
dependencies = [
 "crypto-bigint",
 "ff",
 "rand_core",
 "subtle",
 "zeroize",
]
```

This causes issues down the line, like for nix builds and this also makes clippy error out:
```
error: multiple versions for dependency `primefield`: 0.14.0-pre.2, 0.14.0-pre.2
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#multiple_crate_versions
  = note: `-D clippy::multiple-crate-versions` implied by `-D clippy::cargo`
  = help: to override `-D clippy::cargo` add `#[allow(clippy::multiple_crate_versions)]`
```