### PR TITLE
`hash2curve`: remove `MapToCurve::CurvePoint`

### DIFF
--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -192,26 +192,20 @@ impl Neg for FieldElement {
 }
 
 impl MapToCurve for Ed448 {
-    type CurvePoint = EdwardsPoint;
     type FieldElement = FieldElement;
     type FieldLength = U84;
     type ScalarLength = U84;
 
-    fn map_to_curve(element: FieldElement) -> Self::CurvePoint {
+    fn map_to_curve(element: FieldElement) -> EdwardsPoint {
         element.map_to_curve_elligator2().isogeny().to_edwards()
     }
 
     fn map_to_subgroup(point: EdwardsPoint) -> EdwardsPoint {
         point.clear_cofactor()
     }
-
-    fn add_and_map_to_subgroup(lhs: EdwardsPoint, rhs: EdwardsPoint) -> EdwardsPoint {
-        (lhs + rhs).clear_cofactor()
-    }
 }
 
 impl MapToCurve for Decaf448 {
-    type CurvePoint = DecafPoint;
     type FieldElement = FieldElement;
     type FieldLength = U56;
     type ScalarLength = U64;

--- a/hash2curve/src/map2curve.rs
+++ b/hash2curve/src/map2curve.rs
@@ -8,9 +8,6 @@ use elliptic_curve::{CurveArithmetic, ProjectivePoint};
 /// Trait for converting field elements into a point via a mapping method like
 /// Simplified Shallue-van de Woestijne-Ulas or Elligator.
 pub trait MapToCurve: CurveArithmetic<Scalar: Reduce<Array<u8, Self::ScalarLength>>> {
-    /// The intermediate representation, an element of the curve which may or may not
-    /// be in the curve subgroup.
-    type CurvePoint;
     /// The field element representation for a group value with multiple elements.
     type FieldElement: Reduce<Array<u8, Self::FieldLength>> + Default + Copy;
     /// The `L` parameter as specified in the [RFC](https://www.rfc-editor.org/rfc/rfc9380.html#section-5-6) for field elements.
@@ -19,20 +16,18 @@ pub trait MapToCurve: CurveArithmetic<Scalar: Reduce<Array<u8, Self::ScalarLengt
     type ScalarLength: ArraySize + NonZero;
 
     /// Map a field element into a curve point.
-    fn map_to_curve(element: Self::FieldElement) -> Self::CurvePoint;
+    fn map_to_curve(element: Self::FieldElement) -> ProjectivePoint<Self>;
 
     /// Map a curve point to a point in the curve subgroup.
     /// This is usually done by clearing the cofactor, if necessary.
-    fn map_to_subgroup(point: Self::CurvePoint) -> ProjectivePoint<Self>;
+    fn map_to_subgroup(point: ProjectivePoint<Self>) -> ProjectivePoint<Self>;
 
     /// Combine two curve points into a point in the curve subgroup.
-    /// This is usually done by clearing the cofactor of the sum. In case
-    /// addition is not implemented for `Self::CurvePoint`, then both terms
-    /// must be mapped to the subgroup individually before being added.
+    /// This is usually done by clearing the cofactor of the sum.
     fn add_and_map_to_subgroup(
-        lhs: Self::CurvePoint,
-        rhs: Self::CurvePoint,
+        lhs: ProjectivePoint<Self>,
+        rhs: ProjectivePoint<Self>,
     ) -> ProjectivePoint<Self> {
-        Self::map_to_subgroup(lhs) + Self::map_to_subgroup(rhs)
+        Self::map_to_subgroup(lhs + rhs)
     }
 }

--- a/k256/src/arithmetic/hash2curve.rs
+++ b/k256/src/arithmetic/hash2curve.rs
@@ -128,12 +128,11 @@ impl OsswuMap for FieldElement {
 }
 
 impl MapToCurve for Secp256k1 {
-    type CurvePoint = ProjectivePoint;
     type FieldElement = FieldElement;
     type FieldLength = U48;
     type ScalarLength = U48;
 
-    fn map_to_curve(element: FieldElement) -> Self::CurvePoint {
+    fn map_to_curve(element: FieldElement) -> ProjectivePoint {
         let (rx, ry) = element.osswu();
         let (qx, qy) = FieldElement::isogeny(rx, ry);
 
@@ -145,7 +144,7 @@ impl MapToCurve for Secp256k1 {
         .into()
     }
 
-    fn map_to_subgroup(point: Self::CurvePoint) -> ProjectivePoint {
+    fn map_to_subgroup(point: ProjectivePoint) -> ProjectivePoint {
         point
     }
 }

--- a/p256/src/arithmetic/hash2curve.rs
+++ b/p256/src/arithmetic/hash2curve.rs
@@ -58,12 +58,11 @@ impl OsswuMap for FieldElement {
 }
 
 impl MapToCurve for NistP256 {
-    type CurvePoint = ProjectivePoint;
     type FieldElement = FieldElement;
     type FieldLength = U48;
     type ScalarLength = U48;
 
-    fn map_to_curve(element: Self::FieldElement) -> Self::CurvePoint {
+    fn map_to_curve(element: Self::FieldElement) -> ProjectivePoint {
         let (qx, qy) = element.osswu();
 
         // TODO(tarcieri): assert that `qy` is correct? less circuitous conversion?
@@ -72,7 +71,7 @@ impl MapToCurve for NistP256 {
             .into()
     }
 
-    fn map_to_subgroup(point: Self::CurvePoint) -> ProjectivePoint {
+    fn map_to_subgroup(point: ProjectivePoint) -> ProjectivePoint {
         point
     }
 }

--- a/p384/src/arithmetic/hash2curve.rs
+++ b/p384/src/arithmetic/hash2curve.rs
@@ -60,12 +60,11 @@ impl OsswuMap for FieldElement {
 }
 
 impl MapToCurve for NistP384 {
-    type CurvePoint = ProjectivePoint;
     type FieldElement = FieldElement;
     type FieldLength = U72;
     type ScalarLength = U72;
 
-    fn map_to_curve(element: FieldElement) -> Self::CurvePoint {
+    fn map_to_curve(element: FieldElement) -> ProjectivePoint {
         let (qx, qy) = element.osswu();
 
         // TODO(tarcieri): assert that `qy` is correct? less circuitous conversion?
@@ -74,7 +73,7 @@ impl MapToCurve for NistP384 {
             .into()
     }
 
-    fn map_to_subgroup(point: Self::CurvePoint) -> ProjectivePoint {
+    fn map_to_subgroup(point: ProjectivePoint) -> ProjectivePoint {
         point
     }
 }

--- a/p521/src/arithmetic/hash2curve.rs
+++ b/p521/src/arithmetic/hash2curve.rs
@@ -63,12 +63,11 @@ impl OsswuMap for FieldElement {
 }
 
 impl MapToCurve for NistP521 {
-    type CurvePoint = ProjectivePoint;
     type FieldElement = FieldElement;
     type FieldLength = U98;
     type ScalarLength = U98;
 
-    fn map_to_curve(element: FieldElement) -> Self::CurvePoint {
+    fn map_to_curve(element: FieldElement) -> ProjectivePoint {
         let (qx, qy) = element.osswu();
 
         // TODO(tarcieri): assert that `qy` is correct? less circuitous conversion?
@@ -77,7 +76,7 @@ impl MapToCurve for NistP521 {
             .into()
     }
 
-    fn map_to_subgroup(point: Self::CurvePoint) -> ProjectivePoint {
+    fn map_to_subgroup(point: ProjectivePoint) -> ProjectivePoint {
         point
     }
 }


### PR DESCRIPTION
This isn't needed anymore. We can now also have a correctly optimized default implementation for `MapToCurve::add_and_map_to_subgroup()`.