### PR TITLE
primefield: impl `ConstMontyParams` for field element types

### DIFF
--- a/p384/src/arithmetic/hash2curve.rs
+++ b/p384/src/arithmetic/hash2curve.rs
@@ -97,7 +97,7 @@ mod tests {
     use elliptic_curve::{
         Curve,
         array::Array,
-        bigint::{ArrayEncoding, CheckedSub, NonZero, U384, U576},
+        bigint::{ArrayEncoding, CheckedSub, NonZero, U384, U576, modular::ConstMontyParams},
         consts::U72,
         group::cofactor::CofactorGroup,
         ops::Reduce,
@@ -113,7 +113,7 @@ mod tests {
     fn params() {
         let params = <FieldElement as OsswuMap>::PARAMS;
 
-        let c1 = FieldElement::PARAMS
+        let c1 = <FieldElement as ConstMontyParams<{ U384::LIMBS }>>::PARAMS
             .modulus()
             .checked_sub(&U384::from_u8(3))
             .unwrap()

--- a/primefield/src/macros.rs
+++ b/primefield/src/macros.rs
@@ -123,10 +123,6 @@ macro_rules! monty_field_element {
             pub const ONE: Self =
                 Self($crate::MontyFieldElement::<$params, { <$params>::LIMBS }>::ONE);
 
-            /// Montgomery parameters constant.
-            pub const PARAMS: $crate::bigint::modular::MontyParams<{ <$uint>::LIMBS }> =
-                <$params>::PARAMS;
-
             /// Create a [`
             #[doc = stringify!($fe)]
             /// `] from a canonical big-endian representation.
@@ -230,6 +226,12 @@ macro_rules! monty_field_element {
             pub const fn pow_vartime(&self, exp: &[u64]) -> Self {
                 Self(self.0.pow_vartime(exp))
             }
+        }
+
+        impl $crate::bigint::modular::ConstMontyParams<{ <$params>::LIMBS }> for $fe {
+            const LIMBS: usize = <$params>::LIMBS;
+            const PARAMS: $crate::bigint::modular::MontyParams<{ <$uint>::LIMBS }> =
+                <$params>::PARAMS;
         }
 
         impl $crate::ff::Field for $fe {

--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -5,7 +5,7 @@ use crate::ByteOrder;
 use bigint::{
     ArrayEncoding, ByteArray, Integer, Invert, Reduce, Uint, Word,
     hybrid_array::{Array, ArraySize, typenum::Unsigned},
-    modular::{ConstMontyForm as MontyForm, ConstMontyParams},
+    modular::{ConstMontyForm as MontyForm, ConstMontyParams, MontyParams},
 };
 use core::{
     cmp::Ordering,
@@ -349,7 +349,7 @@ where
 
     /// Returns `self^exp`, where `exp` is a little-endian integer exponent
     ///
-    /// **This operation is variable time with respect to the exponent.**
+    /// **This operation is variable time with respect to the exponent `exp`.**
     ///
     /// If the exponent is fixed, this operation is constant time.
     pub const fn pow_vartime(&self, exp: &[u64]) -> Self {
@@ -373,9 +373,11 @@ where
         res
     }
 
-    /// Returns self^(2^n) mod p.
+    /// Returns `self^(2^n) mod p`.
     ///
-    /// Variable-time with respect to `n`.
+    /// **This operation is variable time with respect to the exponent `n`.**
+    ///
+    /// If the exponent is fixed, this operation is constant time.
     pub const fn sqn_vartime(&self, n: usize) -> Self {
         let mut x = *self;
         let mut i = 0;
@@ -770,6 +772,14 @@ where
 //
 // Miscellaneous trait impls
 //
+
+impl<MOD, const LIMBS: usize> ConstMontyParams<LIMBS> for MontyFieldElement<MOD, LIMBS>
+where
+    MOD: MontyFieldParams<LIMBS>,
+{
+    const LIMBS: usize = LIMBS;
+    const PARAMS: MontyParams<LIMBS> = MOD::PARAMS;
+}
 
 impl<MOD, const LIMBS: usize> Default for MontyFieldElement<MOD, LIMBS>
 where


### PR DESCRIPTION
- Adds an impl to `primefield::MontyFieldElement`
- Also emits an impl from the `monty_field_element!` macro