### PR TITLE
refactor(projective): remove deprecated methods identity and generator

### DIFF
--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -56,18 +56,7 @@ impl ProjectivePoint {
         z: FieldElement::ONE,
     };
 
-    /// Returns the additive identity of SECP256k1, also known as the "neutral element" or
-    /// "point at infinity".
-    #[deprecated(since = "0.10.2", note = "use `ProjectivePoint::IDENTITY` instead")]
-    pub const fn identity() -> ProjectivePoint {
-        Self::IDENTITY
-    }
 
-    /// Returns the base point of SECP256k1.
-    #[deprecated(since = "0.10.2", note = "use `ProjectivePoint::GENERATOR` instead")]
-    pub fn generator() -> ProjectivePoint {
-        Self::GENERATOR
-    }
 
     /// Returns the affine representation of this point.
     pub fn to_affine(&self) -> AffinePoint {


### PR DESCRIPTION
Removed deprecated methods identity and generator from ProjectivePoint per deprecation note since v0.10.2