### PR TITLE
ed448-goldilocks: improve CI times

### DIFF
--- a/.github/workflows/ed448-goldilocks.yml
+++ b/.github/workflows/ed448-goldilocks.yml
@@ -89,8 +89,11 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: ${{ matrix.deps }}
-      - run: cargo test --release --target ${{ matrix.target }} --no-default-features
-      - run: cargo hack test --feature-powerset --target ${{ matrix.target }}
+      - run: cargo test --target ${{ matrix.target }} --no-default-features
+      - run: cargo hack test --feature-powerset --target ${{ matrix.target }} --exclude-features bits,std
+      - run: cargo test --target ${{ matrix.target }} --features bits
+      - run: cargo test --target ${{ matrix.target }} --features std
+      - run: cargo test --target ${{ matrix.target }} --all-features
       - run: cargo test --release --target ${{ matrix.target }} --all-features
 
   cross:

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -31,6 +31,7 @@ signature = { version = "3.0.0-rc.3", optional = true, default-features = false,
 default = ["std", "signing", "pkcs8"]
 alloc = ["ed448?/alloc", "elliptic-curve/alloc", "serdect?/alloc", "signature?/alloc"]
 std = ["alloc"]
+
 bits = ["elliptic-curve/bits"]
 pkcs8 = ["ed448?/pkcs8", "elliptic-curve/pkcs8"]
 signing = ["dep:ed448", "dep:signature"]


### PR DESCRIPTION
Reduces the number of feature combinations tested by `cargo hack` by excluding the `bits` and `std` features