### PR TITLE
ed448-goldilocks: source `zeroize` from `elliptic-curve`

### DIFF
--- a/.github/workflows/ed448-goldilocks.yml
+++ b/.github/workflows/ed448-goldilocks.yml
@@ -40,8 +40,7 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features signing
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features zeroize
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,pkcs8,signing,serde,zeroize
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,pkcs8,signing,serde
 
   benches:
     runs-on: ubuntu-latest
@@ -85,8 +84,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: ${{ matrix.deps }}
       - run: cargo test --release --target ${{ matrix.target }} --no-default-features
-      - run: cargo hack test --feature-powerset --target ${{ matrix.target }} --exclude-features bits
-      - run: cargo test --release --target ${{ matrix.target }} --no-default-features --features bits
+      - run: cargo hack test --feature-powerset --target ${{ matrix.target }}
       - run: cargo test --release --target ${{ matrix.target }} --all-features
 
   cross:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,6 @@ dependencies = [
  "sha3",
  "signature",
  "subtle",
- "zeroize",
 ]
 
 [[package]]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -22,18 +22,16 @@ rand_core = { version = "0.9", default-features = false }
 serdect = { version = "0.3.0", optional = true }
 sha3 = { version = "0.11.0-rc.0", default-features = false }
 subtle = { version = "2.6", default-features = false }
-zeroize = { version = "1.8", default-features = false, optional = true }
 
 [features]
 default = ["std", "signing", "pkcs8"]
-alloc = ["serdect/alloc", "zeroize/alloc", "crypto_signature/alloc", "elliptic-curve/alloc"]
+alloc = ["crypto_signature/alloc", "elliptic-curve/alloc", "serdect/alloc"]
 std = ["alloc"]
 
 bits = ["elliptic-curve/bits"]
 pkcs8 = ["elliptic-curve/pkcs8"]
-signing = ["dep:crypto_signature", "zeroize"]
+signing = ["dep:crypto_signature"]
 serde = ["dep:serdect"]
-zeroize = ["dep:zeroize"]
 
 [dev-dependencies]
 hex-literal = "1"

--- a/ed448-goldilocks/src/curve/edwards/affine.rs
+++ b/ed448-goldilocks/src/curve/edwards/affine.rs
@@ -2,11 +2,8 @@ use crate::curve::edwards::EdwardsPoint;
 use crate::field::FieldElement;
 use crate::*;
 use core::ops::Mul;
-use elliptic_curve::{Error, Result, point::NonIdentity};
+use elliptic_curve::{Error, Result, point::NonIdentity, zeroize::DefaultIsZeroes};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
-
-#[cfg(feature = "zeroize")]
-use zeroize::DefaultIsZeroes;
 
 /// Affine point on untwisted curve
 #[derive(Copy, Clone, Debug)]
@@ -64,7 +61,6 @@ impl elliptic_curve::point::AffineCoordinates for AffinePoint {
     }
 }
 
