### PR TITLE
primefield: rename field macros

### DIFF
--- a/bign256/src/arithmetic/field.rs
+++ b/bign256/src/arithmetic/field.rs
@@ -53,9 +53,9 @@ pub struct FieldElement(
     pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
 );
 
-primefield::field_element_type!(FieldElement, FieldParams, U256);
+primefield::monty_field_element!(FieldElement, FieldParams, U256);
 
-primefield::fiat_field_arithmetic!(
+primefield::monty_field_fiat_arithmetic!(
     FieldElement,
     FieldParams,
     U256,

--- a/bign256/src/arithmetic/scalar.rs
+++ b/bign256/src/arithmetic/scalar.rs
@@ -66,9 +66,9 @@ primefield::monty_field_params!(
 #[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(pub(super) primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
 
-primefield::field_element_type!(Scalar, ScalarParams, U256);
+primefield::monty_field_element!(Scalar, ScalarParams, U256);
 
-primefield::fiat_field_arithmetic!(
+primefield::monty_field_fiat_arithmetic!(
     Scalar,
     ScalarParams,
     U256,

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -47,9 +47,9 @@ pub struct FieldElement(
     pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
 );
 
-primefield::field_element_type!(FieldElement, FieldParams, U256);
+primefield::monty_field_element!(FieldElement, FieldParams, U256);
 
-primefield::fiat_field_arithmetic!(
+primefield::monty_field_fiat_arithmetic!(
     FieldElement,
     FieldParams,
     U256,

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -49,9 +49,9 @@ primefield::monty_field_params!(
 #[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(pub(super) primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
 
-primefield::field_element_type!(Scalar, ScalarParams, U256);
+primefield::monty_field_element!(Scalar, ScalarParams, U256);
 
-primefield::fiat_field_arithmetic!(
+primefield::monty_field_fiat_arithmetic!(
     Scalar,
     ScalarParams,
     U256,

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -47,9 +47,9 @@ pub struct FieldElement(
     pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
 );
 
-primefield::field_element_type!(FieldElement, FieldParams, U384);
+primefield::monty_field_element!(FieldElement, FieldParams, U384);
 
-primefield::fiat_field_arithmetic!(
+primefield::monty_field_fiat_arithmetic!(
     FieldElement,
     FieldParams,
     U384,

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -49,9 +49,9 @@ primefield::monty_field_params!(
 #[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(pub(super) primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
 
-primefield::field_element_type!(Scalar, ScalarParams, U384);
+primefield::monty_field_element!(Scalar, ScalarParams, U384);
 
-primefield::fiat_field_arithmetic!(
+primefield::monty_field_fiat_arithmetic!(
     Scalar,
     ScalarParams,
     U384,

--- a/p192/src/arithmetic/field.rs
+++ b/p192/src/arithmetic/field.rs
@@ -48,9 +48,9 @@ pub struct FieldElement(
     pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
 );
 
-primefield::field_element_type!(FieldElement, FieldParams, U192);
+primefield::monty_field_element!(FieldElement, FieldParams, U192);
 
-primefield::fiat_field_arithmetic!(
+primefield::monty_field_fiat_arithmetic!(
     FieldElement,
     FieldParams,
     U192,

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -77,9 +77,9 @@ primefield::monty_field_params!(
 #[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
 
-primefield::field_element_type!(Scalar, ScalarParams, U192);
+primefield::monty_field_element!(Scalar, ScalarParams, U192);
 
-primefield::fiat_field_arithmetic!(
+primefield::monty_field_fiat_arithmetic!(
     Scalar,
     ScalarParams,
     U192,

--- a/p224/src/arithmetic/field.rs
+++ b/p224/src/arithmetic/field.rs
@@ -51,9 +51,9 @@ pub struct FieldElement(
     pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
 );
 
-primefield::field_element_type!(FieldElement, FieldParams, Uint);
+primefield::monty_field_element!(FieldElement, FieldParams, Uint);
 
-primefield::fiat_field_arithmetic!(
+primefield::monty_field_fiat_arithmetic!(
     FieldElement,
     FieldParams,
     Uint,

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -84,9 +84,9 @@ primefield::monty_field_params!(
 #[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
 
-primefield::field_element_type!(Scalar, ScalarParams, Uint);
+primefield::monty_field_element!(Scalar, ScalarParams, Uint);
 
-primefield::fiat_field_arithmetic!(
+primefield::monty_field_fiat_arithmetic!(
     Scalar,
     ScalarParams,
     Uint,

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -36,7 +36,7 @@ pub struct FieldElement(
     pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
 );
 
-primefield::field_element_type!(FieldElement, FieldParams, U256);
+primefield::monty_field_element!(FieldElement, FieldParams, U256);
 
 impl FieldElement {
     /// Decode [`FieldElement`] from [`U256`] converting it into Montgomery form.

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -48,9 +48,9 @@ pub struct FieldElement(
     pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
 );
 
-primefield::field_element_type!(FieldElement, FieldParams, U384);
+primefield::monty_field_element!(FieldElement, FieldParams, U384);
 
-primefield::fiat_field_arithmetic!(
+primefield::monty_field_fiat_arithmetic!(
     FieldElement,
     FieldParams,
     U384,

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -85,9 +85,9 @@ primefield::monty_field_params!(
 #[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
 
-primefield::field_element_type!(Scalar, ScalarParams, U384);
+primefield::monty_field_element!(Scalar, ScalarParams, U384);
 
-primefield::fiat_field_arithmetic!(
+primefield::monty_field_fiat_arithmetic!(
     Scalar,
     ScalarParams,
     U384,

--- a/primefield/src/macros.rs
+++ b/primefield/src/macros.rs
@@ -112,7 +112,7 @@ macro_rules! monty_field_params {
 /// - `ShrAssign`
 /// - `Invert`
 #[macro_export]
-macro_rules! field_element_type {
+macro_rules! monty_field_element {
     ($fe:tt, $params:ty, $uint:tt) => {
         impl $fe {
             /// Zero element.

--- a/primefield/src/macros/fiat.rs
+++ b/primefield/src/macros/fiat.rs
@@ -8,7 +8,7 @@
 ///
 /// This provides a complete arithmetic implementation except for `sqrt`.
 #[macro_export]
-macro_rules! fiat_field_arithmetic {
+macro_rules! monty_field_fiat_arithmetic {
     (
         $fe:tt,
         $params:ty,

--- a/sm2/src/arithmetic/field.rs
+++ b/sm2/src/arithmetic/field.rs
@@ -50,9 +50,9 @@ pub struct FieldElement(
     pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
 );
 
-primefield::field_element_type!(FieldElement, FieldParams, U256);
+primefield::monty_field_element!(FieldElement, FieldParams, U256);
 
-primefield::fiat_field_arithmetic!(
+primefield::monty_field_fiat_arithmetic!(
     FieldElement,
     FieldParams,
     U256,

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -80,9 +80,9 @@ primefield::monty_field_params!(
 #[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct Scalar(pub(super) primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
 
-primefield::field_element_type!(Scalar, ScalarParams, U256);
+primefield::monty_field_element!(Scalar, ScalarParams, U256);
 
-primefield::fiat_field_arithmetic!(
+primefield::monty_field_fiat_arithmetic!(
     Scalar,
     ScalarParams,
     U256,


### PR DESCRIPTION
Renames the following:
- `field_element_type!` => `monty_field_element!`
- `fiat_field_arithmetic!` => `monty_field_fiat_arithmetic!`