### PR TITLE
Bump `signature` to v3.0.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,8 +363,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.6"
-source = "git+https://github.com/RustCrypto/signatures?rev=2cd53cf4fbe82c61c2e2ac7b2099ba743b01074e#2cd53cf4fbe82c61c2e2ac7b2099ba743b01074e"
+version = "0.17.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ab355ec063f7a110eb627471058093aba00eb7f4e70afbd15e696b79d1077b"
 dependencies = [
  "der",
  "digest",
@@ -378,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "ed448"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd2909b183f83f4c02df6111d7b26add0313584e17cf2d74ce2f578a12a123"
+checksum = "812bad302d88d3e1774df473dffc64f18fedc4be6b6066c470ae3c733b9f9765"
 dependencies = [
  "pkcs8",
  "serde",
@@ -1181,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.3"
+version = "3.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39195ff4c0dc41c93e123825ca1f0d11b856df8b26d5fe140a522355632c4345"
+checksum = "fc280a6ff65c79fbd6622f64d7127f32b85563bca8c53cd2e9141d6744a9056d"
 dependencies = [
  "digest",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,6 @@ members = [
 opt-level = 2
 
 [patch.crates-io]
-# https://github.com/RustCrypto/traits/pull/1996
-ecdsa = { git = "https://github.com/RustCrypto/signatures", rev = "2cd53cf4fbe82c61c2e2ac7b2099ba743b01074e" }
-
 ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }

--- a/bign256/Cargo.toml
+++ b/bign256/Cargo.toml
@@ -33,7 +33,7 @@ pkcs8 = { version = "0.11.0-rc.3", optional = true }
 primefield = { version = "=0.14.0-pre.5", optional = true }
 primeorder = { version = "=0.14.0-pre.8", optional = true }
 sec1 = { version = "0.8.0-rc.9", optional = true }
-signature = { version = "3.0.0-pre.3", optional = true }
+signature = { version = "3.0.0-rc.4", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.0-rc.14", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.6", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.7", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "=0.14.0-pre.5", optional = true }
 primeorder = { version = "=0.14.0-pre.8", optional = true }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.0-rc.14", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.6", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.7", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "=0.14.0-pre.5", optional = true }
 primeorder = { version = "=0.14.0-pre.8", optional = true }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -23,9 +23,9 @@ sha3 = { version = "0.11.0-rc.3", default-features = false }
 subtle = { version = "2.6", default-features = false }
 
 # optional dependencies
-ed448 = { version = "0.5.0-rc.0", optional = true, default-features = false }
+ed448 = { version = "0.5.0-rc.1", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true }
-signature = { version = "3.0.0-rc.3", optional = true, default-features = false, features = ["digest", "rand_core"] }
+signature = { version = "3.0.0-rc.4", optional = true, default-features = false, features = ["digest", "rand_core"] }
 
 [features]
 default = ["std", "signing", "pkcs8"]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -25,17 +25,17 @@ hash2curve = { version = "0.14.0-rc.1", optional = true }
 
 # optional dependencies
 once_cell = { version = "1.21", optional = true, default-features = false }
-ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primeorder = { version = "=0.14.0-pre.8", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
-signature = { version = "3.0.0-rc.3", optional = true }
+signature = { version = "3.0.0-rc.4", optional = true }
 
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4.3"
 hex-literal = "1"
 num-bigint = "0.4"

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -20,14 +20,14 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.0-rc.14", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.5", optional = true }
 primeorder = { version = "=0.14.0-pre.8", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "=0.14.0-pre.8", features = ["dev"] }
 

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.0-rc.14", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.5", optional = true }
 primeorder = { version = "=0.14.0-pre.8", optional = true }
@@ -29,7 +29,7 @@ sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
-ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "=0.14.0-pre.8", features = ["dev"] }
 rand_core = { version = "0.9", features = ["os_rng"] }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.0-rc.14", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.1", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.5", optional = true }
@@ -32,7 +32,7 @@ sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primefield = { version = "=0.14.0-pre.5" }
 primeorder = { version = "=0.14.0-pre.8", features = ["dev"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.0-rc.14", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.1", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.5", optional = true }
@@ -32,7 +32,7 @@ sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "=0.14.0-pre.8", features = ["dev"] }
 proptest = "1.7"

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -21,7 +21,7 @@ base16ct = "0.3"
 elliptic-curve = { version = "0.14.0-rc.14", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.1", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.5", optional = true }
@@ -33,7 +33,7 @@ sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.6", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "=0.14.0-pre.8", features = ["dev"] }
 proptest = "1.7"

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -26,7 +26,7 @@ primefield = { version = "=0.14.0-pre.5", optional = true }
 primeorder = { version = "=0.14.0-pre.8", optional = true }
 rfc6979 = { version = "0.5.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-signature = { version = "3.0.0-rc.3", optional = true, features = ["rand_core"] }
+signature = { version = "3.0.0-rc.4", optional = true, features = ["rand_core"] }
 sm3 = { version = "0.5.0-rc.1", optional = true, default-features = false }
 der = { version = "0.8.0-rc.8", optional = true }
 


### PR DESCRIPTION
Also bumps `ecdsa` to v0.17.0-rc.7

This brings `*DigestSigner`/`*DigestVerifier` changes introduced in RustCrypto/traits#2004

cc @daxpedda 