### PR TITLE
x448: add back `PublicKey::as_bytes`

### DIFF
--- a/x448/src/lib.rs
+++ b/x448/src/lib.rs
@@ -66,6 +66,11 @@ impl PublicKey {
 
         Some(PublicKey(point))
     }
+
+    /// Converts a public key into a byte slice
+    pub fn as_bytes(&self) -> &[u8; 56] {
+        self.0.as_bytes()
+    }
 }
 
 impl SharedSecret {


### PR DESCRIPTION
Accidentally removed in #1378, but we still want the bytes of the *public* key to be accessible.

cc @daxpedda