### PR TITLE
Use `elliptic_curve::scalar_impls!` instead of `scalar_from_impls!`

### DIFF
--- a/ed448-goldilocks/src/decaf/affine.rs
+++ b/ed448-goldilocks/src/decaf/affine.rs
@@ -93,36 +93,6 @@ impl From<NonIdentity<AffinePoint>> for AffinePoint {
     }
 }
 
-impl Mul<DecafScalar> for AffinePoint {
-    type Output = DecafPoint;
-
-    #[inline]
-    #[expect(clippy::op_ref, reason = "false-positive")]
-    fn mul(self, scalar: DecafScalar) -> DecafPoint {
-        &self * scalar
-    }
-}
-
-#[allow(clippy::op_ref)] // https://github.com/rust-lang/rust-clippy/issues/12463
-impl Mul<DecafScalar> for &AffinePoint {
-    type Output = DecafPoint;
-
-    #[inline]
-    fn mul(self, scalar: DecafScalar) -> DecafPoint {
-        self * &scalar
-    }
-}
-
-#[allow(clippy::op_ref)] // https://github.com/rust-lang/rust-clippy/issues/12463
-impl Mul<&DecafScalar> for AffinePoint {
-    type Output = DecafPoint;
-
-    #[inline]
-    fn mul(self, scalar: &DecafScalar) -> DecafPoint {
-        &self * scalar
-    }
-}
-
 impl Mul<&DecafScalar> for &AffinePoint {
     type Output = DecafPoint;
 
@@ -132,20 +102,4 @@ impl Mul<&DecafScalar> for &AffinePoint {
     }
 }
 
-impl Mul<AffinePoint> for DecafScalar {
-    type Output = DecafPoint;
-
-    #[inline]
-    fn mul(self, point: AffinePoint) -> DecafPoint {
-        point * self
-    }
-}
-
-impl Mul<&AffinePoint> for DecafScalar {
-    type Output = DecafPoint;
-
-    #[inline]
-    fn mul(self, point: &AffinePoint) -> DecafPoint {
-        point * self
-    }
-}
+define_mul_variants!(LHS = AffinePoint, RHS = DecafScalar, Output = DecafPoint);

--- a/ed448-goldilocks/src/decaf/ops.rs
+++ b/ed448-goldilocks/src/decaf/ops.rs
@@ -20,16 +20,6 @@ impl Mul<&DecafScalar> for &DecafPoint {
 
 define_mul_variants!(LHS = DecafPoint, RHS = DecafScalar, Output = DecafPoint);
 
-impl Mul<&DecafPoint> for &DecafScalar {
-    type Output = DecafPoint;
-
-    fn mul(self, point: &DecafPoint) -> DecafPoint {
-        point * self
-    }
-}
-
-define_mul_variants!(LHS = DecafScalar, RHS = DecafPoint, Output = DecafPoint);
-
 impl<'s> MulAssign<&'s DecafScalar> for DecafPoint {
     fn mul_assign(&mut self, scalar: &'s DecafScalar) {
         *self = *self * scalar;

--- a/ed448-goldilocks/src/decaf/scalar.rs
+++ b/ed448-goldilocks/src/decaf/scalar.rs
@@ -52,7 +52,7 @@ impl DecafScalar {
     }
 }
 
-elliptic_curve::scalar_from_impls!(Decaf448, DecafScalar);
+elliptic_curve::scalar_impls!(Decaf448, DecafScalar);
 
 /// The number of bytes needed to represent the scalar field
 pub type DecafScalarBytes = ScalarBytes<Decaf448>;

--- a/ed448-goldilocks/src/edwards/affine.rs
+++ b/ed448-goldilocks/src/edwards/affine.rs
@@ -135,21 +135,17 @@ impl TryFrom<AffinePoint> for NonIdentity<AffinePoint> {
     }
 }
 
-impl Mul<AffinePoint> for EdwardsScalar {
+impl Mul<&EdwardsScalar> for &AffinePoint {
     type Output = EdwardsPoint;
 
     #[inline]
-    #[expect(clippy::op_ref, reason = "false-positive")]
-    fn mul(self, rhs: AffinePoint) -> EdwardsPoint {
-        self * &rhs
+    fn mul(self, scalar: &EdwardsScalar) -> Self::Output {
+        self.to_edwards() * scalar
     }
 }
 
-impl Mul<&AffinePoint> for EdwardsScalar {
-    type Output = EdwardsPoint;
-
-    #[inline]
-    fn mul(self, rhs: &AffinePoint) -> EdwardsPoint {
-        rhs.to_edwards() * self
-    }
-}
+define_mul_variants!(
+    LHS = AffinePoint,
+    RHS = EdwardsScalar,
+    Output = EdwardsPoint
+);

--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -937,11 +937,6 @@ define_mul_variants!(
     RHS = EdwardsScalar,
     Output = EdwardsPoint
 );
-define_mul_variants!(
-    LHS = EdwardsScalar,
-    RHS = EdwardsPoint,
-    Output = EdwardsPoint
-);
 
 impl Mul<&EdwardsScalar> for &EdwardsPoint {
     type Output = EdwardsPoint;
@@ -949,15 +944,6 @@ impl Mul<&EdwardsScalar> for &EdwardsPoint {
     /// Scalar multiplication: compute `scalar * self`.
     fn mul(self, scalar: &EdwardsScalar) -> EdwardsPoint {
         self.scalar_mul(scalar)
-    }
-}
-
-impl Mul<&EdwardsPoint> for &EdwardsScalar {
-    type Output = EdwardsPoint;
-
-    /// Scalar multiplication: compute `scalar * self`.
-    fn mul(self, point: &EdwardsPoint) -> EdwardsPoint {
-        point * self
     }
 }
 

--- a/ed448-goldilocks/src/edwards/scalar.rs
+++ b/ed448-goldilocks/src/edwards/scalar.rs
@@ -68,7 +68,7 @@ impl EdwardsScalar {
     }
 }
 
-elliptic_curve::scalar_from_impls!(Ed448, EdwardsScalar);
+elliptic_curve::scalar_impls!(Ed448, EdwardsScalar);
 
 /// The number of bytes needed to represent the scalar field
 pub type EdwardsScalarBytes = ScalarBytes<Ed448>;


### PR DESCRIPTION
This gets rid of a bunch of manual implementations in favor of using `elliptic_curve::scalar_impls!` instead of `scalar_from_impls!`.