### PR TITLE
primefield: make `MontyFieldElement` the interior field element type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,8 +319,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto-bigint"
 version = "0.7.0-rc.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c069823f41bdc75e99546bfd59eb1ed27d69dc720e5c949fe502b82926f8448"
+source = "git+https://github.com/RustCrypto/crypto-bigint#7bb8509234898b8bba62aea0343bbd99b5439944"
 dependencies = [
  "hybrid-array",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,11 @@ members = [
 opt-level = 2
 
 [patch.crates-io]
-ed448-goldilocks = { path = "ed448-goldilocks" }
 # https://github.com/RustCrypto/traits/pull/1996
+crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint" }
 elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
+
+ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -27,11 +27,12 @@ default = ["pkcs8", "std"]
 alloc = ["ecdsa?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "ecdsa?/std", "elliptic-curve/std"]
 
+arithmetic = ["dep:primefield", "dep:primeorder"]
+bits = ["arithmetic", "elliptic-curve/bits"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa/serde", "elliptic-curve/serde"]
 sha256 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
-arithmetic = ["dep:primefield", "dep:primeorder"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -15,43 +15,36 @@
 mod field_impl;
 
 use self::field_impl::*;
-use crate::{FieldBytes, U256};
+use crate::U256;
 use elliptic_curve::{
-    bigint::NonZero,
     ff::PrimeField,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
 /// Constant representing the modulus serialized as hex.
 const MODULUS_HEX: &str = "a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5377";
-const MODULUS: NonZero<U256> = NonZero::<U256>::from_be_hex(MODULUS_HEX);
 
 primefield::monty_field_params!(
     name: FieldParams,
-    fe_name: "FieldElement",
     modulus: MODULUS_HEX,
     uint: U256,
     byte_order: primefield::ByteOrder::BigEndian,
-    doc: "brainpoolP256 field modulus",
-    multiplicative_generator: 11
+    multiplicative_generator: 11,
+    fe_name: "FieldElement",
+    doc: "brainpoolP256 field modulus"
 );
 
 /// Element of the brainpoolP256's base field used for curve point coordinates.
 #[derive(Clone, Copy)]
-pub struct FieldElement(pub(super) U256);
-
-primefield::field_element_type!(
-    FieldElement,
-    FieldBytes,
-    U256,
-    MODULUS,
-    crate::decode_field_bytes,
-    crate::encode_field_bytes
+pub struct FieldElement(
+    pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
 );
+
+primefield::field_element_type!(FieldElement, FieldParams, U256);
 
 primefield::fiat_field_arithmetic!(
     FieldElement,
-    FieldBytes,
+    FieldParams,
     U256,
     fiat_bp256_non_montgomery_domain_field_element,
     fiat_bp256_montgomery_domain_field_element,
@@ -82,36 +75,6 @@ impl FieldElement {
             0x2a7ed5f6e87baa6f,
         ]);
         CtOption::new(sqrt, sqrt.square().ct_eq(self))
-    }
-}
-
-impl PrimeField for FieldElement {
-    type Repr = FieldBytes;
-
-    const MODULUS: &'static str = MODULUS_HEX;
-    const NUM_BITS: u32 = 256;
-    const CAPACITY: u32 = 255;
-    const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
-    const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(11);
-    const S: u32 = 1;
-    const ROOT_OF_UNITY: Self =
-        Self::from_hex_vartime("a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5376");
-    const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
-    const DELTA: Self = Self::from_u64(121);
-
-    #[inline]
-    fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
-        Self::from_bytes(&bytes)
-    }
-
-    #[inline]
-    fn to_repr(&self) -> FieldBytes {
-        self.to_bytes()
-    }
-
-    #[inline]
-    fn is_odd(&self) -> Choice {
-        self.is_odd()
     }
 }
 

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -27,11 +27,12 @@ default = ["pkcs8", "std"]
 alloc = ["ecdsa?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "ecdsa?/std", "elliptic-curve/std"]
 
+arithmetic = ["dep:primefield", "dep:primeorder"]
+bits = ["arithmetic", "elliptic-curve/bits"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa/serde", "elliptic-curve/serde"]
 sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
-arithmetic = ["dep:primefield", "dep:primeorder"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -15,43 +15,36 @@
 mod field_impl;
 
 use self::field_impl::*;
-use crate::{FieldBytes, U384};
+use crate::U384;
 use elliptic_curve::{
-    bigint::NonZero,
     ff::PrimeField,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
 /// Constant representing the modulus serialized as hex.
 const MODULUS_HEX: &str = "8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec53";
-const MODULUS: NonZero<U384> = NonZero::<U384>::from_be_hex(MODULUS_HEX);
 
 primefield::monty_field_params!(
     name: FieldParams,
-    fe_name: "FieldElement",
     modulus: MODULUS_HEX,
     uint: U384,
     byte_order: primefield::ByteOrder::BigEndian,
-    doc: "brainpoolP384 field modulus",
-    multiplicative_generator: 3
+    multiplicative_generator: 3,
+    fe_name: "FieldElement",
+    doc: "brainpoolP384 field modulus"
 );
 
 /// Element of the brainpoolP384's base field used for curve point coordinates.
 #[derive(Clone, Copy)]
-pub struct FieldElement(pub(super) U384);
-
-primefield::field_element_type!(
-    FieldElement,
-    FieldBytes,
-    U384,
-    MODULUS,
-    crate::decode_field_bytes,
-    crate::encode_field_bytes
+pub struct FieldElement(
+    pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
 );
+
+primefield::field_element_type!(FieldElement, FieldParams, U384);
 
 primefield::fiat_field_arithmetic!(
     FieldElement,
-    FieldBytes,
+    FieldParams,
     U384,
     fiat_bp384_non_montgomery_domain_field_element,
     fiat_bp384_montgomery_domain_field_element,
@@ -84,37 +77,6 @@ impl FieldElement {
             0x232e47a0a8ce1b4a,
         ]);
         CtOption::new(sqrt, sqrt.square().ct_eq(self))
-    }
-}
-
-impl PrimeField for FieldElement {
-    type Repr = FieldBytes;
-
-    const MODULUS: &'static str = MODULUS_HEX;
-    const NUM_BITS: u32 = 384;
-    const CAPACITY: u32 = 383;
-    const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
-    const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(3);
-    const S: u32 = 1;
-    const ROOT_OF_UNITY: Self = Self::from_hex_vartime(
-        "8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec52",
-    );
-    const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
-    const DELTA: Self = Self::from_u64(9);
-
-    #[inline]
-    fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
-        Self::from_bytes(&bytes)
-    }
-
-    #[inline]
-    fn to_repr(&self) -> FieldBytes {
-        self.to_bytes()
-    }
-
-    #[inline]
-    fn is_odd(&self) -> Choice {
-        self.is_odd()
     }
 }
 

--- a/p256/src/arithmetic/field/field32.rs
+++ b/p256/src/arithmetic/field/field32.rs
@@ -3,7 +3,7 @@
 use super::MODULUS;
 use elliptic_curve::bigint::{Limb, U256};
 
-pub(super) const fn add(a: U256, b: U256) -> U256 {
+pub(super) const fn add(a: &U256, b: &U256) -> U256 {
     let a = a.as_limbs();
     let b = b.as_limbs();
 
@@ -39,7 +39,7 @@ pub(super) const fn add(a: U256, b: U256) -> U256 {
     ])
 }
 
-pub(super) const fn sub(a: U256, b: U256) -> U256 {
+pub(super) const fn sub(a: &U256, b: &U256) -> U256 {
     let a = a.as_limbs();
     let b = b.as_limbs();
 
@@ -53,8 +53,8 @@ pub(super) const fn sub(a: U256, b: U256) -> U256 {
 }
 
 #[inline]
-pub(super) const fn to_canonical(a: U256) -> U256 {
-    montgomery_reduce(a, U256::ZERO)
+pub(super) const fn to_canonical(a: &U256) -> U256 {
+    montgomery_reduce(a, &U256::ZERO)
 }
 
 /// Montgomery Reduction
@@ -105,7 +105,7 @@ pub(super) const fn to_canonical(a: U256) -> U256 {
 ///   https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf
 #[inline]
 #[allow(clippy::too_many_arguments)]
-pub(super) const fn montgomery_reduce(lo: U256, hi: U256) -> U256 {
+pub(super) const fn montgomery_reduce(lo: &U256, hi: &U256) -> U256 {
     let lo = lo.as_limbs();
     let hi = hi.as_limbs();
 

--- a/p256/src/arithmetic/field/field64.rs
+++ b/p256/src/arithmetic/field/field64.rs
@@ -3,7 +3,7 @@
 use super::MODULUS;
 use elliptic_curve::bigint::{Limb, U256};
 
-pub(super) const fn add(a: U256, b: U256) -> U256 {
+pub(super) const fn add(a: &U256, b: &U256) -> U256 {
     let a = a.as_limbs();
     let b = b.as_limbs();
 
@@ -27,7 +27,7 @@ pub(super) const fn add(a: U256, b: U256) -> U256 {
     U256::new([result[0], result[1], result[2], result[3]])
 }
 
-pub(super) const fn sub(a: U256, b: U256) -> U256 {
+pub(super) const fn sub(a: &U256, b: &U256) -> U256 {
     let a = a.as_limbs();
     let b = b.as_limbs();
 
@@ -39,8 +39,8 @@ pub(super) const fn sub(a: U256, b: U256) -> U256 {
 }
 
 #[inline]
-pub(super) const fn to_canonical(a: U256) -> U256 {
-    montgomery_reduce(a, U256::ZERO)
+pub(super) const fn to_canonical(a: &U256) -> U256 {
+    montgomery_reduce(a, &U256::ZERO)
 }
 
 /// Montgomery Reduction
@@ -85,7 +85,7 @@ pub(super) const fn to_canonical(a: U256) -> U256 {
 ///   https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf
 #[inline]
 #[allow(clippy::too_many_arguments)]
-pub(super) const fn montgomery_reduce(lo: U256, hi: U256) -> U256 {
+pub(super) const fn montgomery_reduce(lo: &U256, hi: &U256) -> U256 {
     let lo = lo.as_limbs();
     let hi = hi.as_limbs();
 
@@ -147,6 +147,7 @@ pub(super) const fn montgomery_reduce(lo: U256, hi: U256) -> U256 {
         [a4, a5, a6, a7, a8],
         [modulus[0], modulus[1], modulus[2], modulus[3], Limb::ZERO],
     );
+
     U256::new([result[0], result[1], result[2], result[3]])
 }
 

--- a/p256/src/arithmetic/hash2curve.rs
+++ b/p256/src/arithmetic/hash2curve.rs
@@ -16,7 +16,7 @@ impl GroupDigest for NistP256 {
 
 impl Reduce<Array<u8, U48>> for FieldElement {
     fn reduce(value: &Array<u8, U48>) -> Self {
-        const F_2_192: FieldElement = FieldElement(U256::from_be_hex(
+        const F_2_192: FieldElement = FieldElement::from_montgomery(U256::from_be_hex(
             "00000000000000030000000200000000fffffffffffffffefffffffeffffffff",
         ));
 
@@ -46,11 +46,11 @@ impl OsswuMap for FieldElement {
             0x4000_0000_0000_0000,
             0x3fff_ffff_c000_0000,
         ],
-        c2: FieldElement(U256::from_be_hex(
+        c2: FieldElement::from_montgomery(U256::from_be_hex(
             "9051d26e12a8f3046913c88f9ea8dfee78400ad7423dcf70a1fd38ee98a195fd",
         )),
         map_a: FieldElement::from_u64(3).neg(),
-        map_b: FieldElement(U256::from_be_hex(
+        map_b: FieldElement::from_montgomery(U256::from_be_hex(
             "dc30061d04874834e5a220abf7212ed6acf005cd78843090d89cdf6229c4bddf",
         )),
         z: FieldElement::from_u64(10).neg(),

--- a/p256/src/arithmetic/scalar/scalar32.rs
+++ b/p256/src/arithmetic/scalar/scalar32.rs
@@ -20,6 +20,8 @@ const MU: [Limb; 9] = [
 
 /// Barrett Reduction
 ///
+/// NOTE: this implementation is specialized to P-256's order! See #1155
+///
 /// The general algorithm is:
 /// ```text
 /// p = n = order of group

--- a/p256/src/arithmetic/scalar/scalar64.rs
+++ b/p256/src/arithmetic/scalar/scalar64.rs
@@ -16,6 +16,8 @@ const MU: [Limb; 5] = [
 
 /// Barrett Reduction
 ///
+/// NOTE: this implementation is specialized to P-256's order! See #1155
+///
 /// The general algorithm is:
 /// ```text
 /// p = n = order of group

--- a/p384/src/arithmetic/hash2curve.rs
+++ b/p384/src/arithmetic/hash2curve.rs
@@ -89,10 +89,7 @@ impl Reduce<Array<u8, U72>> for Scalar {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        NistP384, Scalar,
-        arithmetic::field::{FieldElement, MODULUS},
-    };
+    use crate::{NistP384, Scalar, arithmetic::field::FieldElement};
     use elliptic_curve::{
         Curve,
         array::Array,
@@ -112,7 +109,10 @@ mod tests {
     fn params() {
         let params = <FieldElement as OsswuMap>::PARAMS;
 
-        let c1 = MODULUS.checked_sub(&U384::from_u8(3)).unwrap()
+        let c1 = FieldElement::PARAMS
+            .modulus()
+            .checked_sub(&U384::from_u8(3))
+            .unwrap()
             / NonZero::new(U384::from_u8(4)).unwrap();
         assert_eq!(
             Array::from_iter(params.c1.iter().rev().flat_map(|v| v.to_be_bytes())),

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -48,12 +48,12 @@ use super::util::{u32x18_to_u64x9, u64x9_to_u32x18};
 
 primefield::monty_field_params!(
     name: ScalarParams,
-    fe_name: "Scalar",
     modulus: ORDER_HEX,
     uint: U576,
     byte_order: primefield::ByteOrder::BigEndian,
-    doc: "P-521 scalar modulus",
-    multiplicative_generator: 3
+    multiplicative_generator: 3,
+    fe_name: "Scalar",
+    doc: "P-521 scalar modulus"
 );
 
 /// Scalars are elements in the finite field modulo `n`.
@@ -79,6 +79,7 @@ primefield::monty_field_params!(
 ///   operations over field elements represented as bits (requires `bits` feature)
 ///
 /// Please see the documentation for the relevant traits for more information.
+// TODO(tarcieri): `primefield::MontyFieldElement` as the interior type
 #[derive(Clone, Copy, Debug, PartialOrd, Ord)]
 pub struct Scalar(fiat_p521_scalar_montgomery_domain_field_element);
 
@@ -102,9 +103,7 @@ impl Scalar {
 
     /// Decode [`Scalar`] from [`U576`] converting it into Montgomery form:
     ///
-    /// ```text
-    /// w * R^2 * R^-1 mod p = wR mod p
-    /// ```
+    /// `w * R^2 * R^-1 mod p = wR mod p`
     pub fn from_uint(uint: U576) -> CtOption<Self> {
         let is_some = uint.ct_lt(&NistP521::ORDER);
         CtOption::new(Self::from_uint_unchecked(uint), is_some)
@@ -535,6 +534,7 @@ impl IsHigh for Scalar {
     }
 }
 
+// TODO(tarcieri): use `primefield` to derive `PrimeField` impl
 impl PrimeField for Scalar {
     type Repr = FieldBytes;
 

--- a/primefield/src/lib.rs
+++ b/primefield/src/lib.rs
@@ -12,7 +12,7 @@ mod dev;
 mod macros;
 mod monty;
 
-pub use crate::monty::{MontyFieldElement, MontyFieldParams, compute_t};
+pub use crate::monty::{MontyFieldBytes, MontyFieldElement, MontyFieldParams, compute_t};
 pub use array::typenum::consts;
 pub use bigint;
 pub use bigint::hybrid_array as array;

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -34,12 +34,6 @@ use elliptic_curve::{
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
 
-#[cfg(feature = "bits")]
-use {
-    crate::ScalarBits,
-    elliptic_curve::{bigint::Word, group::ff::PrimeFieldBits},
-};
-
 #[cfg(feature = "serde")]
 use {
     elliptic_curve::ScalarPrimitive,
@@ -51,12 +45,12 @@ use core::ops::{Add, Mul, Neg, Sub};
 
 primefield::monty_field_params!(
     name: ScalarParams,
-    fe_name: "Scalar",
     modulus: ORDER_HEX,
     uint: U256,
     byte_order: primefield::ByteOrder::BigEndian,
-    doc: "SM2 scalar modulus",
-    multiplicative_generator: 3
+    multiplicative_generator: 3,
+    fe_name: "Scalar",
+    doc: "SM2 scalar modulus"
 );
 
 /// Scalars are elements in the finite field modulo `n`.
@@ -83,20 +77,13 @@ primefield::monty_field_params!(
 ///
 /// Please see the documentation for the relevant traits for more information.
 #[derive(Clone, Copy, PartialOrd, Ord)]
-pub struct Scalar(U256);
+pub struct Scalar(pub(super) primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
 
-primefield::field_element_type!(
-    Scalar,
-    FieldBytes,
-    U256,
-    Sm2::ORDER,
-    FieldBytesEncoding::<Sm2>::decode_field_bytes,
-    FieldBytesEncoding::<Sm2>::encode_field_bytes
-);
+primefield::field_element_type!(Scalar, ScalarParams, U256);
 
 primefield::fiat_field_arithmetic!(
     Scalar,
-    FieldBytes,
+    ScalarParams,
     U256,
     fiat_sm2_scalar_non_montgomery_domain_field_element,
     fiat_sm2_scalar_montgomery_domain_field_element,
@@ -152,49 +139,6 @@ impl IsHigh for Scalar {
     }
 }
 
-impl PrimeField for Scalar {
-    type Repr = FieldBytes;
-
-    const MODULUS: &'static str = ORDER_HEX;
-    const NUM_BITS: u32 = 256;
-    const CAPACITY: u32 = 255;
-    const TWO_INV: Self = Self::from_u64(2).invert_unchecked();
-    const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(3);
-    const S: u32 = 1;
-    const ROOT_OF_UNITY: Self =
-        Self::from_hex_vartime("fffffffeffffffffffffffffffffffff7203df6b21c6052b53bbf40939d54122");
-    const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.invert_unchecked();
-    const DELTA: Self = Self::from_u64(9);
-
-    #[inline]
-    fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
-        Self::from_bytes(&bytes)
-    }
-
-    #[inline]
-    fn to_repr(&self) -> FieldBytes {
-        self.to_bytes()
-    }
-
-    #[inline]
-    fn is_odd(&self) -> Choice {
-        self.is_odd()
-    }
-}
-
-#[cfg(feature = "bits")]
-impl PrimeFieldBits for Scalar {
-    type ReprBits = [Word; U256::LIMBS];
-
-    fn to_le_bits(&self) -> ScalarBits {
-        self.to_canonical().to_words().into()
-    }
-
-    fn char_le_bits() -> ScalarBits {
-        Sm2::ORDER.to_words().into()
-    }
-}
-
 impl Reduce<U256> for Scalar {
     fn reduce(w: &U256) -> Self {
         let (r, underflow) = w.borrowing_sub(&Sm2::ORDER, Limb::ZERO);
@@ -215,7 +159,15 @@ impl TryFrom<U256> for Scalar {
     type Error = Error;
 
     fn try_from(w: U256) -> Result<Self> {
-        Option::from(Self::from_uint(w)).ok_or(Error)
+        Self::try_from(&w)
+    }
+}
+
+impl TryFrom<&U256> for Scalar {
+    type Error = Error;
+
+    fn try_from(w: &U256) -> Result<Self> {
+        Self::from_uint(w).into_option().ok_or(Error)
     }
 }
 

--- a/sm2/src/pke/encrypting.rs
+++ b/sm2/src/pke/encrypting.rs
@@ -158,7 +158,7 @@ fn encrypt<R: TryCryptoRng + ?Sized>(
     let mut hpb: AffinePoint;
     loop {
         // A1: generate a random number 𝑘 ∈ [1, 𝑛 − 1] with the random number generator
-        let k = Scalar::from_uint(next_k(rng, N_BYTES)?).unwrap();
+        let k = Scalar::from_uint(&next_k(rng, N_BYTES)?).unwrap();
 
         // A2: compute point 𝐶1 = [𝑘]𝐺 = (𝑥1, 𝑦1)
         let kg = ProjectivePoint::mul_by_generator(&k).to_affine();


### PR DESCRIPTION
Modifies the field type macros to emit code which expects a `MontyFieldElement` as the interior type, itself a newtype for `ConstMontyForm` from the `crypto-bigint` crate.

Previously they were `crypto_bigint::Uint`s in Montgomery form, which couldn't leverage any of the modular arithmetic support from that crate.

Notably, this change doesn't leverage that support quite yet: instead the existing fiat-crypto synthesized arithmetic implementations are retained (or in the case of `p256`, handwritten ones). That keeps the impact of this particular change low so we can get it in place first and then experiment with using `crypto-bigint` itself for modular arithmetic.

The longer-term goal will be to expose `cfg` attributes that make it possible to select between `crypto-bigint` or `fiat-crypto` for the arithmetic implementation.

Closes #1191