### PR TITLE
chore: fixup clippy 1.88 warnings

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.85.0
+        toolchain: 1.88.0
         components: clippy
     - run: cargo clippy --all --all-features -- -D warnings
 

--- a/bign256/src/ecdsa.rs
+++ b/bign256/src/ecdsa.rs
@@ -166,7 +166,7 @@ impl Debug for Signature {
         write!(f, "bignp256::dsa::Signature(")?;
 
         for byte in self.to_bytes() {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{byte:02X}")?;
         }
 
         write!(f, ")")

--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -42,7 +42,7 @@ impl elliptic_curve::zeroize::Zeroize for CompressedEdwardsY {
 impl Display for CompressedEdwardsY {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         for b in &self.0[..] {
-            write!(f, "{:02x}", b)?;
+            write!(f, "{b:02x}")?;
         }
         Ok(())
     }
@@ -51,7 +51,7 @@ impl Display for CompressedEdwardsY {
 impl LowerHex for CompressedEdwardsY {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         for b in &self.0[..] {
-            write!(f, "{:02x}", b)?;
+            write!(f, "{b:02x}")?;
         }
         Ok(())
     }
@@ -60,7 +60,7 @@ impl LowerHex for CompressedEdwardsY {
 impl UpperHex for CompressedEdwardsY {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         for b in &self.0[..] {
-            write!(f, "{:02X}", b)?;
+            write!(f, "{b:02X}")?;
         }
         Ok(())
     }

--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -94,7 +94,7 @@ impl<C: CurveWithScalar> Display for Scalar<C> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         let bytes = self.to_repr();
         for b in &bytes {
-            write!(f, "{:02x}", b)?;
+            write!(f, "{b:02x}")?;
         }
         Ok(())
     }
@@ -454,7 +454,7 @@ impl<C: CurveWithScalar> core::fmt::LowerHex for Scalar<C> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         let tmp = C::to_repr(self);
         for &b in tmp.iter() {
-            write!(f, "{:02x}", b)?;
+            write!(f, "{b:02x}")?;
         }
         Ok(())
     }
@@ -464,7 +464,7 @@ impl<C: CurveWithScalar> core::fmt::UpperHex for Scalar<C> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         let tmp = C::to_repr(self);
         for &b in tmp.iter() {
-            write!(f, "{:02X}", b)?;
+            write!(f, "{b:02X}")?;
         }
         Ok(())
     }

--- a/sm2/src/dsa.rs
+++ b/sm2/src/dsa.rs
@@ -150,7 +150,7 @@ impl Debug for Signature {
         write!(f, "sm2::dsa::Signature(")?;
 
         for byte in self.to_bytes() {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{byte:02X}")?;
         }
 
         write!(f, ")")

--- a/sm2/tests/dsa_extended.rs
+++ b/sm2/tests/dsa_extended.rs
@@ -18,7 +18,7 @@ fn create_test_signing_key() -> SigningKey {
     let test_key = [42u8; 32];
     let scalar = <Scalar as Reduce<U256>>::reduce_bytes(&test_key.into());
     let scalar = NonZeroScalar::new(scalar).unwrap();
-    SigningKey::from_nonzero_scalar(IDENTITY.into(), scalar).unwrap()
+    SigningKey::from_nonzero_scalar(IDENTITY, scalar).unwrap()
 }
 
 #[test]

--- a/sm2/tests/pkcs8.rs
+++ b/sm2/tests/pkcs8.rs
@@ -148,5 +148,5 @@ fn test_x509() {
     let secret_key = PKCS8_PRIVATE_KEY_PEM.parse::<sm2::SecretKey>().unwrap();
     const IDENTITY: &str = "example@rustcrypto.org";
     let signing_key = SigningKey::new(IDENTITY, &secret_key).unwrap();
-    let _signature = dummy_cert_builder::<_, Signature>(&signing_key);
+    dummy_cert_builder::<_, Signature>(&signing_key);
 }


### PR DESCRIPTION
This is just to limit noise for the folks running a local rust version higher than the minimum 1.85 of the crate.