### PR TITLE
ed448-goldilocks: remove unused `elliptic-curve` features

### DIFF
--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -18,7 +18,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 [dependencies]
 crypto-bigint = { version = "=0.7.0-pre.4", features = ["hybrid-array"], default-features = false }
 crypto_signature = { version = "3.0.0-rc.0", default-features = false, features = ["digest", "rand_core"], optional = true, package = "signature" }
-elliptic-curve = { version = "0.14.0-rc.4", features = ["arithmetic", "bits", "hash2curve", "jwk", "pkcs8", "pem", "sec1"] }
+elliptic-curve = { version = "0.14.0-rc.4", features = ["arithmetic", "bits", "hash2curve", "pkcs8", "pem"] }
 rand_core = { version = "0.9", default-features = false }
 serdect = { version = "0.3.0", optional = true }
 sha3 = { version = "0.11.0-rc.0", default-features = false }
@@ -27,7 +27,7 @@ zeroize = { version = "1.8", default-features = false, optional = true }
 
 [features]
 default = ["std", "signing", "pkcs8"]
-alloc = ["serdect/alloc", "zeroize/alloc", "crypto_signature/alloc"]
+alloc = ["serdect/alloc", "zeroize/alloc", "crypto_signature/alloc", "elliptic-curve/alloc"]
 pkcs8 = ["elliptic-curve/pkcs8"]
 signing = ["dep:crypto_signature", "zeroize"]
 serde = ["dep:serdect"]


### PR DESCRIPTION
The `jwk` and `sec1` features are unused