### PR TITLE
hash2curve: use `crypto_common::KeyInit` instead of `FromOkm`

### DIFF
--- a/ed448-goldilocks/src/curve/scalar.rs
+++ b/ed448-goldilocks/src/curve/scalar.rs
@@ -5,7 +5,7 @@ use elliptic_curve::array::Array;
 use elliptic_curve::bigint::{Limb, NonZero, U448, U704};
 use elliptic_curve::consts::{U57, U84, U88};
 use elliptic_curve::scalar::FromUintUnchecked;
-use hash2curve::FromOkm;
+use hash2curve::{KeyInit, KeySizeUser};
 use subtle::{Choice, CtOption};
 
 impl CurveWithScalar for Ed448 {
@@ -82,10 +82,12 @@ impl From<&EdwardsScalar> for elliptic_curve::scalar::ScalarBits<Ed448> {
     }
 }
 
-impl FromOkm for EdwardsScalar {
-    type Length = U84;
+impl KeySizeUser for EdwardsScalar {
+    type KeySize = U84;
+}
 
-    fn from_okm(data: &Array<u8, Self::Length>) -> Self {
+impl KeyInit for EdwardsScalar {
+    fn new(data: &Array<u8, Self::KeySize>) -> Self {
         const SEMI_WIDE_MODULUS: NonZero<U704> = NonZero::<U704>::new_unwrap(U704::from_be_hex(
             "00000000000000000000000000000000000000000000000000000000000000003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f3",
         ));

--- a/ed448-goldilocks/src/decaf/scalar.rs
+++ b/ed448-goldilocks/src/decaf/scalar.rs
@@ -5,7 +5,7 @@ use elliptic_curve::array::Array;
 use elliptic_curve::bigint::{Limb, NonZero, U448, U512};
 use elliptic_curve::consts::{U56, U64};
 use elliptic_curve::scalar::FromUintUnchecked;
-use hash2curve::FromOkm;
+use hash2curve::{KeyInit, KeySizeUser};
 use subtle::{Choice, CtOption};
 
 impl CurveWithScalar for Decaf448 {
@@ -66,10 +66,12 @@ impl From<&DecafScalar> for elliptic_curve::scalar::ScalarBits<Decaf448> {
     }
 }
 
-impl FromOkm for DecafScalar {
-    type Length = U64;
+impl KeySizeUser for DecafScalar {
+    type KeySize = U64;
+}
 
-    fn from_okm(data: &Array<u8, Self::Length>) -> Self {
+impl KeyInit for DecafScalar {
+    fn new(data: &Array<u8, Self::KeySize>) -> Self {
         const SEMI_WIDE_MODULUS: NonZero<U512> = NonZero::<U512>::new_unwrap(U512::from_be_hex(
             "00000000000000003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f3",
         ));

--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -15,7 +15,7 @@ use elliptic_curve::{
     group::cofactor::CofactorGroup,
     zeroize::DefaultIsZeroes,
 };
-use hash2curve::{FromOkm, MapToCurve};
+use hash2curve::{KeyInit, KeySizeUser, MapToCurve};
 use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq};
 
 #[derive(Clone, Copy, Default)]
@@ -64,10 +64,12 @@ impl PartialEq for FieldElement {
 }
 impl Eq for FieldElement {}
 
-impl FromOkm for Ed448FieldElement {
-    type Length = U84;
+impl KeySizeUser for Ed448FieldElement {
+    type KeySize = U84;
+}
 
-    fn from_okm(data: &Array<u8, Self::Length>) -> Self {
+impl KeyInit for Ed448FieldElement {
+    fn new(data: &Array<u8, Self::KeySize>) -> Self {
         const SEMI_WIDE_MODULUS: NonZero<U704> = NonZero::<U704>::new_unwrap(U704::from_be_hex(
             "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         ));
@@ -85,10 +87,12 @@ impl FromOkm for Ed448FieldElement {
     }
 }
 
-impl FromOkm for Decaf448FieldElement {
-    type Length = U56;
+impl KeySizeUser for Decaf448FieldElement {
+    type KeySize = U56;
+}
 
-    fn from_okm(data: &Array<u8, Self::Length>) -> Self {
+impl KeyInit for Decaf448FieldElement {
+    fn new(data: &Array<u8, Self::KeySize>) -> Self {
         Self(FieldElement::from_bytes(&data.0))
     }
 }
@@ -450,7 +454,7 @@ mod tests {
     use sha3::Shake256;
 
     #[test]
-    fn from_okm_curve448() {
+    fn key_init_curve448() {
         const DST: &[u8] = b"QUUX-V01-CS02-with-curve448_XOF:SHAKE256_ELL2_RO_";
         const MSGS: &[(&[u8], [u8; 56], [u8; 56])] = &[
             (b"", hex!("c704c7b3d3b36614cf3eedd0324fe6fe7d1402c50efd16cff89ff63f50938506280d3843478c08e24f7842f4e3ef45f6e3c4897f9d976148"), hex!("c25427dc97fff7a5ad0a78654e2c6c27b1c1127b5b53c7950cd1fd6edd2703646b25f341e73deedfebf022d1d3cecd02b93b4d585ead3ed7")),
@@ -470,7 +474,7 @@ mod tests {
             let mut data = Array::<u8, U84>::default();
             expander.fill_bytes(&mut data);
             // TODO: This should be `Curve448FieldElement`.
-            let u0 = Ed448FieldElement::from_okm(&data).0;
+            let u0 = Ed448FieldElement::new(&data).0;
             let mut e_u0 = *expected_u0;
             e_u0.reverse();
             let mut e_u1 = *expected_u1;
@@ -478,13 +482,13 @@ mod tests {
             assert_eq!(u0.to_bytes(), e_u0);
             expander.fill_bytes(&mut data);
             // TODO: This should be `Curve448FieldElement`.
-            let u1 = Ed448FieldElement::from_okm(&data).0;
+            let u1 = Ed448FieldElement::new(&data).0;
             assert_eq!(u1.to_bytes(), e_u1);
         }
     }
 
     #[test]
-    fn from_okm_edwards448() {
+    fn key_init_edwards448() {
         const DST: &[u8] = b"QUUX-V01-CS02-with-edwards448_XOF:SHAKE256_ELL2_RO_";
         const MSGS: &[(&[u8], [u8; 56], [u8; 56])] = &[
             (b"", hex!("0847c5ebf957d3370b1f98fde499fb3e659996d9fc9b5707176ade785ba72cd84b8a5597c12b1024be5f510fa5ba99642c4cec7f3f69d3e7"), hex!("f8cbd8a7ae8c8deed071f3ac4b93e7cfcb8f1eac1645d699fd6d3881cb295a5d3006d9449ed7cad412a77a1fe61e84a9e41d59ef384d6f9a")),
@@ -503,14 +507,14 @@ mod tests {
             .unwrap();
             let mut data = Array::<u8, U84>::default();
             expander.fill_bytes(&mut data);
-            let u0 = Ed448FieldElement::from_okm(&data).0;
+            let u0 = Ed448FieldElement::new(&data).0;
             let mut e_u0 = *expected_u0;
             e_u0.reverse();
             let mut e_u1 = *expected_u1;
             e_u1.reverse();
             assert_eq!(u0.to_bytes(), e_u0);
             expander.fill_bytes(&mut data);
-            let u1 = Ed448FieldElement::from_okm(&data).0;
+            let u1 = Ed448FieldElement::new(&data).0;
             assert_eq!(u1.to_bytes(), e_u1);
         }
     }

--- a/hash2curve/CHANGELOG.md
+++ b/hash2curve/CHANGELOG.md
@@ -5,5 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.2.0 (UNRELEASED)
+
 - Initial release
 
+### Changed
+
+- Removed `FromOkm` in favor of the `crypto_common::KeyInit` trait.

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -28,7 +28,7 @@ pub trait GroupDigest: MapToCurve {
     ///   - [`ExpandMsgXmd`]
     ///   - [`ExpandMsgXof`]
     ///
-    /// `len_in_bytes = <Self::FieldElement as FromOkm>::Length * 2`
+    /// `len_in_bytes = <Self::FieldElement as KeySizeUser>::KeySize * 2`
     ///
     /// [`ExpandMsgXmd`]: crate::ExpandMsgXmd
     /// [`ExpandMsgXof`]: crate::ExpandMsgXof
@@ -59,7 +59,7 @@ pub trait GroupDigest: MapToCurve {
     ///   - [`ExpandMsgXmd`]
     ///   - [`ExpandMsgXof`]
     ///
-    /// `len_in_bytes = <Self::FieldElement as FromOkm>::Length`
+    /// `len_in_bytes = <Self::FieldElement as KeySizeUser>::KeySize`
     ///
     /// [`ExpandMsgXmd`]: crate::ExpandMsgXmd
     /// [`ExpandMsgXof`]: crate::ExpandMsgXof
@@ -83,7 +83,7 @@ pub trait GroupDigest: MapToCurve {
     ///   - [`ExpandMsgXmd`]
     ///   - [`ExpandMsgXof`]
     ///
-    /// `len_in_bytes = <Self::Scalar as FromOkm>::Length`
+    /// `len_in_bytes = <Self::Scalar as KeySizeUser>::KeySize`
     ///
     /// [`ExpandMsgXmd`]: crate::ExpandMsgXmd
     /// [`ExpandMsgXof`]: crate::ExpandMsgXof

--- a/hash2curve/src/hash2field.rs
+++ b/hash2curve/src/hash2field.rs
@@ -6,13 +6,10 @@ mod expand_msg;
 
 use core::num::NonZeroU16;
 
-use digest::crypto_common::{KeySizeUser, KeyInit};
+use digest::crypto_common::{KeyInit, KeySizeUser};
 pub use expand_msg::{xmd::*, xof::*, *};
 
-use elliptic_curve::array::{
-    Array,
-    typenum::Unsigned,
-};
+use elliptic_curve::array::{Array, typenum::Unsigned};
 use elliptic_curve::{Error, Result};
 
 /// Convert an arbitrary byte sequence into a field element.

--- a/hash2curve/src/lib.rs
+++ b/hash2curve/src/lib.rs
@@ -35,3 +35,4 @@ pub use isogeny::*;
 pub use map2curve::*;
 pub use oprf::*;
 pub use osswu::*;
+pub use digest::{KeyInit, crypto_common::KeySizeUser};

--- a/hash2curve/src/lib.rs
+++ b/hash2curve/src/lib.rs
@@ -29,10 +29,10 @@ mod map2curve;
 mod oprf;
 mod osswu;
 
+pub use digest::{KeyInit, crypto_common::KeySizeUser};
 pub use group_digest::*;
 pub use hash2field::*;
 pub use isogeny::*;
 pub use map2curve::*;
 pub use oprf::*;
 pub use osswu::*;
-pub use digest::{KeyInit, crypto_common::KeySizeUser};

--- a/hash2curve/src/map2curve.rs
+++ b/hash2curve/src/map2curve.rs
@@ -1,17 +1,16 @@
 //! Traits for mapping field elements to points on the curve.
 
+use digest::crypto_common::KeyInit;
 use elliptic_curve::{CurveArithmetic, ProjectivePoint};
-
-use super::FromOkm;
 
 /// Trait for converting field elements into a point via a mapping method like
 /// Simplified Shallue-van de Woestijne-Ulas or Elligator.
-pub trait MapToCurve: CurveArithmetic<Scalar: FromOkm> {
+pub trait MapToCurve: CurveArithmetic<Scalar: KeyInit> {
     /// The intermediate representation, an element of the curve which may or may not
     /// be in the curve subgroup.
     type CurvePoint;
     /// The field element representation for a group value with multiple elements.
-    type FieldElement: FromOkm + Default + Copy;
+    type FieldElement: KeyInit + Default + Copy;
 
     /// Map a field element into a curve point.
     fn map_to_curve(element: Self::FieldElement) -> Self::CurvePoint;

--- a/k256/src/arithmetic/hash2curve.rs
+++ b/k256/src/arithmetic/hash2curve.rs
@@ -4,7 +4,8 @@ use elliptic_curve::bigint::{ArrayEncoding, U256};
 use elliptic_curve::consts::{U4, U16, U48};
 use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 use hash2curve::{
-    GroupDigest, Isogeny, IsogenyCoefficients, MapToCurve, OsswuMap, OsswuMapParams, Sgn0, KeyInit, KeySizeUser
+    GroupDigest, Isogeny, IsogenyCoefficients, KeyInit, KeySizeUser, MapToCurve, OsswuMap,
+    OsswuMapParams, Sgn0,
 };
 
 use crate::{AffinePoint, ProjectivePoint, Scalar, Secp256k1};
@@ -273,7 +274,7 @@ mod tests {
         bigint::{ArrayEncoding, NonZero, U384},
         consts::U48,
     };
-    use hash2curve::{GroupDigest, MapToCurve, KeyInit};
+    use hash2curve::{GroupDigest, KeyInit, MapToCurve};
     use hex_literal::hex;
     use proptest::{num::u64::ANY, prelude::ProptestConfig, proptest};
 

--- a/p384/src/arithmetic/hash2curve.rs
+++ b/p384/src/arithmetic/hash2curve.rs
@@ -8,7 +8,7 @@ use elliptic_curve::{
     point::DecompressPoint,
     subtle::Choice,
 };
-use hash2curve::{GroupDigest, MapToCurve, OsswuMap, OsswuMapParams, Sgn0, KeyInit, KeySizeUser};
+use hash2curve::{GroupDigest, KeyInit, KeySizeUser, MapToCurve, OsswuMap, OsswuMapParams, Sgn0};
 
 impl GroupDigest for NistP384 {
     type K = U24;
@@ -117,7 +117,7 @@ mod tests {
         ops::Reduce,
         sec1::{self, ToEncodedPoint},
     };
-    use hash2curve::{self, ExpandMsgXmd, GroupDigest, MapToCurve, OsswuMap, KeyInit};
+    use hash2curve::{self, ExpandMsgXmd, GroupDigest, KeyInit, MapToCurve, OsswuMap};
     use hex_literal::hex;
     use proptest::{num::u64::ANY, prelude::ProptestConfig, proptest};
     use sha2::Sha384;

--- a/p521/src/arithmetic/hash2curve.rs
+++ b/p521/src/arithmetic/hash2curve.rs
@@ -120,7 +120,7 @@ mod tests {
         ops::Reduce,
         sec1::{self, ToEncodedPoint},
     };
-    use hash2curve::{self, ExpandMsgXmd, KeyInit, GroupDigest, MapToCurve, OsswuMap};
+    use hash2curve::{self, ExpandMsgXmd, GroupDigest, KeyInit, MapToCurve, OsswuMap};
     use hex_literal::hex;
     use proptest::{num, prelude::ProptestConfig, proptest};
     use sha2::Sha512;


### PR DESCRIPTION
Discussed in https://github.com/RustCrypto/traits/issues/1926. Reduces the API surface by removing a duplicate trait.