### PR TITLE
Remove usage of `hybrid-array`'s `[T; N] as AsRef<Array<T, U { N }>>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,8 +574,7 @@ dependencies = [
 [[package]]
 name = "hybrid-array"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
+source = "git+https://github.com/kayabaNerve/hybrid-array?branch=remove-as-ref#8caa508976c93696a67f40734537c91be7cecd96"
 dependencies = [
  "typenum",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
+
+# https://github.com/RustCrypto/hybrid-array/pull/132
+hybrid-array = { git = "https://github.com/kayabaNerve/hybrid-array", branch = "remove-as-ref" }

--- a/p256/benches/field.rs
+++ b/p256/benches/field.rs
@@ -8,14 +8,14 @@ use p256::FieldElement;
 
 fn test_field_element_x() -> FieldElement {
     FieldElement::from_bytes(
-        hex!("1ccbe91c075fc7f4f033bfa248db8fccd3565de94bbfb12f3c59ff46c271bf83").as_ref(),
+        (&hex!("1ccbe91c075fc7f4f033bfa248db8fccd3565de94bbfb12f3c59ff46c271bf83")).into(),
     )
     .unwrap()
 }
 
 fn test_field_element_y() -> FieldElement {
     FieldElement::from_bytes(
-        hex!("ce4014c68811f9a21a1fdb2c0e6113e06db7ca93b7404e78dc7ccd5ca89a4ca9").as_ref(),
+        (&hex!("ce4014c68811f9a21a1fdb2c0e6113e06db7ca93b7404e78dc7ccd5ca89a4ca9")).into(),
     )
     .unwrap()
 }

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -210,17 +210,17 @@ mod tests {
         );
         assert_eq!(
             FieldElement::from_bytes(
-                [
+                (&[
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                     0, 0, 0, 0, 0, 1
-                ]
-                .as_ref()
+                ])
+                    .into()
             )
             .unwrap(),
             FieldElement::ONE
         );
         assert!(bool::from(
-            FieldElement::from_bytes([0xff; 32].as_ref()).is_none()
+            FieldElement::from_bytes((&[0xff; 32]).into()).is_none()
         ));
     }
 

--- a/p521/benches/field.rs
+++ b/p521/benches/field.rs
@@ -9,14 +9,14 @@ use std::hint::black_box;
 
 fn test_field_element_x() -> FieldElement {
     black_box(FieldElement::from_bytes(
-        hex!("01a7596d38aac7868327ddc1ef5e8178cf052b7ebc512828e8a45955d85bef49494d15278198bbcc5454358c12a2af9a3874e7002e1a2f02fcb36ff3e3b4bc0c69e7").as_ref()
+        (&hex!("01a7596d38aac7868327ddc1ef5e8178cf052b7ebc512828e8a45955d85bef49494d15278198bbcc5454358c12a2af9a3874e7002e1a2f02fcb36ff3e3b4bc0c69e7")).into()
     )
     .unwrap())
 }
 
 fn test_field_element_y() -> FieldElement {
     black_box(FieldElement::from_bytes(
-        hex!("0184902e515982bb225b8c84f245e61b327c08e94d41c07d0b4101a963e02fe52f6a9f33e8b1de2394e0cb74c40790b4e489b5500e6804cabed0fe8c192443d4027b").as_ref()
+        (&hex!("0184902e515982bb225b8c84f245e61b327c08e94d41c07d0b4101a963e02fe52f6a9f33e8b1de2394e0cb74c40790b4e489b5500e6804cabed0fe8c192443d4027b")).into()
     )
     .unwrap())
 }


### PR DESCRIPTION
This only affects tests/benches.

https://github.com/RustCrypto/hybrid-array/pull/132