### PR TITLE
primefield: add `MontyFieldElement` methods to fiat macros

### DIFF
--- a/bign256/src/arithmetic.rs
+++ b/bign256/src/arithmetic.rs
@@ -34,12 +34,16 @@ impl PrimeCurveArithmetic for BignP256 {
 impl PrimeCurveParams for BignP256 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
-    const EQUATION_A: Self::FieldElement =
-        FieldElement::from_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF40");
-    const EQUATION_B: Self::FieldElement =
-        FieldElement::from_hex("77CE6C1515F3A8EDD2C13AABE4D8FBBE4CF55069978B9253B22E7D6BD69C03F1");
+    const EQUATION_A: Self::FieldElement = FieldElement::from_hex_vartime(
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF40",
+    );
+    const EQUATION_B: Self::FieldElement = FieldElement::from_hex_vartime(
+        "77CE6C1515F3A8EDD2C13AABE4D8FBBE4CF55069978B9253B22E7D6BD69C03F1",
+    );
     const GENERATOR: (Self::FieldElement, Self::FieldElement) = (
         FieldElement::ZERO,
-        FieldElement::from_hex("6BF7FC3CFB16D69F5CE4C9A351D6835D78913966C408F6521E29CF1804516A93"),
+        FieldElement::from_hex_vartime(
+            "6BF7FC3CFB16D69F5CE4C9A351D6835D78913966C408F6521E29CF1804516A93",
+        ),
     );
 }

--- a/bign256/src/arithmetic/field.rs
+++ b/bign256/src/arithmetic/field.rs
@@ -116,7 +116,7 @@ impl PrimeField for FieldElement {
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(2);
     const S: u32 = 1;
     const ROOT_OF_UNITY: Self =
-        Self::from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff42");
+        Self::from_hex_vartime("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff42");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
     const DELTA: Self = Self::from_u64(4);
 }

--- a/bign256/src/arithmetic/scalar.rs
+++ b/bign256/src/arithmetic/scalar.rs
@@ -149,7 +149,7 @@ impl PrimeField for Scalar {
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(3);
     const S: u32 = 1;
     const ROOT_OF_UNITY: Self =
-        Self::from_hex("ffffffffffffffffffffffffffffffffd95c8ed60dfb4dfc7e5abf99263d6606");
+        Self::from_hex_vartime("ffffffffffffffffffffffffffffffffd95c8ed60dfb4dfc7e5abf99263d6606");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
     const DELTA: Self = Self::from_u64(9);
 }

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -85,7 +85,7 @@ impl PrimeField for FieldElement {
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(11);
     const S: u32 = 1;
     const ROOT_OF_UNITY: Self =
-        Self::from_hex("a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5376");
+        Self::from_hex_vartime("a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5376");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
     const DELTA: Self = Self::from_u64(121);
 

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -111,7 +111,7 @@ impl PrimeField for Scalar {
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(3);
     const S: u32 = 1;
     const ROOT_OF_UNITY: Self =
-        Self::from_hex("a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a6");
+        Self::from_hex_vartime("a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a6");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
     const DELTA: Self = Self::from_u64(9);
 

--- a/bp256/src/r1/arithmetic.rs
+++ b/bp256/src/r1/arithmetic.rs
@@ -31,12 +31,18 @@ impl PrimeCurveParams for BrainpoolP256r1 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
 
-    const EQUATION_A: FieldElement =
-        FieldElement::from_hex("7d5a0975fc2c3057eef67530417affe7fb8055c126dc5c6ce94a4b44f330b5d9");
-    const EQUATION_B: FieldElement =
-        FieldElement::from_hex("26dc5c6ce94a4b44f330b5d9bbd77cbf958416295cf7e1ce6bccdc18ff8c07b6");
+    const EQUATION_A: FieldElement = FieldElement::from_hex_vartime(
+        "7d5a0975fc2c3057eef67530417affe7fb8055c126dc5c6ce94a4b44f330b5d9",
+    );
+    const EQUATION_B: FieldElement = FieldElement::from_hex_vartime(
+        "26dc5c6ce94a4b44f330b5d9bbd77cbf958416295cf7e1ce6bccdc18ff8c07b6",
+    );
     const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_hex("8bd2aeb9cb7e57cb2c4b482ffc81b7afb9de27e1e3bd23c23a4453bd9ace3262"),
-        FieldElement::from_hex("547ef835c3dac4fd97f8461a14611dc9c27745132ded8e545c1d54c72f046997"),
+        FieldElement::from_hex_vartime(
+            "8bd2aeb9cb7e57cb2c4b482ffc81b7afb9de27e1e3bd23c23a4453bd9ace3262",
+        ),
+        FieldElement::from_hex_vartime(
+            "547ef835c3dac4fd97f8461a14611dc9c27745132ded8e545c1d54c72f046997",
+        ),
     );
 }