-#[cfg(feature = "zeroize")]
 impl DefaultIsZeroes for AffinePoint {}
 
 impl AffinePoint {

--- a/ed448-goldilocks/src/curve/edwards/extended.rs
+++ b/ed448-goldilocks/src/curve/edwards/extended.rs
@@ -36,8 +36,7 @@ pub type PointBytes = [u8; 57];
 #[derive(Copy, Clone, Debug)]
 pub struct CompressedEdwardsY(pub PointBytes);
 
-#[cfg(feature = "zeroize")]
-impl zeroize::Zeroize for CompressedEdwardsY {
+impl elliptic_curve::zeroize::Zeroize for CompressedEdwardsY {
     fn zeroize(&mut self) {
         self.0.zeroize()
     }
@@ -1034,8 +1033,7 @@ impl<'de> serdect::serde::Deserialize<'de> for EdwardsPoint {
     }
 }
 
-#[cfg(feature = "zeroize")]
-impl zeroize::DefaultIsZeroes for EdwardsPoint {}
+impl elliptic_curve::zeroize::DefaultIsZeroes for EdwardsPoint {}
 
 #[cfg(test)]
 mod tests {

--- a/ed448-goldilocks/src/curve/montgomery.rs
+++ b/ed448-goldilocks/src/curve/montgomery.rs
@@ -47,8 +47,7 @@ impl Default for MontgomeryPoint {
     }
 }
 
-#[cfg(feature = "zeroize")]
-impl zeroize::DefaultIsZeroes for MontgomeryPoint {}
+impl elliptic_curve::zeroize::DefaultIsZeroes for MontgomeryPoint {}
 
 impl fmt::Debug for MontgomeryPoint {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/ed448-goldilocks/src/curve/twedwards/extended.rs
+++ b/ed448-goldilocks/src/curve/twedwards/extended.rs
@@ -51,8 +51,7 @@ impl Default for ExtendedPoint {
     }
 }
 
-#[cfg(feature = "zeroize")]
-impl zeroize::DefaultIsZeroes for ExtendedPoint {}
+impl elliptic_curve::zeroize::DefaultIsZeroes for ExtendedPoint {}
 
 impl ExtendedPoint {
     /// Generator for the prime subgroup

--- a/ed448-goldilocks/src/decaf/affine.rs
+++ b/ed448-goldilocks/src/decaf/affine.rs
@@ -2,11 +2,8 @@ use crate::curve::twedwards::affine::AffinePoint as InnerAffinePoint;
 use crate::field::FieldElement;
 use crate::{DecafPoint, Scalar};
 use core::ops::Mul;
-use elliptic_curve::{Error, point::NonIdentity};
+use elliptic_curve::{Error, point::NonIdentity, zeroize::DefaultIsZeroes};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
-
-#[cfg(feature = "zeroize")]
-use zeroize::DefaultIsZeroes;
 
 /// Affine point on the twisted curve
 #[derive(Copy, Clone, Debug, Default)]
@@ -56,7 +53,6 @@ impl Eq for AffinePoint {}
 //     }
 // }
 
-#[cfg(feature = "zeroize")]
 impl DefaultIsZeroes for AffinePoint {}
 
 impl AffinePoint {

--- a/ed448-goldilocks/src/decaf/points.rs
+++ b/ed448-goldilocks/src/decaf/points.rs
@@ -293,8 +293,7 @@ impl From<&DecafPoint> for DecafAffinePoint {
     }
 }
 
-#[cfg(feature = "zeroize")]
-impl zeroize::DefaultIsZeroes for DecafPoint {}
+impl elliptic_curve::zeroize::DefaultIsZeroes for DecafPoint {}
 
 impl DecafPoint {
     /// The generator point
@@ -545,8 +544,7 @@ impl<'de> serdect::serde::Deserialize<'de> for CompressedDecaf {
     }
 }
 
-#[cfg(feature = "zeroize")]
-impl zeroize::DefaultIsZeroes for CompressedDecaf {}
+impl elliptic_curve::zeroize::DefaultIsZeroes for CompressedDecaf {}
 
 impl CompressedDecaf {
     /// The compressed generator point

--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -1,22 +1,21 @@
 use core::fmt::{self, Debug, Display, Formatter, LowerHex, UpperHex};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
+use super::ConstMontyType;
+use crate::{
+    AffinePoint, Ed448, EdwardsPoint,
+    curve::twedwards::extended::ExtendedPoint as TwistedExtendedPoint,
+};
 use elliptic_curve::{
     array::Array,
     bigint::{
         NonZero, U448, U704,
         consts::{U84, U88},
     },
-    hash2curve::FromOkm,
+    hash2curve::{FromOkm, MapToCurve},
+    zeroize::DefaultIsZeroes,
 };
 use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq};
-
-#[cfg(feature = "zeroize")]
-use {crate::Ed448, elliptic_curve::hash2curve::MapToCurve, zeroize::DefaultIsZeroes};
-
-use super::ConstMontyType;
-use crate::curve::twedwards::extended::ExtendedPoint as TwistedExtendedPoint;
-use crate::{AffinePoint, EdwardsPoint};
 
 #[derive(Clone, Copy, Default)]
 pub struct FieldElement(pub(crate) ConstMontyType);
@@ -83,7 +82,6 @@ impl FromOkm for FieldElement {
     }
 }
 
-#[cfg(feature = "zeroize")]
 impl DefaultIsZeroes for FieldElement {}
 
 impl Add<&FieldElement> for &FieldElement {
@@ -180,7 +178,6 @@ impl Neg for FieldElement {
     }
 }
 
-#[cfg(feature = "zeroize")]
 impl MapToCurve for Ed448 {
     type CurvePoint = EdwardsPoint;
     type FieldElement = FieldElement;

--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -51,12 +51,10 @@ pub const MODULUS_LIMBS: [u32; 14] = [
     0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0x3fffffff,
 ];
 
-#[cfg(feature = "zeroize")]
 elliptic_curve::scalar_from_impls!(Ed448, Scalar);
 
 // TODO(tarcieri): RustCrypto/elliptic-curves#1229
-//#[cfg(feature = "zeroize")]
-//scalar_from_impls!(Decaf448, Scalar);
+// scalar_from_impls!(Decaf448, Scalar);
 
 impl Display for Scalar {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
@@ -410,8 +408,7 @@ impl<'de> serdect::serde::Deserialize<'de> for Scalar {
     }
 }
 
-#[cfg(feature = "zeroize")]
-impl zeroize::DefaultIsZeroes for Scalar {}
+impl elliptic_curve::zeroize::DefaultIsZeroes for Scalar {}
 
 impl core::fmt::LowerHex for Scalar {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
@@ -600,7 +597,7 @@ impl ShrAssign<usize> for Scalar {
     }
 }
 
-#[cfg(all(feature = "bits", feature = "zeroize"))]
+#[cfg(feature = "bits")]
 impl From<&Scalar> for Ed448ScalarBits {
     fn from(scalar: &Scalar) -> Self {
         scalar.0.to_words().into()

--- a/ed448-goldilocks/src/lib.rs
+++ b/ed448-goldilocks/src/lib.rs
@@ -105,7 +105,6 @@ impl FieldBytesEncoding<Ed448> for U448 {
     }
 }
 
-#[cfg(feature = "zeroize")]
 impl elliptic_curve::CurveArithmetic for Ed448 {
     type AffinePoint = AffinePoint;
     type ProjectivePoint = EdwardsPoint;
@@ -152,8 +151,7 @@ impl FieldBytesEncoding<Decaf448> for U448 {
 }
 
 // TODO(tarcieri): RustCrypto/elliptic-curves#1229
-// #[cfg(feature = "zeroize")]
-// impl elliptic_curve::CurveArithmetic for Decaf448 {
+// // impl elliptic_curve::CurveArithmetic for Decaf448 {
 //     type AffinePoint = DecafAffinePoint;
 //     type ProjectivePoint = DecafPoint;
 //     type Scalar = Scalar;

--- a/ed448-goldilocks/src/sign/expanded.rs
+++ b/ed448-goldilocks/src/sign/expanded.rs
@@ -1,14 +1,13 @@
-use crate::sign::{HASH_HEAD, InnerSignature};
 use crate::{
     EdwardsPoint, SECRET_KEY_LENGTH, Scalar, ScalarBytes, SecretKey, SigningError, VerifyingKey,
     WideScalarBytes,
+    sign::{HASH_HEAD, InnerSignature},
 };
-use sha3::digest::ExtendableOutputReset;
+use elliptic_curve::zeroize::{Zeroize, ZeroizeOnDrop};
 use sha3::{
     Shake256,
-    digest::{ExtendableOutput, Update, XofReader},
+    digest::{ExtendableOutput, ExtendableOutputReset, Update, XofReader},
 };
-use zeroize::{Zeroize, ZeroizeOnDrop};
 
 #[derive(Clone)]
 pub struct ExpandedSecretKey {

--- a/ed448-goldilocks/src/sign/signing_key.rs
+++ b/ed448-goldilocks/src/sign/signing_key.rs
@@ -3,17 +3,18 @@
 
 use crate::sign::expanded::ExpandedSecretKey;
 use crate::*;
-#[cfg(feature = "pkcs8")]
-use crate::{PUBLIC_KEY_LENGTH, curve::edwards::extended::PointBytes};
 use core::fmt::{self, Debug, Formatter};
 use crypto_signature::Error;
+use elliptic_curve::zeroize::{Zeroize, ZeroizeOnDrop};
 use rand_core::CryptoRng;
 use sha3::digest::{
     Digest, ExtendableOutput, FixedOutput, FixedOutputReset, HashMarker, Update, XofReader,
     consts::U64, crypto_common::BlockSizeUser, typenum::IsEqual,
 };
 use subtle::{Choice, ConstantTimeEq};
-use zeroize::{Zeroize, ZeroizeOnDrop};
+
+#[cfg(feature = "pkcs8")]
+use crate::{PUBLIC_KEY_LENGTH, curve::edwards::extended::PointBytes};
 
 /// Ed448 secret key as defined in [RFC8032 § 5.2.5]
 ///


### PR DESCRIPTION
The `zeroize` crate is a hard dependency of `elliptic-curve` (which uses its traits in bounds), which is in turn a hard dependency of `ed448-goldilocks`.

As such, a `zeroize` feature does not accomplish much, since `zeroize` is still a transitive dependency.

This commit removes the `zeroize` feature and explicit `zeroize` dependency and sources it instead as `elliptic_curve::zeroize`.