### PR TITLE
p256+p384: use `MontyFieldElement::sqn_vartime`

### DIFF
--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -94,17 +94,6 @@ impl FieldElement {
         self.multiply(self)
     }
 
-    /// Returns self^(2^n) mod p
-    const fn sqn(&self, n: usize) -> Self {
-        let mut x = *self;
-        let mut i = 0;
-        while i < n {
-            x = x.square();
-            i += 1;
-        }
-        x
-    }
-
     /// Returns the multiplicative inverse of self, if self is non-zero.
     pub fn invert(&self) -> CtOption<Self> {
         CtOption::new(self.invert_unchecked(), !self.is_zero())
@@ -160,6 +149,11 @@ impl FieldElement {
             sqrt,
             (&sqrt * &sqrt).ct_eq(self), // Only return Some if it's the square root.
         )
+    }
+
+    /// Returns self^(2^n) mod p
+    const fn sqn(&self, n: usize) -> Self {
+        Self(self.0.sqn_vartime(n))
     }
 
     /// Construct a field element from a [`U256`] in Montgomery form.

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -96,13 +96,9 @@ impl FieldElement {
         CtOption::new(x, x.square().ct_eq(&t1))
     }
 
-    /// Returns self^(2^n) mod p.
-    fn sqn(&self, n: usize) -> Self {
-        let mut x = *self;
-        for _ in 0..n {
-            x = x.square();
-        }
-        x
+    /// Returns self^(2^n) mod p
+    const fn sqn(&self, n: usize) -> Self {
+        Self(self.0.sqn_vartime(n))
     }
 }
 

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -150,12 +150,9 @@ impl Scalar {
         CtOption::new(x, x.square().ct_eq(&t1))
     }
 
-    fn sqn(&self, n: usize) -> Self {
-        let mut x = *self;
-        for _ in 0..n {
-            x = x.square();
-        }
-        x
+    /// Returns self^(2^n) mod p
+    const fn sqn(&self, n: usize) -> Self {
+        Self(self.0.sqn_vartime(n))
     }
 }
 

--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -376,7 +376,7 @@ where
     /// Returns self^(2^n) mod p.
     ///
     /// Variable-time with respect to `n`.
-    pub(crate) const fn sqn_vartime(&self, n: usize) -> Self {
+    pub const fn sqn_vartime(&self, n: usize) -> Self {
         let mut x = *self;
         let mut i = 0;
         while i < n {


### PR DESCRIPTION
Uses a common upstream implementation rather than a copy-pasted one