### PR TITLE
Reduce unnecessary conversions to `ExtensiblePoint` and back

### DIFF
--- a/ed448-goldilocks/src/curve/scalar_mul/double_and_add.rs
+++ b/ed448-goldilocks/src/curve/scalar_mul/double_and_add.rs
@@ -1,9 +1,10 @@
 use crate::curve::twedwards::extended::ExtendedPoint;
+use crate::curve::twedwards::extensible::ExtensiblePoint;
 use subtle::{Choice, ConditionallySelectable};
 
 /// Traditional double and add algorithm
-pub(crate) fn double_and_add(point: &ExtendedPoint, s_bits: [bool; 448]) -> ExtendedPoint {
-    let mut result = ExtendedPoint::IDENTITY;
+pub(crate) fn double_and_add(point: &ExtendedPoint, s_bits: [bool; 448]) -> ExtensiblePoint {
+    let mut result = ExtensiblePoint::IDENTITY;
 
     // NB, we reverse here, so we are going from MSB to LSB
     // XXX: Would be great if subtle had a From<u32> for Choice. But maybe that is not it's purpose?
@@ -12,7 +13,7 @@ pub(crate) fn double_and_add(point: &ExtendedPoint, s_bits: [bool; 448]) -> Exte
 
         let mut p = ExtendedPoint::IDENTITY;
         p.conditional_assign(point, Choice::from(bit as u8));
-        result = result.add(&p);
+        result = result.to_extended().add_extended(&p);
     }
 
     result

--- a/ed448-goldilocks/src/curve/scalar_mul/window/wnaf.rs
+++ b/ed448-goldilocks/src/curve/scalar_mul/window/wnaf.rs
@@ -6,13 +6,14 @@ pub struct LookupTable([ProjectiveNielsPoint; 8]);
 
 /// Precomputes odd multiples of the point passed in
 impl From<&ExtendedPoint> for LookupTable {
-    fn from(point: &ExtendedPoint) -> LookupTable {
-        let P = point.to_extensible();
-
+    fn from(P: &ExtendedPoint) -> LookupTable {
         let mut table = [P.to_projective_niels(); 8];
 
         for i in 1..8 {
-            table[i] = P.add_projective_niels(&table[i - 1]).to_projective_niels();
+            table[i] = P
+                .add_projective_niels(&table[i - 1])
+                .to_extended()
+                .to_projective_niels();
         }
 
         LookupTable(table)
@@ -42,11 +43,8 @@ fn test_lookup() {
     let mut expected_point = ExtendedPoint::IDENTITY;
     for i in 0..8 {
         let selected_point = points.select(i);
-        assert_eq!(selected_point.to_extended(), expected_point);
+        assert_eq!(selected_point.to_extensible(), expected_point);
 
-        expected_point = expected_point
-            .to_extensible()
-            .add_extended(&p)
-            .to_extended();
+        expected_point = expected_point.add_extended(&p).to_extended();
     }
 }

--- a/ed448-goldilocks/src/curve/twedwards/affine.rs
+++ b/ed448-goldilocks/src/curve/twedwards/affine.rs
@@ -121,13 +121,14 @@ impl AffineNielsPoint {
             && (self.td == other.td)
     }
 
-    /// Converts an AffineNielsPoint to an ExtendedPoint
-    pub(crate) fn to_extended(self) -> ExtendedPoint {
-        ExtendedPoint {
+    /// Converts an AffineNielsPoint to an ExtensiblePoint
+    pub(crate) fn to_extensible(self) -> ExtensiblePoint {
+        ExtensiblePoint {
             X: self.y_plus_x - self.y_minus_x,
             Y: self.y_minus_x + self.y_plus_x,
             Z: FieldElement::ONE,
-            T: self.y_plus_x * self.y_minus_x,
+            T1: self.y_plus_x,
+            T2: self.y_minus_x,
         }
     }
 }
@@ -140,7 +141,7 @@ mod tests {
     #[test]
     fn test_negation() {
         use crate::TWISTED_EDWARDS_BASE_POINT;
-        let a = TWISTED_EDWARDS_BASE_POINT.to_affine();
+        let a = TWISTED_EDWARDS_BASE_POINT.to_extensible().to_affine();
         assert!(a.is_on_curve());
 
         let neg_a = a.negate();

--- a/ed448-goldilocks/src/curve/twedwards/extended.rs
+++ b/ed448-goldilocks/src/curve/twedwards/extended.rs
@@ -1,9 +1,9 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
-use crate::curve::twedwards::affine::AffinePoint;
+use crate::curve::twedwards::affine::AffineNielsPoint;
 use crate::curve::twedwards::extensible::ExtensiblePoint;
-use crate::edwards::EdwardsPoint as EdwardsExtendedPoint;
+use crate::curve::twedwards::projective::ProjectiveNielsPoint;
 use crate::field::FieldElement;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
@@ -43,6 +43,11 @@ impl PartialEq for ExtendedPoint {
         self.ct_eq(other).into()
     }
 }
+impl PartialEq<ExtensiblePoint> for ExtendedPoint {
+    fn eq(&self, other: &ExtensiblePoint) -> bool {
+        self.to_extensible().ct_eq(other).into()
+    }
+}
 impl Eq for ExtendedPoint {}
 
 impl Default for ExtendedPoint {
@@ -69,14 +74,90 @@ impl ExtendedPoint {
         T: FieldElement::ZERO,
     };
 
-    /// Doubles an extended point
-    pub(crate) fn double(&self) -> ExtendedPoint {
-        self.to_extensible().double().to_extended()
+    /// Adds an extensible point to an extended point
+    /// Returns an extensible point
+    /// (3.1) https://iacr.org/archive/asiacrypt2008/53500329/53500329.pdf
+    pub fn add_extended(&self, other: &ExtendedPoint) -> ExtensiblePoint {
+        let A = self.X * other.X;
+        let B = self.Y * other.Y;
+        let C = self.T * other.T * FieldElement::TWISTED_D;
+        let D = self.Z * other.Z;
+        let E = (self.X + self.Y) * (other.X + other.Y) - A - B;
+        let F = D - C;
+        let G = D + C;
+        let H = B + A;
+        ExtensiblePoint {
+            X: E * F,
+            Y: G * H,
+            T1: E,
+            T2: H,
+            Z: F * G,
+        }
     }
 
-    /// Adds an extended point to itself
-    pub(crate) fn add(&self, other: &ExtendedPoint) -> ExtendedPoint {
-        self.to_extensible().add_extended(other).to_extended()
+    /// Subtracts an extensible point from an extended point
+    /// Returns an extensible point
+    /// This is a direct modification of the addition formula to the negation of `other`
+    pub fn sub_extended(&self, other: &ExtendedPoint) -> ExtensiblePoint {
+        let A = self.X * other.X;
+        let B = self.Y * other.Y;
+        let C = self.T * other.T * FieldElement::TWISTED_D;
+        let D = self.Z * other.Z;
+        let E = (self.X + self.Y) * (other.Y - other.X) + A - B;
+        let F = D + C;
+        let G = D - C;
+        let H = B - A;
+        ExtensiblePoint {
+            X: E * F,
+            Y: G * H,
+            T1: E,
+            T2: H,
+            Z: F * G,
+        }
+    }
+
+    /// Adds an extensible point to an AffineNiels point
+    /// Returns an Extensible point
+    pub fn add_affine_niels(&self, other: AffineNielsPoint) -> ExtensiblePoint {
+        let A = other.y_minus_x * (self.Y - self.X);
+        let B = other.y_plus_x * (self.X + self.Y);
+        let C = other.td * self.T;
+        let D = B + A;
+        let E = B - A;
+        let F = self.Z - C;
+        let G = self.Z + C;
+        ExtensiblePoint {
+            X: E * F,
+            Y: G * D,
+            Z: F * G,
+            T1: E,
+            T2: D,
+        }
+    }
+
+    /// Adds an extensible point to a ProjectiveNiels point
+    /// Returns an extensible point
+    /// (3.1)[Last set of formulas] https://iacr.org/archive/asiacrypt2008/53500329/53500329.pdf
+    /// This differs from the formula above by a factor of 2. Saving 1 Double
+    /// Cost 8M
+    pub fn add_projective_niels(&self, other: &ProjectiveNielsPoint) -> ExtensiblePoint {
+        // This is the only step which makes it different than adding an AffineNielsPoint
+        let Z = self.Z * other.Z;
+
+        let A = (self.Y - self.X) * other.Y_minus_X;
+        let B = (self.Y + self.X) * other.Y_plus_X;
+        let C = other.Td * self.T;
+        let D = B + A;
+        let E = B - A;
+        let F = Z - C;
+        let G = Z + C;
+        ExtensiblePoint {
+            X: E * F,
+            Y: G * D,
+            Z: F * G,
+            T1: E,
+            T2: D,
+        }
     }
 
     /// Converts an ExtendedPoint to an ExtensiblePoint
@@ -90,51 +171,14 @@ impl ExtendedPoint {
         }
     }
 
-    /// Converts an extended point to Affine co-ordinates
-    pub(crate) fn to_affine(self) -> AffinePoint {
-        // Points to consider:
-        // - All points where Z=0, translate to (0,0)
-        // - The identity point has z=1, so it is not a problem
-
-        let INV_Z = self.Z.invert();
-
-        let x = self.X * INV_Z;
-        let y = self.Y * INV_Z;
-
-        AffinePoint { x, y }
-    }
-
-    /// Edwards_Isogeny is derived from the doubling formula
-    /// XXX: There is a duplicate method in the twisted edwards module to compute the dual isogeny
-    /// XXX: Not much point trying to make it generic I think. So what we can do is optimise each respective isogeny method for a=1 or a = -1 (currently, I just made it really slow and simple)
-    fn edwards_isogeny(&self, a: FieldElement) -> EdwardsExtendedPoint {
-        // Convert to affine now, then derive extended version later
-        let affine = self.to_affine();
-        let x = affine.x;
-        let y = affine.y;
-
-        // Compute x
-        let xy = x * y;
-        let x_numerator = xy.double();
-        let x_denom = y.square() - (a * x.square());
-        let new_x = x_numerator * x_denom.invert();
-
-        // Compute y
-        let y_numerator = y.square() + (a * x.square());
-        let y_denom = (FieldElement::ONE + FieldElement::ONE) - y.square() - (a * x.square());
-        let new_y = y_numerator * y_denom.invert();
-
-        EdwardsExtendedPoint {
-            X: new_x,
-            Y: new_y,
-            Z: FieldElement::ONE,
-            T: new_x * new_y,
+    /// Converts an Extensible point to a ProjectiveNiels Point
+    pub fn to_projective_niels(self) -> ProjectiveNielsPoint {
+        ProjectiveNielsPoint {
+            Y_plus_X: self.X + self.Y,
+            Y_minus_X: self.Y - self.X,
+            Z: self.Z.double(),
+            Td: self.T * FieldElement::TWO_TIMES_TWISTED_D,
         }
-    }
-
-    /// Uses a 2-isogeny to map the point to the Ed448-Goldilocks
-    pub fn to_untwisted(self) -> EdwardsExtendedPoint {
-        self.edwards_isogeny(FieldElement::MINUS_ONE)
     }
 
     /// Checks if the point is on the curve
@@ -178,6 +222,7 @@ impl ExtendedPoint {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::curve::twedwards::affine::AffinePoint;
     use crate::{GOLDILOCKS_BASE_POINT, TWISTED_EDWARDS_BASE_POINT};
 
     fn hex_to_field(hex: &'static str) -> FieldElement {
@@ -196,7 +241,7 @@ mod tests {
         let y = hex_to_field(
             "ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed",
         );
-        let a = AffinePoint { x, y }.to_extended();
+        let a = AffinePoint { x, y }.to_extensible();
         let twist_a = a.to_untwisted().to_twisted();
         assert_eq!(twist_a, a.double().double())
     }
@@ -220,28 +265,28 @@ mod tests {
     #[test]
     fn test_point_add() {
         let a = TWISTED_EDWARDS_BASE_POINT;
-        let b = a.double();
+        let b = a.to_extensible().double().to_extended();
 
         // A + B = B + A = C
-        let c_1 = a.to_extensible().add_extended(&b).to_extended();
-        let c_2 = b.to_extensible().add_extended(&a).to_extended();
+        let c_1 = a.add_extended(&b).to_extended();
+        let c_2 = b.add_extended(&a).to_extended();
         assert!(c_1 == c_2);
 
         // Adding identity point should not change result
-        let c = c_1.to_extensible().add_extended(&ExtendedPoint::IDENTITY);
-        assert!(c.to_extended() == c_1);
+        let c = c_1.add_extended(&ExtendedPoint::IDENTITY);
+        assert!(c == c_1);
     }
 
     #[test]
     fn test_point_sub() {
         let a = TWISTED_EDWARDS_BASE_POINT;
-        let b = a.double();
+        let b = a.to_extensible().double().to_extended();
 
         // A - B = C
-        let c_1 = a.to_extensible().sub_extended(&b).to_extended();
+        let c_1 = a.sub_extended(&b).to_extended();
 
         // -B + A = C
-        let c_2 = b.negate().to_extensible().add_extended(&a).to_extended();
+        let c_2 = b.negate().add_extended(&a).to_extended();
         assert!(c_1 == c_2);
     }
 
@@ -250,6 +295,6 @@ mod tests {
         let a = TWISTED_EDWARDS_BASE_POINT;
         let neg_a = a.negate();
 
-        assert!(a.to_extensible().add_extended(&neg_a) == ExtensiblePoint::IDENTITY);
+        assert!(a.add_extended(&neg_a) == ExtensiblePoint::IDENTITY);
     }
 }

--- a/ed448-goldilocks/src/curve/twedwards/extensible.rs
+++ b/ed448-goldilocks/src/curve/twedwards/extensible.rs
@@ -1,9 +1,8 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
-use crate::curve::twedwards::{
-    affine::AffineNielsPoint, extended::ExtendedPoint, projective::ProjectiveNielsPoint,
-};
+use crate::curve::twedwards::{affine::AffinePoint, extended::ExtendedPoint};
+use crate::edwards::EdwardsPoint as EdwardsExtendedPoint;
 use crate::field::FieldElement;
 use subtle::{Choice, ConstantTimeEq};
 
@@ -12,6 +11,7 @@ use subtle::{Choice, ConstantTimeEq};
 // Where x = X/Z , y = Y/Z , T1 * T2 = T
 // XXX: I think we have too many point representations,
 // But let's not remove any yet
+#[derive(Copy, Clone, Debug)]
 pub struct ExtensiblePoint {
     pub(crate) X: FieldElement,
     pub(crate) Y: FieldElement,
@@ -34,6 +34,11 @@ impl ConstantTimeEq for ExtensiblePoint {
 impl PartialEq for ExtensiblePoint {
     fn eq(&self, other: &ExtensiblePoint) -> bool {
         self.ct_eq(other).into()
+    }
+}
+impl PartialEq<ExtendedPoint> for ExtensiblePoint {
+    fn eq(&self, other: &ExtendedPoint) -> bool {
+        self.ct_eq(&other.to_extensible()).into()
     }
 }
 impl Eq for ExtensiblePoint {}
@@ -67,99 +72,8 @@ impl ExtensiblePoint {
         }
     }
 
-    /// Adds two extensible points together by converting the other point to a ExtendedPoint
-    pub fn add_extensible(&self, other: &ExtensiblePoint) -> ExtensiblePoint {
-        self.add_extended(&other.to_extended())
-    }
-
-    /// Adds an extensible point to an extended point
-    /// Returns an extensible point
-    /// (3.1) https://iacr.org/archive/asiacrypt2008/53500329/53500329.pdf
-    pub fn add_extended(&self, other: &ExtendedPoint) -> ExtensiblePoint {
-        let A = self.X * other.X;
-        let B = self.Y * other.Y;
-        let C = self.T1 * self.T2 * other.T * FieldElement::TWISTED_D;
-        let D = self.Z * other.Z;
-        let E = (self.X + self.Y) * (other.X + other.Y) - A - B;
-        let F = D - C;
-        let G = D + C;
-        let H = B + A;
-        ExtensiblePoint {
-            X: E * F,
-            Y: G * H,
-            T1: E,
-            T2: H,
-            Z: F * G,
-        }
-    }
-
-    /// Subtracts an extensible point from an extended point
-    /// Returns an extensible point
-    /// This is a direct modification of the addition formula to the negation of `other`
-    pub fn sub_extended(&self, other: &ExtendedPoint) -> ExtensiblePoint {
-        let A = self.X * other.X;
-        let B = self.Y * other.Y;
-        let C = self.T1 * self.T2 * other.T * FieldElement::TWISTED_D;
-        let D = self.Z * other.Z;
-        let E = (self.X + self.Y) * (other.Y - other.X) + A - B;
-        let F = D + C;
-        let G = D - C;
-        let H = B - A;
-        ExtensiblePoint {
-            X: E * F,
-            Y: G * H,
-            T1: E,
-            T2: H,
-            Z: F * G,
-        }
-    }
-
-    /// Adds an extensible point to an AffineNiels point
-    /// Returns an Extensible point
-    pub fn add_affine_niels(&self, other: AffineNielsPoint) -> ExtensiblePoint {
-        let A = other.y_minus_x * (self.Y - self.X);
-        let B = other.y_plus_x * (self.X + self.Y);
-        let C = other.td * self.T1 * self.T2;
-        let D = B + A;
-        let E = B - A;
-        let F = self.Z - C;
-        let G = self.Z + C;
-        ExtensiblePoint {
-            X: E * F,
-            Y: G * D,
-            Z: F * G,
-            T1: E,
-            T2: D,
-        }
-    }
-
-    /// Adds an extensible point to a ProjectiveNiels point
-    /// Returns an extensible point
-    /// (3.1)[Last set of formulas] https://iacr.org/archive/asiacrypt2008/53500329/53500329.pdf
-    /// This differs from the formula above by a factor of 2. Saving 1 Double
-    /// Cost 8M
-    pub fn add_projective_niels(&self, other: &ProjectiveNielsPoint) -> ExtensiblePoint {
-        // This is the only step which makes it different than adding an AffineNielsPoint
-        let Z = self.Z * other.Z;
-
-        let A = (self.Y - self.X) * other.Y_minus_X;
-        let B = (self.Y + self.X) * other.Y_plus_X;
-        let C = other.Td * self.T1 * self.T2;
-        let D = B + A;
-        let E = B - A;
-        let F = Z - C;
-        let G = Z + C;
-        ExtensiblePoint {
-            X: E * F,
-            Y: G * D,
-            Z: F * G,
-            T1: E,
-            T2: D,
-        }
-    }
-
     /// Converts an extensible point to an extended point
-    pub fn to_extended(&self) -> ExtendedPoint {
+    pub fn to_extended(self) -> ExtendedPoint {
         ExtendedPoint {
             X: self.X,
             Y: self.Y,
@@ -168,13 +82,50 @@ impl ExtensiblePoint {
         }
     }
 
-    /// Converts an Extensible point to a ProjectiveNiels Point
-    pub fn to_projective_niels(&self) -> ProjectiveNielsPoint {
-        ProjectiveNielsPoint {
-            Y_plus_X: self.X + self.Y,
-            Y_minus_X: self.Y - self.X,
-            Z: self.Z + self.Z,
-            Td: self.T1 * self.T2 * FieldElement::TWO_TIMES_TWISTED_D,
+    /// Converts an extended point to Affine co-ordinates
+    pub(crate) fn to_affine(self) -> AffinePoint {
+        // Points to consider:
+        // - All points where Z=0, translate to (0,0)
+        // - The identity point has z=1, so it is not a problem
+
+        let INV_Z = self.Z.invert();
+
+        let x = self.X * INV_Z;
+        let y = self.Y * INV_Z;
+
+        AffinePoint { x, y }
+    }
+
+    /// Edwards_Isogeny is derived from the doubling formula
+    /// XXX: There is a duplicate method in the twisted edwards module to compute the dual isogeny
+    /// XXX: Not much point trying to make it generic I think. So what we can do is optimise each respective isogeny method for a=1 or a = -1 (currently, I just made it really slow and simple)
+    fn edwards_isogeny(&self, a: FieldElement) -> EdwardsExtendedPoint {
+        // Convert to affine now, then derive extended version later
+        let affine = self.to_affine();
+        let x = affine.x;
+        let y = affine.y;
+
+        // Compute x
+        let xy = x * y;
+        let x_numerator = xy.double();
+        let x_denom = y.square() - (a * x.square());
+        let new_x = x_numerator * x_denom.invert();
+
+        // Compute y
+        let y_numerator = y.square() + (a * x.square());
+        let y_denom = (FieldElement::ONE + FieldElement::ONE) - y.square() - (a * x.square());
+        let new_y = y_numerator * y_denom.invert();
+
+        EdwardsExtendedPoint {
+            X: new_x,
+            Y: new_y,
+            Z: FieldElement::ONE,
+            T: new_x * new_y,
         }
+    }
+
+    /// Uses a 2-isogeny to map the point to the Ed448-Goldilocks
+    pub fn to_untwisted(self) -> EdwardsExtendedPoint {
+        self.edwards_isogeny(FieldElement::MINUS_ONE)
     }
 }

--- a/ed448-goldilocks/src/curve/twedwards/projective.rs
+++ b/ed448-goldilocks/src/curve/twedwards/projective.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
-use crate::curve::twedwards::{extended::ExtendedPoint, extensible::ExtensiblePoint};
+use crate::curve::twedwards::extended::ExtendedPoint;
+use crate::curve::twedwards::extensible::ExtensiblePoint;
 use crate::field::FieldElement;
 use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable};
 
@@ -22,7 +23,7 @@ pub struct ProjectiveNielsPoint {
 
 impl PartialEq for ProjectiveNielsPoint {
     fn eq(&self, other: &ProjectiveNielsPoint) -> bool {
-        self.to_extended().eq(&other.to_extended())
+        self.to_extensible().eq(&other.to_extensible())
     }
 }
 impl Eq for ProjectiveNielsPoint {}
@@ -46,17 +47,18 @@ impl ConditionallyNegatable for ProjectiveNielsPoint {
 
 impl ProjectiveNielsPoint {
     pub fn identity() -> ProjectiveNielsPoint {
-        ExtensiblePoint::IDENTITY.to_projective_niels()
+        ExtendedPoint::IDENTITY.to_projective_niels()
     }
 
-    pub fn to_extended(self) -> ExtendedPoint {
+    pub fn to_extensible(self) -> ExtensiblePoint {
         let A = self.Y_plus_X - self.Y_minus_X;
         let B = self.Y_plus_X + self.Y_minus_X;
-        ExtendedPoint {
+        ExtensiblePoint {
             X: self.Z * A,
             Y: self.Z * B,
             Z: self.Z.square(),
-            T: B * A,
+            T1: B,
+            T2: A,
         }
     }
 }
@@ -68,10 +70,10 @@ mod tests {
     fn test_conditional_negate() {
         let bp = ExtendedPoint::GENERATOR;
 
-        let mut bp_neg = bp.to_extensible().to_projective_niels();
+        let mut bp_neg = bp.to_projective_niels();
         bp_neg.conditional_negate(1.into());
 
-        let expect_identity = bp_neg.to_extended().add(&bp);
+        let expect_identity = bp_neg.to_extensible().to_extended().add_extended(&bp);
         assert_eq!(ExtendedPoint::IDENTITY, expect_identity);
     }
 }

--- a/ed448-goldilocks/src/decaf/ops.rs
+++ b/ed448-goldilocks/src/decaf/ops.rs
@@ -14,7 +14,7 @@ impl Mul<&DecafScalar> for &DecafPoint {
 
     fn mul(self, scalar: &DecafScalar) -> DecafPoint {
         // XXX: We can do better than double and add
-        DecafPoint(double_and_add(&self.0, scalar.bits()))
+        DecafPoint(double_and_add(&self.0, scalar.bits()).to_extended())
     }
 }
 
@@ -37,7 +37,7 @@ impl Add<&DecafPoint> for &DecafPoint {
     type Output = DecafPoint;
 
     fn add(self, other: &DecafPoint) -> DecafPoint {
-        DecafPoint(self.0.to_extensible().add_extended(&other.0).to_extended())
+        DecafPoint(self.0.add_extended(&other.0).to_extended())
     }
 }
 
@@ -101,7 +101,7 @@ impl Sub<&DecafPoint> for &DecafPoint {
     type Output = DecafPoint;
 
     fn sub(self, other: &DecafPoint) -> DecafPoint {
-        DecafPoint(self.0.to_extensible().sub_extended(&other.0).to_extended())
+        DecafPoint(self.0.sub_extended(&other.0).to_extended())
     }
 }
 

--- a/ed448-goldilocks/src/decaf/points.rs
+++ b/ed448-goldilocks/src/decaf/points.rs
@@ -192,7 +192,7 @@ impl Group for DecafPoint {
     }
 
     fn double(&self) -> Self {
-        Self(self.0.double())
+        Self(self.0.to_extensible().double().to_extended())
     }
 }
 
@@ -240,31 +240,31 @@ impl CurveGroup for DecafPoint {
     type AffineRepr = DecafAffinePoint;
 
     fn to_affine(&self) -> Self::AffineRepr {
-        DecafAffinePoint(self.0.to_affine())
+        DecafAffinePoint(self.0.to_extensible().to_affine())
     }
 }
 
 impl From<EdwardsPoint> for DecafPoint {
     fn from(point: EdwardsPoint) -> Self {
-        Self(point.to_twisted())
+        Self(point.to_twisted().to_extended())
     }
 }
 
 impl From<&EdwardsPoint> for DecafPoint {
     fn from(point: &EdwardsPoint) -> Self {
-        Self(point.to_twisted())
+        Self(point.to_twisted().to_extended())
     }
 }
 
 impl From<DecafPoint> for EdwardsPoint {
     fn from(point: DecafPoint) -> Self {
-        point.0.to_untwisted()
+        point.0.to_extensible().to_untwisted()
     }
 }
 
 impl From<&DecafPoint> for EdwardsPoint {
     fn from(point: &DecafPoint) -> Self {
-        point.0.to_untwisted()
+        point.0.to_extensible().to_untwisted()
     }
 }
 
@@ -282,13 +282,13 @@ impl From<&DecafAffinePoint> for DecafPoint {
 
 impl From<DecafPoint> for DecafAffinePoint {
     fn from(point: DecafPoint) -> Self {
-        DecafAffinePoint(point.0.to_affine())
+        DecafAffinePoint(point.0.to_extensible().to_affine())
     }
 }
 
 impl From<&DecafPoint> for DecafAffinePoint {
     fn from(point: &DecafPoint) -> Self {
-        DecafAffinePoint(point.0.to_affine())
+        DecafAffinePoint(point.0.to_extensible().to_affine())
     }
 }
 
@@ -307,12 +307,12 @@ impl DecafPoint {
 
     /// Add two points
     pub fn add(&self, other: &DecafPoint) -> DecafPoint {
-        DecafPoint(self.0.to_extensible().add_extended(&other.0).to_extended())
+        DecafPoint(self.0.add_extended(&other.0).to_extended())
     }
 
     /// Subtract two points
     pub fn sub(&self, other: &DecafPoint) -> DecafPoint {
-        DecafPoint(self.0.to_extensible().sub_extended(&other.0).to_extended())
+        DecafPoint(self.0.sub_extended(&other.0).to_extended())
     }
 
     /// Compress this point
@@ -369,7 +369,7 @@ impl DecafPoint {
         let u1 = FieldElement::from_bytes(&hi);
         let q0 = u0.map_to_curve_decaf448();
         let q1 = u1.map_to_curve_decaf448();
-        Self(q0.add(&q1))
+        Self(q0.add_extended(&q1).to_extended())
     }
 }
 
@@ -600,8 +600,8 @@ mod test {
 
         let P = TWISTED_EDWARDS_BASE_POINT;
 
-        let P2 = P.double();
-        let P3 = P2.to_extensible().add_extended(&P).to_extended();
+        let P2 = P.to_extensible().double().to_extended();
+        let P3 = P2.add_extended(&P).to_extended();
 
         // Encode and decode to make them Decaf points
         let Decaf_P = DecafPoint(P).compress().decompress().unwrap();


### PR DESCRIPTION
Currently most mathematical operations on the twisted curve are implemented on `ExtensiblePoint` and take an `ExtendedPoint` as parameter. However, these operations often just convert to an `ExtendedPoint` internally (by multiplying T1 and T2).

This PR moves operations to "where they belong" to make sure we don't unnecessarily call these conversions. This achieves removing 1 multiplication from Decaf point add/sub operations from previously 9 in total, so a ~10% performance improvement.

There are a couple of other operations that are affected negligibly:
- Removes 7 multiplications from the lookup table construction for Edwards scalar multiplication. #1303 switches Decaf scalar multiplication to the same algorithm.
- Removes 226 multiplications from Decaf scalar multiplication. While this is very major, #1303 switches to a different unaffected algorithm.
- Removes 1 multiplication from Edwards point scalar multiplication when converting back to un-twisted form.