--- a/bp256/src/t1/arithmetic.rs
+++ b/bp256/src/t1/arithmetic.rs
@@ -31,12 +31,18 @@ impl PrimeCurveParams for BrainpoolP256t1 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
 
-    const EQUATION_A: FieldElement =
-        FieldElement::from_hex("a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5374");
-    const EQUATION_B: FieldElement =
-        FieldElement::from_hex("662c61c430d84ea4fe66a7733d0b76b7bf93ebc4af2f49256ae58101fee92b04");
+    const EQUATION_A: FieldElement = FieldElement::from_hex_vartime(
+        "a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5374",
+    );
+    const EQUATION_B: FieldElement = FieldElement::from_hex_vartime(
+        "662c61c430d84ea4fe66a7733d0b76b7bf93ebc4af2f49256ae58101fee92b04",
+    );
     const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_hex("a3e8eb3cc1cfe7b7732213b23a656149afa142c47aafbc2b79a191562e1305f4"),
-        FieldElement::from_hex("2d996c823439c56d7f7b22e14644417e69bcb6de39d027001dabe8f35b25c9be"),
+        FieldElement::from_hex_vartime(
+            "a3e8eb3cc1cfe7b7732213b23a656149afa142c47aafbc2b79a191562e1305f4",
+        ),
+        FieldElement::from_hex_vartime(
+            "2d996c823439c56d7f7b22e14644417e69bcb6de39d027001dabe8f35b25c9be",
+        ),
     );
 }

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -86,7 +86,7 @@ impl PrimeField for FieldElement {
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(3);
     const S: u32 = 1;
-    const ROOT_OF_UNITY: Self = Self::from_hex(
+    const ROOT_OF_UNITY: Self = Self::from_hex_vartime(
         "8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec52",
     );
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -117,7 +117,7 @@ impl PrimeField for Scalar {
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(2);
     const S: u32 = 2;
-    const ROOT_OF_UNITY: Self = Self::from_hex(
+    const ROOT_OF_UNITY: Self = Self::from_hex_vartime(
         "76cdc6369fb54dde55a851fce47cc5f830bb074c85684b3ee476be128dc50cfa8602aeecf53a1982fcf3b95f8d4258ff",
     );
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();

--- a/bp384/src/r1/arithmetic.rs
+++ b/bp384/src/r1/arithmetic.rs
@@ -31,17 +31,17 @@ impl PrimeCurveParams for BrainpoolP384r1 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
 
-    const EQUATION_A: FieldElement = FieldElement::from_hex(
+    const EQUATION_A: FieldElement = FieldElement::from_hex_vartime(
         "7bc382c63d8c150c3c72080ace05afa0c2bea28e4fb22787139165efba91f90f8aa5814a503ad4eb04a8c7dd22ce2826",
     );
-    const EQUATION_B: FieldElement = FieldElement::from_hex(
+    const EQUATION_B: FieldElement = FieldElement::from_hex_vartime(
         "04a8c7dd22ce28268b39b55416f0447c2fb77de107dcd2a62e880ea53eeb62d57cb4390295dbc9943ab78696fa504c11",
     );
     const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_hex(
+        FieldElement::from_hex_vartime(
             "1d1c64f068cf45ffa2a63a81b7c13f6b8847a3e77ef14fe3db7fcafe0cbd10e8e826e03436d646aaef87b2e247d4af1e",
         ),
-        FieldElement::from_hex(
+        FieldElement::from_hex_vartime(
             "8abe1d7520f9c2a45cb1eb8e95cfd55262b70b29feec5864e19c054ff99129280e4646217791811142820341263c5315",
         ),
     );

--- a/bp384/src/t1/arithmetic.rs
+++ b/bp384/src/t1/arithmetic.rs
@@ -31,17 +31,17 @@ impl PrimeCurveParams for BrainpoolP384t1 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
 
-    const EQUATION_A: FieldElement = FieldElement::from_hex(
+    const EQUATION_A: FieldElement = FieldElement::from_hex_vartime(
         "8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec50",
     );
-    const EQUATION_B: FieldElement = FieldElement::from_hex(
+    const EQUATION_B: FieldElement = FieldElement::from_hex_vartime(
         "7f519eada7bda81bd826dba647910f8c4b9346ed8ccdc64e4b1abd11756dce1d2074aa263b88805ced70355a33b471ee",
     );
     const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_hex(
+        FieldElement::from_hex_vartime(
             "18de98b02db9a306f2afcd7235f72a819b80ab12ebd653172476fecd462aabffc4ff191b946a5f54d8d0aa2f418808cc",
         ),
-        FieldElement::from_hex(
+        FieldElement::from_hex_vartime(
             "25ab056962d30651a114afd2755ad336747f93475b7a1fca3b88f2b6a208ccfe469408584dc2b2912675bf5b9e582928",
         ),
     );

--- a/p192/src/arithmetic.rs
+++ b/p192/src/arithmetic.rs
@@ -40,7 +40,7 @@ impl PrimeCurveParams for NistP192 {
 
     /// b = 0x64210519 e59c80e7 0fa7e9ab 72243049 feb8deec c146b9b1
     const EQUATION_B: FieldElement =
-        FieldElement::from_hex("64210519e59c80e70fa7e9ab72243049feb8deecc146b9b1");
+        FieldElement::from_hex_vartime("64210519e59c80e70fa7e9ab72243049feb8deecc146b9b1");
 
     /// Base point of P-192.
     ///
@@ -49,7 +49,7 @@ impl PrimeCurveParams for NistP192 {
     /// Gᵧ = 0x07192b95 ffc8da78 631011ed 6b24cdd5 73f977a1 1e794811
     /// ```
     const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_hex("188da80eb03090f67cbf20eb43a18800f4ff0afd82ff1012"),
-        FieldElement::from_hex("07192b95ffc8da78631011ed6b24cdd573f977a11e794811"),
+        FieldElement::from_hex_vartime("188da80eb03090f67cbf20eb43a18800f4ff0afd82ff1012"),
+        FieldElement::from_hex_vartime("07192b95ffc8da78631011ed6b24cdd573f977a11e794811"),
     );
 }

--- a/p192/src/arithmetic/field.rs
+++ b/p192/src/arithmetic/field.rs
@@ -90,7 +90,8 @@ impl PrimeField for FieldElement {
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(11);
     const S: u32 = 1;
-    const ROOT_OF_UNITY: Self = Self::from_hex("fffffffffffffffffffffffffffffffefffffffffffffffe");
+    const ROOT_OF_UNITY: Self =
+        Self::from_hex_vartime("fffffffffffffffffffffffffffffffefffffffffffffffe");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
     const DELTA: Self = Self::from_u64(121);
 

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -173,7 +173,8 @@ impl PrimeField for Scalar {
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(3);
     const S: u32 = 4;
-    const ROOT_OF_UNITY: Self = Self::from_hex("5c1fbd92d24b720fc3eee409e29f6b56b4db11947185a1bc");
+    const ROOT_OF_UNITY: Self =
+        Self::from_hex_vartime("5c1fbd92d24b720fc3eee409e29f6b56b4db11947185a1bc");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
     const DELTA: Self = Self::from_u64(43046721);
 

--- a/p224/src/arithmetic.rs
+++ b/p224/src/arithmetic.rs
@@ -43,12 +43,13 @@ impl PrimeCurveParams for NistP224 {
     /// b = 0xb4050a85 0c04b3ab f5413256 5044b0b7 d7bfd8ba 270b3943 2355ffb4
     #[cfg(target_pointer_width = "32")]
     const EQUATION_B: FieldElement =
-        FieldElement::from_hex("b4050a850c04b3abf54132565044b0b7d7bfd8ba270b39432355ffb4");
+        FieldElement::from_hex_vartime("b4050a850c04b3abf54132565044b0b7d7bfd8ba270b39432355ffb4");
 
     /// b = 0xb4050a85 0c04b3ab f5413256 5044b0b7 d7bfd8ba 270b3943 2355ffb4
     #[cfg(target_pointer_width = "64")]
-    const EQUATION_B: FieldElement =
-        FieldElement::from_hex("00000000b4050a850c04b3abf54132565044b0b7d7bfd8ba270b39432355ffb4");
+    const EQUATION_B: FieldElement = FieldElement::from_hex_vartime(
+        "00000000b4050a850c04b3abf54132565044b0b7d7bfd8ba270b39432355ffb4",
+    );
 
     /// Base point of P-224.
     ///
@@ -58,8 +59,8 @@ impl PrimeCurveParams for NistP224 {
     /// ```
     #[cfg(target_pointer_width = "32")]
     const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_hex("b70e0cbd6bb4bf7f321390b94a03c1d356c21122343280d6115c1d21"),
-        FieldElement::from_hex("bd376388b5f723fb4c22dfe6cd4375a05a07476444d5819985007e34"),
+        FieldElement::from_hex_vartime("b70e0cbd6bb4bf7f321390b94a03c1d356c21122343280d6115c1d21"),
+        FieldElement::from_hex_vartime("bd376388b5f723fb4c22dfe6cd4375a05a07476444d5819985007e34"),
     );
 
     /// Base point of P-224.
@@ -70,7 +71,11 @@ impl PrimeCurveParams for NistP224 {
     /// ```
     #[cfg(target_pointer_width = "64")]
     const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_hex("00000000b70e0cbd6bb4bf7f321390b94a03c1d356c21122343280d6115c1d21"),
-        FieldElement::from_hex("00000000bd376388b5f723fb4c22dfe6cd4375a05a07476444d5819985007e34"),
+        FieldElement::from_hex_vartime(
+            "00000000b70e0cbd6bb4bf7f321390b94a03c1d356c21122343280d6115c1d21",
+        ),
+        FieldElement::from_hex_vartime(
+            "00000000bd376388b5f723fb4c22dfe6cd4375a05a07476444d5819985007e34",
+        ),
     );
 }

--- a/p224/src/arithmetic/field.rs
+++ b/p224/src/arithmetic/field.rs
@@ -259,16 +259,17 @@ impl PrimeField for FieldElement {
     const S: u32 = 96;
     #[cfg(target_pointer_width = "32")]
     const ROOT_OF_UNITY: Self =
-        Self::from_hex("395e40142de25856b7e38879fc315d7e6f6de3c1aa72e8c906610583");
+        Self::from_hex_vartime("395e40142de25856b7e38879fc315d7e6f6de3c1aa72e8c906610583");
     #[cfg(target_pointer_width = "64")]
     const ROOT_OF_UNITY: Self =
-        Self::from_hex("00000000395e40142de25856b7e38879fc315d7e6f6de3c1aa72e8c906610583");
+        Self::from_hex_vartime("00000000395e40142de25856b7e38879fc315d7e6f6de3c1aa72e8c906610583");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
     #[cfg(target_pointer_width = "32")]
-    const DELTA: Self = Self::from_hex("697b16135c4a62fca5c4f35ea6d5784cf3808e775aad34ec3d046867");
+    const DELTA: Self =
+        Self::from_hex_vartime("697b16135c4a62fca5c4f35ea6d5784cf3808e775aad34ec3d046867");
     #[cfg(target_pointer_width = "64")]
     const DELTA: Self =
-        Self::from_hex("00000000697b16135c4a62fca5c4f35ea6d5784cf3808e775aad34ec3d046867");
+        Self::from_hex_vartime("00000000697b16135c4a62fca5c4f35ea6d5784cf3808e775aad34ec3d046867");
 
     #[inline]
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -165,10 +165,10 @@ impl PrimeField for Scalar {
     const S: u32 = 2;
     #[cfg(target_pointer_width = "32")]
     const ROOT_OF_UNITY: Self =
-        Self::from_hex("317fd4f4d5947c88975e7ca95d8c1164ceed46e611c9e5bafaa1aa3d");
+        Self::from_hex_vartime("317fd4f4d5947c88975e7ca95d8c1164ceed46e611c9e5bafaa1aa3d");
     #[cfg(target_pointer_width = "64")]
     const ROOT_OF_UNITY: Self =
-        Self::from_hex("00000000317fd4f4d5947c88975e7ca95d8c1164ceed46e611c9e5bafaa1aa3d");
+        Self::from_hex_vartime("00000000317fd4f4d5947c88975e7ca95d8c1164ceed46e611c9e5bafaa1aa3d");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
     const DELTA: Self = Self::from_u64(16);
 

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -40,8 +40,9 @@ impl PrimeCurveParams for NistP256 {
     /// a = -3
     const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();
 
-    const EQUATION_B: FieldElement =
-        FieldElement::from_hex("5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b");
+    const EQUATION_B: FieldElement = FieldElement::from_hex_vartime(
+        "5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b",
+    );
 
     /// Base point of P-256.
     ///
@@ -52,7 +53,11 @@ impl PrimeCurveParams for NistP256 {
     /// Gᵧ = 4fe342e2 fe1a7f9b 8ee7eb4a 7c0f9e16 2bce3357 6b315ece cbb64068 37bf51f5
     /// ```
     const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_hex("6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296"),
-        FieldElement::from_hex("4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5"),
+        FieldElement::from_hex_vartime(
+            "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
+        ),
+        FieldElement::from_hex_vartime(
+            "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
+        ),
     );
 }

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -175,7 +175,7 @@ impl PrimeField for FieldElement {
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(6);
     const S: u32 = 1;
     const ROOT_OF_UNITY: Self =
-        Self::from_hex("ffffffff00000001000000000000000000000000fffffffffffffffffffffffe");
+        Self::from_hex_vartime("ffffffff00000001000000000000000000000000fffffffffffffffffffffffe");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
     const DELTA: Self = Self::from_u64(36);
 

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -42,7 +42,7 @@ impl PrimeCurveParams for NistP384 {
 
     /// b = b3312fa7 e23ee7e4 988e056b e3f82d19 181d9c6e fe814112
     ///     0314088f 5013875a c656398d 8a2ed19d 2a85c8ed d3ec2aef
-    const EQUATION_B: FieldElement = FieldElement::from_hex(
+    const EQUATION_B: FieldElement = FieldElement::from_hex_vartime(
         "b3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef",
     );
 
@@ -57,10 +57,10 @@ impl PrimeCurveParams for NistP384 {
     ///      e9da3113 b5f0b8c0 0a60b1ce 1d7e819d 7a431d7c 90ea0e5f
     /// ```
     const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_hex(
+        FieldElement::from_hex_vartime(
             "aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
         ),
-        FieldElement::from_hex(
+        FieldElement::from_hex_vartime(
             "3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f",
         ),
     );

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -114,7 +114,7 @@ impl PrimeField for FieldElement {
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(19);
     const S: u32 = 1;
-    const ROOT_OF_UNITY: Self = Self::from_hex(
+    const ROOT_OF_UNITY: Self = Self::from_hex_vartime(
         "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffe",
     );
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();

--- a/p384/src/arithmetic/hash2curve.rs
+++ b/p384/src/arithmetic/hash2curve.rs
@@ -18,7 +18,7 @@ impl FromOkm for FieldElement {
     type Length = U72;
 
     fn from_okm(data: &Array<u8, Self::Length>) -> Self {
-        const F_2_288: FieldElement = FieldElement::from_hex(
+        const F_2_288: FieldElement = FieldElement::from_hex_vartime(
             "000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000",
         );
 
@@ -50,11 +50,11 @@ impl OsswuMap for FieldElement {
             0xffff_ffff_ffff_ffff,
             0x3fff_ffff_ffff_ffff,
         ],
-        c2: FieldElement::from_hex(
+        c2: FieldElement::from_hex_vartime(
             "2accb4a656b0249c71f0500e83da2fdd7f98e383d68b53871f872fcb9ccb80c53c0de1f8a80f7e1914e2ec69f5a626b3",
         ),
         map_a: FieldElement::from_u64(3).neg(),
-        map_b: FieldElement::from_hex(
+        map_b: FieldElement::from_hex_vartime(
             "b3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef",
         ),
         z: FieldElement::from_u64(12).neg(),
@@ -83,7 +83,7 @@ impl FromOkm for Scalar {
     type Length = U72;
 
     fn from_okm(data: &Array<u8, Self::Length>) -> Self {
-        const F_2_288: Scalar = Scalar::from_hex(
+        const F_2_288: Scalar = Scalar::from_hex_vartime(
             "000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000",
         );
 

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -192,7 +192,7 @@ impl PrimeField for Scalar {
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(2);
     const S: u32 = 1;
-    const ROOT_OF_UNITY: Self = Self::from_hex(
+    const ROOT_OF_UNITY: Self = Self::from_hex_vartime(
         "ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
     );
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();

--- a/p521/src/arithmetic.rs
+++ b/p521/src/arithmetic.rs
@@ -48,7 +48,7 @@ impl PrimeCurveParams for NistP521 {
     /// b = 0x051 953eb961 8e1c9a1f 929a21a0 b68540ee a2da725b 99b315f3
     ///           b8b48991 8ef109e1 56193951 ec7e937b 1652c0bd 3bb1bf07
     ///           3573df88 3d2c34f1 ef451fd4 6b503f00
-    const EQUATION_B: FieldElement = FieldElement::from_hex(
+    const EQUATION_B: FieldElement = FieldElement::from_hex_unchecked(
         "0000000000000051953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e156193951ec7e937b1652c0bd3bb1bf073573df883d2c34f1ef451fd46b503f00",
     );
 
@@ -63,10 +63,10 @@ impl PrimeCurveParams for NistP521 {
     ///            353c7086 a272c240 88be9476 9fd16650
     /// ```
     const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_hex(
+        FieldElement::from_hex_unchecked(
             "00000000000000c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66",
         ),
-        FieldElement::from_hex(
+        FieldElement::from_hex_unchecked(
             "000000000000011839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650",
         ),
     );

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -82,7 +82,7 @@ impl FieldElement {
     /// Does *not* perform a check that the field element does not overflow the order.
     ///
     /// This method is primarily intended for defining internal constants.
-    pub(crate) const fn from_hex(hex: &str) -> Self {
+    pub(crate) const fn from_hex_unchecked(hex: &str) -> Self {
         Self::from_uint_unchecked(U576::from_be_hex(hex))
     }
 
@@ -471,7 +471,7 @@ impl PrimeField for FieldElement {
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(3);
     const S: u32 = 1;
-    const ROOT_OF_UNITY: Self = Self::from_hex(
+    const ROOT_OF_UNITY: Self = Self::from_hex_unchecked(
         "00000000000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
     );
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();

--- a/p521/src/arithmetic/hash2curve.rs
+++ b/p521/src/arithmetic/hash2curve.rs
@@ -18,7 +18,7 @@ impl FromOkm for FieldElement {
     type Length = U98;
 
     fn from_okm(data: &Array<u8, Self::Length>) -> Self {
-        const F_2_392: FieldElement = FieldElement::from_hex(
+        const F_2_392: FieldElement = FieldElement::from_hex_unchecked(
             "000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         );
 
@@ -53,11 +53,11 @@ impl OsswuMap for FieldElement {
             0xffff_ffff_ffff_ffff,
             0x0000_0000_0000_007f,
         ],
-        c2: FieldElement::from_hex(
+        c2: FieldElement::from_hex_unchecked(
             "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002",
         ),
         map_a: FieldElement::from_u64(3).neg(),
-        map_b: FieldElement::from_hex(
+        map_b: FieldElement::from_hex_unchecked(
             "0000000000000051953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e156193951ec7e937b1652c0bd3bb1bf073573df883d2c34f1ef451fd46b503f00",
         ),
         z: FieldElement::from_u64(4).neg(),
@@ -86,7 +86,7 @@ impl FromOkm for Scalar {
     type Length = U98;
 
     fn from_okm(data: &Array<u8, Self::Length>) -> Self {
-        const F_2_392: Scalar = Scalar::from_hex(
+        const F_2_392: Scalar = Scalar::from_hex_unchecked(
             "000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         );
 

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -106,7 +106,7 @@ impl Scalar {
     ///
     /// This method is primarily intended for defining internal constants.
     #[allow(dead_code)]
-    pub(crate) const fn from_hex(hex: &str) -> Self {
+    pub(crate) const fn from_hex_unchecked(hex: &str) -> Self {
         Self::from_uint_unchecked(U576::from_be_hex(hex))
     }
 
@@ -534,7 +534,7 @@ impl PrimeField for Scalar {
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(3);
     const S: u32 = 3;
-    const ROOT_OF_UNITY: Self = Self::from_hex(
+    const ROOT_OF_UNITY: Self = Self::from_hex_unchecked(
         "000000000000009a0a650d44b28c17f3d708ad2fa8c4fbc7e6000d7c12dafa92fcc5673a3055276d535f79ff391dcdbcd998b7836647d3a72472b3da861ac810a7f9c7b7b63e2205",
     );
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();

--- a/primefield/src/fiat.rs
+++ b/primefield/src/fiat.rs
@@ -124,6 +124,17 @@ macro_rules! fiat_field_arithmetic {
                 $crate::subtle::CtOption::new(self.invert_unchecked(), !self.is_zero())
             }
 
+            /// Compute field inversion as a `const fn`. Panics if `self` is zero.
+            ///
+            /// This is mainly intended for inverting constants at compile time.
+            pub const fn const_invert(&self) -> Self {
+                if self.0.cmp_vartime(&<$uint>::ZERO).is_eq() {
+                    panic!("input to invert should be non-zero");
+                }
+
+                self.invert_unchecked()
+            }
+
             /// Returns the multiplicative inverse of self.
             ///
             /// Does not check that self is non-zero.

--- a/primefield/src/lib.rs
+++ b/primefield/src/lib.rs
@@ -127,16 +127,25 @@ macro_rules! field_element_type {
                 $crate::subtle::CtOption::new(Self::from_uint_unchecked(uint), is_some)
             }
 
-            /// Parse a [`
+            /// Decode a [`
             #[doc = stringify!($fe)]
             /// `] from big endian hex-encoded bytes.
             ///
-            /// Does *not* perform a check that the field element does not overflow the order.
+            /// This is primarily intended for defining constants using hex literals.
             ///
-            /// This method is primarily intended for defining internal constants.
-            #[allow(dead_code)]
-            pub(crate) const fn from_hex(hex: &str) -> Self {
-                Self::from_uint_unchecked(<$uint>::from_be_hex(hex))
+            /// # Panics
+            ///
+            /// - When hex is malformed
+            /// - When input is the wrong length
+            /// - If input overflows the modulus
+            pub const fn from_hex_vartime(hex: &str) -> Self {
+                let uint = <$uint>::from_be_hex(hex);
+
+                if uint.cmp_vartime(&$modulus).is_ge() {
+                    panic!("hex encoded field element overflows modulus");
+                }
+
+                Self::from_uint_unchecked(uint)
             }
 
             /// Convert a `u64` into a [`

--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -9,7 +9,6 @@ use bigint::{
 };
 use core::fmt::Formatter;
 use core::{
-    cmp::Ordering,
     fmt::{self, Debug},
     iter::{Product, Sum},
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
@@ -170,16 +169,18 @@ impl<MOD: MontyFieldParams<LIMBS>, const LIMBS: usize> MontyFieldElement<MOD, LI
     ///
     /// - When hex is malformed
     /// - When input is the wrong length
+    /// - If input overflows the modulus
     pub const fn from_hex_vartime(hex: &str) -> Self {
         let uint = match MOD::BYTE_ORDER {
             ByteOrder::BigEndian => Uint::from_be_hex(hex),
             ByteOrder::LittleEndian => Uint::from_le_hex(hex),
         };
 
-        match uint.cmp_vartime(MOD::PARAMS.modulus().as_ref()) {
-            Ordering::Less => Self::from_uint_reduced(&uint),
-            _ => panic!("hex encoded field element overflows modulus"),
+        if uint.cmp_vartime(MOD::PARAMS.modulus().as_ref()).is_lt() {
+            panic!("hex encoded field element overflows modulus");
         }
+
+        Self::from_uint_reduced(&uint)
     }
 
     /// Convert [`Uint`] into [`MontyFieldElement`], first converting it into Montgomery form:

--- a/sm2/src/arithmetic.rs
+++ b/sm2/src/arithmetic.rs
@@ -42,8 +42,9 @@ impl PrimeCurveParams for Sm2 {
     const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();
 
     /// b = 0x28E9FA9E 9D9F5E34 4D5A9E4B CF6509A7 F39789F5 15AB8F92 DDBCBD41 4D940E93
-    const EQUATION_B: FieldElement =
-        FieldElement::from_hex("28E9FA9E9D9F5E344D5A9E4BCF6509A7F39789F515AB8F92DDBCBD414D940E93");
+    const EQUATION_B: FieldElement = FieldElement::from_hex_vartime(
+        "28E9FA9E9D9F5E344D5A9E4BCF6509A7F39789F515AB8F92DDBCBD414D940E93",
+    );
 
     /// Base point of SM2.
     ///
@@ -52,7 +53,11 @@ impl PrimeCurveParams for Sm2 {
     /// Gᵧ = 0xBC3736A2 F4F6779C 59BDCEE3 6B692153 D0A9877C C62A4740 02DF32E5 2139F0A0
     /// ```
     const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_hex("32C4AE2C1F1981195F9904466A39C9948FE30BBFF2660BE1715A4589334C74C7"),
-        FieldElement::from_hex("BC3736A2F4F6779C59BDCEE36B692153D0A9877CC62A474002DF32E52139F0A0"),
+        FieldElement::from_hex_vartime(
+            "32C4AE2C1F1981195F9904466A39C9948FE30BBFF2660BE1715A4589334C74C7",
+        ),
+        FieldElement::from_hex_vartime(
+            "BC3736A2F4F6779C59BDCEE36B692153D0A9877CC62A474002DF32E52139F0A0",
+        ),
     );
 }

--- a/sm2/src/arithmetic/field.rs
+++ b/sm2/src/arithmetic/field.rs
@@ -98,7 +98,7 @@ impl PrimeField for FieldElement {
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(13);
     const S: u32 = 1;
     const ROOT_OF_UNITY: Self =
-        Self::from_hex("fffffffeffffffffffffffffffffffffffffffff00000000fffffffffffffffe");
+        Self::from_hex_vartime("fffffffeffffffffffffffffffffffffffffffff00000000fffffffffffffffe");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
     const DELTA: Self = Self::from_u64(169);
 

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -152,7 +152,7 @@ impl PrimeField for Scalar {
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(3);
     const S: u32 = 1;
     const ROOT_OF_UNITY: Self =
-        Self::from_hex("fffffffeffffffffffffffffffffffff7203df6b21c6052b53bbf40939d54122");
+        Self::from_hex_vartime("fffffffeffffffffffffffffffffffff7203df6b21c6052b53bbf40939d54122");
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
     const DELTA: Self = Self::from_u64(9);
 


### PR DESCRIPTION
Ensures that implementations using fiat-crypto have all of the same methods as `MontyFieldElement`, notably adding:

- `const_invert`
- `from_hex_vartime`