### PR TITLE
Expose `AffineCoordinates::y`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,8 +405,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bedd367b8649edac0efb2120e420460cffc41988f94eb55f009832484a45c46f"
+source = "git+https://github.com/RustCrypto/traits#c190381106c260f5a577587385bd3234dc3f9874"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ members = [
 opt-level = 2
 
 [patch.crates-io]
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }

--- a/ed448-goldilocks/src/curve/edwards/affine.rs
+++ b/ed448-goldilocks/src/curve/edwards/affine.rs
@@ -51,6 +51,14 @@ impl elliptic_curve::point::AffineCoordinates for AffinePoint {
         Ed448FieldBytes::from(self.x.to_bytes_extended())
     }
 
+    fn y(&self) -> Self::FieldRepr {
+        Ed448FieldBytes::from(self.y.to_bytes_extended())
+    }
+
+    fn x_is_odd(&self) -> Choice {
+        self.x.is_negative()
+    }
+
     fn y_is_odd(&self) -> Choice {
         self.y.is_negative()
     }

--- a/ed448-goldilocks/src/decaf/affine.rs
+++ b/ed448-goldilocks/src/decaf/affine.rs
@@ -1,6 +1,6 @@
 use crate::curve::twedwards::affine::AffinePoint as InnerAffinePoint;
 use crate::field::FieldElement;
-use crate::{Decaf448FieldBytes, DecafPoint, Scalar};
+use crate::{DecafPoint, Scalar};
 use core::ops::Mul;
 use elliptic_curve::{Error, point::NonIdentity};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -35,17 +35,26 @@ impl PartialEq for AffinePoint {
 
 impl Eq for AffinePoint {}
 
-impl elliptic_curve::point::AffineCoordinates for AffinePoint {
-    type FieldRepr = Decaf448FieldBytes;
-
-    fn x(&self) -> Self::FieldRepr {
-        Decaf448FieldBytes::from(self.x())
-    }
-
-    fn y_is_odd(&self) -> Choice {
-        self.0.y.is_negative()
-    }
-}
+// TODO(tarcieri): RustCrypto/elliptic-curves#1229
+// impl AffineCoordinates for AffinePoint {
+//     type FieldRepr = Decaf448FieldBytes;
+//
+//     fn x(&self) -> Self::FieldRepr {
+//         Decaf448FieldBytes::from(self.x())
+//     }
+//
+//     fn y(&self) -> Self::FieldRepr {
+//         Decaf448FieldBytes::from(self.y())
+//     }
+//
+//     fn x_is_odd(&self) -> Choice {
+//         self.0.x.is_negative()
+//     }
+//
+//     fn y_is_odd(&self) -> Choice {
+//         self.0.y.is_negative()
+//     }
+// }
 
 #[cfg(feature = "zeroize")]
 impl DefaultIsZeroes for AffinePoint {}
@@ -61,7 +70,7 @@ impl AffinePoint {
 
     /// The X coordinate
     pub fn x(&self) -> [u8; 57] {
-        // TODO: fix this to be 56 bytes as per
+        // TODO(RustCrypto/elliptic-curves#1229): fix this to be 56 bytes as per
         // https://datatracker.ietf.org/doc/draft-irtf-cfrg-ristretto255-decaf448
         // This might require creating a separate DecafScalar
         self.0.x.to_bytes_extended()

--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -51,8 +51,10 @@ pub const MODULUS_LIMBS: [u32; 14] = [
 
 #[cfg(feature = "zeroize")]
 scalar_from_impls!(Ed448, Scalar);
-#[cfg(feature = "zeroize")]
-scalar_from_impls!(Decaf448, Scalar);
+
+// TODO(tarcieri): RustCrypto/elliptic-curves#1229
+//#[cfg(feature = "zeroize")]
+//scalar_from_impls!(Decaf448, Scalar);
 
 impl Display for Scalar {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {

--- a/ed448-goldilocks/src/lib.rs
+++ b/ed448-goldilocks/src/lib.rs
@@ -185,9 +185,10 @@ impl FieldBytesEncoding<Decaf448> for U448 {
     }
 }
 
-#[cfg(feature = "zeroize")]
-impl elliptic_curve::CurveArithmetic for Decaf448 {
-    type AffinePoint = DecafAffinePoint;
-    type ProjectivePoint = DecafPoint;
-    type Scalar = Scalar;
-}
+// TODO(tarcieri): RustCrypto/elliptic-curves#1229
+// #[cfg(feature = "zeroize")]
+// impl elliptic_curve::CurveArithmetic for Decaf448 {
+//     type AffinePoint = DecafAffinePoint;
+//     type ProjectivePoint = DecafPoint;
+//     type Scalar = Scalar;
+// }

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -114,6 +114,14 @@ impl AffineCoordinates for AffinePoint {
         self.x.to_bytes()
     }
 
+    fn y(&self) -> FieldBytes {
+        self.y.to_bytes()
+    }
+
+    fn x_is_odd(&self) -> Choice {
+        self.x.normalize().is_odd()
+    }
+
     fn y_is_odd(&self) -> Choice {
         self.y.normalize().is_odd()
     }

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -87,6 +87,14 @@ where
         self.x.to_repr()
     }
 
+    fn y(&self) -> FieldBytes<C> {
+        self.y.to_repr()
+    }
+
+    fn x_is_odd(&self) -> Choice {
+        self.x.is_odd()
+    }
+
     fn y_is_odd(&self) -> Choice {
         self.y.is_odd()
     }


### PR DESCRIPTION
Companion PR to RustCrypto/traits#1891 which adds access to affine y-coordinates.

Notably we've just added an Edwards curve with `ed448-goldilocks`, and these curves use compressed Edwards y-coordinates, so y-coordinate access is needed to even implement point compression generically for these curves.

Note that due to RustCrypto/elliptic-curves#1229 it's currently not possible to impl the extened `AffineCoordinates API for the Decaf implementation in the `ed448-goldilocks` crate. This PR comments out the relevant code for now with a TODO to fix it.