### PR TITLE
ed448-goldilocks: `bits` feature

### DIFF
--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -18,7 +18,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 [dependencies]
 crypto-bigint = { version = "=0.7.0-pre.4", features = ["hybrid-array"], default-features = false }
 crypto_signature = { version = "3.0.0-rc.0", default-features = false, features = ["digest", "rand_core"], optional = true, package = "signature" }
-elliptic-curve = { version = "0.14.0-rc.4", features = ["arithmetic", "bits", "hash2curve", "pkcs8", "pem"] }
+elliptic-curve = { version = "0.14.0-rc.4", features = ["arithmetic", "hash2curve", "pkcs8", "pem"] }
 rand_core = { version = "0.9", default-features = false }
 serdect = { version = "0.3.0", optional = true }
 sha3 = { version = "0.11.0-rc.0", default-features = false }
@@ -28,6 +28,7 @@ zeroize = { version = "1.8", default-features = false, optional = true }
 [features]
 default = ["std", "signing", "pkcs8"]
 alloc = ["serdect/alloc", "zeroize/alloc", "crypto_signature/alloc", "elliptic-curve/alloc"]
+bits = ["elliptic-curve/bits"]
 pkcs8 = ["elliptic-curve/pkcs8"]
 signing = ["dep:crypto_signature", "zeroize"]
 serde = ["dep:serdect"]

--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -11,13 +11,16 @@ use elliptic_curve::{
     array::{Array, typenum::Unsigned},
     bigint::{Limb, NonZero, U448, U704, U896},
     consts::{U28, U84, U88, U114},
-    ff::{Field, FieldBits, PrimeFieldBits, helpers},
+    ff::{Field, helpers},
     hash2curve::{ExpandMsg, Expander, FromOkm},
     ops::{Invert, Reduce, ReduceNonZero},
     scalar::{FromUintUnchecked, IsHigh},
 };
 use rand_core::{CryptoRng, RngCore, TryRngCore};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, CtOption};
+
+#[cfg(feature = "bits")]
+use elliptic_curve::ff::{FieldBits, PrimeFieldBits};
 
 /// This is the scalar field
 /// size = 4q = 2^446 - 0x8335dc163bb124b65129c96fde933d8d723a70aadc873d6d54a7bb0d
@@ -507,6 +510,7 @@ impl ReduceNonZero<U896> for Scalar {
     }
 }
 
+#[cfg(feature = "bits")]
 impl PrimeFieldBits for Scalar {
     type ReprBits = [crypto_bigint::Word; U448::LIMBS];
 
@@ -597,7 +601,7 @@ impl ShrAssign<usize> for Scalar {
     }
 }
 
-#[cfg(feature = "zeroize")]
+#[cfg(all(feature = "bits", feature = "zeroize"))]
 impl From<&Scalar> for Ed448ScalarBits {
     fn from(scalar: &Scalar) -> Self {
         scalar.0.to_words().into()

--- a/ed448-goldilocks/src/lib.rs
+++ b/ed448-goldilocks/src/lib.rs
@@ -104,6 +104,7 @@ pub struct Ed448;
 pub type Ed448FieldBytes = elliptic_curve::FieldBytes<Ed448>;
 
 /// Scalar bits of the Ed448 scalar
+#[cfg(feature = "bits")]
 pub type Ed448ScalarBits = elliptic_curve::scalar::ScalarBits<Ed448>;
 
 /// Non-zero scalar of the Ed448 scalar
@@ -152,6 +153,7 @@ pub struct Decaf448;
 pub type Decaf448FieldBytes = elliptic_curve::FieldBytes<Decaf448>;
 
 /// Scalar bits of the Decaf448 scalar
+#[cfg(feature = "bits")]
 pub type Decaf448ScalarBits = elliptic_curve::scalar::ScalarBits<Decaf448>;
 
 /// Non-zero scalar of the Decaf448 scalar


### PR DESCRIPTION
Makes `bits` an optional feature, since it pulls in `bitvec` as a dependency