### PR TITLE
Fix `ConstantTimeEq` for `DecafPoint`

### DIFF
--- a/ed448-goldilocks/src/decaf/points.rs
+++ b/ed448-goldilocks/src/decaf/points.rs
@@ -63,7 +63,7 @@ impl UpperHex for DecafPoint {
 
 impl ConstantTimeEq for DecafPoint {
     fn ct_eq(&self, other: &DecafPoint) -> Choice {
-        (self.0.X * other.0.Y).ct_eq(&(self.0.Y * other.0.X))
+        self.0.ct_eq(&other.0)
     }
 }
 


### PR DESCRIPTION
Comparison of Decaf points requires normalization. To avoid inversion operations, we use scaling.

However, the current implementation for `DecafPoint`s forgets about having a Z-coordinate. This PR fixes that by just delegating the comparison implementation to the already correct implementation of `ExtendedPoint`.