### PR TITLE
primeorder: fix Bernstein-Yang inversion iteration count

### DIFF
--- a/primefield/src/fiat.rs
+++ b/primefield/src/fiat.rs
@@ -128,15 +128,10 @@ macro_rules! fiat_field_arithmetic {
             ///
             /// Does not check that self is non-zero.
             const fn invert_unchecked(&self) -> Self {
-                const BITS: usize = {
-                    let mut f = [0; <$uint>::LIMBS + 1];
-                    $msat(&mut f);
-                    $crate::bigint::Uint::from_words(f).bits_vartime() as usize
-                };
                 let words = $crate::fiat_bernstein_yang_invert!(
                     &$mont_type(self.0.to_words()),
                     &$mont_type(Self::ONE.0.to_words()),
-                    BITS,
+                    <$fe as $crate::ff::PrimeField>::NUM_BITS as usize,
                     <$uint>::LIMBS,
                     $crate::bigint::Word,
                     $non_mont_type,

--- a/primefield/src/fiat.rs
+++ b/primefield/src/fiat.rs
@@ -128,10 +128,15 @@ macro_rules! fiat_field_arithmetic {
             ///
             /// Does not check that self is non-zero.
             const fn invert_unchecked(&self) -> Self {
+                const BITS: usize = {
+                    let mut f = [0; <$uint>::LIMBS + 1];
+                    $msat(&mut f);
+                    $crate::bigint::Uint::from_words(f).bits_vartime() as usize
+                };
                 let words = $crate::fiat_bernstein_yang_invert!(
                     &$mont_type(self.0.to_words()),
                     &$mont_type(Self::ONE.0.to_words()),
-                    size_of::<$bytes>() * 8,
+                    BITS,
                     <$uint>::LIMBS,
                     $crate::bigint::Word,
                     $non_mont_type,


### PR DESCRIPTION
The `d` value used to calculate the iteration count is meant to be the max of the bit size of the modulus and the number being inverted, which would just be the size of the modulus in this case. For a modulus of 254 bits in a 256-bit representation this was setting `d` to 256, which produced the wrong result.