### PR TITLE
Bump hash dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,7 +731,6 @@ dependencies = [
  "hex-literal",
  "primefield",
  "primeorder",
- "sec1",
  "serdect",
 ]
 
@@ -1172,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e6a92fd180fd205defdc0b78288ce847c7309d329fd6647a814567e67db50e"
+checksum = "b3c185ed8cff82204014bfaa7649b4c945ca565e03c0534eb33a8d2a01572932"
 dependencies = [
  "digest",
  "keccak",

--- a/bign256/Cargo.toml
+++ b/bign256/Cargo.toml
@@ -23,16 +23,16 @@ elliptic-curve = { version = "0.14.0-rc.13", features = ["sec1"] }
 # optional dependencies
 belt-hash = { version = "0.2.0-rc.0", optional = true, default-features = false }
 der = { version = "0.8.0-rc.8" }
-digest = { version = "0.11.0-rc.0", optional = true }
+digest = { version = "0.11.0-rc.1", optional = true }
 hex-literal = { version = "1", optional = true }
 hkdf = { version = "0.13.0-rc.0", optional = true }
 hmac = { version = "0.13.0-rc.0", optional = true }
 rand_core = "0.9"
-rfc6979 = { version = "0.5.0-rc.0", optional = true }
+rfc6979 = { version = "0.5.0-rc.1", optional = true }
 pkcs8 = { version = "0.11.0-rc.3", optional = true }
 primefield = { version = "=0.14.0-pre.4", optional = true }
 primeorder = { version = "=0.14.0-pre.7", optional = true }
-sec1 = { version = "0.8.0-rc.1", optional = true }
+sec1 = { version = "0.8.0-rc.9", optional = true }
 signature = { version = "3.0.0-pre.3", optional = true }
 
 [dev-dependencies]

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -20,7 +20,7 @@ elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features 
 ecdsa = { version = "0.17.0-rc.6", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "=0.14.0-pre.4", optional = true }
 primeorder = { version = "=0.14.0-pre.7", optional = true }
-sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -20,7 +20,7 @@ elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features 
 ecdsa = { version = "0.17.0-rc.6", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "=0.14.0-pre.4", optional = true }
 primeorder = { version = "=0.14.0-pre.7", optional = true }
-sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [features]
 default = ["pkcs8", "std"]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -19,7 +19,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 elliptic-curve = { version = "0.14.0-rc.13", features = ["arithmetic", "pkcs8"] }
 hash2curve = { version = "0.14.0-rc.0" }
 rand_core = { version = "0.9", default-features = false }
-sha3 = { version = "0.11.0-rc.0", default-features = false }
+sha3 = { version = "0.11.0-rc.2", default-features = false }
 subtle = { version = "2.6", default-features = false }
 
 # optional dependencies

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -14,12 +14,12 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-digest = { version = "0.11.0-rc.0" }
+digest = { version = "0.11.0-rc.1" }
 elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features = ["arithmetic"] }
 ff = { version = "=0.14.0-pre.0", default-features = false }
 subtle = { version = "2.6", default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"
-sha3 = { version = "0.11.0-rc.0", default-features = false }
-sha2 = { version = "0.11.0-rc.0", default-features = false }
+sha3 = { version = "0.11.0-rc.2", default-features = false }
+sha2 = { version = "0.11.0-rc.2", default-features = false }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -41,7 +41,7 @@ num-bigint = "0.4"
 num-traits = "0.2"
 proptest = "1.7"
 rand_core = { version = "0.9", features = ["os_rng"] }
-sha3 = { version = "0.11.0-rc.0", default-features = false }
+sha3 = { version = "0.11.0-rc.2", default-features = false }
 
 [features]
 default = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "schnorr", "std"]

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -18,7 +18,6 @@ rust-version = "1.85"
 
 [dependencies]
 elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features = ["sec1"] }
-sec1 = { version = "0.8.0-rc.1", default-features = false }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -25,7 +25,7 @@ hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.4", optional = true }
 primeorder = { version = "=0.14.0-pre.7", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -27,7 +27,7 @@ hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.4", optional = true }
 primeorder = { version = "=0.14.0-pre.7", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -27,7 +27,7 @@ hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.4", optional = true }
 primeorder = { version = "=0.14.0-pre.7", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -28,7 +28,7 @@ primefield = { version = "=0.14.0-pre.4", optional = true }
 primeorder = { version = "=0.14.0-pre.7", optional = true }
 rand_core = { version = "0.9", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -24,7 +24,7 @@ rand_core = { version = "0.9", default-features = false }
 # optional dependencies
 primefield = { version = "=0.14.0-pre.4", optional = true }
 primeorder = { version = "=0.14.0-pre.7", optional = true }
-rfc6979 = { version = "0.5.0-rc.0", optional = true }
+rfc6979 = { version = "0.5.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 signature = { version = "3.0.0-rc.3", optional = true, features = ["rand_core"] }
 sm3 = { version = "0.5.0-rc.1", optional = true, default-features = false }


### PR DESCRIPTION
- Bumps `sha2` and `sha3` to v0.11.0-rc.2
- Bumps `digest` to v0.11.0-rc.1