### PR TITLE
primeorder v0.14.0-pre.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-pre.5"
+version = "0.14.0-pre.6"
 dependencies = [
  "blobby",
  "cfg-if",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-pre.5"
+version = "0.14.0-pre.6"
 dependencies = [
  "blobby",
  "criterion",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-pre.5"
+version = "0.14.0-pre.6"
 dependencies = [
  "blobby",
  "criterion",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-pre.5"
+version = "0.14.0-pre.6"
 dependencies = [
  "base16ct",
  "blobby",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-pre.4"
+version = "0.14.0-pre.5"
 dependencies = [
  "elliptic-curve",
  "serdect",

--- a/bign256/Cargo.toml
+++ b/bign256/Cargo.toml
@@ -31,14 +31,14 @@ rand_core = "0.9"
 rfc6979 = { version = "0.5.0-rc.0", optional = true }
 pkcs8 = { version = "0.11.0-rc.3", optional = true }
 primefield = { version = "=0.14.0-pre.2", optional = true }
-primeorder = { version = "=0.14.0-pre.4", optional = true }
+primeorder = { version = "=0.14.0-pre.5", optional = true }
 sec1 = { version = "0.8.0-rc.1", optional = true }
 signature = { version = "3.0.0-pre.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.6"
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.4", features = ["dev"] }
+primeorder = { version = "=0.14.0-pre.5", features = ["dev"] }
 proptest = "1"
 rand_core = { version = "0.9", features = ["os_rng"] }
 hex = { version = "0.4" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -19,7 +19,7 @@ elliptic-curve = { version = "0.14.0-rc.6", default-features = false, features =
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.1", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "=0.14.0-pre.2", optional = true }
-primeorder = { version = "=0.14.0-pre.4", optional = true }
+primeorder = { version = "=0.14.0-pre.5", optional = true }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
 [features]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -19,7 +19,7 @@ elliptic-curve = { version = "0.14.0-rc.6", default-features = false, features =
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.1", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "=0.14.0-pre.2", optional = true }
-primeorder = { version = "=0.14.0-pre.4", optional = true }
+primeorder = { version = "=0.14.0-pre.5", optional = true }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
 [features]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.14.0-pre.5"
+version = "0.14.0-pre.6"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification/public-key recovery, Taproot Schnorr signatures (BIP340),

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -24,13 +24,13 @@ sec1 = { version = "0.8.0-rc.1", default-features = false }
 ecdsa-core = { version = "0.17.0-rc.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.2", optional = true }
-primeorder = { version = "=0.14.0-pre.4", optional = true }
+primeorder = { version = "=0.14.0-pre.5", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false }
 
 [dev-dependencies]
 ecdsa-core = { version = "0.17.0-rc.1", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.4", features = ["dev"] }
+primeorder = { version = "=0.14.0-pre.5", features = ["dev"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -23,7 +23,7 @@ elliptic-curve = { version = "0.14.0-rc.6", default-features = false, features =
 ecdsa-core = { version = "0.17.0-rc.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.2", optional = true }
-primeorder = { version = "=0.14.0-pre.4", optional = true }
+primeorder = { version = "=0.14.0-pre.5", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
@@ -31,7 +31,7 @@ sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 blobby = "0.3"
 ecdsa-core = { version = "0.17.0-rc.1", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.4", features = ["dev"] }
+primeorder = { version = "=0.14.0-pre.5", features = ["dev"] }
 rand_core = { version = "0.9", features = ["os_rng"] }
 
 [features]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256"
-version = "0.14.0-pre.5"
+version = "0.14.0-pre.6"
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve as defined in SP 800-186, with support for ECDH, ECDSA
@@ -24,7 +24,7 @@ elliptic-curve = { version = "0.14.0-rc.6", default-features = false, features =
 ecdsa-core = { version = "0.17.0-rc.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.2", optional = true }
-primeorder = { version = "=0.14.0-pre.4", optional = true }
+primeorder = { version = "=0.14.0-pre.5", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
@@ -34,7 +34,7 @@ criterion = "0.6"
 ecdsa-core = { version = "0.17.0-rc.1", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primefield = { version = "=0.14.0-pre.2" }
-primeorder = { version = "=0.14.0-pre.4", features = ["dev"] }
+primeorder = { version = "=0.14.0-pre.5", features = ["dev"] }
 proptest = "1"
 rand_core = { version = "0.9", features = ["os_rng"] }
 

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p384"
-version = "0.14.0-pre.5"
+version = "0.14.0-pre.6"
 description = """
 Pure Rust implementation of the NIST P-384 (a.k.a. secp384r1) elliptic curve
 as defined in SP 800-186 with support for ECDH, ECDSA signing/verification,
@@ -24,7 +24,7 @@ elliptic-curve = { version = "0.14.0-rc.6", default-features = false, features =
 ecdsa-core = { version = "0.17.0-rc.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.2", optional = true }
-primeorder = { version = "=0.14.0-pre.4", optional = true }
+primeorder = { version = "=0.14.0-pre.5", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
@@ -33,7 +33,7 @@ blobby = "0.3"
 criterion = "0.6"
 ecdsa-core = { version = "0.17.0-rc.1", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.4", features = ["dev"] }
+primeorder = { version = "=0.14.0-pre.5", features = ["dev"] }
 proptest = "1.7"
 rand_core = { version = "0.9", features = ["os_rng"] }
 

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p521"
-version = "0.14.0-pre.5"
+version = "0.14.0-pre.6"
 description = """
 Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve
 as defined in SP 800-186
@@ -24,7 +24,7 @@ elliptic-curve = { version = "0.14.0-rc.6", default-features = false, features =
 ecdsa-core = { version = "0.17.0-rc.1", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.2", optional = true }
-primeorder = { version = "=0.14.0-pre.4", optional = true }
+primeorder = { version = "=0.14.0-pre.5", optional = true }
 rand_core = { version = "0.9", optional = true, default-features = false }
 serdect = { version = "0.3", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
@@ -34,7 +34,7 @@ blobby = "0.3"
 criterion = "0.6"
 ecdsa-core = { version = "0.17.0-rc.1", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.4", features = ["dev"] }
+primeorder = { version = "=0.14.0-pre.5", features = ["dev"] }
 proptest = "1.7"
 rand_core = { version = "0.9", features = ["os_rng"] }
 

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.14.0-pre.4"
+version = "0.14.0-pre.5"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -23,7 +23,7 @@ rand_core = { version = "0.9", default-features = false }
 
 # optional dependencies
 primefield = { version = "=0.14.0-pre.2", optional = true }
-primeorder = { version = "=0.14.0-pre.4", optional = true }
+primeorder = { version = "=0.14.0-pre.5", optional = true }
 rfc6979 = { version = "0.5.0-rc.0", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false }
 signature = { version = "3.0.0-rc.1", optional = true, features = ["rand_core"] }


### PR DESCRIPTION
Also cuts prereleases of `k256`, `p256`, `p384`, and `p521`