### PR TITLE
Run CI on hash2curve dependents

### DIFF
--- a/.github/workflows/ed448-goldilocks.yml
+++ b/.github/workflows/ed448-goldilocks.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/ed448-goldilocks.yml"
       - "ed448-goldilocks/**"
+      - "hash2curve/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/k256.yml"
       - "k256/**"
+      - "hash2curve/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/p256.yml"
       - "p256/**"
+      - "hash2curve/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/p384.yml"
       - "p384/**"
+      - "hash2curve/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/p521.yml
+++ b/.github/workflows/p521.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/p521.yml"
       - "p521/**"
+      - "hash2curve/**"
       - "Cargo.*"
   push:
     branches: master


### PR DESCRIPTION
When we break things in hash2curve in the future, we should let dependents run CI as well.