### PR TITLE
x448: Add `StaticSecret` in a feature-flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,6 +1473,7 @@ dependencies = [
  "ed448-goldilocks",
  "rand",
  "rand_core",
+ "serdect",
  "zeroize",
 ]
 

--- a/x448/Cargo.toml
+++ b/x448/Cargo.toml
@@ -17,6 +17,8 @@ description = "Pure Rust implementation of X448, an elliptic curve Diffie-Hellma
 ed448-goldilocks = { version = "0.14.0-pre.4", default-features = false }
 rand_core = { version = "0.9", default-features = false }
 
+serdect = { version = "0.4", optional = true }
+
 [dependencies.zeroize]
 version = "1"
 default-features = false
@@ -24,3 +26,7 @@ features = ["zeroize_derive"]
 
 [dev-dependencies]
 rand = "0.9"
+
+[features]
+static_secrets = []
+serde = ["dep:serdect", "ed448-goldilocks/serde"]


### PR DESCRIPTION
Some implementations (like rpgp) will serialize a secret and can use static secret similar to what we can find in x25519.

This is a fixup on https://github.com/RustCrypto/elliptic-curves/pull/1378 which removed that support