### PR TITLE
hash2curve `Expander` improvements

### DIFF
--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -464,7 +464,7 @@ mod tests {
             )
             .unwrap();
             let mut data = Array::<u8, U84>::default();
-            expander.fill_bytes(&mut data);
+            expander.fill_bytes(&mut data).unwrap();
             // TODO: This should be `Curve448FieldElement`.
             let u0 = Ed448FieldElement::from_okm(&data).0;
             let mut e_u0 = *expected_u0;
@@ -472,7 +472,7 @@ mod tests {
             let mut e_u1 = *expected_u1;
             e_u1.reverse();
             assert_eq!(u0.to_bytes(), e_u0);
-            expander.fill_bytes(&mut data);
+            expander.fill_bytes(&mut data).unwrap();
             // TODO: This should be `Curve448FieldElement`.
             let u1 = Ed448FieldElement::from_okm(&data).0;
             assert_eq!(u1.to_bytes(), e_u1);
@@ -498,14 +498,14 @@ mod tests {
             )
             .unwrap();
             let mut data = Array::<u8, U84>::default();
-            expander.fill_bytes(&mut data);
+            expander.fill_bytes(&mut data).unwrap();
             let u0 = Ed448FieldElement::from_okm(&data).0;
             let mut e_u0 = *expected_u0;
             e_u0.reverse();
             let mut e_u1 = *expected_u1;
             e_u1.reverse();
             assert_eq!(u0.to_bytes(), e_u0);
-            expander.fill_bytes(&mut data);
+            expander.fill_bytes(&mut data).unwrap();
             let u1 = Ed448FieldElement::from_okm(&data).0;
             assert_eq!(u1.to_bytes(), e_u1);
         }

--- a/hash2curve/src/hash2field.rs
+++ b/hash2curve/src/hash2field.rs
@@ -51,7 +51,9 @@ where
     let mut tmp = Array::<u8, <T as FromOkm>::Length>::default();
     let mut expander = E::expand_message(data, domain, len_in_bytes)?;
     Ok(core::array::from_fn(|_| {
-        expander.fill_bytes(&mut tmp);
+        expander
+            .fill_bytes(&mut tmp)
+            .expect("never exceeds `len_in_bytes`");
         T::from_okm(&tmp)
     }))
 }

--- a/hash2curve/src/hash2field/expand_msg.rs
+++ b/hash2curve/src/hash2field/expand_msg.rs
@@ -39,8 +39,12 @@ pub trait ExpandMsg<K> {
 
 /// Expander that, call `read` until enough bytes have been consumed.
 pub trait Expander {
-    /// Fill the array with the expanded bytes
-    fn fill_bytes(&mut self, okm: &mut [u8]);
+    /// Fill the array with the expanded bytes, returning how many bytes were read.
+    ///
+    /// # Errors
+    ///
+    /// If no bytes are left.
+    fn fill_bytes(&mut self, okm: &mut [u8]) -> Result<usize>;
 }
 
 /// The domain separation tag

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -171,6 +171,31 @@ mod test {
     use hex_literal::hex;
     use sha2::Sha256;
 
+    #[test]
+    fn edge_cases() {
+        fn generate() -> ExpanderXmd<'static, Sha256> {
+            <ExpandMsgXmd<Sha256> as ExpandMsg<U4>>::expand_message(
+                &[b"test message"],
+                &[b"test DST"],
+                NonZero::new(64).unwrap(),
+            )
+            .unwrap()
+        }
+
+        assert_eq!(generate().fill_bytes(&mut [0; 0]), Ok(0));
+        assert_eq!(generate().fill_bytes(&mut [0; 1]), Ok(1));
+        assert_eq!(generate().fill_bytes(&mut [0; 64]), Ok(64));
+        assert_eq!(generate().fill_bytes(&mut [0; 65]), Ok(64));
+
+        let mut expander = generate();
+        assert_eq!(expander.fill_bytes(&mut [0; 0]), Ok(0));
+        assert_eq!(expander.fill_bytes(&mut [0; 32]), Ok(32));
+        assert_eq!(expander.fill_bytes(&mut [0; 0]), Ok(0));
+        assert_eq!(expander.fill_bytes(&mut [0; 31]), Ok(31));
+        assert_eq!(expander.fill_bytes(&mut [0; 2]), Ok(1));
+        assert_eq!(expander.fill_bytes(&mut [0; 1]), Err(Error));
+    }
+
     fn assert_message<HashT>(
         msg: &[u8],
         domain: &Domain<'_, HashT::OutputSize>,

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -51,8 +51,10 @@ where
             return Err(Error);
         }
 
-        let ell = u8::try_from(usize::from(len_in_bytes.get()).div_ceil(b_in_bytes))
-            .expect("should never pass the previous check");
+        debug_assert!(
+            usize::from(len_in_bytes.get()).div_ceil(b_in_bytes) <= u8::MAX.into(),
+            "should never pass the previous check"
+        );
 
         let domain = Domain::xmd::<HashT>(dst)?;
         let mut b_0 = HashT::default();
@@ -81,7 +83,7 @@ where
             domain,
             index: 1,
             offset: 0,
-            ell,
+            remaining: len_in_bytes.get(),
         })
     }
 }
