### PR TITLE
ed448-goldilocks: cleanup toplevel attributes

### DIFF
--- a/ed448-goldilocks/README.md
+++ b/ed448-goldilocks/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="resources/bear.png" width = "400">
+<img src="https://raw.githubusercontent.com/RustCrypto/elliptic-curves/c797d60/ed448-goldilocks/resources/bear.png" width = "400">
 </p>
 
 # [RustCrypto]: Ed448-Goldilocks Elliptic Curve
@@ -12,6 +12,43 @@
 [![Project Chat][chat-image]][chat-link]
 
 THIS CODE HAS NOT BEEN AUDITED OR REVIEWED. USE AT YOUR OWN RISK.
+
+## About
+
+This crate provides a pure Rust implementation of Curve448, Edwards, Decaf, and Ristretto.
+It is intended to be portable, fast, and safe.
+
+## Usage
+
+```rust
+use ed448_goldilocks::{EdwardsPoint, CompressedEdwardsY, Scalar, elliptic_curve::hash2curve::ExpandMsgXof, sha3::Shake256};
+use elliptic_curve::Field;
+use rand_core::OsRng;
+
+let secret_key = Scalar::TWO;
+let public_key = EdwardsPoint::GENERATOR * &secret_key;
+
+assert_eq!(public_key, EdwardsPoint::GENERATOR + EdwardsPoint::GENERATOR);
+
+let secret_key = Scalar::try_from_rng(&mut OsRng).unwrap();
+let public_key = EdwardsPoint::GENERATOR * &secret_key;
+let compressed_public_key = public_key.compress();
+
+assert_eq!(compressed_public_key.to_bytes().len(), 57);
+
+let hashed_scalar = Scalar::hash::<ExpandMsgXof<Shake256>>(b"test", b"edwards448_XOF:SHAKE256_ELL2_RO_");
+let input = hex_literal::hex!("c8c6c8f584e0c25efdb6af5ad234583c56dedd7c33e0c893468e96740fa0cf7f1a560667da40b7bde340a39252e89262fcf707d1180fd43400");
+let expected_scalar = Scalar::from_canonical_bytes(&input.into()).unwrap();
+assert_eq!(hashed_scalar, expected_scalar);
+
+let hashed_point = EdwardsPoint::hash::<ExpandMsgXof<Shake256>>(b"test", b"edwards448_XOF:SHAKE256_ELL2_RO_");
+let expected = hex_literal::hex!("d15c4427b5c5611a53593c2be611fd3635b90272d331c7e6721ad3735e95dd8b9821f8e4e27501ce01aa3c913114052dce2e91e8ca050f4980");
+let expected_point = CompressedEdwardsY(expected).decompress().unwrap();
+assert_eq!(hashed_point, expected_point);
+
+let hashed_point = EdwardsPoint::hash_with_defaults(b"test");
+assert_eq!(hashed_point, expected_point);
+```
 
 ## Field Choice
 
@@ -33,22 +70,22 @@ The three explicitly implemented curves are:
 ## Ed448-Goldilocks Curve
 
 - The goldilocks curve is an Edwards curve with affine equation x^2 + y^2 = 1 - 39081x^2y^2 .
-- This curve was defined by Mike Hamburg in https://eprint.iacr.org/2015/625.pdf . 
+- This curve was defined by Mike Hamburg in <https://eprint.iacr.org/2015/625.pdf>. 
 - The cofactor of this curve over the goldilocks prime is 4.
 
 ## Twisted-Goldilocks Curve
 
 - The twisted goldilocks curve is a Twisted Edwards curve with affine equation y^2 - x^2 = 1 - 39082x^2y^2 .
-- This curve is also defined in https://eprint.iacr.org/2015/625.pdf .
+- This curve is also defined in <https://eprint.iacr.org/2015/625.pdf>.
 - The cofactor of this curve over the goldilocks prime is 4.
 
 ### Isogeny
 
-- This curve is 2-isogenous to Ed448-Goldilocks. Details of the isogeny can be found here: https://www.shiftleft.org/papers/isogeny/isogeny.pdf
+- This curve is 2-isogenous to Ed448-Goldilocks. Details of the isogeny can be found here: <https://www.shiftleft.org/papers/isogeny/isogeny.pdf>.
 
 ## Curve448
 
-This curve is 2-isogenous to Ed448-Goldilocks. Details of Curve448 can be found here: https://tools.ietf.org/html/rfc7748
+This curve is 2-isogenous to Ed448-Goldilocks. Details of Curve448 can be found here: <https://tools.ietf.org/html/rfc7748>.
 
 The main usage of this curve is for X448.
 
@@ -60,13 +97,13 @@ The main strategy for group arithmetic on Ed448-Goldilocks is to perform the 2-i
 
 # Decaf
 
-The Decaf strategy [link paper] is used to build a group of prime order from the Twisted Goldilocks curve. The Twisted Goldilocks curve is used as it has faster formulas. We can also use Curve448 or Ed448-Goldilocks. Decaf takes advantage of an isogeny with a Jacobi Quartic curve which is not explicitly defined. Details of this can be found here: https://www.shiftleft.org/papers/decaf/decaf.pdf However, to my knowledge there is no documentation for the Decaf protocol implemented in this repository, which is a tweaked version of the original decaf protocol linked in the paper.
+The Decaf strategy [link paper] is used to build a group of prime order from the Twisted Goldilocks curve. The Twisted Goldilocks curve is used as it has faster formulas. We can also use Curve448 or Ed448-Goldilocks. Decaf takes advantage of an isogeny with a Jacobi Quartic curve which is not explicitly defined. Details of this can be found here: <https://www.shiftleft.org/papers/decaf/decaf.pdf>. However, to my knowledge there is no documentation for the Decaf protocol implemented in this repository, which is a tweaked version of the original decaf protocol linked in the paper.
 
 ## Completed Point vs Extensible Point
 
 Deviating from Curve25519-Dalek, this library will implement Extensible points instead of Completed Points. Due to the following observation:
 
