### PR TITLE
primefield: write `TryFrom` impls for `Uxyz`/`&Uyz`

### DIFF
--- a/bignp256/src/arithmetic/scalar.rs
+++ b/bignp256/src/arithmetic/scalar.rs
@@ -19,7 +19,7 @@ mod scalar_impl;
 use self::scalar_impl::*;
 use crate::{BignP256, FieldBytes, ORDER_HEX, U256};
 use elliptic_curve::{
-    Curve as _, Error, FieldBytesEncoding, Result,
+    Curve as _, FieldBytesEncoding,
     bigint::Limb,
     ff::PrimeField,
     ops::Reduce,
@@ -139,22 +139,6 @@ impl Reduce<FieldBytes> for Scalar {
     fn reduce(bytes: &FieldBytes) -> Self {
         let w = <U256 as FieldBytesEncoding<BignP256>>::decode_field_bytes(bytes);
         Self::reduce(&w)
-    }
-}
-
-impl TryFrom<U256> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: U256) -> Result<Self> {
-        Self::try_from(&w)
-    }
-}
-
-impl TryFrom<&U256> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: &U256) -> Result<Self> {
-        Self::from_uint(w).into_option().ok_or(Error)
     }
 }
 

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -24,7 +24,6 @@ mod scalar_impl;
 use self::scalar_impl::*;
 use crate::{BrainpoolP256r1, BrainpoolP256t1, FieldBytes, ORDER, ORDER_HEX, U256};
 use elliptic_curve::{
-    Error, Result,
     bigint::{ArrayEncoding, Limb},
     ff::PrimeField,
     ops::Reduce,
@@ -123,22 +122,6 @@ impl Reduce<FieldBytes> for Scalar {
     #[inline]
     fn reduce(bytes: &FieldBytes) -> Self {
         Self::reduce(&U256::from_be_byte_array(*bytes))
-    }
-}
-
-impl TryFrom<U256> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: U256) -> Result<Self> {
-        Self::try_from(&w)
-    }
-}
-
-impl TryFrom<&U256> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: &U256) -> Result<Self> {
-        Self::from_uint(w).into_option().ok_or(Error)
     }
 }
 

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -24,7 +24,6 @@ mod scalar_impl;
 use self::scalar_impl::*;
 use crate::{BrainpoolP384r1, BrainpoolP384t1, FieldBytes, ORDER, ORDER_HEX, U384};
 use elliptic_curve::{
-    Error, Result,
     bigint::{ArrayEncoding, Limb},
     ff::PrimeField,
     ops::Reduce,
@@ -130,22 +129,6 @@ impl Reduce<FieldBytes> for Scalar {
     #[inline]
     fn reduce(bytes: &FieldBytes) -> Self {
         Self::reduce(&U384::from_be_byte_array(*bytes))
-    }
-}
-
-impl TryFrom<U384> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: U384) -> Result<Self> {
-        Self::try_from(&w)
-    }
-}
-
-impl TryFrom<&U384> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: &U384) -> Result<Self> {
-        Self::from_uint(w).into_option().ok_or(Error)
     }
 }
 

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -24,7 +24,7 @@ mod scalar_impl;
 use self::scalar_impl::*;
 use crate::{FieldBytes, FieldBytesEncoding, NistP192, ORDER_HEX, U192};
 use elliptic_curve::{
-    Curve as _, Error, Result,
+    Curve as _,
     bigint::Limb,
     ff::PrimeField,
     ops::Reduce,
@@ -177,25 +177,9 @@ impl Reduce<FieldBytes> for Scalar {
     }
 }
 
