### PR TITLE
primefield: have `test_primefield_constants!` compute `T`

### DIFF
--- a/bign256/src/arithmetic/field.rs
+++ b/bign256/src/arithmetic/field.rs
@@ -123,15 +123,6 @@ impl PrimeField for FieldElement {
 
 #[cfg(test)]
 mod tests {
-    use super::FieldElement;
-
-    // t = (modulus - 1) >> S
-    const T: [u64; 4] = [
-        0xffffffffffffffa1,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0x7fffffffffffffff,
-    ];
-
-    primefield::test_primefield!(FieldElement, T);
+    use super::{FieldElement, U256};
+    primefield::test_primefield!(FieldElement, U256);
 }

--- a/bign256/src/arithmetic/scalar.rs
+++ b/bign256/src/arithmetic/scalar.rs
@@ -193,15 +193,6 @@ impl TryFrom<U256> for Scalar {
 
 #[cfg(test)]
 mod tests {
-    use super::Scalar;
-
-    // t = (modulus - 1) >> S
-    const T: [u64; 4] = [
-        0x3f2d5fcc931eb303,
-        0xecae476b06fda6fe,
-        0xffffffffffffffff,
-        0x7fffffffffffffff,
-    ];
-
-    primefield::test_primefield!(Scalar, T);
+    use super::{Scalar, U256};
+    primefield::test_primefield!(Scalar, U256);
 }

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -107,16 +107,6 @@ impl PrimeField for FieldElement {
 
 #[cfg(test)]
 mod tests {
-    use super::FieldElement;
-
-    /// t = (modulus - 1) >> S
-    /// 0x54fdabedd0f754de1f3305484ec1c6b9371dfb11ea9310141009a40e8fb729bb
-    const T: [u64; 4] = [
-        0x1009a40e8fb729bb,
-        0x371dfb11ea931014,
-        0x1f3305484ec1c6b9,
-        0x54fdabedd0f754de,
-    ];
-
-    primefield::test_primefield!(FieldElement, T);
+    use super::{FieldElement, U256};
+    primefield::test_primefield!(FieldElement, U256);
 }

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -156,16 +156,6 @@ impl TryFrom<U256> for Scalar {
 
 #[cfg(test)]
 mod tests {
-    use super::Scalar;
-
-    /// t = (modulus - 1) >> S
-    /// 0x54fdabedd0f754de1f3305484ec1c6b8c61cbd51dab0d37bc80f07414ba42b53
-    const T: [u64; 4] = [
-        0xc80f07414ba42b53,
-        0xc61cbd51dab0d37b,
-        0x1f3305484ec1c6b8,
-        0x54fdabedd0f754de,
-    ];
-
-    primefield::test_primefield!(Scalar, T);
+    use super::{Scalar, U256};
+    primefield::test_primefield!(Scalar, U256);
 }

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -110,18 +110,6 @@ impl PrimeField for FieldElement {
 
 #[cfg(test)]
 mod tests {
-    use super::FieldElement;
-
-    /// t = (modulus - 1) >> S
-    /// 0x465c8f41519c369407aeb7bf287320ef8a97b884f6aa2b5a0958ed0cbfdb8891d669d394c80e8d38c3a380099883f629
-    const T: [u64; 6] = [
-        0xc3a380099883f629,
-        0xd669d394c80e8d38,
-        0x958ed0cbfdb8891,
-        0x8a97b884f6aa2b5a,
-        0x7aeb7bf287320ef,
-        0x465c8f41519c3694,
-    ];
-
-    primefield::test_primefield!(FieldElement, T);
+    use super::{FieldElement, U384};
+    primefield::test_primefield!(FieldElement, U384);
 }

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -164,18 +164,6 @@ impl TryFrom<U384> for Scalar {
 
 #[cfg(test)]
 mod tests {
-    use super::Scalar;
-
-    /// t = (modulus - 1) >> S
-    /// 0x232e47a0a8ce1b4a03d75bdf94399077c54bdc427b5515acc7c59b9b2b010969f3ceadabdadff0c40ee20c80ba411959
-    const T: [u64; 6] = [
-        0x0ee20c80ba411959,
-        0xf3ceadabdadff0c4,
-        0xc7c59b9b2b010969,
-        0xc54bdc427b5515ac,
-        0x03d75bdf94399077,
-        0x232e47a0a8ce1b4a,
-    ];
-
-    primefield::test_primefield!(Scalar, T);
+    use super::{Scalar, U384};
+    primefield::test_primefield!(Scalar, U384);
 }

--- a/p192/src/arithmetic/field.rs
+++ b/p192/src/arithmetic/field.rs
@@ -112,10 +112,6 @@ impl PrimeField for FieldElement {
 
 #[cfg(test)]
 mod tests {
-    use super::FieldElement;
-
-    /// t = (modulus - 1) >> S
-    const T: [u64; 3] = [0x7fffffffffffffff, 0xffffffffffffffff, 0x7fffffffffffffff];
-
-    primefield::test_primefield!(FieldElement, T);
+    use super::{FieldElement, U192};
+    primefield::test_primefield!(FieldElement, U192);
 }

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -252,11 +252,6 @@ impl<'de> Deserialize<'de> for Scalar {
 
 #[cfg(test)]
 mod tests {
-    use super::Scalar;
-
-    /// t = (modulus - 1) >> S
-    /// 0xffffffffffffffffffffffff99def836146bc9b1b4d2283
-    const T: [u64; 3] = [0x6146bc9b1b4d2283, 0xfffffffff99def83, 0x0fffffffffffffff];
-
-    primefield::test_primefield!(Scalar, T);
+    use super::{Scalar, U192};
+    primefield::test_primefield!(Scalar, U192);
 }

--- a/p224/src/arithmetic/field.rs
+++ b/p224/src/arithmetic/field.rs
@@ -34,14 +34,12 @@ use elliptic_curve::{
 
 /// Constant representing the modulus serialized as hex.
 /// p = 2^{224} − 2^{96} + 1
-const MODULUS_HEX: &str = "ffffffffffffffffffffffffffffffff000000000000000000000001";
-
 #[cfg(target_pointer_width = "32")]
-const MODULUS: Uint = Uint::from_be_hex(MODULUS_HEX);
-
+const MODULUS_HEX: &str = "ffffffffffffffffffffffffffffffff000000000000000000000001";
 #[cfg(target_pointer_width = "64")]
-const MODULUS: Uint =
-    Uint::from_be_hex("00000000ffffffffffffffffffffffffffffffff000000000000000000000001");
+const MODULUS_HEX: &str = "00000000ffffffffffffffffffffffffffffffff000000000000000000000001";
+
+const MODULUS: Uint = Uint::from_be_hex(MODULUS_HEX);
 
 /// Element of the secp224r1 base field used for curve coordinates.
 #[derive(Clone, Copy)]
@@ -290,15 +288,6 @@ impl PrimeField for FieldElement {
 
 #[cfg(test)]
 mod tests {
-    use super::FieldElement;
-
-    /// t = (modulus - 1) >> S
-    const T: [u64; 4] = [
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0x0000000000000000,
-        0x0000000000000000,
-    ];
-
-    primefield::test_primefield!(FieldElement, T);
+    use super::{FieldElement, Uint};
+    primefield::test_primefield!(FieldElement, Uint);
 }

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -247,15 +247,6 @@ impl<'de> Deserialize<'de> for Scalar {
 
 #[cfg(test)]
 mod tests {
-    use super::Scalar;
-
-    /// t = (modulus - 1) >> S
-    const T: [u64; 4] = [
-        0x84f74a5157170a8f,
-        0xffffc5a8b82e3c0f,
-        0xffffffffffffffff,
-        0x000000003fffffff,
-    ];
-
-    primefield::test_primefield!(Scalar, T);
+    use super::{Scalar, Uint};
+    primefield::test_primefield!(Scalar, Uint);
 }

--- a/p224/src/lib.rs
+++ b/p224/src/lib.rs
@@ -42,14 +42,15 @@ use elliptic_curve::{
 };
 
 #[cfg(target_pointer_width = "32")]
-pub use elliptic_curve::bigint::U224 as Uint;
-
+use elliptic_curve::bigint::U224 as Uint;
 #[cfg(target_pointer_width = "64")]
 use elliptic_curve::bigint::U256 as Uint;
 
 /// Order of NIST P-224's elliptic curve group (i.e. scalar modulus) in hexadecimal.
-#[cfg(any(target_pointer_width = "32", feature = "arithmetic"))]
+#[cfg(target_pointer_width = "32")]
 const ORDER_HEX: &str = "ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3d";
+#[cfg(target_pointer_width = "64")]
+const ORDER_HEX: &str = "00000000ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3d";
 
 /// NIST P-224 elliptic curve.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
@@ -63,13 +64,7 @@ impl elliptic_curve::Curve for NistP224 {
     type Uint = Uint;
 
     /// Order of NIST P-224's elliptic curve group (i.e. scalar modulus).
-    #[cfg(target_pointer_width = "32")]
     const ORDER: Uint = Uint::from_be_hex(ORDER_HEX);
-
-    /// Order of NIST P-224's elliptic curve group (i.e. scalar modulus).
-    #[cfg(target_pointer_width = "64")]
-    const ORDER: Uint =
-        Uint::from_be_hex("00000000ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3d");
 }
 
 impl elliptic_curve::PrimeCurve for NistP224 {}

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -195,22 +195,12 @@ impl PrimeField for FieldElement {
 #[cfg(test)]
 mod tests {
     use super::FieldElement;
-    use crate::{FieldBytes, test_vectors::field::DBL_TEST_VECTORS};
+    use crate::{FieldBytes, U256, test_vectors::field::DBL_TEST_VECTORS};
 
-    #[cfg(target_pointer_width = "64")]
-    use crate::U256;
     #[cfg(target_pointer_width = "64")]
     use proptest::{num::u64::ANY, prelude::*};
 
-    /// t = (modulus - 1) >> S
-    const T: [u64; 4] = [
-        0xffffffffffffffff,
-        0x000000007fffffff,
-        0x8000000000000000,
-        0x7fffffff80000000,
-    ];
-
-    primefield::test_primefield!(FieldElement, T);
+    primefield::test_primefield!(FieldElement, U256);
 
     #[test]
     fn from_bytes() {

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -713,22 +713,15 @@ impl<'de> Deserialize<'de> for Scalar {
 mod tests {
     use super::{Scalar, U256};
     use crate::{FieldBytes, NistP256, NonZeroScalar, SecretKey};
-    use elliptic_curve::Curve;
-    use elliptic_curve::array::Array;
-    use elliptic_curve::group::ff::{Field, PrimeField};
-    use elliptic_curve::ops::{BatchInvert, ReduceNonZero};
-    use proptest::prelude::any;
-    use proptest::{prop_compose, proptest};
+    use elliptic_curve::{
+        Curve,
+        array::Array,
+        group::ff::{Field, PrimeField},
+        ops::{BatchInvert, ReduceNonZero},
+    };
+    use proptest::{prelude::any, prop_compose, proptest};
 
-    /// t = (modulus - 1) >> S
-    const T: [u64; 4] = [
-        0x4f3b9cac2fc63255,
-        0xfbce6faada7179e8,
-        0x0fffffffffffffff,
-        0x0ffffffff0000000,
-    ];
-
-    primefield::test_primefield!(Scalar, T);
+    primefield::test_primefield!(Scalar, U256);
 
     #[test]
     fn from_to_bytes_roundtrip() {

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -138,17 +138,6 @@ impl PrimeField for FieldElement {
 
 #[cfg(test)]
 mod tests {
-    use super::FieldElement;
-
-    /// t = (modulus - 1) >> S
-    const T: [u64; 6] = [
-        0x000000007fffffff,
-        0x7fffffff80000000,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0x7fffffffffffffff,
-    ];
-
-    primefield::test_primefield!(FieldElement, T);
+    use super::{FieldElement, U384};
+    primefield::test_primefield!(FieldElement, U384);
 }

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -295,17 +295,7 @@ mod tests {
     };
     use proptest::{prelude::any, prop_compose, proptest};
 
-    /// t = (modulus - 1) >> S
-    const T: [u64; 6] = [
-        0x76760cb5666294b9,
-        0xac0d06d9245853bd,
-        0xe3b1a6c0fa1b96ef,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0x7fffffffffffffff,
-    ];
-
-    primefield::test_primefield!(Scalar, T);
+    primefield::test_primefield!(Scalar, U384);
 
     #[test]
     fn from_to_bytes_roundtrip() {

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -43,10 +43,10 @@ use elliptic_curve::{
     zeroize::DefaultIsZeroes,
 };
 
+const MODULUS_HEX: &str = "00000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
 /// Field modulus: p = 2^{521} − 1
-pub(crate) const MODULUS: U576 = U576::from_be_hex(
-    "00000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-);
+pub(crate) const MODULUS: U576 = U576::from_be_hex(MODULUS_HEX);
 
 /// Element of the secp521r1 base field used for curve coordinates.
 #[derive(Clone, Copy)]
@@ -465,7 +465,7 @@ impl Field for FieldElement {
 impl PrimeField for FieldElement {
     type Repr = FieldBytes;
 
-    const MODULUS: &'static str = "1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    const MODULUS: &'static str = MODULUS_HEX;
     const NUM_BITS: u32 = 521;
     const CAPACITY: u32 = 520;
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
@@ -667,23 +667,10 @@ impl Invert for FieldElement {
 
 #[cfg(test)]
 mod tests {
-    use super::FieldElement;
+    use super::{FieldElement, U576};
     use hex_literal::hex;
 
-    /// t = (modulus - 1) >> S
-    const T: [u64; 9] = [
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0x00000000000000ff,
-    ];
-
-    primefield::test_primefield!(FieldElement, T);
+    primefield::test_primefield!(FieldElement, U576);
 
     /// Regression test for RustCrypto/elliptic-curves#965
     #[test]

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -15,7 +15,7 @@
 mod scalar_impl;
 
 use self::scalar_impl::*;
-use crate::{FieldBytes, NistP521, U576};
+use crate::{FieldBytes, NistP521, ORDER_HEX, U576};
 use core::{
     iter::{Product, Sum},
     ops::{Add, AddAssign, Mul, MulAssign, Neg, SubAssign},
@@ -528,7 +528,7 @@ impl IsHigh for Scalar {
 impl PrimeField for Scalar {
     type Repr = FieldBytes;
 
-    const MODULUS: &'static str = "01fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409";
+    const MODULUS: &'static str = ORDER_HEX;
     const CAPACITY: u32 = 520;
     const NUM_BITS: u32 = 521;
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
@@ -652,20 +652,7 @@ mod tests {
     };
     use proptest::{prelude::any, prop_compose, proptest};
 
-    /// t = (modulus - 1) >> S
-    const T: [u64; 9] = [
-        0xd76df6e3d2270c81,
-        0x0776b937113388f5,
-        0x6ff980291ee134ba,
-        0x4a30d0f077e5f2cd,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0x000000000000003f,
-    ];
-
-    primefield::test_primefield_constants!(Scalar, T);
+    primefield::test_primefield_constants!(Scalar, U576);
     primefield::test_field_identity!(Scalar);
     primefield::test_field_invert!(Scalar);
     //primefield::test_field_sqrt!(Scalar); // TODO(tarcieri): impl this

--- a/p521/src/lib.rs
+++ b/p521/src/lib.rs
@@ -55,6 +55,8 @@ use elliptic_curve::{FieldBytesEncoding, array::Array, consts::U66};
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct NistP521;
 
+const ORDER_HEX: &str = "00000000000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409";
+
 impl elliptic_curve::Curve for NistP521 {
     /// 66-byte serialized field elements.
     type FieldBytesSize = U66;
@@ -63,9 +65,7 @@ impl elliptic_curve::Curve for NistP521 {
     type Uint = U576;
 
     /// Order of NIST P-521's elliptic curve group (i.e. scalar modulus).
-    const ORDER: U576 = U576::from_be_hex(
-        "00000000000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
-    );
+    const ORDER: U576 = U576::from_be_hex(ORDER_HEX);
 }
 
 impl elliptic_curve::PrimeCurve for NistP521 {}

--- a/sm2/src/arithmetic/field.rs
+++ b/sm2/src/arithmetic/field.rs
@@ -120,16 +120,6 @@ impl PrimeField for FieldElement {
 
 #[cfg(test)]
 mod tests {
-    use super::FieldElement;
-
-    /// t = (modulus - 1) >> S
-    /// 0x7fffffff7fffffffffffffffffffffffffffffff800000007fffffffffffffff
-    const T: [u64; 4] = [
-        0x7fffffffffffffff,
-        0xffffffff80000000,
-        0xffffffffffffffff,
-        0x7fffffff7fffffff,
-    ];
-
-    primefield::test_primefield!(FieldElement, T);
+    use super::{FieldElement, U256};
+    primefield::test_primefield!(FieldElement, U256);
 }

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -231,16 +231,6 @@ impl<'de> Deserialize<'de> for Scalar {
 
 #[cfg(test)]
 mod tests {
-    use super::Scalar;
-
-    /// t = (modulus - 1) >> S
-    /// 0x7fffffff7fffffffffffffffffffffffb901efb590e30295a9ddfa049ceaa091
-    const T: [u64; 4] = [
-        0xa9ddfa049ceaa091,
-        0xb901efb590e30295,
-        0xffffffffffffffff,
-        0x7fffffff7fffffff,
-    ];
-
-    primefield::test_primefield!(Scalar, T);
+    use super::{Scalar, U256};
+    primefield::test_primefield!(Scalar, U256);
 }


### PR DESCRIPTION
...where `T` is `(modulus - 1) >> S`.

Previously this was precomputed manually on a curve-by-curve basis. This commit changes it to compute `T` from the other constants.