### PR TITLE
ed448-goldilocks: enforce RFC 8032 context length in Ed448 verification

### DIFF
--- a/ed448-goldilocks/src/sign/verifying_key.rs
+++ b/ed448-goldilocks/src/sign/verifying_key.rs
@@ -279,13 +279,9 @@ impl VerifyingKey {
             return Err(SigningError::InvalidSignatureSComponent.into());
         }
 
-        // RFC 8032 mandates context length <= 255 bytes. Enforce consistently with signing path.
-        if ctx.len() > 255 {
-            return Err(SigningError::PrehashedContextLength.into());
-        }
-
         // SHAKE256(dom4(F, C) || R || A || PH(M), 114) -> scalar k
         let mut bytes = WideEdwardsScalarBytes::default();
+        // RFC 8032 mandates context length <= 255 bytes. Enforce consistently with signing path.
         let ctx_len = u8::try_from(ctx.len()).map_err(|_| SigningError::PrehashedContextLength)?;
         let mut reader = Shake256::default()
             .chain(HASH_HEAD)


### PR DESCRIPTION
Add a guard in VerifyingKey::verify_inner to error when ctx.len() > 255 instead of truncating to u8. Aligns verification behavior with signing (ExpandedSecretKey::sign_inner) and prevents silent context truncation.