### PR TITLE
Bump `der` to v0.8.0-rc.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7050e8041c28720851f7db83183195b6acf375bb7bb28e3b86f0fe6cbd69459d"
+checksum = "e9d8dd2f26c86b27a2a8ea2767ec7f9df7a89516e4794e54ac01ee618dda3aa4"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.6"
+version = "0.11.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53e5d0804fa4070b1b2a5b320102f2c1c094920a7533d5d87c2630609bcbd34"
+checksum = "93eac55f10aceed84769df670ea4a32d2ffad7399400d41ee1c13b1cd8e1b478"
 dependencies = [
  "der",
  "spki",
@@ -1094,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.9"
+version = "0.8.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e67a3c9fb9a8f065af9fa30d65812fcc16a66cbf911eff1f6946957ce48f16"
+checksum = "1dff52f6118bc9f0ac974a54a639d499ac26a6cad7a6e39bc0990c19625e793b"
 dependencies = [
  "base16ct",
  "der",

--- a/sm2/src/pke.rs
+++ b/sm2/src/pke.rs
@@ -117,8 +117,8 @@ impl<'a> DecodeValue<'a> for Cipher<'a> {
         decoder.read_nested(header.length(), |nr| {
             let x = UintRef::decode(nr)?.as_bytes();
             let y = UintRef::decode(nr)?.as_bytes();
-            let digest = OctetStringRef::decode(nr)?.into();
-            let cipher = OctetStringRef::decode(nr)?.into();
+            let digest = <&'a OctetStringRef>::decode(nr)?.into();
+            let cipher = <&'a OctetStringRef>::decode(nr)?.into();
             Ok(Cipher {
                 x: Uint::from_be_bytes(zero_pad_byte_slice(x)?),
                 y: Uint::from_be_bytes(zero_pad_byte_slice(y)?),


### PR DESCRIPTION
Notably this needed some `OctetStringRef`-related changes to `sm2`