### PR TITLE
primefield: remove `shr` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.10"
-source = "git+https://github.com/RustCrypto/traits.git#a10ef181945a480bba5d2fb36ad6f3f78a3474db"
+source = "git+https://github.com/RustCrypto/traits.git#d5355ef8a85577d9842505cf3241f6e1d011d0da"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/primefield/src/lib.rs
+++ b/primefield/src/lib.rs
@@ -197,22 +197,6 @@ macro_rules! field_element_type {
 
                 res
             }
-
-            /// Right shifts the [`
-            #[doc = stringify!($fe)]
-            /// `].
-            pub const fn shr(&self, shift: u32) -> Self {
-                Self(self.0.wrapping_shr(shift))
-            }
-
-            /// Right shifts the [`
-            #[doc = stringify!($fe)]
-            /// `].
-            ///
-            /// Note: not constant-time with respect to the `shift` parameter.
-            pub const fn shr_vartime(&self, shift: u32) -> Self {
-                Self(self.0.wrapping_shr_vartime(shift))
-            }
         }
 
         impl $crate::ff::Field for $fe {
@@ -320,56 +304,6 @@ macro_rules! field_element_type {
             #[inline]
             fn neg(self) -> $fe {
                 <$fe>::neg(self)
-            }
-        }
-
-        impl ::core::ops::Shr<u32> for $fe {
-            type Output = Self;
-
-            #[inline]
-            fn shr(self, rhs: u32) -> Self {
-                Self::shr(&self, rhs)
-            }
-        }
-
-        impl ::core::ops::Shr<u32> for &$fe {
-            type Output = Self;
-
-            #[inline]
-            fn shr(self, rhs: u32) -> Self {
-                Self::shr(self, rhs)
-            }
-        }
-
-        impl ::core::ops::ShrAssign<u32> for $fe {
-            #[inline]
-            fn shr_assign(&mut self, rhs: u32) {
-                *self = Self::shr(self, rhs)
-            }
-        }
-
-        impl ::core::ops::Shr<usize> for $fe {
-            type Output = Self;
-
-            #[inline]
-            fn shr(self, rhs: usize) -> Self {
-                Self::shr(&self, rhs as u32)
-            }
-        }
-
-        impl ::core::ops::Shr<usize> for &$fe {
-            type Output = Self;
-
-            #[inline]
-            fn shr(self, rhs: usize) -> Self {
-                Self::shr(self, rhs as u32)
-            }
-        }
-
-        impl ::core::ops::ShrAssign<usize> for $fe {
-            #[inline]
-            fn shr_assign(&mut self, rhs: usize) {
-                *self = Self::shr(self, rhs as u32)
             }
         }
 


### PR DESCRIPTION
It was noted as buggy in #1319 because `shr` was being computed on values within the Montgomery domain directly. They either need to be converted to canonical form first, or a Montgomery multiplication needs to be used in place of a bit shift.

Turns out it was completely unused, aside from fulfilling a bound in the `elliptic-curve` crate, which has since been removed.

This removes `shr` support from all curves whose `Scalar` uses an internal Montgomery representation. It has been retained on `k256` and `p256` which use canonical form `Scalar` types.

Closes #1319