### PR TITLE
Use rejection sampling for random point generation

### DIFF
--- a/ed448-goldilocks/src/decaf/points.rs
+++ b/ed448-goldilocks/src/decaf/points.rs
@@ -174,9 +174,14 @@ impl Group for DecafPoint {
     where
         R: TryRngCore + ?Sized,
     {
-        let mut uniform_bytes = [0u8; 112];
-        rng.try_fill_bytes(&mut uniform_bytes)?;
-        Ok(Self::from_uniform_bytes(&uniform_bytes))
+        let mut bytes = DecafPointRepr::default();
+
+        loop {
+            rng.try_fill_bytes(bytes.as_mut())?;
+            if let Some(point) = Self::from_bytes(&bytes).into() {
+                return Ok(point);
+            }
+        }
     }
 
     fn identity() -> Self {

--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -341,9 +341,14 @@ impl Group for EdwardsPoint {
     where
         R: TryRngCore + ?Sized,
     {
-        let mut bytes = [0u8; 32];
-        rng.try_fill_bytes(&mut bytes)?;
-        Ok(Self::hash_with_defaults(&bytes))
+        let mut bytes = Array::default();
+
+        loop {
+            rng.try_fill_bytes(bytes.as_mut())?;
+            if let Some(point) = Self::from_bytes(&bytes).into() {
+                return Ok(point);
+            }
+        }
     }
 
     fn identity() -> Self {

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -12,7 +12,6 @@ use elliptic_curve::{
     BatchNormalize, CurveGroup, Error, Result,
     group::{
         Group, GroupEncoding,
-        ff::Field,
         prime::{PrimeCurve, PrimeCurveAffine, PrimeGroup},
     },
     rand_core::TryRngCore,
@@ -411,7 +410,7 @@ impl Group for ProjectivePoint {
     type Scalar = Scalar;
 
     fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
-        Ok(Self::GENERATOR * Scalar::try_from_rng(rng)?)
+        AffinePoint::try_from_rng(rng).map(Self::from)
     }
 
     fn identity() -> Self {

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -258,13 +258,13 @@ where
 
 impl<C> Group for ProjectivePoint<C>
 where
-    Self: Double,
     C: PrimeCurveParams,
+    FieldBytes<C>: Copy,
 {
     type Scalar = Scalar<C>;
 
     fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
-        Ok(Self::GENERATOR * <Scalar<C> as Field>::try_from_rng(rng)?)
+        AffinePoint::try_from_rng(rng).map(Self::from)
     }
 
     fn identity() -> Self {
@@ -311,8 +311,8 @@ where
 
 impl<C> CurveGroup for ProjectivePoint<C>
 where
-    Self: Double,
     C: PrimeCurveParams,
+    FieldBytes<C>: Copy,
 {
     type AffineRepr = AffinePoint<C>;
 
@@ -331,8 +331,8 @@ where
 
 impl<const N: usize, C> BatchNormalize<[ProjectivePoint<C>; N]> for ProjectivePoint<C>
 where
-    Self: Double,
     C: PrimeCurveParams,
+    FieldBytes<C>: Copy,
 {
     type Output = [<Self as CurveGroup>::AffineRepr; N];
 
@@ -348,8 +348,8 @@ where
 #[cfg(feature = "alloc")]
 impl<C> BatchNormalize<[ProjectivePoint<C>]> for ProjectivePoint<C>
 where
-    Self: Double,
     C: PrimeCurveParams,
+    FieldBytes<C>: Copy,
 {
     type Output = Vec<<Self as CurveGroup>::AffineRepr>;
 
@@ -400,16 +400,16 @@ where
 
 impl<C> LinearCombination<[(Self, Scalar<C>)]> for ProjectivePoint<C>
 where
-    Self: Double,
     C: PrimeCurveParams,
+    FieldBytes<C>: Copy,
 {
     // TODO(tarcieri): optimized implementation
 }
 
 impl<C, const N: usize> LinearCombination<[(Self, Scalar<C>); N]> for ProjectivePoint<C>
 where
-    Self: Double,
     C: PrimeCurveParams,
+    FieldBytes<C>: Copy,
 {
     // TODO(tarcieri): optimized implementation
 }


### PR DESCRIPTION
This PR changes random point generation to use rejection sampling by de-serialization instead of deriving a point from a random scalar.

Fixes #1140.