### PR TITLE
Cut prereleases with `hybrid-array` v0.4 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "bp256"
-version = "0.7.0-pre"
+version = "0.14.0-pre.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "bp384"
-version = "0.7.0-pre"
+version = "0.14.0-pre.0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "ed448-goldilocks"
-version = "0.14.0-pre.2"
+version = "0.14.0-pre.3"
 dependencies = [
  "criterion",
  "ed448",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "hash2curve"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 dependencies = [
  "digest",
  "elliptic-curve",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-pre.9"
+version = "0.14.0-pre.10"
 dependencies = [
  "blobby",
  "cfg-if",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-pre.9"
+version = "0.14.0-pre.10"
 dependencies = [
  "blobby",
  "criterion",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-pre.9"
+version = "0.14.0-pre.10"
 dependencies = [
  "blobby",
  "criterion",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-pre.9"
+version = "0.14.0-pre.10"
 dependencies = [
  "base16ct",
  "blobby",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "x448"
-version = "0.7.0-pre"
+version = "0.14.0-pre.0"
 dependencies = [
  "ed448-goldilocks",
  "rand",

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp256"
-version = "0.7.0-pre"
+version = "0.14.0-pre.0"
 description = "Brainpool P-256 (brainpoolP256r1 and brainpoolP256t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp384"
-version = "0.7.0-pre"
+version = "0.14.0-pre.0"
 description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed448-goldilocks"
-version = "0.14.0-pre.2"
+version = "0.14.0-pre.3"
 authors = ["RustCrypto Developers"]
 categories = ["cryptography"]
 keywords = ["cryptography", "decaf", "ed448", "ed448-goldilocks"]
@@ -17,7 +17,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 
 [dependencies]
 elliptic-curve = { version = "0.14.0-rc.13", features = ["arithmetic", "pkcs8"] }
-hash2curve = { version = "0.14.0-rc.0" }
+hash2curve = { version = "0.14.0-rc.1" }
 rand_core = { version = "0.9", default-features = false }
 sha3 = { version = "0.11.0-rc.2", default-features = false }
 subtle = { version = "2.6", default-features = false }

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash2curve"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 description = "hash2curve algorithm implementation"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.14.0-pre.9"
+version = "0.14.0-pre.10"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification/public-key recovery, Taproot Schnorr signatures (BIP340),
@@ -21,7 +21,7 @@ rust-version = "1.85"
 [dependencies]
 cfg-if = "1.0"
 elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features = ["sec1"] }
-hash2curve = { version = "0.14.0-rc.0", optional = true }
+hash2curve = { version = "0.14.0-rc.1", optional = true }
 
 # optional dependencies
 once_cell = { version = "1.21", optional = true, default-features = false }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256"
-version = "0.14.0-pre.9"
+version = "0.14.0-pre.10"
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve as defined in SP 800-186, with support for ECDH, ECDSA
@@ -22,7 +22,7 @@ elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features 
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.0", optional = true }
+hash2curve = { version = "0.14.0-rc.1", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.5", optional = true }
 primeorder = { version = "=0.14.0-pre.8", optional = true }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p384"
-version = "0.14.0-pre.9"
+version = "0.14.0-pre.10"
 description = """
 Pure Rust implementation of the NIST P-384 (a.k.a. secp384r1) elliptic curve
 as defined in SP 800-186 with support for ECDH, ECDSA signing/verification,
@@ -22,7 +22,7 @@ elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features 
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.0", optional = true }
+hash2curve = { version = "0.14.0-rc.1", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.5", optional = true }
 primeorder = { version = "=0.14.0-pre.8", optional = true }

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p521"
-version = "0.14.0-pre.9"
+version = "0.14.0-pre.10"
 description = """
 Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve
 as defined in SP 800-186
@@ -22,7 +22,7 @@ elliptic-curve = { version = "0.14.0-rc.13", default-features = false, features 
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.0", optional = true }
+hash2curve = { version = "0.14.0-rc.1", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.5", optional = true }
 primeorder = { version = "=0.14.0-pre.8", optional = true }

--- a/x448/Cargo.toml
+++ b/x448/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "x448"
-version = "0.7.0-pre"
+version = "0.14.0-pre.0"
 authors = ["RustCrypto Developers"]
 categories = ["cryptography"]
-keywords = ["cryptography", "crypto", "x448", "diffie-hellman", "curve448",]
+keywords = ["cryptography", "crypto", "x448", "diffie-hellman", "curve448", ]
 homepage = "https://docs.rs/x448/"
 repository = "https://github.com/RustCrypto/elliptic-curves/tree/master/x448"
 documentation = "https://docs.rs/ed448-goldilocks"
@@ -14,8 +14,8 @@ readme = "README.md"
 description = "A pure-Rust implementation of X448."
 
 [dependencies]
-ed448-goldilocks = { version = "0.14.0-pre.0", default-features = false }
-rand_core = { version = "0.9", default-features = false } 
+ed448-goldilocks = { version = "0.14.0-pre.3", default-features = false }
+rand_core = { version = "0.9", default-features = false }
 
 [dependencies.zeroize]
 version = "1"


### PR DESCRIPTION
Releases the following:
- `bp256` v0.14.0-pre.0
- `bp384` v0.14.0-pre.0
- `ed448-goldilocks` v0.14.0-pre.3
- `hash2curve` v0.14.0-rc.1
- `k256` v0.14.0-pre.10
- `p256` v0.14.0-pre.10
- `p384` v0.14.0-pre.10
- `p521` v0.14.0-pre.10
- `x448` v0.14.0-pre.0