### PR TITLE
ed448-goldilocks: impl `GroupDigest` for `Ed448` and `Decaf448`

### DIFF
--- a/ed448-goldilocks/README.md
+++ b/ed448-goldilocks/README.md
@@ -17,9 +17,9 @@ It is intended to be portable, fast, and safe.
 ## Usage
 
 ```rust
-use ed448_goldilocks::{EdwardsPoint, CompressedEdwardsY, EdwardsScalar, sha3::Shake256};
+use ed448_goldilocks::{Ed448, EdwardsPoint, CompressedEdwardsY, EdwardsScalar, sha3::Shake256};
 use elliptic_curve::Field;
-use hash2curve::ExpandMsgXof;
+use hash2curve::{ExpandMsgXof, GroupDigest};
 use rand_core::OsRng;
 
 let secret_key = EdwardsScalar::TWO;
@@ -33,12 +33,12 @@ let compressed_public_key = public_key.compress();
 
 assert_eq!(compressed_public_key.to_bytes().len(), 57);
 
-let hashed_scalar = EdwardsScalar::hash::<ExpandMsgXof<Shake256>>(b"test", b"edwards448_XOF:SHAKE256_ELL2_RO_");
+let hashed_scalar = Ed448::hash_to_scalar::<ExpandMsgXof<Shake256>>(&[b"test"], &[b"edwards448_XOF:SHAKE256_ELL2_RO_"]).unwrap();
 let input = hex_literal::hex!("c8c6c8f584e0c25efdb6af5ad234583c56dedd7c33e0c893468e96740fa0cf7f1a560667da40b7bde340a39252e89262fcf707d1180fd43400");
 let expected_scalar = EdwardsScalar::from_canonical_bytes(&input.into()).unwrap();
 assert_eq!(hashed_scalar, expected_scalar);
 
-let hashed_point = EdwardsPoint::hash::<ExpandMsgXof<Shake256>>(b"test", b"edwards448_XOF:SHAKE256_ELL2_RO_");
+let hashed_point = Ed448::hash_from_bytes::<ExpandMsgXof<Shake256>>(&[b"test"], &[b"edwards448_XOF:SHAKE256_ELL2_RO_"]).unwrap();
 let expected = hex_literal::hex!("d15c4427b5c5611a53593c2be611fd3635b90272d331c7e6721ad3735e95dd8b9821f8e4e27501ce01aa3c913114052dce2e91e8ca050f4980");
 let expected_point = CompressedEdwardsY(expected).decompress().unwrap();
 assert_eq!(hashed_point, expected_point);

--- a/ed448-goldilocks/src/curve/scalar.rs
+++ b/ed448-goldilocks/src/curve/scalar.rs
@@ -104,6 +104,7 @@ impl FromOkm for EdwardsScalar {
 mod test {
     use super::*;
     use elliptic_curve::array::Array;
+    use hash2curve::GroupDigest;
     use hex_literal::hex;
 
     #[test]
@@ -312,7 +313,8 @@ mod test {
     fn scalar_hash() {
         let msg = b"hello world";
         let dst = b"edwards448_XOF:SHAKE256_ELL2_RO_";
-        let res = EdwardsScalar::hash::<hash2curve::ExpandMsgXof<sha3::Shake256>>(msg, dst);
+        let res = Ed448::hash_to_scalar::<hash2curve::ExpandMsgXof<sha3::Shake256>>(&[msg], &[dst])
+            .unwrap();
         let expected: [u8; 57] = hex_literal::hex!(
             "2d32a08f09b88275cc5f437e625696b18de718ed94559e17e4d64aafd143a8527705132178b5ce7395ea6214735387398a35913656b4951300"
         );

--- a/ed448-goldilocks/src/decaf/scalar.rs
+++ b/ed448-goldilocks/src/decaf/scalar.rs
@@ -87,6 +87,7 @@ mod test {
     use super::*;
     use elliptic_curve::PrimeField;
     use elliptic_curve::array::Array;
+    use hash2curve::GroupDigest;
     use hex_literal::hex;
 
     #[test]
@@ -283,7 +284,9 @@ mod test {
     fn scalar_hash() {
         let msg = b"hello world";
         let dst = b"decaf448_XOF:SHAKE256_D448MAP_RO_";
-        let res = DecafScalar::hash::<hash2curve::ExpandMsgXof<sha3::Shake256>>(msg, dst);
+        let res =
+            Decaf448::hash_to_scalar::<hash2curve::ExpandMsgXof<sha3::Shake256>>(&[msg], &[dst])
+                .unwrap();
         let expected: [u8; 56] = hex_literal::hex!(
             "55e7b59aa035db959409c6b69b817a18c8133d9ad06687665f5720672924da0a84eab7fee415ef13e7aaebdd227291ee8e156f32c507ad2e"
         );

--- a/ed448-goldilocks/src/decaf/scalar.rs
+++ b/ed448-goldilocks/src/decaf/scalar.rs
@@ -87,8 +87,9 @@ mod test {
     use super::*;
     use elliptic_curve::PrimeField;
     use elliptic_curve::array::Array;
-    use hash2curve::GroupDigest;
+    use hash2curve::{ExpandMsgXof, GroupDigest};
     use hex_literal::hex;
+    use sha3::Shake256;
 
     #[test]
     fn test_basic_add() {
@@ -284,12 +285,63 @@ mod test {
     fn scalar_hash() {
         let msg = b"hello world";
         let dst = b"decaf448_XOF:SHAKE256_D448MAP_RO_";
-        let res =
-            Decaf448::hash_to_scalar::<hash2curve::ExpandMsgXof<sha3::Shake256>>(&[msg], &[dst])
-                .unwrap();
+        let res = Decaf448::hash_to_scalar::<ExpandMsgXof<Shake256>>(&[msg], &[dst]).unwrap();
         let expected: [u8; 56] = hex_literal::hex!(
             "55e7b59aa035db959409c6b69b817a18c8133d9ad06687665f5720672924da0a84eab7fee415ef13e7aaebdd227291ee8e156f32c507ad2e"
         );
         assert_eq!(res.to_repr(), Array::from(expected));
+    }
+
+    /// Taken from <https://www.rfc-editor.org/rfc/rfc9497.html#name-decaf448-shake256>.
+    #[test]
+    fn hash_to_scalar_voprf() {
+        struct TestVector {
+            dst: &'static [u8],
+            sk_sm: &'static [u8],
+        }
+
+        const KEY_INFO: &[u8] = b"test key";
+        const SEED: &[u8] =
+            &hex!("a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3");
+
+        const TEST_VECTORS: &[TestVector] = &[
+            TestVector {
+                dst: b"DeriveKeyPairOPRFV1-\x00-decaf448-SHAKE256",
+                sk_sm: &hex!(
+                    "e8b1375371fd11ebeb224f832dcc16d371b4188951c438f751425699ed29ecc80c6c13e558ccd67634fd82eac94aa8d1f0d7fee990695d1e"
+                ),
+            },
+            TestVector {
+                dst: b"DeriveKeyPairOPRFV1-\x01-decaf448-SHAKE256",
+                sk_sm: &hex!(
+                    "e3c01519a076a326a0eb566343e9b21c115fa18e6e85577ddbe890b33104fcc2835ddfb14a928dc3f5d79b936e17c76b99e0bf6a1680930e"
+                ),
+            },
+            TestVector {
+                dst: b"DeriveKeyPairOPRFV1-\x02-decaf448-SHAKE256",
+                sk_sm: &hex!(
+                    "792a10dcbd3ba4a52a054f6f39186623208695301e7adb9634b74709ab22de402990eb143fd7c67ac66be75e0609705ecea800992aac8e19"
+                ),
+            },
+        ];
+
+        let key_info_len = u16::try_from(KEY_INFO.len()).unwrap().to_be_bytes();
+
+        'outer: for test_vector in TEST_VECTORS {
+            for counter in 0_u8..=u8::MAX {
+                let scalar = Decaf448::hash_to_scalar::<ExpandMsgXof<Shake256>>(
+                    &[SEED, &key_info_len, KEY_INFO, &counter.to_be_bytes()],
+                    &[test_vector.dst],
+                )
+                .unwrap();
+
+                if !bool::from(scalar.is_zero()) {
+                    assert_eq!(scalar.to_bytes().as_slice(), test_vector.sk_sm);
+                    continue 'outer;
+                }
+            }
+
+            panic!("deriving key failed");
+        }
     }
 }

--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -10,7 +10,7 @@ use elliptic_curve::{
     array::Array,
     bigint::{
         NonZero, U448, U704,
-        consts::{U84, U88},
+        consts::{U56, U84, U88},
     },
     group::cofactor::CofactorGroup,
     zeroize::DefaultIsZeroes,
@@ -64,7 +64,7 @@ impl PartialEq for FieldElement {
 }
 impl Eq for FieldElement {}
 
-impl FromOkm for FieldElement {
+impl FromOkm for Ed448FieldElement {
     type Length = U84;
 
     fn from_okm(data: &Array<u8, Self::Length>) -> Self {
@@ -79,7 +79,17 @@ impl FromOkm for FieldElement {
 
         let bytes =
             <[u8; 56]>::try_from(&num.to_le_bytes()[..56]).expect("slice is the wrong length");
-        FieldElement(ConstMontyType::new(&U448::from_le_slice(&bytes)))
+        Self(FieldElement(ConstMontyType::new(&U448::from_le_slice(
+            &bytes,
+        ))))
+    }
+}
+
+impl FromOkm for Decaf448FieldElement {
+    type Length = U56;
+
+    fn from_okm(data: &Array<u8, Self::Length>) -> Self {
+        Self(FieldElement::from_bytes(&data.0))
     }
 }
 
@@ -179,12 +189,15 @@ impl Neg for FieldElement {
     }
 }
 
+#[derive(Clone, Copy, Default, Debug)]
+pub struct Ed448FieldElement(FieldElement);
+
 impl MapToCurve for Ed448 {
     type CurvePoint = EdwardsPoint;
-    type FieldElement = FieldElement;
+    type FieldElement = Ed448FieldElement;
 
-    fn map_to_curve(element: FieldElement) -> Self::CurvePoint {
-        element.map_to_curve_elligator2().isogeny().to_edwards()
+    fn map_to_curve(element: Ed448FieldElement) -> Self::CurvePoint {
+        element.0.map_to_curve_elligator2().isogeny().to_edwards()
     }
 
     fn map_to_subgroup(point: EdwardsPoint) -> EdwardsPoint {
@@ -196,12 +209,15 @@ impl MapToCurve for Ed448 {
     }
 }
 
+#[derive(Clone, Copy, Default, Debug)]
+pub struct Decaf448FieldElement(FieldElement);
+
 impl MapToCurve for Decaf448 {
     type CurvePoint = DecafPoint;
-    type FieldElement = FieldElement;
+    type FieldElement = Decaf448FieldElement;
 
-    fn map_to_curve(element: FieldElement) -> DecafPoint {
-        DecafPoint(element.map_to_curve_decaf448())
+    fn map_to_curve(element: Decaf448FieldElement) -> DecafPoint {
+        DecafPoint(element.0.map_to_curve_decaf448())
     }
 
     fn map_to_subgroup(point: DecafPoint) -> DecafPoint {
@@ -453,14 +469,16 @@ mod tests {
             .unwrap();
             let mut data = Array::<u8, U84>::default();
             expander.fill_bytes(&mut data);
-            let u0 = FieldElement::from_okm(&data);
+            // TODO: This should be `Curve448FieldElement`.
+            let u0 = Ed448FieldElement::from_okm(&data).0;
             let mut e_u0 = *expected_u0;
             e_u0.reverse();
             let mut e_u1 = *expected_u1;
             e_u1.reverse();
             assert_eq!(u0.to_bytes(), e_u0);
             expander.fill_bytes(&mut data);
-            let u1 = FieldElement::from_okm(&data);
+            // TODO: This should be `Curve448FieldElement`.
+            let u1 = Ed448FieldElement::from_okm(&data).0;
             assert_eq!(u1.to_bytes(), e_u1);
         }
     }
@@ -485,14 +503,14 @@ mod tests {
             .unwrap();
             let mut data = Array::<u8, U84>::default();
             expander.fill_bytes(&mut data);
-            let u0 = FieldElement::from_okm(&data);
+            let u0 = Ed448FieldElement::from_okm(&data).0;
             let mut e_u0 = *expected_u0;
             e_u0.reverse();
             let mut e_u1 = *expected_u1;
             e_u1.reverse();
             assert_eq!(u0.to_bytes(), e_u0);
             expander.fill_bytes(&mut data);
-            let u1 = FieldElement::from_okm(&data);
+            let u1 = Ed448FieldElement::from_okm(&data).0;
             assert_eq!(u1.to_bytes(), e_u1);
         }
     }

--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -3,7 +3,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use super::ConstMontyType;
 use crate::{
-    AffinePoint, Ed448, EdwardsPoint,
+    AffinePoint, Decaf448, DecafPoint, Ed448, EdwardsPoint,
     curve::twedwards::extended::ExtendedPoint as TwistedExtendedPoint,
 };
 use elliptic_curve::{
@@ -12,6 +12,7 @@ use elliptic_curve::{
         NonZero, U448, U704,
         consts::{U84, U88},
     },
+    group::cofactor::CofactorGroup,
     zeroize::DefaultIsZeroes,
 };
 use hash2curve::{FromOkm, MapToCurve};
@@ -183,10 +184,27 @@ impl MapToCurve for Ed448 {
     type FieldElement = FieldElement;
 
     fn map_to_curve(element: FieldElement) -> Self::CurvePoint {
-        element.map_to_curve_elligator2().to_edwards()
+        element.map_to_curve_elligator2().isogeny().to_edwards()
     }
 
     fn map_to_subgroup(point: EdwardsPoint) -> EdwardsPoint {
+        point.clear_cofactor()
+    }
+
+    fn add_and_map_to_subgroup(lhs: EdwardsPoint, rhs: EdwardsPoint) -> EdwardsPoint {
+        (lhs + rhs).clear_cofactor()
+    }
+}
+
+impl MapToCurve for Decaf448 {
+    type CurvePoint = DecafPoint;
+    type FieldElement = FieldElement;
+
+    fn map_to_curve(element: FieldElement) -> DecafPoint {
+        DecafPoint(element.map_to_curve_decaf448())
+    }
+
+    fn map_to_subgroup(point: DecafPoint) -> DecafPoint {
         point
     }
 }

--- a/ed448-goldilocks/src/lib.rs
+++ b/ed448-goldilocks/src/lib.rs
@@ -65,10 +65,11 @@ pub use sign::*;
 
 use elliptic_curve::{
     Curve, FieldBytesEncoding, PrimeCurve,
-    array::typenum::{U56, U57},
+    array::typenum::{U28, U56, U57},
     bigint::{ArrayEncoding, U448},
     point::PointCompression,
 };
+use hash2curve::GroupDigest;
 
 /// Edwards448 curve.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -115,6 +116,10 @@ impl elliptic_curve::CurveArithmetic for Ed448 {
     type Scalar = EdwardsScalar;
 }
 
+impl GroupDigest for Ed448 {
+    type K = U28;
+}
+
 /// Decaf448 curve.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Decaf448;
@@ -158,4 +163,8 @@ impl elliptic_curve::CurveArithmetic for Decaf448 {
     type AffinePoint = DecafAffinePoint;
     type ProjectivePoint = DecafPoint;
     type Scalar = DecafScalar;
+}
+
+impl GroupDigest for Decaf448 {
+    type K = U28;
 }


### PR DESCRIPTION
This implements `GroupDigest` for `Ed448` and `Decaf448` and removes the already existing standalone functions. Test vectors from the hash2curve specification were already in place.

I also added test vectors for `hash_to_scalar` from OPRF, like we already have in place for P-256, P-384 and P-521.