### PR TITLE
Release `primefield` and `primeorder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-pre.4"
+version = "0.14.0-pre.5"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-pre.7"
+version = "0.14.0-pre.8"
 dependencies = [
  "elliptic-curve",
  "serdect",

--- a/bign256/Cargo.toml
+++ b/bign256/Cargo.toml
@@ -30,15 +30,15 @@ hmac = { version = "0.13.0-rc.0", optional = true }
 rand_core = "0.9"
 rfc6979 = { version = "0.5.0-rc.1", optional = true }
 pkcs8 = { version = "0.11.0-rc.3", optional = true }
-primefield = { version = "=0.14.0-pre.4", optional = true }
-primeorder = { version = "=0.14.0-pre.7", optional = true }
+primefield = { version = "=0.14.0-pre.5", optional = true }
+primeorder = { version = "=0.14.0-pre.8", optional = true }
 sec1 = { version = "0.8.0-rc.9", optional = true }
 signature = { version = "3.0.0-pre.3", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.7", features = ["dev"] }
+primeorder = { version = "=0.14.0-pre.8", features = ["dev"] }
 proptest = "1"
 rand_core = { version = "0.9", features = ["os_rng"] }
 hex = { version = "0.4" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -18,8 +18,8 @@ elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features 
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.6", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "=0.14.0-pre.4", optional = true }
-primeorder = { version = "=0.14.0-pre.7", optional = true }
+primefield = { version = "=0.14.0-pre.5", optional = true }
+primeorder = { version = "=0.14.0-pre.8", optional = true }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [features]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -18,8 +18,8 @@ elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features 
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.6", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "=0.14.0-pre.4", optional = true }
-primeorder = { version = "=0.14.0-pre.7", optional = true }
+primefield = { version = "=0.14.0-pre.5", optional = true }
+primeorder = { version = "=0.14.0-pre.8", optional = true }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [features]

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -22,14 +22,14 @@ elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.4", optional = true }
-primeorder = { version = "=0.14.0-pre.7", optional = true }
+primefield = { version = "=0.14.0-pre.5", optional = true }
+primeorder = { version = "=0.14.0-pre.8", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
 ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.7", features = ["dev"] }
+primeorder = { version = "=0.14.0-pre.8", features = ["dev"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -22,8 +22,8 @@ elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.4", optional = true }
-primeorder = { version = "=0.14.0-pre.7", optional = true }
+primefield = { version = "=0.14.0-pre.5", optional = true }
+primeorder = { version = "=0.14.0-pre.8", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
@@ -31,7 +31,7 @@ sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 blobby = "0.3"
 ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.7", features = ["dev"] }
+primeorder = { version = "=0.14.0-pre.8", features = ["dev"] }
 rand_core = { version = "0.9", features = ["os_rng"] }
 
 [features]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -24,8 +24,8 @@ elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features 
 ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.0", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.4", optional = true }
-primeorder = { version = "=0.14.0-pre.7", optional = true }
+primefield = { version = "=0.14.0-pre.5", optional = true }
+primeorder = { version = "=0.14.0-pre.8", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
@@ -34,8 +34,8 @@ blobby = "0.3"
 criterion = "0.7"
 ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primefield = { version = "=0.14.0-pre.4" }
-primeorder = { version = "=0.14.0-pre.7", features = ["dev"] }
+primefield = { version = "=0.14.0-pre.5" }
+primeorder = { version = "=0.14.0-pre.8", features = ["dev"] }
 proptest = "1"
 rand_core = { version = "0.9", features = ["os_rng"] }
 

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -24,8 +24,8 @@ elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features 
 ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.0", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.4", optional = true }
-primeorder = { version = "=0.14.0-pre.7", optional = true }
+primefield = { version = "=0.14.0-pre.5", optional = true }
+primeorder = { version = "=0.14.0-pre.8", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
@@ -34,7 +34,7 @@ blobby = "0.3"
 criterion = "0.7"
 ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.7", features = ["dev"] }
+primeorder = { version = "=0.14.0-pre.8", features = ["dev"] }
 proptest = "1.7"
 rand_core = { version = "0.9", features = ["os_rng"] }
 

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -24,8 +24,8 @@ elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features 
 ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.0", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "=0.14.0-pre.4", optional = true }
-primeorder = { version = "=0.14.0-pre.7", optional = true }
+primefield = { version = "=0.14.0-pre.5", optional = true }
+primeorder = { version = "=0.14.0-pre.8", optional = true }
 rand_core = { version = "0.9", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
@@ -35,7 +35,7 @@ blobby = "0.3"
 criterion = "0.7"
 ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "=0.14.0-pre.7", features = ["dev"] }
+primeorder = { version = "=0.14.0-pre.8", features = ["dev"] }
 proptest = "1.7"
 rand_core = { version = "0.9", features = ["os_rng"] }
 

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primefield"
-version = "0.14.0-pre.4"
+version = "0.14.0-pre.5"
 description = "Macros for generating prime field implementations"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.14.0-pre.7"
+version = "0.14.0-pre.8"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -22,8 +22,8 @@ elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features 
 rand_core = { version = "0.9", default-features = false }
 
 # optional dependencies
-primefield = { version = "=0.14.0-pre.4", optional = true }
-primeorder = { version = "=0.14.0-pre.7", optional = true }
+primefield = { version = "=0.14.0-pre.5", optional = true }
+primeorder = { version = "=0.14.0-pre.8", optional = true }
 rfc6979 = { version = "0.5.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 signature = { version = "3.0.0-rc.3", optional = true, features = ["rand_core"] }


### PR DESCRIPTION
Releases the following with `hybrid-array` v0.4 support:

- `primefield` v0.14.0-pre.5
- `primeorder` v0.14.0-pre.8