### PR TITLE
CI: trigger builds on `primefield`/`primeorder` changes

### DIFF
--- a/.github/workflows/bignp256.yml
+++ b/.github/workflows/bignp256.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - ".github/workflows/bignp256.yml"
       - "bignp256/**"
+      - "primefield/**"
+      - "primeorder/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/bp256.yml
+++ b/.github/workflows/bp256.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - ".github/workflows/bp256.yml"
       - "bp256/**"
+      - "primefield/**"
+      - "primeorder/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/bp384.yml
+++ b/.github/workflows/bp384.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - ".github/workflows/bp384.yml"
       - "bp384/**"
+      - "primefield/**"
+      - "primeorder/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/p192.yml
+++ b/.github/workflows/p192.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - ".github/workflows/p192.yml"
       - "p192/**"
+      - "primefield/**"
+      - "primeorder/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/p224.yml
+++ b/.github/workflows/p224.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - ".github/workflows/p224.yml"
       - "p224/**"
+      - "primefield/**"
+      - "primeorder/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -6,6 +6,8 @@ on:
       - ".github/workflows/p384.yml"
       - "p384/**"
       - "hash2curve/**"
+      - "primefield/**"
+      - "primeorder/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/p521.yml
+++ b/.github/workflows/p521.yml
@@ -6,6 +6,8 @@ on:
       - ".github/workflows/p521.yml"
       - "p521/**"
       - "hash2curve/**"
+      - "primefield/**"
+      - "primeorder/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/sm2.yml
+++ b/.github/workflows/sm2.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/sm2.yml"
+      - "primefield/**"
+      - "primeorder/**"
       - "sm2/**"
       - "Cargo.*"
   push:


### PR DESCRIPTION
Run tests on downstream curve crates when `primefield` and/or `primeorder` are changed