### PR TITLE
Implement `AffineCoordinates::from_coordinates`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,8 +419,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b95fd42abd85018a59f5dbe05551e9eed19edfd1182a415cd98f90ca5af1422"
+source = "git+https://github.com/RustCrypto/traits#b93df4aabac35b714fbcdf3ea951803ee8b00e56"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ opt-level = 2
 
 [patch.crates-io]
 ed448-goldilocks = { path = "ed448-goldilocks" }
+# https://github.com/RustCrypto/traits/pull/1996
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }

--- a/ed448-goldilocks/src/edwards/affine.rs
+++ b/ed448-goldilocks/src/edwards/affine.rs
@@ -45,6 +45,15 @@ impl Eq for AffinePoint {}
 impl elliptic_curve::point::AffineCoordinates for AffinePoint {
     type FieldRepr = Ed448FieldBytes;
 
+    fn from_coordinates(x: &Self::FieldRepr, y: &Self::FieldRepr) -> CtOption<Self> {
+        let point = Self {
+            x: FieldElement::from_bytes_extended(&x.0),
+            y: FieldElement::from_bytes_extended(&y.0),
+        };
+
+        CtOption::new(point, point.is_on_curve())
+    }
+
     fn x(&self) -> Self::FieldRepr {
         Ed448FieldBytes::from(self.x.to_bytes_extended())
     }

--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -363,6 +363,10 @@ impl FieldElement {
         Self(ConstMontyType::new(&U448::from_le_slice(bytes)))
     }
 
+    pub fn from_bytes_extended(bytes: &[u8; 57]) -> Self {
+        Self(ConstMontyType::new(&U448::from_le_slice(&bytes[..56])))
+    }
+
     pub fn from_repr(bytes: &[u8; 56]) -> CtOption<Self> {
         let integer = U448::from_le_slice(bytes);
         let is_some = integer.ct_lt(MODULUS::PARAMS.modulus());


### PR DESCRIPTION
Implementation of https://github.com/RustCrypto/traits/pull/1996 addressing https://github.com/RustCrypto/traits/issues/1994.

I didn't add a const method to `AffinePoint`, but let me know if this is desired at this point and I'm happy to do it here or in a follow-up.