### PR TITLE
bp256: fix divstep postcondition comment

### DIFF
--- a/bp256/src/arithmetic/field/bp256_32.rs
+++ b/bp256/src/arithmetic/field/bp256_32.rs
@@ -5249,7 +5249,7 @@ pub const fn fiat_bp256_msat(out1: &mut [u32; 9]) {
 ///   twos_complement_eval out2 = (if 0 < arg1 ∧ (twos_complement_eval arg3) is odd then twos_complement_eval arg3 else twos_complement_eval arg2)
 ///   twos_complement_eval out3 = (if 0 < arg1 ∧ (twos_complement_eval arg3) is odd then ⌊(twos_complement_eval arg3 - twos_complement_eval arg2) / 2⌋ else ⌊(twos_complement_eval arg3 + (twos_complement_eval arg3 mod 2) * twos_complement_eval arg2) / 2⌋)
 ///   eval (from_montgomery out4) mod m = (if 0 < arg1 ∧ (twos_complement_eval arg3) is odd then (2 * eval (from_montgomery arg5)) mod m else (2 * eval (from_montgomery arg4)) mod m)
-///   eval (from_montgomery out5) mod m = (if 0 < arg1 ∧ (twos_complement_eval arg3) is odd then (eval (from_montgomery arg4) - eval (from_montgomery arg4)) mod m else (eval (from_montgomery arg5) + (twos_complement_eval arg3 mod 2) * eval (from_montgomery arg4)) mod m)
+///   eval (from_montgomery out5) mod m = (if 0 < arg1 ∧ (twos_complement_eval arg3) is odd then (eval (from_montgomery arg4) - eval (from_montgomery arg5)) mod m else (eval (from_montgomery arg5) + (twos_complement_eval arg3 mod 2) * eval (from_montgomery arg4)) mod m)
 ///   0 ≤ eval out5 < m
 ///   0 ≤ eval out5 < m
 ///   0 ≤ eval out2 < m


### PR DESCRIPTION
Correct the divstep spec comment for out5 to subtract arg5 from arg4 in the “then” branch. This aligns with standard fiat-crypto documentation. No functional code changes.