### PR TITLE
primefield: remove `ConstMontyFormInverter`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto-bigint"
 version = "0.7.0-pre.7"
-source = "git+https://github.com/RustCrypto/crypto-bigint#bfd010775118fe29c02f5141a80a8e153472ead7"
+source = "git+https://github.com/RustCrypto/crypto-bigint#cb71acaa8bc6d39439a71612f5560cb7b8a19db5"
 dependencies = [
  "hybrid-array",
  "num-traits",

--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -5,7 +5,7 @@ use crate::ByteOrder;
 use bigint::{
     ArrayEncoding, ByteArray, Integer, Invert, Uint,
     hybrid_array::{Array, ArraySize, typenum::Unsigned},
-    modular::{ConstMontyForm as MontyForm, ConstMontyFormInverter, ConstMontyParams},
+    modular::{ConstMontyForm as MontyForm, ConstMontyParams},
 };
 use core::fmt::Formatter;
 use core::{
@@ -331,11 +331,7 @@ impl<MOD: MontyFieldParams<LIMBS>, const LIMBS: usize> MontyFieldElement<MOD, LI
     ///
     /// This is mainly intended for inverting constants at compile time.
     pub const fn const_invert(&self) -> Self {
-        Self(
-            ConstMontyFormInverter::<MOD, LIMBS>::new()
-                .invert(&self.0)
-                .expect("input to invert should be non-zero"),
-        )
+        Self(self.0.invert().expect("input to invert should be non-zero"))
     }
 
     /// Returns `self^exp`, where `exp` is a little-endian integer exponent.


### PR DESCRIPTION
Now that the bounds on inversion have been removed, we no longer need to use this directly