### PR TITLE
`hash2curve`: replace `FromOkm` with `Reduce`

### DIFF
--- a/ed448-goldilocks/src/decaf/scalar.rs
+++ b/ed448-goldilocks/src/decaf/scalar.rs
@@ -4,8 +4,8 @@ use crate::field::{CurveWithScalar, ORDER, Scalar, ScalarBytes, WideScalarBytes}
 use elliptic_curve::array::Array;
 use elliptic_curve::bigint::{Limb, NonZero, U448, U512};
 use elliptic_curve::consts::{U56, U64};
+use elliptic_curve::ops::Reduce;
 use elliptic_curve::scalar::FromUintUnchecked;
-use hash2curve::FromOkm;
 use subtle::{Choice, CtOption};
 
 impl CurveWithScalar for Decaf448 {
@@ -66,15 +66,13 @@ impl From<&DecafScalar> for elliptic_curve::scalar::ScalarBits<Decaf448> {
     }
 }
 
-impl FromOkm for DecafScalar {
-    type Length = U64;
-
-    fn from_okm(data: &Array<u8, Self::Length>) -> Self {
+impl Reduce<Array<u8, U64>> for DecafScalar {
+    fn reduce(value: &Array<u8, U64>) -> Self {
         const SEMI_WIDE_MODULUS: NonZero<U512> = NonZero::<U512>::new_unwrap(U512::from_be_hex(
             "00000000000000003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f3",
         ));
 
-        let mut num = U512::from_le_slice(data);
+        let mut num = U512::from_le_slice(value);
         num %= SEMI_WIDE_MODULUS;
         let mut words = [0; U448::LIMBS];
         words.copy_from_slice(&num.to_words()[..U448::LIMBS]);

--- a/ed448-goldilocks/src/edwards/scalar.rs
+++ b/ed448-goldilocks/src/edwards/scalar.rs
@@ -4,8 +4,8 @@ use crate::field::{CurveWithScalar, ORDER, Scalar, ScalarBytes, WideScalarBytes}
 use elliptic_curve::array::Array;
 use elliptic_curve::bigint::{Limb, NonZero, U448, U704};
 use elliptic_curve::consts::{U57, U84, U88};
+use elliptic_curve::ops::Reduce;
 use elliptic_curve::scalar::FromUintUnchecked;
-use hash2curve::FromOkm;
 use subtle::{Choice, CtOption};
 
 impl CurveWithScalar for Ed448 {
@@ -82,15 +82,13 @@ impl From<&EdwardsScalar> for elliptic_curve::scalar::ScalarBits<Ed448> {
     }
 }
 
-impl FromOkm for EdwardsScalar {
-    type Length = U84;
-
-    fn from_okm(data: &Array<u8, Self::Length>) -> Self {
+impl Reduce<Array<u8, U84>> for EdwardsScalar {
+    fn reduce(value: &Array<u8, U84>) -> Self {
         const SEMI_WIDE_MODULUS: NonZero<U704> = NonZero::<U704>::new_unwrap(U704::from_be_hex(
             "00000000000000000000000000000000000000000000000000000000000000003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f3",
         ));
         let mut tmp = Array::<u8, U88>::default();
-        tmp[4..].copy_from_slice(&data[..]);
+        tmp[4..].copy_from_slice(&value[..]);
 
         let mut num = U704::from_be_slice(&tmp[..]);
         num %= SEMI_WIDE_MODULUS;

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -35,7 +35,7 @@ pub trait GroupDigest: MapToCurve {
     where
         X: ExpandMsg<Self::SecurityLevel>,
     {
-        let [u0, u1] = hash_to_field::<2, X, _, Self::FieldElement>(msg, dst)?;
+        let [u0, u1] = hash_to_field::<2, X, _, Self::FieldElement, Self::FieldLength>(msg, dst)?;
         let q0 = Self::map_to_curve(u0);
         let q1 = Self::map_to_curve(u1);
         Ok(Self::add_and_map_to_subgroup(q0, q1))
@@ -65,7 +65,7 @@ pub trait GroupDigest: MapToCurve {
     where
         X: ExpandMsg<Self::SecurityLevel>,
     {
-        let [u] = hash_to_field::<1, X, _, Self::FieldElement>(msg, dst)?;
+        let [u] = hash_to_field::<1, X, _, Self::FieldElement, Self::FieldLength>(msg, dst)?;
         let q0 = Self::map_to_curve(u);
         Ok(Self::map_to_subgroup(q0))
     }
@@ -88,7 +88,7 @@ pub trait GroupDigest: MapToCurve {
     where
         X: ExpandMsg<Self::SecurityLevel>,
     {
-        let [u] = hash_to_field::<1, X, _, Self::Scalar>(msg, dst)?;
+        let [u] = hash_to_field::<1, X, _, Self::Scalar, Self::ScalarLength>(msg, dst)?;
         Ok(u)
     }
 }

--- a/hash2curve/src/hash2field.rs
+++ b/hash2curve/src/hash2field.rs
@@ -8,52 +8,44 @@ use core::num::NonZeroU16;
 
 pub use expand_msg::{xmd::*, xof::*, *};
 
-use elliptic_curve::array::{
-    Array, ArraySize,
-    typenum::{NonZero, Unsigned},
+use elliptic_curve::{
+    array::{Array, ArraySize, typenum::NonZero},
+    ops::Reduce,
 };
-
-/// The trait for helping to convert to a field element.
-pub trait FromOkm {
-    /// The number of bytes needed to convert to a field element.
-    type Length: ArraySize + NonZero;
-
-    /// Convert a byte sequence into a field element.
-    fn from_okm(data: &Array<u8, Self::Length>) -> Self;
-}
 
 /// Convert an arbitrary byte sequence into a field element.
 ///
 /// <https://www.rfc-editor.org/rfc/rfc9380.html#name-hash_to_field-implementatio>
 ///
-/// For the `expand_message` call, `len_in_bytes = T::Length * N`.
+/// For the `expand_message` call, `len_in_bytes = L * N`.
 ///
 /// # Errors
 ///
 /// Returns an error if the [`ExpandMsg`] implementation fails.
 #[doc(hidden)]
-pub fn hash_to_field<const N: usize, E, K, T>(
+pub fn hash_to_field<const N: usize, E, K, T, L>(
     data: &[&[u8]],
     domain: &[&[u8]],
 ) -> Result<[T; N], E::Error>
 where
     E: ExpandMsg<K>,
-    T: FromOkm + Default,
+    T: Reduce<Array<u8, L>> + Default,
+    L: ArraySize + NonZero,
 {
-    // Completely degenerate case; `N` and `T::Length` would need to be extremely large.
+    // Completely degenerate case; `N` and `L` would need to be extremely large.
     let len_in_bytes = const {
         assert!(
-            T::Length::USIZE.saturating_mul(N) <= u16::MAX as usize,
-            "The product of `T::Length` and `N` must not exceed `u16::MAX`."
+            L::USIZE.saturating_mul(N) <= u16::MAX as usize,
+            "The product of `L` and `N` must not exceed `u16::MAX`."
         );
-        NonZeroU16::new(T::Length::U16 * N as u16).expect("N is greater than 0")
+        NonZeroU16::new(L::U16 * N as u16).expect("N is greater than 0")
     };
-    let mut tmp = Array::<u8, <T as FromOkm>::Length>::default();
+    let mut tmp = Array::<u8, L>::default();
     let mut expander = E::expand_message(data, domain, len_in_bytes)?;
     Ok(core::array::from_fn(|_| {
         expander
             .fill_bytes(&mut tmp)
             .expect("never exceeds `len_in_bytes`");
-        T::from_okm(&tmp)
+        T::reduce(&tmp)
     }))
 }

--- a/hash2curve/src/map2curve.rs
+++ b/hash2curve/src/map2curve.rs
@@ -1,17 +1,22 @@
 //! Traits for mapping field elements to points on the curve.
 
+use elliptic_curve::array::typenum::NonZero;
+use elliptic_curve::array::{Array, ArraySize};
+use elliptic_curve::ops::Reduce;
 use elliptic_curve::{CurveArithmetic, ProjectivePoint};
-
-use super::FromOkm;
 
 /// Trait for converting field elements into a point via a mapping method like
 /// Simplified Shallue-van de Woestijne-Ulas or Elligator.
-pub trait MapToCurve: CurveArithmetic<Scalar: FromOkm> {
+pub trait MapToCurve: CurveArithmetic<Scalar: Reduce<Array<u8, Self::ScalarLength>>> {
     /// The intermediate representation, an element of the curve which may or may not
     /// be in the curve subgroup.
     type CurvePoint;
     /// The field element representation for a group value with multiple elements.
-    type FieldElement: FromOkm + Default + Copy;
+    type FieldElement: Reduce<Array<u8, Self::FieldLength>> + Default + Copy;
+    /// The `L` parameter as specified in the [RFC](https://www.rfc-editor.org/rfc/rfc9380.html#section-5-6) for field elements.
+    type FieldLength: ArraySize + NonZero;
+    /// The `L` parameter as specified in the [RFC](https://www.rfc-editor.org/rfc/rfc9380.html#section-5-6) for scalars.
+    type ScalarLength: ArraySize + NonZero;
 
     /// Map a field element into a curve point.
     fn map_to_curve(element: Self::FieldElement) -> Self::CurvePoint;

--- a/p256/tests/projective.rs
+++ b/p256/tests/projective.rs
@@ -5,6 +5,7 @@
 use elliptic_curve::{
     BatchNormalize, Group,
     array::Array,
+    consts::U32,
     group::{GroupEncoding, ff::PrimeField},
     ops::{LinearCombination, Reduce, ReduceNonZero},
     point::NonIdentity,
@@ -39,13 +40,13 @@ prop_compose! {
 
 prop_compose! {
     fn projective()(bytes in any::<[u8; 32]>()) -> ProjectivePoint {
-        ProjectivePoint::mul_by_generator(&Scalar::reduce(&Array::from(bytes)))
+        ProjectivePoint::mul_by_generator(&Scalar::reduce(&Array::<u8, U32>::from(bytes)))
     }
 }
 
 prop_compose! {
     fn scalar()(bytes in any::<[u8; 32]>()) -> Scalar {
-        Scalar::reduce(&Array::from(bytes))
+        Scalar::reduce(&Array::<u8, U32>::from(bytes))
     }
 }
 


### PR DESCRIPTION
This PR removes `hash2curve::FromOkm` in favor of `Reduce`.

This was previously discussed in #1295.