### PR TITLE
`hash2curve`: make `hash_to_field` output an array instead of taking an out parameter.

### DIFF
--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -1,6 +1,7 @@
 //! Traits for handling hash to curve.
 
 use super::{ExpandMsg, MapToCurve, hash_to_field};
+use digest::consts::{U1, U2};
 use elliptic_curve::array::typenum::Unsigned;
 use elliptic_curve::{ProjectivePoint, Result};
 
@@ -36,8 +37,7 @@ pub trait GroupDigest: MapToCurve {
     where
         X: ExpandMsg<Self::K>,
     {
-        let mut u = [Self::FieldElement::default(), Self::FieldElement::default()];
-        hash_to_field::<X, _, _>(msg, dst, &mut u)?;
+        let u = hash_to_field::<X, _, Self::FieldElement, U2>(msg, dst)?;
         let q0 = Self::map_to_curve(u[0]);
         let q1 = Self::map_to_curve(u[1]);
         Ok(Self::add_and_map_to_subgroup(q0, q1))
@@ -67,8 +67,7 @@ pub trait GroupDigest: MapToCurve {
     where
         X: ExpandMsg<Self::K>,
     {
-        let mut u = [Self::FieldElement::default()];
-        hash_to_field::<X, _, _>(msg, dst, &mut u)?;
+        let u = hash_to_field::<X, _, Self::FieldElement, U1>(msg, dst)?;
         let q0 = Self::map_to_curve(u[0]);
         Ok(Self::map_to_subgroup(q0))
     }
@@ -91,8 +90,7 @@ pub trait GroupDigest: MapToCurve {
     where
         X: ExpandMsg<Self::K>,
     {
-        let mut u = [Self::Scalar::default()];
-        hash_to_field::<X, _, _>(msg, dst, &mut u)?;
+        let u = hash_to_field::<X, _, Self::Scalar, U1>(msg, dst)?;
         Ok(u[0])
     }
 }

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -1,7 +1,6 @@
 //! Traits for handling hash to curve.
 
 use super::{ExpandMsg, MapToCurve, hash_to_field};
-use digest::consts::{U1, U2};
 use elliptic_curve::array::typenum::Unsigned;
 use elliptic_curve::{ProjectivePoint, Result};
 
@@ -37,9 +36,9 @@ pub trait GroupDigest: MapToCurve {
     where
         X: ExpandMsg<Self::K>,
     {
-        let u = hash_to_field::<X, _, Self::FieldElement, U2>(msg, dst)?;
-        let q0 = Self::map_to_curve(u[0]);
-        let q1 = Self::map_to_curve(u[1]);
+        let [u0, u1] = hash_to_field::<2, X, _, Self::FieldElement>(msg, dst)?;
+        let q0 = Self::map_to_curve(u0);
+        let q1 = Self::map_to_curve(u1);
         Ok(Self::add_and_map_to_subgroup(q0, q1))
     }
 
@@ -67,8 +66,8 @@ pub trait GroupDigest: MapToCurve {
     where
         X: ExpandMsg<Self::K>,
     {
-        let u = hash_to_field::<X, _, Self::FieldElement, U1>(msg, dst)?;
-        let q0 = Self::map_to_curve(u[0]);
+        let [u] = hash_to_field::<1, X, _, Self::FieldElement>(msg, dst)?;
+        let q0 = Self::map_to_curve(u);
         Ok(Self::map_to_subgroup(q0))
     }
 
@@ -90,7 +89,7 @@ pub trait GroupDigest: MapToCurve {
     where
         X: ExpandMsg<Self::K>,
     {
-        let u = hash_to_field::<X, _, Self::Scalar, U1>(msg, dst)?;
-        Ok(u[0])
+        let [u] = hash_to_field::<1, X, _, Self::Scalar>(msg, dst)?;
+        Ok(u)
     }
 }

--- a/hash2curve/src/hash2field.rs
+++ b/hash2curve/src/hash2field.rs
@@ -38,23 +38,20 @@ pub trait FromOkm {
 /// [`ExpandMsgXmd`]: crate::hash2field::ExpandMsgXmd
 /// [`ExpandMsgXof`]: crate::hash2field::ExpandMsgXof
 #[doc(hidden)]
-pub fn hash_to_field<E, K, T, C>(data: &[&[u8]], domain: &[&[u8]]) -> Result<Array<T, C>>
+pub fn hash_to_field<const N: usize, E, K, T>(data: &[&[u8]], domain: &[&[u8]]) -> Result<[T; N]>
 where
     E: ExpandMsg<K>,
     T: FromOkm + Default,
-    C: ArraySize,
 {
     let len_in_bytes = T::Length::USIZE
-        .checked_mul(C::USIZE)
+        .checked_mul(N)
         .and_then(|len| len.try_into().ok())
         .and_then(NonZeroU16::new)
         .ok_or(Error)?;
     let mut tmp = Array::<u8, <T as FromOkm>::Length>::default();
     let mut expander = E::expand_message(data, domain, len_in_bytes)?;
-    let mut out = Array::<T, C>::default();
-    for o in out.iter_mut() {
+    Ok(core::array::from_fn(|_| {
         expander.fill_bytes(&mut tmp);
-        *o = T::from_okm(&tmp);
-    }
-    Ok(out)
+        T::from_okm(&tmp)
+    }))
 }

--- a/k256/src/arithmetic/hash2curve.rs
+++ b/k256/src/arithmetic/hash2curve.rs
@@ -353,12 +353,12 @@ mod tests {
 
         for test_vector in TEST_VECTORS {
             // in parts
-            let mut u = [FieldElement::default(), FieldElement::default()];
-            hash2curve::hash_to_field::<
+            let u = hash2curve::hash_to_field::<
+                2,
                 ExpandMsgXmd<Sha256>,
                 <Secp256k1 as GroupDigest>::K,
                 FieldElement,
-            >(&[test_vector.msg], &[DST], &mut u)
+            >(&[test_vector.msg], &[DST])
             .unwrap();
             assert_eq!(u[0].to_bytes().as_slice(), test_vector.u_0);
             assert_eq!(u[1].to_bytes().as_slice(), test_vector.u_1);

--- a/p256/src/arithmetic/hash2curve.rs
+++ b/p256/src/arithmetic/hash2curve.rs
@@ -204,12 +204,12 @@ mod tests {
 
         for test_vector in TEST_VECTORS {
             // in parts
-            let mut u = [FieldElement::default(), FieldElement::default()];
-            hash2curve::hash_to_field::<
+            let u = hash2curve::hash_to_field::<
+                2,
                 ExpandMsgXmd<Sha256>,
                 <NistP256 as GroupDigest>::K,
                 FieldElement,
-            >(&[test_vector.msg], &[DST], &mut u)
+            >(&[test_vector.msg], &[DST])
             .unwrap();
 
             /// Assert that the provided projective point matches the given test vector.

--- a/p384/src/arithmetic/hash2curve.rs
+++ b/p384/src/arithmetic/hash2curve.rs
@@ -209,12 +209,12 @@ mod tests {
 
         for test_vector in TEST_VECTORS {
             // in parts
-            let mut u = [FieldElement::default(), FieldElement::default()];
-            hash2curve::hash_to_field::<
+            let u = hash2curve::hash_to_field::<
+                2,
                 ExpandMsgXmd<Sha384>,
                 <NistP384 as GroupDigest>::K,
                 FieldElement,
-            >(&[test_vector.msg], &[DST], &mut u)
+            >(&[test_vector.msg], &[DST])
             .unwrap();
 
             /// Assert that the provided projective point matches the given test vector.

--- a/p521/src/arithmetic/hash2curve.rs
+++ b/p521/src/arithmetic/hash2curve.rs
@@ -212,12 +212,12 @@ mod tests {
 
         for test_vector in TEST_VECTORS {
             // in parts
-            let mut u = [FieldElement::default(), FieldElement::default()];
-            hash2curve::hash_to_field::<
+            let u = hash2curve::hash_to_field::<
+                2,
                 ExpandMsgXmd<Sha512>,
                 <NistP521 as GroupDigest>::K,
                 FieldElement,
-            >(&[test_vector.msg], &[DST], &mut u)
+            >(&[test_vector.msg], &[DST])
             .unwrap();
 
             /// Assert that the provided projective point matches the given test vector.


### PR DESCRIPTION
Discussed as part of #1295.