### PR TITLE
`ed448-goldilocks`: remove unnecessary `constants` module

### DIFF
--- a/ed448-goldilocks/src/constants.rs
+++ b/ed448-goldilocks/src/constants.rs
@@ -1,8 +1,0 @@
-use crate::*;
-
-pub const DECAF_BASEPOINT: DecafPoint = DecafPoint(curve::twedwards::extended::ExtendedPoint {
-    X: TWISTED_EDWARDS_BASE_POINT.X,
-    Y: TWISTED_EDWARDS_BASE_POINT.Y,
-    Z: TWISTED_EDWARDS_BASE_POINT.Z,
-    T: TWISTED_EDWARDS_BASE_POINT.T,
-});

--- a/ed448-goldilocks/src/decaf/points.rs
+++ b/ed448-goldilocks/src/decaf/points.rs
@@ -1,4 +1,3 @@
-use crate::constants::DECAF_BASEPOINT;
 use crate::curve::twedwards::extended::ExtendedPoint;
 use crate::field::FieldElement;
 use crate::*;
@@ -304,7 +303,7 @@ impl elliptic_curve::zeroize::DefaultIsZeroes for DecafPoint {}
 
 impl DecafPoint {
     /// The generator point
-    pub const GENERATOR: DecafPoint = DECAF_BASEPOINT;
+    pub const GENERATOR: DecafPoint = DecafPoint(TWISTED_EDWARDS_BASE_POINT);
     /// The identity point
     pub const IDENTITY: DecafPoint = DecafPoint(ExtendedPoint::IDENTITY);
 

--- a/ed448-goldilocks/src/lib.rs
+++ b/ed448-goldilocks/src/lib.rs
@@ -39,8 +39,6 @@ pub use rand_core;
 pub use sha3;
 pub use subtle;
 
-// As usual, we will use this file to carefully define the API/ what we expose to the user
-pub(crate) mod constants;
 pub(crate) mod curve;
 pub(crate) mod decaf;
 pub(crate) mod edwards;


### PR DESCRIPTION
As in the title.