### PR TITLE
`hash2curve`: rename `GroupDigest::K` to `SecurityLevel`

### DIFF
--- a/ed448-goldilocks/src/lib.rs
+++ b/ed448-goldilocks/src/lib.rs
@@ -118,7 +118,7 @@ impl elliptic_curve::CurveArithmetic for Ed448 {
 }
 
 impl GroupDigest for Ed448 {
-    type K = U28;
+    type SecurityLevel = U28;
 }
 
 /// Decaf448 curve.
@@ -167,5 +167,5 @@ impl elliptic_curve::CurveArithmetic for Decaf448 {
 }
 
 impl GroupDigest for Decaf448 {
-    type K = U28;
+    type SecurityLevel = U28;
 }

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -8,7 +8,7 @@ pub trait GroupDigest: MapToCurve {
     /// The target security level in bytes:
     /// <https://www.rfc-editor.org/rfc/rfc9380.html#section-8.9-2.2>
     /// <https://www.rfc-editor.org/rfc/rfc9380.html#name-target-security-levels>
-    type K: Unsigned;
+    type SecurityLevel: Unsigned;
 
     /// Computes the hash to curve routine.
     ///
@@ -33,7 +33,7 @@ pub trait GroupDigest: MapToCurve {
     /// [`ExpandMsgXofError`]: crate::ExpandMsgXofError
     fn hash_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<ProjectivePoint<Self>, X::Error>
     where
-        X: ExpandMsg<Self::K>,
+        X: ExpandMsg<Self::SecurityLevel>,
     {
         let [u0, u1] = hash_to_field::<2, X, _, Self::FieldElement>(msg, dst)?;
         let q0 = Self::map_to_curve(u0);
@@ -63,7 +63,7 @@ pub trait GroupDigest: MapToCurve {
     /// [`ExpandMsgXofError`]: crate::ExpandMsgXofError
     fn encode_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<ProjectivePoint<Self>, X::Error>
     where
-        X: ExpandMsg<Self::K>,
+        X: ExpandMsg<Self::SecurityLevel>,
     {
         let [u] = hash_to_field::<1, X, _, Self::FieldElement>(msg, dst)?;
         let q0 = Self::map_to_curve(u);
@@ -86,7 +86,7 @@ pub trait GroupDigest: MapToCurve {
     /// [`ExpandMsgXofError`]: crate::ExpandMsgXofError
     fn hash_to_scalar<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<Self::Scalar, X::Error>
     where
-        X: ExpandMsg<Self::K>,
+        X: ExpandMsg<Self::SecurityLevel>,
     {
         let [u] = hash_to_field::<1, X, _, Self::Scalar>(msg, dst)?;
         Ok(u)

--- a/hash2curve/src/oprf.rs
+++ b/hash2curve/src/oprf.rs
@@ -25,5 +25,5 @@ pub trait OprfParameters: GroupDigest + PrimeCurve {
     /// and `HashToScalar` as defined in [section 4 of RFC9497][oprf].
     ///
     /// [oprf]: https://www.rfc-editor.org/rfc/rfc9497.html#name-ciphersuites
-    type ExpandMsg: ExpandMsg<<Self as GroupDigest>::K>;
+    type ExpandMsg: ExpandMsg<<Self as GroupDigest>::SecurityLevel>;
 }

--- a/k256/src/arithmetic/hash2curve.rs
+++ b/k256/src/arithmetic/hash2curve.rs
@@ -12,7 +12,7 @@ use crate::{AffinePoint, ProjectivePoint, Scalar, Secp256k1};
 use super::FieldElement;
 
 impl GroupDigest for Secp256k1 {
-    type K = U16;
+    type SecurityLevel = U16;
 }
 
 impl FromOkm for FieldElement {
@@ -356,7 +356,7 @@ mod tests {
             let u = hash2curve::hash_to_field::<
                 2,
                 ExpandMsgXmd<Sha256>,
-                <Secp256k1 as GroupDigest>::K,
+                <Secp256k1 as GroupDigest>::SecurityLevel,
                 FieldElement,
             >(&[test_vector.msg], &[DST])
             .unwrap();

--- a/p256/src/arithmetic/hash2curve.rs
+++ b/p256/src/arithmetic/hash2curve.rs
@@ -10,7 +10,7 @@ use elliptic_curve::{
 use hash2curve::{FromOkm, GroupDigest, MapToCurve, OsswuMap, OsswuMapParams, Sgn0};
 
 impl GroupDigest for NistP256 {
-    type K = U16;
+    type SecurityLevel = U16;
 }
 
 impl FromOkm for FieldElement {
@@ -207,7 +207,7 @@ mod tests {
             let u = hash2curve::hash_to_field::<
                 2,
                 ExpandMsgXmd<Sha256>,
-                <NistP256 as GroupDigest>::K,
+                <NistP256 as GroupDigest>::SecurityLevel,
                 FieldElement,
             >(&[test_vector.msg], &[DST])
             .unwrap();

--- a/p384/src/arithmetic/hash2curve.rs
+++ b/p384/src/arithmetic/hash2curve.rs
@@ -11,7 +11,7 @@ use elliptic_curve::{
 use hash2curve::{FromOkm, GroupDigest, MapToCurve, OsswuMap, OsswuMapParams, Sgn0};
 
 impl GroupDigest for NistP384 {
-    type K = U24;
+    type SecurityLevel = U24;
 }
 
 impl FromOkm for FieldElement {
@@ -212,7 +212,7 @@ mod tests {
             let u = hash2curve::hash_to_field::<
                 2,
                 ExpandMsgXmd<Sha384>,
-                <NistP384 as GroupDigest>::K,
+                <NistP384 as GroupDigest>::SecurityLevel,
                 FieldElement,
             >(&[test_vector.msg], &[DST])
             .unwrap();

--- a/p521/src/arithmetic/hash2curve.rs
+++ b/p521/src/arithmetic/hash2curve.rs
@@ -11,7 +11,7 @@ use elliptic_curve::{
 use hash2curve::{FromOkm, GroupDigest, MapToCurve, OsswuMap, OsswuMapParams, Sgn0};
 
 impl GroupDigest for NistP521 {
-    type K = U32;
+    type SecurityLevel = U32;
 }
 
 impl FromOkm for FieldElement {
@@ -215,7 +215,7 @@ mod tests {
             let u = hash2curve::hash_to_field::<
                 2,
                 ExpandMsgXmd<Sha512>,
-                <NistP521 as GroupDigest>::K,
+                <NistP521 as GroupDigest>::SecurityLevel,
                 FieldElement,
             >(&[test_vector.msg], &[DST])
             .unwrap();


### PR DESCRIPTION
I also considered renaming all `K` generics, but it seems overkill.

This was discussed previously in #1295.