### PR TITLE
Use `ConstMontyForm::invert()` in place of `pow()`

### DIFF
--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -263,12 +263,8 @@ impl FieldElement {
     }
 
     /// Inverts a field element
-    /// Previous chain length: 462, new length 460
     pub fn invert(&self) -> Self {
-        const INV_EXP: U448 = U448::from_be_hex(
-            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffffffffffffffffffffffffffffffffffffffffffffffffffffd",
-        );
-        Self(self.0.pow(&INV_EXP))
+        Self(self.0.invert().unwrap_or(ConstMontyType::default()))
     }
 
     pub fn square(&self) -> Self {


### PR DESCRIPTION
I didn't add this in #1302 because the performance was much worse. Now with the latest changes in crypto-bigint this isn't the case anymore. Instead the new `ConstMontyForm::invert()` improves the performance by 85% (on my PC).