@@ -98,36 +100,7 @@ where
     domain: Domain<'a, HashT::OutputSize>,
     index: u8,
     offset: usize,
-    ell: u8,
-}
-
-impl<HashT> ExpanderXmd<'_, HashT>
-where
-    HashT: BlockSizeUser + Default + FixedOutput + HashMarker,
-    HashT::OutputSize: IsLessOrEqual<HashT::BlockSize, Output = True>,
-{
-    fn next(&mut self) -> bool {
-        if self.index < self.ell {
-            self.index += 1;
-            self.offset = 0;
-            // b_0 XOR b_(idx - 1)
-            let mut tmp = Array::<u8, HashT::OutputSize>::default();
-            self.b_0
-                .iter()
-                .zip(&self.b_vals[..])
-                .enumerate()
-                .for_each(|(j, (b0val, bi1val))| tmp[j] = b0val ^ bi1val);
-            let mut b_vals = HashT::default();
-            b_vals.update(&tmp);
-            b_vals.update(&[self.index]);
-            self.domain.update_hash(&mut b_vals);
-            b_vals.update(&[self.domain.len()]);
-            self.b_vals = b_vals.finalize_fixed();
-            true
-        } else {
-            false
-        }
-    }
+    remaining: u16,
 }
 
 impl<HashT> Expander for ExpanderXmd<'_, HashT>