-impl TryFrom<U192> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: U192) -> Result<Self> {
-        Self::try_from(&w)
-    }
-}
-
-impl TryFrom<&U192> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: &U192) -> Result<Self> {
-        Self::from_uint(w).into_option().ok_or(Error)
-    }
-}
-
 #[cfg(feature = "serde")]
 impl Serialize for Scalar {
-    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
     {
@@ -205,7 +189,7 @@ impl Serialize for Scalar {
 
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Scalar {
-    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: de::Deserializer<'de>,
     {

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -24,7 +24,7 @@ mod scalar_impl;
 use self::scalar_impl::*;
 use crate::{FieldBytes, FieldBytesEncoding, NistP224, ORDER_HEX, Uint};
 use elliptic_curve::{
-    Curve as _, Error, Result,
+    Curve as _,
     bigint::Limb,
     ff::PrimeField,
     ops::Reduce,
@@ -166,25 +166,9 @@ impl Reduce<FieldBytes> for Scalar {
     }
 }
 
-impl TryFrom<Uint> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: Uint) -> Result<Self> {
-        Self::try_from(&w)
-    }
-}
-
-impl TryFrom<&Uint> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: &Uint) -> Result<Self> {
-        Self::from_uint(w).into_option().ok_or(Error)
-    }
-}
-
 #[cfg(feature = "serde")]
 impl Serialize for Scalar {
-    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
     {
@@ -194,7 +178,7 @@ impl Serialize for Scalar {
 
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Scalar {
-    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: de::Deserializer<'de>,
     {

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -17,7 +17,7 @@ use fiat_crypto::p384_scalar_64::*;
 
 use crate::{FieldBytes, NistP384, ORDER_HEX, U384};
 use elliptic_curve::{
-    Curve as _, Error, Result,
+    Curve as _,
     bigint::{ArrayEncoding, Limb},
     ff::PrimeField,
     ops::{Reduce, ReduceNonZero},
@@ -203,25 +203,9 @@ impl ReduceNonZero<FieldBytes> for Scalar {
     }
 }
 
-impl TryFrom<U384> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: U384) -> Result<Self> {
-        Self::try_from(&w)
-    }
-}
-
-impl TryFrom<&U384> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: &U384) -> Result<Self> {
-        Self::from_uint(w).into_option().ok_or(Error)
-    }
-}
-
 #[cfg(feature = "serde")]
 impl Serialize for Scalar {
-    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
     {
@@ -231,7 +215,7 @@ impl Serialize for Scalar {
 
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Scalar {
-    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: de::Deserializer<'de>,
     {

--- a/primefield/src/error.rs
+++ b/primefield/src/error.rs
@@ -1,0 +1,15 @@
+//! Error types.
+
+use core::fmt;
+
+/// Error type.
+pub struct Error;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "field error")
+    }
+}
+
+/// Result type.
+pub type Result<T> = core::result::Result<T, Error>;

--- a/primefield/src/lib.rs
+++ b/primefield/src/lib.rs
@@ -9,10 +9,14 @@
 #![doc = include_str!("../README.md")]
 
 mod dev;
+mod error;
 mod macros;
 mod monty;
 
-pub use crate::monty::{MontyFieldBytes, MontyFieldElement, MontyFieldParams, compute_t};
+pub use crate::{
+    error::{Error, Result},
+    monty::{MontyFieldBytes, MontyFieldElement, MontyFieldParams, compute_t},
+};
 pub use array::typenum::consts;
 pub use bigint;
 pub use bigint::hybrid_array as array;

--- a/primefield/src/macros.rs
+++ b/primefield/src/macros.rs
@@ -470,6 +470,22 @@ macro_rules! monty_field_element {
             }
         }
 
+        impl TryFrom<$uint> for $fe {
+            type Error = $crate::Error;
+
+            fn try_from(w: $uint) -> $crate::Result<Self> {
+                Self::try_from(&w)
+            }
+        }
+
+        impl TryFrom<&$uint> for $fe {
+            type Error = $crate::Error;
+
+            fn try_from(w: &$uint) -> $crate::Result<Self> {
+                Self::from_uint(w).into_option().ok_or($crate::Error)
+            }
+        }
+
         impl ::core::iter::Sum for $fe {
             #[allow(unused_qualifications)]
             fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -17,7 +17,7 @@ use fiat_crypto::sm2_scalar_64::*;
 
 use crate::{FieldBytes, FieldBytesEncoding, ORDER_HEX, Sm2, U256};
 use elliptic_curve::{
-    Curve as _, Error, Result,
+    Curve as _,
     bigint::Limb,
     ff::PrimeField,
     ops::Reduce,
@@ -146,25 +146,9 @@ impl Reduce<FieldBytes> for Scalar {
     }
 }
 
-impl TryFrom<U256> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: U256) -> Result<Self> {
-        Self::try_from(&w)
-    }
-}
-
-impl TryFrom<&U256> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: &U256) -> Result<Self> {
-        Self::from_uint(w).into_option().ok_or(Error)
-    }
-}
-
 #[cfg(feature = "serde")]
 impl Serialize for Scalar {
-    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
     {
@@ -174,7 +158,7 @@ impl Serialize for Scalar {
 
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Scalar {
-    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: de::Deserializer<'de>,
     {


### PR DESCRIPTION
Replaces the ones that were defined on a field-by-field basis.

Doing this necessitates defining an `Error` type for the first time, along with a `Result` type.