### PR TITLE
primefield: make exponent of `pow_vartime` a `Uint`

### DIFF
--- a/bignp256/src/arithmetic/field.rs
+++ b/bignp256/src/arithmetic/field.rs
@@ -78,14 +78,11 @@ impl FieldElement {
     /// Returns the square root of self mod p, or `None` if no square root
     /// exists.
     pub fn sqrt(&self) -> CtOption<Self> {
-        // Because p ≡ 3 mod 4, sqrt can be done with only one
-        // exponentiation via the computation of self^((p + 1) // 4) (mod p).
-        let sqrt = self.pow_vartime(&[
-            0xffffffffffffffd1,
-            0xffffffffffffffff,
-            0xffffffffffffffff,
-            0x3fffffffffffffff,
-        ]);
+        /// Because p ≡ 3 mod 4, sqrt can be done with only one
+        /// exponentiation via the computation of self^((p + 1) // 4) (mod p).
+        const EXP: U256 =
+            U256::from_be_hex("3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd1");
+        let sqrt = self.pow_vartime(&EXP);
         CtOption::new(sqrt, (sqrt * sqrt).ct_eq(self))
     }
 }

--- a/bignp256/src/arithmetic/scalar.rs
+++ b/bignp256/src/arithmetic/scalar.rs
@@ -93,14 +93,11 @@ impl Scalar {
     /// Returns the square root of self mod p, or `None` if no square root
     /// exists.
     pub fn sqrt(&self) -> CtOption<Self> {
-        // Because p ≡ 3 mod 4, sqrt can be done with only one
-        // exponentiation via the computation of self^((p + 1) // 4) (mod p).
-        let sqrt = self.pow_vartime(&[
-            0x1f96afe6498f5982,
-            0xf65723b5837ed37f,
-            0xffffffffffffffff,
-            0x3fffffffffffffff,
-        ]);
+        /// Because p ≡ 3 mod 4, sqrt can be done with only one
+        /// exponentiation via the computation of self^((p + 1) // 4) (mod p).
+        const EXP: U256 =
+            U256::from_be_hex("3ffffffffffffffffffffffffffffffff65723b5837ed37f1f96afe6498f5982");
+        let sqrt = self.pow_vartime(&EXP);
         CtOption::new(sqrt, (sqrt * sqrt).ct_eq(self))
     }
 }

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -72,15 +72,14 @@ impl FieldElement {
     /// Returns the square root of self mod p, or `None` if no square root
     /// exists.
     pub fn sqrt(&self) -> CtOption<Self> {
-        // Because p ≡ 3 mod 4 for brainpoolP256's base field modulus, sqrt can
-        // be implemented with only one exponentiation via the computation of
-        // self^((p + 1) // 4) (mod p).
-        let sqrt = self.pow_vartime(&[
-            0x0804d20747db94de,
-            0x9b8efd88f549880a,
-            0x0f9982a42760e35c,
-            0x2a7ed5f6e87baa6f,
-        ]);
+        /// Because p ≡ 3 mod 4 for brainpoolP256's base field modulus, sqrt can
+        /// be implemented with only one exponentiation via the computation of
+        /// self^((p + 1) // 4) (mod p).
+        const EXP: U256 =
+            U256::from_be_hex("2a7ed5f6e87baa6f0f9982a42760e35c9b8efd88f549880a0804d20747db94de");
+
+        // Note: vartime only with respect to `EXP`
+        let sqrt = self.pow_vartime(&EXP);
         CtOption::new(sqrt, sqrt.square().ct_eq(self))
     }
 }

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -76,15 +76,14 @@ impl Scalar {
     /// Returns the square root of self mod n, or `None` if no square root
     /// exists.
     pub fn sqrt(&self) -> CtOption<Self> {
-        // Because n ≡ 3 mod 4 for brainpoolP256's scalar field modulus, sqrt
-        // can be implemented with only one exponentiation via the computation
-        // of self^((n + 1) // 4) (mod n).
-        let sqrt = self.pow_vartime(&[
-            0xe40783a0a5d215aa,
-            0x630e5ea8ed5869bd,
-            0x0f9982a42760e35c,
-            0x2a7ed5f6e87baa6f,
-        ]);
+        /// Because n ≡ 3 mod 4 for brainpoolP256's scalar field modulus, sqrt
+        /// can be implemented with only one exponentiation via the computation
+        /// of self^((n + 1) // 4) (mod n).
+        const EXP: U256 =
+            U256::from_be_hex("2a7ed5f6e87baa6f0f9982a42760e35c630e5ea8ed5869bde40783a0a5d215aa");
+
+        // Note: vartime only with respect to `EXP`
+        let sqrt = self.pow_vartime(&EXP);
         CtOption::new(sqrt, sqrt.square().ct_eq(self))
     }
 }

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -72,17 +72,15 @@ impl FieldElement {
     /// Returns the square root of self mod p, or `None` if no square root
     /// exists.
     pub fn sqrt(&self) -> CtOption<Self> {
-        // Because p ≡ 3 mod 4 for brainpoolP384's base field modulus, sqrt can
-        // be implemented with only one exponentiation via the computation of
-        // self^((p + 1) // 4) (mod p).
-        let sqrt = self.pow_vartime(&[
-            0x61d1c004cc41fb15,
-            0xeb34e9ca6407469c,
-            0x04ac76865fedc448,
-            0xc54bdc427b5515ad,
-            0x03d75bdf94399077,
-            0x232e47a0a8ce1b4a,
-        ]);
+        /// Because p ≡ 3 mod 4 for brainpoolP384's base field modulus, sqrt can
+        /// be implemented with only one exponentiation via the computation of
+        /// self^((p + 1) // 4) (mod p).
+        const EXP: U384 = U384::from_be_hex(
+            "232e47a0a8ce1b4a03d75bdf94399077c54bdc427b5515ad04ac76865fedc448eb34e9ca6407469c61d1c004cc41fb15",
+        );
+
+        // Note: vartime only with respect to `EXP`, which is fixed (so therefore not vartime)
+        let sqrt = self.pow_vartime(&EXP);
         CtOption::new(sqrt, sqrt.square().ct_eq(self))
     }
 }

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -77,16 +77,11 @@ impl Scalar {
     /// <https://eips.ethereum.org/assets/eip-3068/2012-685_Square_Root_Even_Ext.pdf>
     /// (page 10, algorithm 3)
     pub fn sqrt(&self) -> CtOption<Self> {
-        let w = &[
-            0x077106405d208cac,
-            0xf9e756d5ed6ff862,
-            0x63e2cdcd958084b4,
-            0xe2a5ee213daa8ad6,
-            0x01ebadefca1cc83b,
-            0x119723d054670da5,
-        ];
-        let t = Self::from_u64(2).pow_vartime(w);
-        let a1 = self.pow_vartime(w);
+        const EXP: U384 = U384::from_be_hex(
+            "119723d054670da501ebadefca1cc83be2a5ee213daa8ad663e2cdcd958084b4f9e756d5ed6ff862077106405d208cac",
+        );
+        let t = Self::from_u64(2).pow_vartime(&EXP);
+        let a1 = self.pow_vartime(&EXP);
         let a0 = (a1.square() * self).square();
         let b = t * a1;
         let ab = self * &b;

--- a/p192/src/arithmetic/field.rs
+++ b/p192/src/arithmetic/field.rs
@@ -73,9 +73,12 @@ impl FieldElement {
     /// Returns the square root of self mod p, or `None` if no square root
     /// exists.
     pub fn sqrt(&self) -> CtOption<Self> {
-        // Because p ≡ 3 mod 4 for secp192r1's base field modulus, sqrt can be done with only one
-        // exponentiation via the computation of self^((p + 1) // 4) (mod p).
-        let sqrt = self.pow_vartime(&[0xc000000000000000, 0xffffffffffffffff, 0x3fffffffffffffff]);
+        /// Because p ≡ 3 mod 4 for secp192r1's base field modulus, sqrt can be done with only one
+        /// exponentiation via the computation of self^((p + 1) // 4) (mod p).
+        const EXP: U192 = U192::from_be_hex("3fffffffffffffffffffffffffffffffc000000000000000");
+
+        // Note: vartime only with respect to `EXP`, which is fixed (so therefore not vartime)
+        let sqrt = self.pow_vartime(&EXP);
         CtOption::new(sqrt, sqrt.square().ct_eq(self))
     }
 }

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -107,7 +107,8 @@ impl Scalar {
     fn sqrt(&self) -> CtOption<Self> {
         // w = self^((t - 1) // 2)
         // Note: `pow_vartime` is constant-time with respect to `self`
-        let w = self.pow_vartime(&[0xb0a35e4d8da69141, 0xfffffffffccef7c1, 0x07ffffffffffffff]);
+        const EXP: U192 = U192::from_be_hex("07fffffffffffffffffffffffccef7c1b0a35e4d8da69141");
+        let w = self.pow_vartime(&EXP);
 
         let mut v = Self::S;
         let mut x = *self * w;

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -112,14 +112,14 @@ impl Scalar {
     /// <https://eips.ethereum.org/assets/eip-3068/2012-685_Square_Root_Even_Ext.pdf>
     /// (page 10, algorithm 3)
     pub fn sqrt(&self) -> CtOption<Self> {
-        let w = &[
-            0xc27ba528ab8b8547,
-            0xffffe2d45c171e07,
-            0xffffffffffffffff,
-            0x1fffffff,
-        ];
-        let t = Self::from_u64(2).pow_vartime(w);
-        let a1 = self.pow_vartime(w);
+        #[cfg(target_pointer_width = "32")]
+        const EXP: Uint =
+            Uint::from_be_hex("1fffffffffffffffffffffffffffe2d45c171e07c27ba528ab8b8547");
+        #[cfg(target_pointer_width = "64")]
+        const EXP: Uint =
+            Uint::from_be_hex("000000001fffffffffffffffffffffffffffe2d45c171e07c27ba528ab8b8547");
+        let t = Self::from_u64(2).pow_vartime(&EXP);
+        let a1 = self.pow_vartime(&EXP);
         let a0 = (a1.square() * self).square();
         let b = t * a1;
         let ab = self * &b;

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -259,7 +259,7 @@ mod tests {
         let one = FieldElement::ONE;
         let two = one + &one;
         let four = two.square();
-        assert_eq!(two.pow_vartime(&[2, 0, 0, 0]), four);
+        assert_eq!(two.pow_vartime(&U256::from_u64(2)), four);
     }
 
     #[cfg(target_pointer_width = "64")]

--- a/sm2/src/arithmetic/field.rs
+++ b/sm2/src/arithmetic/field.rs
@@ -65,14 +65,11 @@ impl FieldElement {
     /// Returns the square root of self mod p, or `None` if no square root
     /// exists.
     pub fn sqrt(&self) -> CtOption<Self> {
-        // Because p ≡ 3 mod 4 for SM2's base field modulus, sqrt can be done with only one
-        // exponentiation via the computation of self^((p + 1) // 4) (mod p).
-        let sqrt = self.pow_vartime(&[
-            0x4000000000000000,
-            0xffffffffc0000000,
-            0xffffffffffffffff,
-            0x3fffffffbfffffff,
-        ]);
+        /// Because p ≡ 3 mod 4 for SM2's base field modulus, sqrt can be done with only one
+        /// exponentiation via the computation of self^((p + 1) // 4) (mod p).
+        const EXP: U256 =
+            U256::from_be_hex("3fffffffbfffffffffffffffffffffffffffffffc00000004000000000000000");
+        let sqrt = self.pow_vartime(&EXP);
         CtOption::new(sqrt, sqrt.square().ct_eq(self))
     }
 }

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -97,14 +97,11 @@ impl Scalar {
     /// Returns the square root of self mod n, or `None` if no square root
     /// exists.
     pub fn sqrt(&self) -> CtOption<Self> {
-        // Because n ≡ 3 mod 4 for SM2's scalar field modulus, sqrt can be done with only one
-        // exponentiation via the computation of self^((n + 1) // 4) (mod n).
-        let sqrt = self.pow_vartime(&[
-            0xd4eefd024e755049,
-            0xdc80f7dac871814a,
-            0xffffffffffffffff,
-            0x3fffffffbfffffff,
-        ]);
+        /// Because n ≡ 3 mod 4 for SM2's scalar field modulus, sqrt can be done with only one
+        /// exponentiation via the computation of self^((n + 1) // 4) (mod n).
+        const EXP: U256 =
+            U256::from_be_hex("3fffffffbfffffffffffffffffffffffdc80f7dac871814ad4eefd024e755049");
+        let sqrt = self.pow_vartime(&EXP);
         CtOption::new(sqrt, sqrt.square().ct_eq(self))
     }
 }


### PR DESCRIPTION
Previously it was `&[u64]`, which dates back to the original code which was adapted from `ff_derive`.

This changes the argument to be a `Uint` (which can be a different number of limbs from `Self`), and also changes `MontyFieldParams::T` to be a `Uint` as well (where `T` can be used to compute many other constants, often by raising them to the power of `T`).

This simplifies dealing with 32-bit vs 64-bit platforms, and also should make it easier to provide a generic implementation of `sqrt` where we may want to calculate constants based on `T`.