### PR TITLE
`hash2curve`: Error rework

### DIFF
--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -1,8 +1,8 @@
 //! Traits for handling hash to curve.
 
 use super::{ExpandMsg, MapToCurve, hash_to_field};
-use elliptic_curve::array::typenum::Unsigned;
-use elliptic_curve::{ProjectivePoint, Result};
+use digest::array::typenum::Unsigned;
+use elliptic_curve::ProjectivePoint;
 
 /// Hash arbitrary byte sequences to a valid group element.
 pub trait GroupDigest: MapToCurve {
@@ -32,7 +32,7 @@ pub trait GroupDigest: MapToCurve {
     ///
     /// [`ExpandMsgXmd`]: crate::ExpandMsgXmd
     /// [`ExpandMsgXof`]: crate::ExpandMsgXof
-    fn hash_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<ProjectivePoint<Self>>
+    fn hash_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<ProjectivePoint<Self>, X::Error>
     where
         X: ExpandMsg<Self::K>,
     {
@@ -62,7 +62,7 @@ pub trait GroupDigest: MapToCurve {
     ///
     /// [`ExpandMsgXmd`]: crate::ExpandMsgXmd
     /// [`ExpandMsgXof`]: crate::ExpandMsgXof
-    fn encode_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<ProjectivePoint<Self>>
+    fn encode_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<ProjectivePoint<Self>, X::Error>
     where
         X: ExpandMsg<Self::K>,
     {
@@ -85,7 +85,7 @@ pub trait GroupDigest: MapToCurve {
     ///
     /// [`ExpandMsgXmd`]: crate::ExpandMsgXmd
     /// [`ExpandMsgXof`]: crate::ExpandMsgXof
-    fn hash_to_scalar<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<Self::Scalar>
+    fn hash_to_scalar<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<Self::Scalar, X::Error>
     where
         X: ExpandMsg<Self::K>,
     {

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -79,8 +79,11 @@ pub trait GroupDigest: MapToCurve {
     ///
     /// # Errors
     ///
-    /// When the chosen [`ExpandMsg`] implementation returns an error. See [`crate::ExpandMsgXmd`]
-    /// and [`crate::ExpandMsgXof`] for examples.
+    /// When the chosen [`ExpandMsg`] implementation returns an error. See [`ExpandMsgXmdError`]
+    /// and [`ExpandMsgXofError`] for examples.
+    ///
+    /// [`ExpandMsgXmdError`]: crate::ExpandMsgXmdError
+    /// [`ExpandMsgXofError`]: crate::ExpandMsgXofError
     fn hash_to_scalar<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<Self::Scalar, X::Error>
     where
         X: ExpandMsg<Self::K>,

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -56,8 +56,11 @@ pub trait GroupDigest: MapToCurve {
     ///
     /// # Errors
     ///
-    /// When the chosen [`ExpandMsg`] implementation returns an error. See [`crate::ExpandMsgXmd`]
-    /// and [`crate::ExpandMsgXof`] for examples.
+    /// When the chosen [`ExpandMsg`] implementation returns an error. See [`ExpandMsgXmdError`]
+    /// and [`ExpandMsgXofError`] for examples.
+    ///
+    /// [`ExpandMsgXmdError`]: crate::ExpandMsgXmdError
+    /// [`ExpandMsgXofError`]: crate::ExpandMsgXofError
     fn encode_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<ProjectivePoint<Self>, X::Error>
     where
         X: ExpandMsg<Self::K>,

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -23,15 +23,9 @@ pub trait GroupDigest: MapToCurve {
     /// > hash function is used.
     ///
     /// # Errors
-    /// - `len_in_bytes > u16::MAX`
-    /// - See implementors of [`ExpandMsg`] for additional errors:
-    ///   - [`ExpandMsgXmd`]
-    ///   - [`ExpandMsgXof`]
     ///
-    /// `len_in_bytes = <Self::FieldElement as FromOkm>::Length * 2`
-    ///
-    /// [`ExpandMsgXmd`]: crate::ExpandMsgXmd
-    /// [`ExpandMsgXof`]: crate::ExpandMsgXof
+    /// When the chosen `ExpandMsg` implementation returns an error. See [`crate::ExpandMsgXmd`]
+    /// and [`crate::ExpandMsgXof`] for examples.
     fn hash_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<ProjectivePoint<Self>, X::Error>
     where
         X: ExpandMsg<Self::K>,
@@ -53,15 +47,9 @@ pub trait GroupDigest: MapToCurve {
     /// > points in this set are more likely to be output than others.
     ///
     /// # Errors
-    /// - `len_in_bytes > u16::MAX`
-    /// - See implementors of [`ExpandMsg`] for additional errors:
-    ///   - [`ExpandMsgXmd`]
-    ///   - [`ExpandMsgXof`]
     ///
-    /// `len_in_bytes = <Self::FieldElement as FromOkm>::Length`
-    ///
-    /// [`ExpandMsgXmd`]: crate::ExpandMsgXmd
-    /// [`ExpandMsgXof`]: crate::ExpandMsgXof
+    /// When the chosen `ExpandMsg` implementation returns an error. See [`crate::ExpandMsgXmd`]
+    /// and [`crate::ExpandMsgXof`] for examples.
     fn encode_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<ProjectivePoint<Self>, X::Error>
     where
         X: ExpandMsg<Self::K>,
@@ -76,15 +64,9 @@ pub trait GroupDigest: MapToCurve {
     /// and returns a scalar.
     ///
     /// # Errors
-    /// - `len_in_bytes > u16::MAX`
-    /// - See implementors of [`ExpandMsg`] for additional errors:
-    ///   - [`ExpandMsgXmd`]
-    ///   - [`ExpandMsgXof`]
     ///
-    /// `len_in_bytes = <Self::Scalar as FromOkm>::Length`
-    ///
-    /// [`ExpandMsgXmd`]: crate::ExpandMsgXmd
-    /// [`ExpandMsgXof`]: crate::ExpandMsgXof
+    /// When the chosen `ExpandMsg` implementation returns an error. See [`crate::ExpandMsgXmd`]
+    /// and [`crate::ExpandMsgXof`] for examples.
     fn hash_to_scalar<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<Self::Scalar, X::Error>
     where
         X: ExpandMsg<Self::K>,

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -2,7 +2,7 @@
 
 use super::{ExpandMsg, MapToCurve, hash_to_field};
 use digest::array::typenum::Unsigned;
-use elliptic_curve::ProjectivePoint;
+use elliptic_curve::{ProjectivePoint, array::typenum::Unsigned};
 
 /// Hash arbitrary byte sequences to a valid group element.
 pub trait GroupDigest: MapToCurve {

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -27,7 +27,11 @@ pub trait GroupDigest: MapToCurve {
     /// # Errors
     ///
     /// When the chosen [`ExpandMsg`] implementation returns an error. See [`crate::ExpandMsgXmd`]
-    /// and [`crate::ExpandMsgXof`] for examples.
+    /// When the chosen [`ExpandMsg`] implementation returns an error. See [`ExpandMsgXmdError`]
+    /// and [`ExpandMsgXofError`] for examples.
+    ///
+    /// [`ExpandMsgXmdError`]: crate::ExpandMsgXmdError
+    /// [`ExpandMsgXofError`]: crate::ExpandMsgXofError
     fn hash_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<ProjectivePoint<Self>, X::Error>
     where
         X: ExpandMsg<Self::K>,

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -1,7 +1,6 @@
 //! Traits for handling hash to curve.
 
 use super::{ExpandMsg, MapToCurve, hash_to_field};
-use digest::array::typenum::Unsigned;
 use elliptic_curve::{ProjectivePoint, array::typenum::Unsigned};
 
 /// Hash arbitrary byte sequences to a valid group element.

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -22,6 +22,8 @@ pub trait GroupDigest: MapToCurve {
     /// > oracle returning points in G assuming a cryptographically secure
     /// > hash function is used.
     ///
+    /// For the `expand_message` call, `len_in_bytes = <Self::FieldElement as FromOkm>::Length * 2`.
+    ///
     /// # Errors
     ///
     /// When the chosen `ExpandMsg` implementation returns an error. See [`crate::ExpandMsgXmd`]
@@ -45,6 +47,8 @@ pub trait GroupDigest: MapToCurve {
     /// > uniformly random in G: the set of possible outputs of
     /// > encode_to_curve is only a fraction of the points in G, and some
     /// > points in this set are more likely to be output than others.
+    /// 
+    /// For the `expand_message` call, `len_in_bytes = <Self::FieldElement as FromOkm>::Length`.
     ///
     /// # Errors
     ///
@@ -62,7 +66,9 @@ pub trait GroupDigest: MapToCurve {
     /// Computes the hash to field routine according to
     /// <https://www.rfc-editor.org/rfc/rfc9380.html#section-5-4>
     /// and returns a scalar.
-    ///
+    ///   
+    /// For the `expand_message` call, `len_in_bytes = <Self::FieldElement as FromOkm>::Length`.
+    /// 
     /// # Errors
     ///
     /// When the chosen `ExpandMsg` implementation returns an error. See [`crate::ExpandMsgXmd`]

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -22,6 +22,7 @@ pub trait GroupDigest: MapToCurve {
     /// > hash function is used.
     ///
     /// For the `expand_message` call, `len_in_bytes = <Self::FieldElement as FromOkm>::Length * 2`.
+    /// This value must be less than `u16::MAX` or otherwise a compiler error will occur.
     ///
     /// # Errors
     ///
@@ -48,6 +49,7 @@ pub trait GroupDigest: MapToCurve {
     /// > points in this set are more likely to be output than others.
     ///
     /// For the `expand_message` call, `len_in_bytes = <Self::FieldElement as FromOkm>::Length`.
+    /// This value must be less than `u16::MAX` or otherwise a compiler error will occur.
     ///
     /// # Errors
     ///
@@ -67,6 +69,7 @@ pub trait GroupDigest: MapToCurve {
     /// and returns a scalar.
     ///   
     /// For the `expand_message` call, `len_in_bytes = <Self::FieldElement as FromOkm>::Length`.
+    /// This value must be less than `u16::MAX` or otherwise a compiler error will occur.
     ///
     /// # Errors
     ///

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -26,7 +26,6 @@ pub trait GroupDigest: MapToCurve {
     ///
     /// # Errors
     ///
-    /// When the chosen [`ExpandMsg`] implementation returns an error. See [`crate::ExpandMsgXmd`]
     /// When the chosen [`ExpandMsg`] implementation returns an error. See [`ExpandMsgXmdError`]
     /// and [`ExpandMsgXofError`] for examples.
     ///

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -26,7 +26,7 @@ pub trait GroupDigest: MapToCurve {
     ///
     /// # Errors
     ///
-    /// When the chosen `ExpandMsg` implementation returns an error. See [`crate::ExpandMsgXmd`]
+    /// When the chosen [`ExpandMsg`] implementation returns an error. See [`crate::ExpandMsgXmd`]
     /// and [`crate::ExpandMsgXof`] for examples.
     fn hash_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<ProjectivePoint<Self>, X::Error>
     where
@@ -53,7 +53,7 @@ pub trait GroupDigest: MapToCurve {
     ///
     /// # Errors
     ///
-    /// When the chosen `ExpandMsg` implementation returns an error. See [`crate::ExpandMsgXmd`]
+    /// When the chosen [`ExpandMsg`] implementation returns an error. See [`crate::ExpandMsgXmd`]
     /// and [`crate::ExpandMsgXof`] for examples.
     fn encode_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<ProjectivePoint<Self>, X::Error>
     where
@@ -73,7 +73,7 @@ pub trait GroupDigest: MapToCurve {
     ///
     /// # Errors
     ///
-    /// When the chosen `ExpandMsg` implementation returns an error. See [`crate::ExpandMsgXmd`]
+    /// When the chosen [`ExpandMsg`] implementation returns an error. See [`crate::ExpandMsgXmd`]
     /// and [`crate::ExpandMsgXof`] for examples.
     fn hash_to_scalar<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<Self::Scalar, X::Error>
     where

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -47,7 +47,7 @@ pub trait GroupDigest: MapToCurve {
     /// > uniformly random in G: the set of possible outputs of
     /// > encode_to_curve is only a fraction of the points in G, and some
     /// > points in this set are more likely to be output than others.
-    /// 
+    ///
     /// For the `expand_message` call, `len_in_bytes = <Self::FieldElement as FromOkm>::Length`.
     ///
     /// # Errors
@@ -68,7 +68,7 @@ pub trait GroupDigest: MapToCurve {
     /// and returns a scalar.
     ///   
     /// For the `expand_message` call, `len_in_bytes = <Self::FieldElement as FromOkm>::Length`.
-    /// 
+    ///
     /// # Errors
     ///
     /// When the chosen `ExpandMsg` implementation returns an error. See [`crate::ExpandMsgXmd`]

--- a/hash2curve/src/hash2field.rs
+++ b/hash2curve/src/hash2field.rs
@@ -27,15 +27,8 @@ pub trait FromOkm {
 /// <https://www.rfc-editor.org/rfc/rfc9380.html#name-hash_to_field-implementatio>
 ///
 /// # Errors
-/// - `len_in_bytes > u16::MAX`
-/// - See implementors of [`ExpandMsg`] for additional errors:
-///   - [`ExpandMsgXmd`]
-///   - [`ExpandMsgXof`]
 ///
-/// `len_in_bytes = T::Length * out.len()`
-///
-/// [`ExpandMsgXmd`]: crate::hash2field::ExpandMsgXmd
-/// [`ExpandMsgXof`]: crate::hash2field::ExpandMsgXof
+/// Returns an error if the [`ExpandMsg`] implementation fails.
 #[doc(hidden)]
 pub fn hash_to_field<const N: usize, E, K, T>(
     data: &[&[u8]],

--- a/hash2curve/src/hash2field.rs
+++ b/hash2curve/src/hash2field.rs
@@ -45,7 +45,7 @@ where
     E: ExpandMsg<K>,
     T: FromOkm + Default,
 {
-    // Completely degenerate case - `N` and `T::Length` would need to be extremely large.
+    // Completely degenerate case; `N` and `T::Length` would need to be extremely large.
     const { assert!(T::Length::USIZE * N <= u16::MAX as usize) }
     let Some(len_in_bytes) = NonZeroU16::new(T::Length::U16 * N as u16) else {
         // Since `T::Length: NonZero`, only `N = 0` can lead to this case.

--- a/hash2curve/src/hash2field.rs
+++ b/hash2curve/src/hash2field.rs
@@ -8,7 +8,7 @@ use core::num::NonZeroU16;
 
 pub use expand_msg::{xmd::*, xof::*, *};
 
-use digest::array::{
+use elliptic_curve::array::{
     Array, ArraySize,
     typenum::{NonZero, Unsigned},
 };

--- a/hash2curve/src/hash2field.rs
+++ b/hash2curve/src/hash2field.rs
@@ -26,6 +26,8 @@ pub trait FromOkm {
 ///
 /// <https://www.rfc-editor.org/rfc/rfc9380.html#name-hash_to_field-implementatio>
 ///
+/// For the `expand_message` call, `len_in_bytes = T::Length * N`.
+///
 /// # Errors
 ///
 /// Returns an error if the [`ExpandMsg`] implementation fails.

--- a/hash2curve/src/hash2field.rs
+++ b/hash2curve/src/hash2field.rs
@@ -39,14 +39,13 @@ where
     T: FromOkm + Default,
 {
     // Completely degenerate case; `N` and `T::Length` would need to be extremely large.
-    const {
+    let len_in_bytes = const {
         assert!(
             T::Length::USIZE.saturating_mul(N) <= u16::MAX as usize,
             "The product of `T::Length` and `N` must not exceed `u16::MAX`."
         );
-        assert!(N > 0, "N must be greater than 0.");
-    }
-    let len_in_bytes = NonZeroU16::new(T::Length::U16 * N as u16).expect("N is greater than 0");
+        NonZeroU16::new(T::Length::U16 * N as u16).expect("N is greater than 0")
+    };
     let mut tmp = Array::<u8, <T as FromOkm>::Length>::default();
     let mut expander = E::expand_message(data, domain, len_in_bytes)?;
     Ok(core::array::from_fn(|_| {

--- a/hash2curve/src/hash2field/expand_msg.rs
+++ b/hash2curve/src/hash2field/expand_msg.rs
@@ -174,8 +174,13 @@ impl core::fmt::Display for DstError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             DstError::Empty => write!(f, "Empty domain separation tag"),
-            DstError::XmdHash => write!(f, "XMD hash function output size is too large to hash the DST"),
-            DstError::XofSecurityLevel => write!(f, "XOF target security level in bytes is too large "),
+            DstError::XmdHash => write!(
+                f,
+                "XMD hash function output size is too large to hash the DST"
+            ),
+            DstError::XofSecurityLevel => {
+                write!(f, "XOF target security level in bytes is too large ")
+            }
         }
     }
 }

--- a/hash2curve/src/hash2field/expand_msg.rs
+++ b/hash2curve/src/hash2field/expand_msg.rs
@@ -62,13 +62,13 @@ pub(crate) enum Domain<'a, L: ArraySize> {
 }
 
 impl<'a, L: ArraySize + IsLess<U256, Output = True>> Domain<'a, L> {
-    pub fn xof<X>(dst: &'a [&'a [u8]]) -> Result<Self, EmptyDST>
+    pub fn xof<X>(dst: &'a [&'a [u8]]) -> Result<Self, EmptyDst>
     where
         X: Default + ExtendableOutput + Update,
     {
         // https://www.rfc-editor.org/rfc/rfc9380.html#section-3.1-4.2
         if dst.iter().map(|slice| slice.len()).sum::<usize>() == 0 {
-            Err(EmptyDST)
+            Err(EmptyDst)
         } else if dst.iter().map(|slice| slice.len()).sum::<usize>() > MAX_DST_LEN {
             let mut data = Array::<u8, L>::default();
             let mut hash = X::default();
@@ -86,13 +86,13 @@ impl<'a, L: ArraySize + IsLess<U256, Output = True>> Domain<'a, L> {
         }
     }
 
-    pub fn xmd<X>(dst: &'a [&'a [u8]]) -> Result<Self, EmptyDST>
+    pub fn xmd<X>(dst: &'a [&'a [u8]]) -> Result<Self, EmptyDst>
     where
         X: Digest<OutputSize = L>,
     {
         // https://www.rfc-editor.org/rfc/rfc9380.html#section-3.1-4.2
         if dst.iter().map(|slice| slice.len()).sum::<usize>() == 0 {
-            Err(EmptyDST)
+            Err(EmptyDst)
         } else if dst.iter().map(|slice| slice.len()).sum::<usize>() > MAX_DST_LEN {
             Ok(Self::Hashed({
                 let mut hash = X::new();
@@ -153,12 +153,12 @@ impl<'a, L: ArraySize + IsLess<U256, Output = True>> Domain<'a, L> {
 
 /// Error when an empty domain separation tag is used.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct EmptyDST;
+pub struct EmptyDst;
 
-impl core::fmt::Display for EmptyDST {
+impl core::fmt::Display for EmptyDst {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Empty domain separation tag")
     }
 }
 
-impl core::error::Error for EmptyDST {}
+impl core::error::Error for EmptyDst {}

--- a/hash2curve/src/hash2field/expand_msg.rs
+++ b/hash2curve/src/hash2field/expand_msg.rs
@@ -60,16 +60,16 @@ pub(crate) enum Domain<'a, L: ArraySize> {
 }
 
 impl<'a, L: ArraySize> Domain<'a, L> {
-    pub fn xof<X>(dst: &'a [&'a [u8]]) -> Result<Self, DstError>
+    pub fn xof<X>(dst: &'a [&'a [u8]]) -> Result<Self, xof::ExpandMsgXofError>
     where
         X: Default + ExtendableOutput + Update,
     {
         // https://www.rfc-editor.org/rfc/rfc9380.html#section-3.1-4.2
         if dst.iter().map(|slice| slice.len()).sum::<usize>() == 0 {
-            Err(DstError::Empty)
+            Err(xof::ExpandMsgXofError::EmptyDst)
         } else if dst.iter().map(|slice| slice.len()).sum::<usize>() > MAX_DST_LEN {
             if L::USIZE > u8::MAX.into() {
-                return Err(DstError::XofSecurityLevel);
+                return Err(xof::ExpandMsgXofError::DstSecurityLevel);
             }
             let mut data = Array::<u8, L>::default();
             let mut hash = X::default();
@@ -87,16 +87,16 @@ impl<'a, L: ArraySize> Domain<'a, L> {
         }
     }
 
-    pub fn xmd<X>(dst: &'a [&'a [u8]]) -> Result<Self, DstError>
+    pub fn xmd<X>(dst: &'a [&'a [u8]]) -> Result<Self, xmd::ExpandMsgXmdError>
     where
         X: Digest<OutputSize = L>,
     {
         // https://www.rfc-editor.org/rfc/rfc9380.html#section-3.1-4.2
         if dst.iter().map(|slice| slice.len()).sum::<usize>() == 0 {
-            Err(DstError::Empty)
+            Err(xmd::ExpandMsgXmdError::EmptyDst)
         } else if dst.iter().map(|slice| slice.len()).sum::<usize>() > MAX_DST_LEN {
             if L::USIZE > u8::MAX.into() {
-                return Err(DstError::XmdHash);
+                return Err(xmd::ExpandMsgXmdError::DstHash);
             }
             Ok(Self::Hashed({
                 let mut hash = X::new();
@@ -154,33 +154,3 @@ impl<'a, L: ArraySize> Domain<'a, L> {
         assert_eq!(self.len(), bytes[bytes.len() - 1]);
     }
 }
-
-/// Error when an empty domain separation tag is used.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DstError {
-    /// Empty domain separation tag.
-    Empty,
-    /// The domain separation tag is too long and needs to be hashed, but the hash function
-    /// selected has an output size too large (greater than `255`).
-    XmdHash,
-    /// The domain separation tag is too long and needs to be hashed, but the chosen `K` (target
-    /// security level in bytes) is too large (greater than `127`),
-    XofSecurityLevel,
-}
-
-impl core::fmt::Display for DstError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            DstError::Empty => write!(f, "Empty domain separation tag"),
-            DstError::XmdHash => write!(
-                f,
-                "XMD hash function output size is too large to hash the DST"
-            ),
-            DstError::XofSecurityLevel => {
-                write!(f, "XOF target security level in bytes is too large ")
-            }
-        }
-    }
-}
-
-impl core::error::Error for DstError {}

--- a/hash2curve/src/hash2field/expand_msg.rs
+++ b/hash2curve/src/hash2field/expand_msg.rs
@@ -8,8 +8,6 @@ use core::num::NonZero;
 use digest::{
     Digest, ExtendableOutput, Update, XofReader,
     array::{Array, ArraySize},
-    consts::{True, U256},
-    typenum::IsLess,
 };
 
 /// Salt when the DST is too long
@@ -61,7 +59,7 @@ pub(crate) enum Domain<'a, L: ArraySize> {
     Array(&'a [&'a [u8]]),
 }
 
-impl<'a, L: ArraySize + IsLess<U256, Output = True>> Domain<'a, L> {
+impl<'a, L: ArraySize> Domain<'a, L> {
     pub fn xof<X>(dst: &'a [&'a [u8]]) -> Result<Self, DstError>
     where
         X: Default + ExtendableOutput + Update,

--- a/hash2curve/src/hash2field/expand_msg.rs
+++ b/hash2curve/src/hash2field/expand_msg.rs
@@ -5,10 +5,8 @@ pub(super) mod xof;
 
 use core::num::NonZero;
 
-use digest::{
-    Digest, ExtendableOutput, Update, XofReader,
-    array::{Array, ArraySize},
-};
+use digest::{Digest, ExtendableOutput, Update, XofReader};
+use elliptic_curve::array::{Array, ArraySize};
 
 /// Salt when the DST is too long
 const OVERSIZE_DST_SALT: &[u8] = b"H2C-OVERSIZE-DST-";

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -152,7 +152,7 @@ where
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExapandMsgXmdError {
     /// The domain separation tag is empty.
-    EmptyDST(EmptyDST),
+    DSTError(EmptyDST),
     /// The length in bytes is too large.
     ///
     /// `len_in_bytes` must be at most `255 * HashT::OutputSize`
@@ -162,7 +162,7 @@ pub enum ExapandMsgXmdError {
 impl core::fmt::Display for ExapandMsgXmdError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::EmptyDST(e) => write!(f, "{e}"),
+            Self::DSTError(e) => write!(f, "{e}"),
             Self::OversizedLen => write!(f, "length in bytes is too large"),
         }
     }
@@ -172,7 +172,7 @@ impl core::error::Error for ExapandMsgXmdError {}
 
 impl From<EmptyDST> for ExapandMsgXmdError {
     fn from(e: EmptyDST) -> Self {
-        Self::EmptyDST(e)
+        Self::DSTError(e)
     }
 }
 

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -165,7 +165,7 @@ impl core::fmt::Display for ExpandMsgXmdError {
             Self::EmptyDst => write!(f, "the domain separation tag is empty"),
             Self::DstHash => write!(
                 f,
-                "`dst` is too long and the hash function has an output size greater than 255"
+                "hash output size is too large"
             ),
             Self::Length => write!(f, "`len_in_bytes` is too large"),
         }

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -163,10 +163,7 @@ impl core::fmt::Display for ExpandMsgXmdError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::EmptyDst => write!(f, "the domain separation tag is empty"),
-            Self::DstHash => write!(
-                f,
-                "hash output size is too large"
-            ),
+            Self::DstHash => write!(f, "hash output size is too large"),
             Self::Length => write!(f, "`len_in_bytes` is too large"),
         }
     }

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -10,8 +10,6 @@ use digest::{
         typenum::{IsGreaterOrEqual, IsLessOrEqual, Prod, True, U2, Unsigned},
     },
     block_api::BlockSizeUser,
-    consts::U256,
-    typenum::IsLess,
 };
 
 /// Implements `expand_message_xof` via the [`ExpandMsg`] trait:
@@ -31,7 +29,7 @@ where
     HashT: BlockSizeUser + Default + FixedOutput + HashMarker,
     // The number of bits output by `HashT` MUST be at most `HashT::BlockSize`.
     // https://www.rfc-editor.org/rfc/rfc9380.html#section-5.3.1-4
-    HashT::OutputSize: IsLessOrEqual<HashT::BlockSize, Output = True> + IsLess<U256, Output = True>,
+    HashT::OutputSize: IsLessOrEqual<HashT::BlockSize, Output = True>,
     // The number of bits output by `HashT` MUST be at least `K * 2`.
     // https://www.rfc-editor.org/rfc/rfc9380.html#section-5.3.1-2.1
     K: Mul<U2>,
@@ -105,7 +103,7 @@ where
 impl<HashT> ExpanderXmd<'_, HashT>
 where
     HashT: BlockSizeUser + Default + FixedOutput + HashMarker,
-    HashT::OutputSize: IsLessOrEqual<HashT::BlockSize, Output = True> + IsLess<U256, Output = True>,
+    HashT::OutputSize: IsLessOrEqual<HashT::BlockSize, Output = True>,
 {
     fn next(&mut self) -> bool {
         if self.index < self.ell {
@@ -134,7 +132,7 @@ where
 impl<HashT> Expander for ExpanderXmd<'_, HashT>
 where
     HashT: BlockSizeUser + Default + FixedOutput + HashMarker,
-    HashT::OutputSize: IsLessOrEqual<HashT::BlockSize, Output = True> + IsLess<U256, Output = True>,
+    HashT::OutputSize: IsLessOrEqual<HashT::BlockSize, Output = True>,
 {
     fn fill_bytes(&mut self, okm: &mut [u8]) {
         for b in okm {
@@ -180,7 +178,7 @@ mod test {
     use super::*;
     use elliptic_curve::array::{
         ArraySize,
-        typenum::{IsLess, U4, U8, U32, U128, U256, U65536},
+        typenum::{IsLess, U4, U8, U32, U128, U65536},
     };
     use hex_literal::hex;
     use sha2::Sha256;
@@ -192,7 +190,6 @@ mod test {
         bytes: &[u8],
     ) where
         HashT: BlockSizeUser + Default + FixedOutput + HashMarker,
-        HashT::OutputSize: IsLess<U256, Output = True>,
     {
         let block = HashT::BlockSize::USIZE;
         assert_eq!(
@@ -230,7 +227,7 @@ mod test {
         where
             HashT: BlockSizeUser + Default + FixedOutput + HashMarker,
             HashT::OutputSize:
-                IsLessOrEqual<HashT::BlockSize, Output = True> + IsLess<U256, Output = True>,
+                IsLessOrEqual<HashT::BlockSize, Output = True>,
             HashT::OutputSize: IsGreaterOrEqual<U8, Output = True>,
             L: ArraySize + IsLess<U65536, Output = True>,
         {

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -17,7 +17,7 @@ use digest::{
 ///
 /// # Errors
 ///
-/// `expand_message` can return an [`ExpandMsgXmdError`].
+/// See [`ExpandMsgXmdError`] for more details.
 #[derive(Debug)]
 pub struct ExpandMsgXmd<HashT>(PhantomData<HashT>)
 where

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -49,7 +49,7 @@ where
 
         // `255 * <b_in_bytes>` can not exceed `u16::MAX`
         if usize::from(len_in_bytes.get()) > 255 * b_in_bytes {
-            return Err(ExpandMsgXmdError::OversizedLen);
+            return Err(ExpandMsgXmdError::Length);
         }
 
         let ell = u8::try_from(usize::from(len_in_bytes.get()).div_ceil(b_in_bytes))
@@ -155,14 +155,14 @@ pub enum ExpandMsgXmdError {
     /// The length in bytes is too large.
     ///
     /// `len_in_bytes` must be at most `255 * HashT::OutputSize`
-    OversizedLen,
+    Length,
 }
 
 impl core::fmt::Display for ExpandMsgXmdError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Dst(e) => write!(f, "{e}"),
-            Self::OversizedLen => write!(f, "`len_in_bytes` is too large"),
+            Self::Length => write!(f, "`len_in_bytes` is too large"),
         }
     }
 }

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -148,7 +148,7 @@ where
 /// Error type for [`ExpandMsgXmd`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExpandMsgXmdError {
-    /// The domain separation tag is invalid because it is empty.
+    /// The domain separation tag must not be empty.
     EmptyDst,
     /// The domain separation tag is too long and needs to be hashed, but the hash function
     /// selected has an output size too large (greater than `255`).

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -2,7 +2,7 @@
 
 use core::{marker::PhantomData, num::NonZero, ops::Mul};
 
-use super::{Domain, EmptyDST, ExpandMsg, Expander};
+use super::{Domain, EmptyDst, ExpandMsg, Expander};
 use digest::{
     FixedOutput, HashMarker,
     array::{
@@ -151,7 +151,7 @@ where
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExpandMsgXmdError {
     /// The domain separation tag is empty.
-    DSTError(EmptyDST),
+    Dst(EmptyDst),
     /// The length in bytes is too large.
     ///
     /// `len_in_bytes` must be at most `255 * HashT::OutputSize`
@@ -161,7 +161,7 @@ pub enum ExpandMsgXmdError {
 impl core::fmt::Display for ExpandMsgXmdError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::DSTError(e) => write!(f, "{e}"),
+            Self::Dst(e) => write!(f, "{e}"),
             Self::OversizedLen => write!(f, "length in bytes is too large"),
         }
     }
@@ -169,9 +169,9 @@ impl core::fmt::Display for ExpandMsgXmdError {
 
 impl core::error::Error for ExpandMsgXmdError {}
 
-impl From<EmptyDST> for ExpandMsgXmdError {
-    fn from(e: EmptyDST) -> Self {
-        Self::DSTError(e)
+impl From<EmptyDst> for ExpandMsgXmdError {
+    fn from(e: EmptyDst) -> Self {
+        Self::Dst(e)
     }
 }
 

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -162,7 +162,7 @@ impl core::fmt::Display for ExpandMsgXmdError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Dst(e) => write!(f, "{e}"),
-            Self::OversizedLen => write!(f, "length in bytes is too large"),
+            Self::OversizedLen => write!(f, "`len_in_bytes` is too large"),
         }
     }
 }

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -226,8 +226,7 @@ mod test {
         fn assert<HashT, L>(&self, dst: &'static [u8], domain: &Domain<'_, HashT::OutputSize>)
         where
             HashT: BlockSizeUser + Default + FixedOutput + HashMarker,
-            HashT::OutputSize:
-                IsLessOrEqual<HashT::BlockSize, Output = True>,
+            HashT::OutputSize: IsLessOrEqual<HashT::BlockSize, Output = True>,
             HashT::OutputSize: IsGreaterOrEqual<U8, Output = True>,
             L: ArraySize + IsLess<U65536, Output = True>,
         {

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -2,7 +2,7 @@
 
 use core::{marker::PhantomData, num::NonZero, ops::Mul};
 
-use super::{Domain, EmptyDst, ExpandMsg, Expander};
+use super::{Domain, DstError, ExpandMsg, Expander};
 use digest::{
     FixedOutput, HashMarker,
     array::{
@@ -151,7 +151,7 @@ where
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExpandMsgXmdError {
     /// The domain separation tag is empty.
-    Dst(EmptyDst),
+    Dst(DstError),
     /// The length in bytes is too large.
     ///
     /// `len_in_bytes` must be at most `255 * HashT::OutputSize`
@@ -169,8 +169,8 @@ impl core::fmt::Display for ExpandMsgXmdError {
 
 impl core::error::Error for ExpandMsgXmdError {}
 
-impl From<EmptyDst> for ExpandMsgXmdError {
-    fn from(e: EmptyDst) -> Self {
+impl From<DstError> for ExpandMsgXmdError {
+    fn from(e: DstError) -> Self {
         Self::Dst(e)
     }
 }

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -17,7 +17,7 @@ use digest::{
 ///
 /// # Errors
 ///
-/// See [`ExpandMsgXmdError`] for more details.
+/// See [`ExpandMsgXmdError`] for details.
 #[derive(Debug)]
 pub struct ExpandMsgXmd<HashT>(PhantomData<HashT>)
 where

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -155,7 +155,7 @@ pub enum ExpandMsgXmdError {
     DstHash,
     /// The length in bytes is too large.
     ///
-    /// `len_in_bytes` must be at most `255 * HashT::OutputSize`
+    /// `len_in_bytes` must be at most `255 * HashT::OutputSize`.
     Length,
 }
 

--- a/hash2curve/src/hash2field/expand_msg/xmd.rs
+++ b/hash2curve/src/hash2field/expand_msg/xmd.rs
@@ -150,8 +150,8 @@ where
 pub enum ExpandMsgXmdError {
     /// The domain separation tag must not be empty.
     EmptyDst,
-    /// The domain separation tag is too long and needs to be hashed, but the hash function
-    /// selected has an output size too large (greater than `255`).
+    /// The hash's output size must not be greater then `255`
+    /// if the domain separation tag is longer than `255`.
     DstHash,
     /// The length in bytes is too large.
     ///

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -1,6 +1,6 @@
 //! `expand_message_xof` for the `ExpandMsg` trait
 
-use super::{Domain, EmptyDST, ExpandMsg, Expander};
+use super::{Domain, EmptyDst, ExpandMsg, Expander};
 use core::{fmt, num::NonZero, ops::Mul};
 use digest::{
     CollisionResistance, ExtendableOutput, HashMarker, Update, XofReader,
@@ -48,13 +48,13 @@ where
     HashT: CollisionResistance<CollisionResistance: IsGreaterOrEqual<K, Output = True>>,
 {
     type Expander<'dst> = Self;
-    type Error = EmptyDST;
+    type Error = EmptyDst;
 
     fn expand_message<'dst>(
         msg: &[&[u8]],
         dst: &'dst [&[u8]],
         len_in_bytes: NonZero<u16>,
-    ) -> Result<Self::Expander<'dst>, EmptyDST> {
+    ) -> Result<Self::Expander<'dst>, EmptyDst> {
         let len_in_bytes = len_in_bytes.get();
 
         let domain = Domain::<Prod<K, U2>>::xof::<HashT>(dst)?;

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -15,7 +15,7 @@ use digest::{
 ///
 /// # Errors
 ///
-/// `expand_message` can return an [`EmptyDST`] error.
+/// `expand_message` can return a [`DstError`] error.
 pub struct ExpandMsgXof<HashT>
 where
     HashT: Default + ExtendableOutput + Update + HashMarker,

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -2,12 +2,10 @@
 
 use super::{Domain, ExpandMsg, Expander};
 use core::{fmt, num::NonZero, ops::Mul};
-use digest::{
-    CollisionResistance, ExtendableOutput, HashMarker, Update, XofReader,
-    array::{
-        ArraySize,
-        typenum::{IsGreaterOrEqual, Prod, True, U2},
-    },
+use digest::{CollisionResistance, ExtendableOutput, HashMarker, Update, XofReader};
+use elliptic_curve::array::{
+    ArraySize,
+    typenum::{IsGreaterOrEqual, Prod, True, U2},
 };
 
 /// Implements `expand_message_xof` via the [`ExpandMsg`] trait:

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -82,8 +82,8 @@ where
 pub enum ExpandMsgXofError {
     /// The domain separation tag is invalid because it is empty.
     EmptyDst,
-    /// The domain separation tag is too long and needs to be hashed, but the selected
-    /// target security level in bytes (`K`) is too large (greater than `127`).
+    /// The target security level (`K`) must not be greater then `127`
+    /// if the domain separation tag is longer than `255`.
     DstSecurityLevel,
 }
 

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -17,7 +17,7 @@ use digest::{
 ///
 /// # Errors
 ///
-/// `expand_message` caa return an [`EmptyDST`] error.
+/// `expand_message` can return an [`EmptyDST`] error.
 pub struct ExpandMsgXof<HashT>
 where
     HashT: Default + ExtendableOutput + Update + HashMarker,

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -1,6 +1,6 @@
 //! `expand_message_xof` for the `ExpandMsg` trait
 
-use super::{Domain, ExpandMsg, Expander};
+use super::{Domain, EmptyDST, ExpandMsg, Expander};
 use core::{fmt, num::NonZero, ops::Mul};
 use digest::{
     CollisionResistance, ExtendableOutput, HashMarker, Update, XofReader,
@@ -16,8 +16,8 @@ use digest::{
 /// <https://www.rfc-editor.org/rfc/rfc9380.html#name-expand_message_xof>
 ///
 /// # Errors
-/// - `dst` contains no bytes
-/// - `dst > 255 && K * 2 > 255`
+/// 
+/// `expand_message` caa return an [`EmptyDST`] error.
 pub struct ExpandMsgXof<HashT>
 where
     HashT: Default + ExtendableOutput + Update + HashMarker,
@@ -48,13 +48,13 @@ where
     HashT: CollisionResistance<CollisionResistance: IsGreaterOrEqual<K, Output = True>>,
 {
     type Expander<'dst> = Self;
-    type Error = super::EmptyDST;
+    type Error = EmptyDST;
 
     fn expand_message<'dst>(
         msg: &[&[u8]],
         dst: &'dst [&[u8]],
         len_in_bytes: NonZero<u16>,
-    ) -> Result<Self::Expander<'dst>, super::EmptyDST> {
+    ) -> Result<Self::Expander<'dst>, EmptyDST> {
         let len_in_bytes = len_in_bytes.get();
 
         let domain = Domain::<Prod<K, U2>>::xof::<HashT>(dst)?;

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -16,7 +16,7 @@ use digest::{
 /// <https://www.rfc-editor.org/rfc/rfc9380.html#name-expand_message_xof>
 ///
 /// # Errors
-/// 
+///
 /// `expand_message` caa return an [`EmptyDST`] error.
 pub struct ExpandMsgXof<HashT>
 where

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -15,7 +15,7 @@ use digest::{
 ///
 /// # Errors
 ///
-/// `expand_message` can return a [`ExpandMsgXofError`] error.
+/// See [`ExpandMsgXofError`] for details.
 pub struct ExpandMsgXof<HashT>
 where
     HashT: Default + ExtendableOutput + Update + HashMarker,

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -1,6 +1,6 @@
 //! `expand_message_xof` for the `ExpandMsg` trait
 
-use super::{Domain, EmptyDst, ExpandMsg, Expander};
+use super::{Domain, DstError, ExpandMsg, Expander};
 use core::{fmt, num::NonZero, ops::Mul};
 use digest::{
     CollisionResistance, ExtendableOutput, HashMarker, Update, XofReader,
@@ -48,13 +48,13 @@ where
     HashT: CollisionResistance<CollisionResistance: IsGreaterOrEqual<K, Output = True>>,
 {
     type Expander<'dst> = Self;
-    type Error = EmptyDst;
+    type Error = DstError;
 
     fn expand_message<'dst>(
         msg: &[&[u8]],
         dst: &'dst [&[u8]],
         len_in_bytes: NonZero<u16>,
-    ) -> Result<Self::Expander<'dst>, EmptyDst> {
+    ) -> Result<Self::Expander<'dst>, DstError> {
         let len_in_bytes = len_in_bytes.get();
 
         let domain = Domain::<Prod<K, U2>>::xof::<HashT>(dst)?;

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -93,7 +93,7 @@ impl core::fmt::Display for ExpandMsgXofError {
             Self::EmptyDst => write!(f, "the domain separation tag is empty"),
             Self::DstSecurityLevel => write!(
                 f,
-                "the domain separation tag is too long and the target security level is too large"
+                "target security level is too large"
             ),
         }
     }

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -6,10 +6,8 @@ use digest::{
     CollisionResistance, ExtendableOutput, HashMarker, Update, XofReader,
     array::{
         ArraySize,
-        typenum::{Prod, True, U2},
+        typenum::{IsGreaterOrEqual, Prod, True, U2},
     },
-    consts::U256,
-    typenum::{IsGreaterOrEqual, IsLess},
 };
 
 /// Implements `expand_message_xof` via the [`ExpandMsg`] trait:
@@ -42,7 +40,7 @@ where
     HashT: Default + ExtendableOutput + Update + HashMarker,
     // If DST is larger than 255 bytes, the length of the computed DST is calculated by `K * 2`.
     // https://www.rfc-editor.org/rfc/rfc9380.html#section-5.3.1-2.1
-    K: Mul<U2, Output: ArraySize + IsLess<U256, Output = True>>,
+    K: Mul<U2, Output: ArraySize>,
     // The collision resistance of `HashT` MUST be at least `K` bits.
     // https://www.rfc-editor.org/rfc/rfc9380.html#section-5.3.2-2.1
     HashT: CollisionResistance<CollisionResistance: IsGreaterOrEqual<K, Output = True>>,

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -91,10 +91,7 @@ impl core::fmt::Display for ExpandMsgXofError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::EmptyDst => write!(f, "the domain separation tag is empty"),
-            Self::DstSecurityLevel => write!(
-                f,
-                "target security level is too large"
-            ),
+            Self::DstSecurityLevel => write!(f, "target security level is too large"),
         }
     }
 }


### PR DESCRIPTION
Discussed in https://github.com/RustCrypto/elliptic-curves/issues/1295. This was planned as a follow up to https://github.com/RustCrypto/elliptic-curves/pull/1317, but I decided to make it as its own PR because #1317 is not unanimous.

Replaces `elliptic_curve::{Error, Result}` with an associated type on `ExpandMsg`.