### PR TITLE
p256: use `primefield::test_primefield` to test `FieldElement`

### DIFF
--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -196,26 +196,21 @@ impl PrimeField for FieldElement {
 mod tests {
     use super::FieldElement;
     use crate::{FieldBytes, test_vectors::field::DBL_TEST_VECTORS};
-    use core::ops::Mul;
 
     #[cfg(target_pointer_width = "64")]
     use crate::U256;
     #[cfg(target_pointer_width = "64")]
     use proptest::{num::u64::ANY, prelude::*};
 
-    #[test]
-    fn zero_is_additive_identity() {
-        let zero = FieldElement::ZERO;
-        let one = FieldElement::ONE;
-        assert_eq!(zero.add(&zero), zero);
-        assert_eq!(one.add(&zero), one);
-    }
+    /// t = (modulus - 1) >> S
+    const T: [u64; 4] = [
+        0xffffffffffffffff,
+        0x000000007fffffff,
+        0x8000000000000000,
+        0x7fffffff80000000,
+    ];
 
-    #[test]
-    fn one_is_multiplicative_identity() {
-        let one = FieldElement::ONE;
-        assert_eq!(one.mul(&one), one);
-    }
+    primefield::test_primefield!(FieldElement, T);
 
     #[test]
     fn from_bytes() {
@@ -293,26 +288,6 @@ mod tests {
         let two = one + &one;
         let four = two.square();
         assert_eq!(two.pow_vartime(&[2, 0, 0, 0]), four);
-    }
-
-    #[test]
-    fn invert() {
-        assert!(bool::from(FieldElement::ZERO.invert().is_none()));
-
-        let one = FieldElement::ONE;
-        assert_eq!(one.invert().unwrap(), one);
-
-        let two = one + &one;
-        let inv_two = two.invert().unwrap();
-        assert_eq!(two * &inv_two, one);
-    }
-
-    #[test]
-    fn sqrt() {
-        let one = FieldElement::ONE;
-        let two = one + &one;
-        let four = two.square();
-        assert_eq!(four.sqrt().unwrap(), two);
     }
 
     #[cfg(target_pointer_width = "64")]


### PR DESCRIPTION
The macro tests the `PrimeField` constants, `invert`, `sqrt`, and other tests which were previously handwritten