### PR TITLE
ed448-goldilocks: remove explicit dep on `crypto-bigint`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,6 @@ dependencies = [
 name = "ed448-goldilocks"
 version = "0.14.0-pre"
 dependencies = [
- "crypto-bigint",
  "elliptic-curve",
  "hex",
  "hex-literal",

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -16,7 +16,6 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-crypto-bigint = { version = "=0.7.0-pre.4", features = ["hybrid-array"], default-features = false }
 crypto_signature = { version = "3.0.0-rc.0", default-features = false, features = ["digest", "rand_core"], optional = true, package = "signature" }
 elliptic-curve = { version = "0.14.0-rc.5", features = ["arithmetic", "hash2curve", "pkcs8"] }
 rand_core = { version = "0.9", default-features = false }

--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -1,11 +1,10 @@
 use core::fmt::{self, Debug, Display, Formatter, LowerHex, UpperHex};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use crypto_bigint::NonZero;
 use elliptic_curve::{
     array::Array,
     bigint::{
-        U448, U704,
+        NonZero, U448, U704,
         consts::{U84, U88},
     },
     hash2curve::FromOkm,

--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -5,11 +5,10 @@ use core::iter::{Product, Sum};
 use core::ops::{
     Add, AddAssign, Index, IndexMut, Mul, MulAssign, Neg, Shr, ShrAssign, Sub, SubAssign,
 };
-use crypto_bigint::Zero;
 use elliptic_curve::{
     PrimeField,
     array::{Array, typenum::Unsigned},
-    bigint::{Limb, NonZero, U448, U704, U896},
+    bigint::{Limb, NonZero, U448, U704, U896, Word, Zero},
     consts::{U28, U84, U88, U114},
     ff::{Field, helpers},
     hash2curve::{ExpandMsg, Expander, FromOkm},
@@ -120,7 +119,7 @@ impl From<u128> for Scalar {
 }
 
 impl Index<usize> for Scalar {
-    type Output = crypto_bigint::Word;
+    type Output = Word;
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.0.as_words()[index]
@@ -512,7 +511,7 @@ impl ReduceNonZero<U896> for Scalar {
 
 #[cfg(feature = "bits")]
 impl PrimeFieldBits for Scalar {
-    type ReprBits = [crypto_bigint::Word; U448::LIMBS];
+    type ReprBits = [Word; U448::LIMBS];
 
     fn to_le_bits(&self) -> FieldBits<Self::ReprBits> {
         self.0.to_words().into()


### PR DESCRIPTION
We can source it through `elliptic-curve`, which is a hard dependency