### PR TITLE
primefield: sqrt improvements

### DIFF
--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -1,6 +1,8 @@
 //! Field elements which use an internal Montgomery form representation, implemented using
 //! `crypto-bigint`'s [`MontyForm`].
 
+mod sqrt;
+
 use crate::ByteOrder;
 use bigint::{
     ArrayEncoding, ByteArray, Integer, Invert, Limb, Reduce, Uint, Word,
@@ -424,48 +426,7 @@ where
     }
 
     fn sqrt(&self) -> CtOption<Self> {
-        // TODO(tarcieri): const algorithm selection
-        if (MOD::PARAMS.modulus().get() % Uint::<LIMBS>::from(4u64)) == Uint::<LIMBS>::from(3u64) {
-            // Because r = 3 (mod 4) sqrt can be done with only one exponentiation,
-            // via the computation of  self^((r + 1) // 4) (mod r)
-            let mod_plus_1_over_4 = MOD::PARAMS.modulus().add(&Uint::<LIMBS>::ONE).shr(2);
-            let sqrt = self.pow_vartime(&mod_plus_1_over_4);
-            CtOption::new(sqrt, (sqrt * sqrt).ct_eq(self))
-        } else {
-            // Tonelli-Shanks algorithm works for every remaining odd prime.
-            // https://eprint.iacr.org/2012/685.pdf (page 12, algorithm 5)
-            let t_minus_1_over_2 = MOD::T.sub(&Uint::<LIMBS>::ONE).shr(1);
-            let w = self.pow_vartime(&t_minus_1_over_2);
-
-            let mut v = Self::S;
-            let mut x = *self * w;
-            let mut b = x * w;
-            let mut z = Self::ROOT_OF_UNITY;
-
-            for max_v in (1..=Self::S).rev() {
-                let mut k = 1;
-                let mut tmp = b.square();
-                let mut j_less_than_v = Choice::from(1);
-
-                for j in 2..max_v {
-                    let tmp_is_one = tmp.ct_eq(&Self::ONE);
-                    let squared = Self::conditional_select(&tmp, &z, tmp_is_one).square();
-                    tmp = Self::conditional_select(&squared, &tmp, tmp_is_one);
-                    let new_z = Self::conditional_select(&z, &squared, tmp_is_one);
-                    j_less_than_v &= !j.ct_eq(&v);
-                    k = u32::conditional_select(&j, &k, tmp_is_one);
-                    z = Self::conditional_select(&z, &new_z, j_less_than_v);
-                }
-
-                let result = x * z;
-                x = Self::conditional_select(&result, &x, b.ct_eq(&Self::ONE));
-                z = z.square();
-                b *= z;
-                v = k;
-            }
-
-            CtOption::new(x, x.square().ct_eq(self))
-        }
+        self.sqrt()
     }
 
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
@@ -960,28 +921,5 @@ mod tests {
     #[test]
     fn computed_delta_constant() {
         assert_eq!(FieldElement::DELTA, FieldElement::from_u64(36));
-    }
-
-    /// Special tests for `sqrt` implementations.
-    ///
-    /// The generic `sqrt` implementation implements multiple algorithms which it selects based on
-    /// specific properties of the modulus. The `p ≡ 3 mod 4` case is covered by the P-256 modulus
-    /// above, so these tests cover the other algorithms.
-    mod sqrt {
-        use crate::{ByteOrder, MontyFieldElement, monty_field_params, test_field_sqrt};
-        use bigint::U192;
-
-        // Tests the generic Tonelli-Shanks implementation, since `p ≡ 1 mod 4`
-        monty_field_params!(
-            name: P192ScalarParams,
-            modulus: "ffffffffffffffffffffffff99def836146bc9b1b4d22831",
-            uint: U192,
-            byte_order: ByteOrder::BigEndian,
-            multiplicative_generator: 3,
-            fe_name: "Scalar",
-            doc: "P-192 scalar modulus"
-        );
-        type P192Scalar = MontyFieldElement<P192ScalarParams, { U192::LIMBS }>;
-        test_field_sqrt!(P192Scalar);
     }
 }


### PR DESCRIPTION
- Extracts `sqrt` implementations into their own module
- Ensures all constants are computed using `const`
- Extracts algorithms into their own function; test individually
- Adds internal `mod_residue` for algorithm selection