@@ -137,11 +110,31 @@ where
 {
     fn fill_bytes(&mut self, okm: &mut [u8]) {
         for b in okm {
-            if self.offset == self.b_vals.len() && !self.next() {
+            if self.remaining == 0 {
                 return;
             }
+
+            if self.offset == self.b_vals.len() {
+                self.index += 1;
+                self.offset = 0;
+                // b_0 XOR b_(idx - 1)
+                let mut tmp = Array::<u8, HashT::OutputSize>::default();
+                self.b_0
+                    .iter()
+                    .zip(&self.b_vals[..])
+                    .enumerate()
+                    .for_each(|(j, (b0val, bi1val))| tmp[j] = b0val ^ bi1val);
+                let mut b_vals = HashT::default();
+                b_vals.update(&tmp);
+                b_vals.update(&[self.index]);
+                self.domain.update_hash(&mut b_vals);
+                b_vals.update(&[self.domain.len()]);
+                self.b_vals = b_vals.finalize_fixed();
+            }
+
             *b = self.b_vals[self.offset];
             self.offset += 1;
+            self.remaining -= 1;
         }
     }
 }

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -108,18 +108,14 @@ where
     HashT: BlockSizeUser + Default + FixedOutput + HashMarker,
     HashT::OutputSize: IsLessOrEqual<HashT::BlockSize, Output = True>,
 {
-    fn fill_bytes(&mut self, okm: &mut [u8]) -> Result<usize> {
+    fn fill_bytes(&mut self, mut okm: &mut [u8]) -> Result<usize> {
+        if self.remaining == 0 {
+            return Err(Error);
+        }
+
         let mut read_bytes = 0;
 
-        for b in okm {
-            if self.remaining == 0 {
-                if read_bytes == 0 {
-                    return Err(Error);
-                } else {
-                    return Ok(read_bytes);
-                }
-            }
-
+        while self.remaining != 0 {
             if self.offset == self.b_vals.len() {
                 self.index += 1;
                 self.offset = 0;
@@ -138,10 +134,27 @@ where
                 self.b_vals = b_vals.finalize_fixed();
             }
 
-            *b = self.b_vals[self.offset];
-            self.offset += 1;
-            self.remaining -= 1;
-            read_bytes += 1;
+            let bytes_to_read = self
+                .remaining
+                .min(okm.len().try_into().unwrap_or(u16::MAX))
+                .min(
+                    (self.b_vals.len() - self.offset)
+                        .try_into()
+                        .unwrap_or(u16::MAX),
+                );
+
+            if bytes_to_read == 0 {
+                return Ok(read_bytes);
+            }
+
+            okm[..bytes_to_read.into()].copy_from_slice(
+                &self.b_vals[self.offset..self.offset + usize::from(bytes_to_read)],
+            );
+            okm = &mut okm[bytes_to_read.into()..];
+
+            self.offset += usize::from(bytes_to_read);
+            self.remaining -= bytes_to_read;
+            read_bytes += usize::from(bytes_to_read);
         }
 
         Ok(read_bytes)

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -108,10 +108,16 @@ where
     HashT: BlockSizeUser + Default + FixedOutput + HashMarker,
     HashT::OutputSize: IsLessOrEqual<HashT::BlockSize, Output = True>,
 {
-    fn fill_bytes(&mut self, okm: &mut [u8]) {
+    fn fill_bytes(&mut self, okm: &mut [u8]) -> Result<usize> {
+        let mut read_bytes = 0;
+
         for b in okm {
             if self.remaining == 0 {
-                return;
+                if read_bytes == 0 {
+                    return Err(Error);
+                } else {
+                    return Ok(read_bytes);
+                }
             }
 
             if self.offset == self.b_vals.len() {
@@ -135,7 +141,10 @@ where
             *b = self.b_vals[self.offset];
             self.offset += 1;
             self.remaining -= 1;
+            read_bytes += 1;
         }
+
+        Ok(read_bytes)
     }
 }
 
@@ -210,7 +219,7 @@ mod test {
             )?;
 
             let mut uniform_bytes = Array::<u8, L>::default();
-            expander.fill_bytes(&mut uniform_bytes);
+            expander.fill_bytes(&mut uniform_bytes).unwrap();
 
             assert_eq!(uniform_bytes.as_slice(), self.uniform_bytes);
             Ok(())

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -22,6 +22,7 @@ where
     HashT: Default + ExtendableOutput + Update + HashMarker,
 {
     reader: <HashT as ExtendableOutput>::Reader,
+    remaining: u16,
 }
 
 impl<HashT> fmt::Debug for ExpandMsgXof<HashT>
@@ -66,7 +67,10 @@ where
         domain.update_hash(&mut reader);
         reader.update(&[domain.len()]);
         let reader = reader.finalize_xof();
-        Ok(Self { reader })
+        Ok(Self {
+            reader,
+            remaining: len_in_bytes,
+        })
     }
 }
 
@@ -75,7 +79,13 @@ where
     HashT: Default + ExtendableOutput + Update + HashMarker,
 {
     fn fill_bytes(&mut self, okm: &mut [u8]) {
-        self.reader.read(okm);
+        if self.remaining == 0 {
+            return;
+        }
+
+        let bytes_to_read = self.remaining.min(okm.len().try_into().unwrap_or(u16::MAX));
+        self.reader.read(&mut okm[..bytes_to_read.into()]);
+        self.remaining -= bytes_to_read;
     }
 }
 

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -103,6 +103,29 @@ mod test {
     use hex_literal::hex;
     use sha3::Shake128;
 
+    #[test]
+    fn edge_cases() {
+        fn generate() -> ExpandMsgXof<Shake128> {
+            <ExpandMsgXof<Shake128> as ExpandMsg<U16>>::expand_message(
+                &[b"test message"],
+                &[b"test DST"],
+                NonZero::new(64).unwrap(),
+            )
+            .unwrap()
+        }
+
+        assert_eq!(generate().fill_bytes(&mut [0; 0]), Ok(0));
+        assert_eq!(generate().fill_bytes(&mut [0; 1]), Ok(1));
+        assert_eq!(generate().fill_bytes(&mut [0; 64]), Ok(64));
+        assert_eq!(generate().fill_bytes(&mut [0; 65]), Ok(64));
+
+        let mut expander = generate();
+        assert_eq!(expander.fill_bytes(&mut [0; 0]), Ok(0));
+        assert_eq!(expander.fill_bytes(&mut [0; 1]), Ok(1));
+        assert_eq!(expander.fill_bytes(&mut [0; 64]), Ok(63));
+        assert_eq!(expander.fill_bytes(&mut [0; 1]), Err(Error));
+    }
+
     fn assert_message(msg: &[u8], domain: &Domain<'_, U32>, len_in_bytes: u16, bytes: &[u8]) {
         let msg_len = msg.len();
         assert_eq!(msg, &bytes[..msg_len]);

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -5,11 +5,11 @@ use core::{fmt, num::NonZero, ops::Mul};
 use digest::{
     CollisionResistance, ExtendableOutput, HashMarker, Update, XofReader, typenum::IsGreaterOrEqual,
 };
-use elliptic_curve::Result;
 use elliptic_curve::array::{
     ArraySize,
     typenum::{Prod, True, U2},
 };
+use elliptic_curve::{Error, Result};
 
 /// Implements `expand_message_xof` via the [`ExpandMsg`] trait:
 /// <https://www.rfc-editor.org/rfc/rfc9380.html#name-expand_message_xof>
@@ -78,14 +78,15 @@ impl<HashT> Expander for ExpandMsgXof<HashT>
 where
     HashT: Default + ExtendableOutput + Update + HashMarker,
 {
-    fn fill_bytes(&mut self, okm: &mut [u8]) {
+    fn fill_bytes(&mut self, okm: &mut [u8]) -> Result<usize> {
         if self.remaining == 0 {
-            return;
+            return Err(Error);
         }
 
         let bytes_to_read = self.remaining.min(okm.len().try_into().unwrap_or(u16::MAX));
         self.reader.read(&mut okm[..bytes_to_read.into()]);
         self.remaining -= bytes_to_read;
+        Ok(bytes_to_read.into())
     }
 }
 
@@ -147,7 +148,7 @@ mod test {
             )?;
 
             let mut uniform_bytes = Array::<u8, L>::default();
-            expander.fill_bytes(&mut uniform_bytes);
+            expander.fill_bytes(&mut uniform_bytes).unwrap();
 
             assert_eq!(uniform_bytes.as_slice(), self.uniform_bytes);
             Ok(())


### PR DESCRIPTION
This PR does three changes:
- Fixes `Expander`s outputting more than `len_in_bytes`.
- Lets `Expander::fill_bytes()` return `Result`, to more closely mimic a rusty `Read`er.
- Optimizes `ExpandMsgXmd` to copy whole slices instead of byte by byte.

This is an alternative take to addressing the issues #1317 found.
However, this PR doesn't get rid of any traits or types. I originally intended to get rid of `ExpanderXmd`, but I remembered again why we kept it in the first place: to remove the lifetime from `ExpandMsg`.