### PR TITLE
Use `primefield::monty_field_params!` where applicable

### DIFF
--- a/bign256/src/arithmetic/field.rs
+++ b/bign256/src/arithmetic/field.rs
@@ -38,10 +38,18 @@ use elliptic_curve::{
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
-/// Constant representing the modulus
-/// p = 2^{256} − 189
-pub(crate) const MODULUS: NonZero<U256> = NonZero::<U256>::from_be_hex(
-    "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF43",
+/// Constant representing the modulus: p = 2^{256} − 189
+const MODULUS_HEX: &str = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff43";
+pub(crate) const MODULUS: NonZero<U256> = NonZero::<U256>::from_be_hex(MODULUS_HEX);
+
+primefield::monty_field_params!(
+    name: FieldParams,
+    fe_name: "FieldElement",
+    modulus: MODULUS_HEX,
+    uint: U256,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "P-256 field modulus",
+    multiplicative_generator: 6
 );
 
 /// Element of the bign-256 base field used for curve coordinates.
@@ -110,8 +118,7 @@ impl PrimeField for FieldElement {
         self.is_odd()
     }
 
-    const MODULUS: &'static str =
-        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff43";
+    const MODULUS: &'static str = MODULUS_HEX;
     const NUM_BITS: u32 = 256;
     const CAPACITY: u32 = 255;
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();

--- a/bign256/src/arithmetic/scalar.rs
+++ b/bign256/src/arithmetic/scalar.rs
@@ -34,6 +34,16 @@ use {
 #[cfg(doc)]
 use core::ops::{Add, Mul, Neg, Sub};
 
+primefield::monty_field_params!(
+    name: ScalarParams,
+    fe_name: "Scalar",
+    modulus: ORDER_HEX,
+    uint: U256,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "Bign P-256 scalar modulus",
+    multiplicative_generator: 3
+);
+
 /// Scalars are elements in the finite field modulo `n`.
 ///
 /// # Trait impls

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -24,8 +24,17 @@ use elliptic_curve::{
 
 /// Constant representing the modulus serialized as hex.
 const MODULUS_HEX: &str = "a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5377";
-
 const MODULUS: NonZero<U256> = NonZero::<U256>::from_be_hex(MODULUS_HEX);
+
+primefield::monty_field_params!(
+    name: FieldParams,
+    fe_name: "FieldElement",
+    modulus: MODULUS_HEX,
+    uint: U256,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "brainpoolP256 field modulus",
+    multiplicative_generator: 11
+);
 
 /// Element of the brainpoolP256's base field used for curve point coordinates.
 #[derive(Clone, Copy)]

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -28,6 +28,16 @@ use elliptic_curve::{
 #[cfg(doc)]
 use core::ops::{Add, Mul, Sub};
 
+primefield::monty_field_params!(
+    name: ScalarParams,
+    fe_name: "Scalar",
+    modulus: ORDER_HEX,
+    uint: U256,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "brainpoolP256 scalar modulus",
+    multiplicative_generator: 3
+);
+
 /// Element of brainpoolP256's scalar field.
 #[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(pub(super) U256);

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -24,8 +24,17 @@ use elliptic_curve::{
 
 /// Constant representing the modulus serialized as hex.
 const MODULUS_HEX: &str = "8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec53";
-
 const MODULUS: NonZero<U384> = NonZero::<U384>::from_be_hex(MODULUS_HEX);
+
+primefield::monty_field_params!(
+    name: FieldParams,
+    fe_name: "FieldElement",
+    modulus: MODULUS_HEX,
+    uint: U384,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "brainpoolP384 field modulus",
+    multiplicative_generator: 3
+);
 
 /// Element of the brainpoolP384's base field used for curve point coordinates.
 #[derive(Clone, Copy)]

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -28,6 +28,16 @@ use elliptic_curve::{
 #[cfg(doc)]
 use core::ops::{Add, Mul, Sub};
 
+primefield::monty_field_params!(
+    name: ScalarParams,
+    fe_name: "Scalar",
+    modulus: ORDER_HEX,
+    uint: U384,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "brainpoolP384 scalar modulus",
+    multiplicative_generator: 2
+);
+
 /// Element of the brainpoolP384's scalar field.
 #[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(pub(super) U384);

--- a/p192/src/arithmetic/field.rs
+++ b/p192/src/arithmetic/field.rs
@@ -36,8 +36,17 @@ use elliptic_curve::{
 /// Constant representing the modulus serialized as hex.
 /// p = 2^{192} − 2^{64} - 1
 const MODULUS_HEX: &str = "fffffffffffffffffffffffffffffffeffffffffffffffff";
-
 const MODULUS: NonZero<U192> = NonZero::<U192>::from_be_hex(MODULUS_HEX);
+
+primefield::monty_field_params!(
+    name: FieldParams,
+    fe_name: "FieldElement",
+    modulus: MODULUS_HEX,
+    uint: U192,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "P-192 field modulus",
+    multiplicative_generator: 11
+);
 
 /// Element of the secp192r1 base field used for curve coordinates.
 #[derive(Clone, Copy)]

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -40,6 +40,16 @@ use {
 #[cfg(doc)]
 use core::ops::{Add, Mul, Neg, Sub};
 
+primefield::monty_field_params!(
+    name: ScalarParams,
+    fe_name: "Scalar",
+    modulus: ORDER_HEX,
+    uint: U192,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "P-192 scalar modulus",
+    multiplicative_generator: 3
+);
+
 /// Scalars are elements in the finite field modulo `n`.
 ///
 /// # Trait impls

--- a/p224/src/arithmetic/field.rs
+++ b/p224/src/arithmetic/field.rs
@@ -42,6 +42,16 @@ const MODULUS_HEX: &str = "00000000ffffffffffffffffffffffffffffffff0000000000000
 
 const MODULUS: NonZero<Uint> = NonZero::<Uint>::new_unwrap(Uint::from_be_hex(MODULUS_HEX));
 
+primefield::monty_field_params!(
+    name: FieldParams,
+    fe_name: "FieldElement",
+    modulus: MODULUS_HEX,
+    uint: Uint,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "P-224 field modulus",
+    multiplicative_generator: 22
+);
+
 /// Element of the secp224r1 base field used for curve coordinates.
 #[derive(Clone, Copy)]
 pub struct FieldElement(pub(super) Uint);

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -40,6 +40,16 @@ use {
 #[cfg(doc)]
 use core::ops::{Add, Mul, Neg, Sub};
 
+primefield::monty_field_params!(
+    name: ScalarParams,
+    fe_name: "Scalar",
+    modulus: ORDER_HEX,
+    uint: Uint,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "P-224 scalar modulus",
+    multiplicative_generator: 2
+);
+
 /// Scalars are elements in the finite field modulo `n`.
 ///
 /// # Trait impls

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -15,11 +15,19 @@ use elliptic_curve::{
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
+/// Constant representing the modulus: p = 2^{224}(2^{32} − 1) + 2^{192} + 2^{96} − 1
 const MODULUS_HEX: &str = "ffffffff00000001000000000000000000000000ffffffffffffffffffffffff";
-
-/// Constant representing the modulus
-/// p = 2^{224}(2^{32} − 1) + 2^{192} + 2^{96} − 1
 pub const MODULUS: NonZero<U256> = NonZero::<U256>::from_be_hex(MODULUS_HEX);
+
+primefield::monty_field_params!(
+    name: FieldParams,
+    fe_name: "FieldElement",
+    modulus: MODULUS_HEX,
+    uint: U256,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "Bign P-256 field modulus",
+    multiplicative_generator: 6
+);
 
 /// R^2 = 2^512 mod p
 const R2: FieldElement = FieldElement(U256::from_be_hex(

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -34,7 +34,18 @@ use elliptic_curve::{
 
 /// Constant representing the modulus
 /// p = 2^{384} − 2^{128} − 2^{96} + 2^{32} − 1
-pub(crate) const MODULUS: NonZero<U384> = NonZero::<U384>::from_be_hex(FieldElement::MODULUS);
+const MODULUS_HEX: &str = "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff";
+pub(crate) const MODULUS: NonZero<U384> = NonZero::<U384>::from_be_hex(MODULUS_HEX);
+
+primefield::monty_field_params!(
+    name: FieldParams,
+    fe_name: "FieldElement",
+    modulus: MODULUS_HEX,
+    uint: U384,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "P-384 field modulus",
+    multiplicative_generator: 19
+);
 
 /// Element of the secp384r1 base field used for curve coordinates.
 #[derive(Clone, Copy)]
@@ -108,7 +119,7 @@ impl FieldElement {
 impl PrimeField for FieldElement {
     type Repr = FieldBytes;
 
-    const MODULUS: &'static str = "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff";
+    const MODULUS: &'static str = MODULUS_HEX;
     const NUM_BITS: u32 = 384;
     const CAPACITY: u32 = 383;
     const TWO_INV: Self = Self::from_u64(2).invert_unchecked();

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -40,6 +40,16 @@ use {
 #[cfg(doc)]
 use core::ops::{Add, Mul, Neg, Sub};
 
+primefield::monty_field_params!(
+    name: ScalarParams,
+    fe_name: "Scalar",
+    modulus: ORDER_HEX,
+    uint: U384,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "P-384 scalar modulus",
+    multiplicative_generator: 2
+);
+
 /// Scalars are elements in the finite field modulo `n`.
 ///
 /// # Trait impls

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -46,6 +46,16 @@ use core::ops::Sub;
 #[cfg(target_pointer_width = "32")]
 use super::util::{u32x18_to_u64x9, u64x9_to_u32x18};
 
+primefield::monty_field_params!(
+    name: ScalarParams,
+    fe_name: "Scalar",
+    modulus: ORDER_HEX,
+    uint: U576,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "P-521 scalar modulus",
+    multiplicative_generator: 3
+);
+
 /// Scalars are elements in the finite field modulo `n`.
 ///
 /// # Trait impls

--- a/sm2/src/arithmetic/field.rs
+++ b/sm2/src/arithmetic/field.rs
@@ -38,8 +38,17 @@ use elliptic_curve::{
 
 /// Constant representing the modulus serialized as hex.
 const MODULUS_HEX: &str = "fffffffeffffffffffffffffffffffffffffffff00000000ffffffffffffffff";
-
 const MODULUS: NonZero<U256> = NonZero::<U256>::from_be_hex(MODULUS_HEX);
+
+primefield::monty_field_params!(
+    name: FieldParams,
+    fe_name: "FieldElement",
+    modulus: MODULUS_HEX,
+    uint: U256,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "SM2 field modulus",
+    multiplicative_generator: 13
+);
 
 /// Element of the SM2 elliptic curve base field used for curve point coordinates.
 #[derive(Clone, Copy)]

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -49,6 +49,16 @@ use {
 #[cfg(doc)]
 use core::ops::{Add, Mul, Neg, Sub};
 
+primefield::monty_field_params!(
+    name: ScalarParams,
+    fe_name: "Scalar",
+    modulus: ORDER_HEX,
+    uint: U256,
+    byte_order: primefield::ByteOrder::BigEndian,
+    doc: "SM2 scalar modulus",
+    multiplicative_generator: 3
+);
+
 /// Scalars are elements in the finite field modulo `n`.
 ///
 /// # Trait impls


### PR DESCRIPTION
This defines the Montgomery field parameters `FieldParams` and `ScalarParams` for all curves which use Montgomery field representations, except for `k256` which doesn't use `primefield` (yet).

These aren't actually used yet, but getting them defined is the first step towards migrating to `MontyField` as the internal field element representation.