### PR TITLE
fix(docs): update broken link to arithmetic module in README

### DIFF
--- a/k256/README.md
+++ b/k256/README.md
@@ -102,7 +102,7 @@ dual licensed as above, without any additional terms or conditions.
 [RustCrypto]: https://github.com/RustCrypto/
 [secp256k1]: https://en.bitcoin.it/wiki/Secp256k1
 [`elliptic-curve`]: https://github.com/RustCrypto/traits/tree/master/elliptic-curve
-[`arithmetic`]: https://docs.rs/k256/latest/k256/arithmetic/index.html
+[`arithmetic`]: https://docs.rs/k256/latest/k256/index.html#arithmetic
 [`group`]: https://github.com/zkcrypto/group
 [ECDH]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie-Hellman
 [ECDSA]: https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm


### PR DESCRIPTION
Fixed outdated link to the arithmetic module in k256/README.md

- Old broken link: https://docs.rs/k256/latest/k256/arithmetic/index.html

- New correct link: https://docs.rs/k256/latest/k256/index.html#arithmetic