-- There is a cost of 3/4 Field multiplications to switch from the CompletedPoint. So if we were to perform repeated doubling, this would add an extra cost for each doubling in projective form. More details on the ExtensiblePoint can be found here [3.2]: https://www.shiftleft.org/papers/fff/fff.pdf
+- There is a cost of 3/4 Field multiplications to switch from the CompletedPoint. So if we were to perform repeated doubling, this would add an extra cost for each doubling in projective form. More details on the ExtensiblePoint can be found here [3.2]: <https://www.shiftleft.org/papers/fff/fff.pdf>
 
 ## Credits
 

--- a/ed448-goldilocks/src/lib.rs
+++ b/ed448-goldilocks/src/lib.rs
@@ -1,64 +1,34 @@
-//! This crate provides a pure Rust implementation of Curve448, Edwards, Decaf, and Ristretto.
-//! It is intended to be portable, fast, and safe.
-//!
-//! # Usage
-//! ```
-//! use ed448_goldilocks::{EdwardsPoint, CompressedEdwardsY, Scalar, elliptic_curve::hash2curve::ExpandMsgXof, sha3::Shake256};
-//! use elliptic_curve::Field;
-//! use rand_core::OsRng;
-//!
-//! let secret_key = Scalar::TWO;
-//! let public_key = EdwardsPoint::GENERATOR * &secret_key;
-//!
-//! assert_eq!(public_key, EdwardsPoint::GENERATOR + EdwardsPoint::GENERATOR);
-//!
-//! let secret_key = Scalar::try_from_rng(&mut OsRng).unwrap();
-//! let public_key = EdwardsPoint::GENERATOR * &secret_key;
-//! let compressed_public_key = public_key.compress();
-//!
-//! assert_eq!(compressed_public_key.to_bytes().len(), 57);
-//!
-//! let hashed_scalar = Scalar::hash::<ExpandMsgXof<Shake256>>(b"test", b"edwards448_XOF:SHAKE256_ELL2_RO_");
-//! let input = hex_literal::hex!("c8c6c8f584e0c25efdb6af5ad234583c56dedd7c33e0c893468e96740fa0cf7f1a560667da40b7bde340a39252e89262fcf707d1180fd43400");
-//! let expected_scalar = Scalar::from_canonical_bytes(&input.into()).unwrap();
-//! assert_eq!(hashed_scalar, expected_scalar);
-//!
-//! let hashed_point = EdwardsPoint::hash::<ExpandMsgXof<Shake256>>(b"test", b"edwards448_XOF:SHAKE256_ELL2_RO_");
-//! let expected = hex_literal::hex!("d15c4427b5c5611a53593c2be611fd3635b90272d331c7e6721ad3735e95dd8b9821f8e4e27501ce01aa3c913114052dce2e91e8ca050f4980");
-//! let expected_point = CompressedEdwardsY(expected).decompress().unwrap();
-//! assert_eq!(hashed_point, expected_point);
-//!
-//! let hashed_point = EdwardsPoint::hash_with_defaults(b"test");
-//! assert_eq!(hashed_point, expected_point);
-//! ```
-//!
-//! [`EdwardsPoint`] implements the [`elliptic_curve::Group`] and [`elliptic_curve::group::GroupEncoding`]
-//! and [`Scalar`] implements [`elliptic_curve::Field`] and [`elliptic_curve::PrimeField`] traits.
-#![deny(unused_attributes, unused_imports, unused_mut, unused_must_use)]
-#![allow(non_snake_case)]
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
+)]
+#![allow(non_snake_case)]
+#![forbid(unsafe_code)]
 #![warn(
-    missing_docs,
-    missing_debug_implementations,
+    clippy::unwrap_used,
+    clippy::mod_module_files,
     missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused,
-    clippy::mod_module_files
+    unused_attributes,
+    unused_imports,
+    unused_mut,
+    unused_must_use
 )]
-#![deny(clippy::unwrap_used)]
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "alloc")]
 use alloc::{boxed::Box, vec::Vec};
-
-#[cfg(feature = "std")]
-use std::{boxed::Box, vec::Vec};
 
 // Internal macros. Must come first!
 #[macro_use]
@@ -110,9 +80,6 @@ pub type Ed448ScalarBits = elliptic_curve::scalar::ScalarBits<Ed448>;
 /// Non-zero scalar of the Ed448 scalar
 pub type Ed448NonZeroScalar = elliptic_curve::NonZeroScalar<Ed448>;
 
-unsafe impl Send for Ed448 {}
-unsafe impl Sync for Ed448 {}
-
 impl Curve for Ed448 {
     type FieldBytesSize = U57;
     type Uint = U448;
@@ -158,9 +125,6 @@ pub type Decaf448ScalarBits = elliptic_curve::scalar::ScalarBits<Decaf448>;
 
 /// Non-zero scalar of the Decaf448 scalar
 pub type Decaf448NonZeroScalar = elliptic_curve::NonZeroScalar<Decaf448>;
-
-unsafe impl Send for Decaf448 {}
-unsafe impl Sync for Decaf448 {}
 
 impl Curve for Decaf448 {
     type FieldBytesSize = U57;


### PR DESCRIPTION
- Moves all toplevel attributes to the top of file
- Includes README.md in the rustdoc
- Moves code example to README.md
- Switch all `deny` lints to `warn` since we deny warnings in CI
- Add `forbid(unsafe)` and remove unnecessary `unsafe impl`s (the traits are auto anyway)