### PR TITLE
`ed448-goldilocks`: reject identity points in `Group::try_from_rng()`

### DIFF
--- a/ed448-goldilocks/src/decaf/points.rs
+++ b/ed448-goldilocks/src/decaf/points.rs
@@ -177,8 +177,11 @@ impl Group for DecafPoint {
         let mut bytes = DecafPointRepr::default();
 
         loop {
-            rng.try_fill_bytes(bytes.as_mut())?;
-            if let Some(point) = Self::from_bytes(&bytes).into() {
+            rng.try_fill_bytes(&mut bytes)?;
+            if let Some(point) = Self::from_bytes(&bytes)
+                .into_option()
+                .filter(|&point| point != Self::IDENTITY)
+            {
                 return Ok(point);
             }
         }

--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -344,8 +344,11 @@ impl Group for EdwardsPoint {
         let mut bytes = Array::default();
 
         loop {
-            rng.try_fill_bytes(bytes.as_mut())?;
-            if let Some(point) = Self::from_bytes(&bytes).into() {
+            rng.try_fill_bytes(&mut bytes)?;
+            if let Some(point) = Self::from_bytes(&bytes)
+                .into_option()
+                .filter(|&point| point != Self::IDENTITY)
+            {
                 return Ok(point);
             }
         }


### PR DESCRIPTION
In #1333 I will remove this specific check from `AffinePoint::try_from_rng()`, which doesn't have the limitations of `Group::try_from_rng()`.

Fixes #1346.