### PR TITLE
primefield: have `monty_field_element!` define field type

### DIFF
--- a/bignp256/src/arithmetic/field.rs
+++ b/bignp256/src/arithmetic/field.rs
@@ -37,23 +37,21 @@ use elliptic_curve::{
 /// Constant representing the modulus: p = 2^{256} − 189
 const MODULUS_HEX: &str = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff43";
 
-primefield::monty_field_params!(
+primefield::monty_field_params! {
     name: FieldParams,
     modulus: MODULUS_HEX,
     uint: U256,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 2,
-    fe_name: "FieldElement",
-    doc: "P-256 field modulus"
-);
+    doc: "Montgomery parameters for the bign-curve256v1 field modulus p = 2^{256} − 189"
+}
 
-/// Element of the bign-256 base field used for curve coordinates.
-#[derive(Clone, Copy)]
-pub struct FieldElement(
-    pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
-);
-
-primefield::monty_field_element!(FieldElement, FieldParams, U256);
+primefield::monty_field_element! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U256,
+    doc: "Element in the bign-curve256v1 finite field modulo p = 2^{256} − 189"
+}
 
 primefield::monty_field_fiat_arithmetic!(
     FieldElement,

--- a/bignp256/src/arithmetic/scalar.rs
+++ b/bignp256/src/arithmetic/scalar.rs
@@ -36,37 +36,15 @@ primefield::monty_field_params!(
     uint: U256,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 3,
-    fe_name: "Scalar",
-    doc: "Bign P-256 scalar modulus"
+    doc: "Montgomery parameters for the bign-curve256v1 scalar modulus"
 );
 
-/// Scalars are elements in the finite field modulo `n`.
-///
-/// # Trait impls
-///
-/// Much of the important functionality of scalars is provided by traits from
-/// the [`ff`](https://docs.rs/ff/) crate, which is re-exported as
-/// `bignp256::elliptic_curve::ff`:
-///
-/// - [`Field`](https://docs.rs/ff/latest/ff/trait.Field.html) -
-///   represents elements of finite fields and provides:
-///   - [`Field::random`](https://docs.rs/ff/latest/ff/trait.Field.html#tymethod.random) -
-///     generate a random scalar
-///   - `double`, `square`, and `invert` operations
-///   - Bounds for [`Add`], [`Sub`], [`Mul`], and [`Neg`] (as well as `*Assign` equivalents)
-///   - Bounds for [`ConditionallySelectable`] from the `subtle` crate
-/// - [`PrimeField`](https://docs.rs/ff/latest/ff/trait.PrimeField.html) -
-///   represents elements of prime fields and provides:
-///   - `from_repr`/`to_repr` for converting field elements from/to big integers.
-///   - `multiplicative_generator` and `root_of_unity` constants.
-/// - [`PrimeFieldBits`](https://docs.rs/ff/latest/ff/trait.PrimeFieldBits.html) -
-///   operations over field elements represented as bits (requires `bits` feature)
-///
-/// Please see the documentation for the relevant traits for more information.
-#[derive(Clone, Copy, PartialOrd, Ord)]
-pub struct Scalar(pub(super) primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
-
-primefield::monty_field_element!(Scalar, ScalarParams, U256);
+primefield::monty_field_element! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U256,
+    doc: "Element in the bign-curve256v1 scalar field modulo n"
+}
 
 primefield::monty_field_fiat_arithmetic!(
     Scalar,

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -31,23 +31,21 @@ use elliptic_curve::{
 /// Constant representing the modulus serialized as hex.
 const MODULUS_HEX: &str = "a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5377";
 
-primefield::monty_field_params!(
+primefield::monty_field_params! {
     name: FieldParams,
     modulus: MODULUS_HEX,
     uint: U256,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 11,
-    fe_name: "FieldElement",
-    doc: "brainpoolP256 field modulus"
-);
+    doc: "Montgomery parameters for brainpoolP256's field modulus"
+}
 
-/// Element of the brainpoolP256's base field used for curve point coordinates.
-#[derive(Clone, Copy)]
-pub struct FieldElement(
-    pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
-);
-
-primefield::monty_field_element!(FieldElement, FieldParams, U256);
+primefield::monty_field_element! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U256,
+    doc: "Element in the brainpoolP256 finite field modulo p"
+}
 
 primefield::monty_field_fiat_arithmetic!(
     FieldElement,

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -34,21 +34,21 @@ use elliptic_curve::{
 #[cfg(doc)]
 use core::ops::{Add, Mul, Sub};
 
-primefield::monty_field_params!(
+primefield::monty_field_params! {
     name: ScalarParams,
     modulus: ORDER_HEX,
     uint: U256,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 3,
-    fe_name: "Scalar",
-    doc: "brainpoolP256 scalar modulus"
-);
+    doc: "Montgomery parameters for brainpoolP256's scalar modulus"
+}
 
-/// Element of brainpoolP256's scalar field.
-#[derive(Clone, Copy, PartialOrd, Ord)]
-pub struct Scalar(pub(super) primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
-
-primefield::monty_field_element!(Scalar, ScalarParams, U256);
+primefield::monty_field_element! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U256,
+    doc: "Element in the brainpoolP256 scalar field modulo n"
+}
 
 primefield::monty_field_fiat_arithmetic!(
     Scalar,

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -31,23 +31,21 @@ use elliptic_curve::{
 /// Constant representing the modulus serialized as hex.
 const MODULUS_HEX: &str = "8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec53";
 
-primefield::monty_field_params!(
+primefield::monty_field_params! {
     name: FieldParams,
     modulus: MODULUS_HEX,
     uint: U384,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 3,
-    fe_name: "FieldElement",
-    doc: "brainpoolP384 field modulus"
-);
+    doc: "Montgomery parameters for brainpoolP384's field modulus"
+}
 
-/// Element of the brainpoolP384's base field used for curve point coordinates.
-#[derive(Clone, Copy)]
-pub struct FieldElement(
-    pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
-);
-
-primefield::monty_field_element!(FieldElement, FieldParams, U384);
+primefield::monty_field_element! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U384,
+    doc: "Element in the brainpoolP256 finite field modulo p"
+}
 
 primefield::monty_field_fiat_arithmetic!(
     FieldElement,

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -34,21 +34,21 @@ use elliptic_curve::{
 #[cfg(doc)]
 use core::ops::{Add, Mul, Sub};
 
-primefield::monty_field_params!(
+primefield::monty_field_params! {
     name: ScalarParams,
     modulus: ORDER_HEX,
     uint: U384,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 2,
-    fe_name: "Scalar",
-    doc: "brainpoolP384 scalar modulus"
-);
+    doc: "Montgomery parameters for brainpoolP384's scalar modulus"
+}
 
-/// Element of the brainpoolP384's scalar field.
-#[derive(Clone, Copy, PartialOrd, Ord)]
-pub struct Scalar(pub(super) primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
-
-primefield::monty_field_element!(Scalar, ScalarParams, U384);
+primefield::monty_field_element! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U384,
+    doc: "Element in the brainpoolP256 scalar field modulo n"
+}
 
 primefield::monty_field_fiat_arithmetic!(
     Scalar,

--- a/p192/src/arithmetic/field.rs
+++ b/p192/src/arithmetic/field.rs
@@ -32,23 +32,21 @@ use elliptic_curve::{
 /// p = 2^{192} − 2^{64} - 1
 const MODULUS_HEX: &str = "fffffffffffffffffffffffffffffffeffffffffffffffff";
 
-primefield::monty_field_params!(
+primefield::monty_field_params! {
     name: FieldParams,
     modulus: MODULUS_HEX,
     uint: U192,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 11,
-    fe_name: "FieldElement",
-    doc: "P-192 field modulus"
-);
+    doc: "Montgomery parameters for the NIST P-192 field modulus: `p = 2^{192} − 2^{64} - 1`."
+}
 
-/// Element of the secp192r1 base field used for curve coordinates.
-#[derive(Clone, Copy)]
-pub struct FieldElement(
-    pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
-);
-
-primefield::monty_field_element!(FieldElement, FieldParams, U192);
+primefield::monty_field_element! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U192,
+    doc: "Element in the finite field modulo `p = 2^{192} − 2^{64} - 1`."
+}
 
 primefield::monty_field_fiat_arithmetic!(
     FieldElement,

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -41,43 +41,21 @@ use {
 #[cfg(doc)]
 use core::ops::{Add, Mul, Neg, Sub};
 
-primefield::monty_field_params!(
+primefield::monty_field_params! {
     name: ScalarParams,
     modulus: ORDER_HEX,
     uint: U192,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 3,
-    fe_name: "Scalar",
-    doc: "P-192 scalar modulus"
-);
+    doc: "Montgomery parameters for the NIST P-192 scalar modulus `n`."
+}
 
-/// Scalars are elements in the finite field modulo `n`.
-///
-/// # Trait impls
-///
-/// Much of the important functionality of scalars is provided by traits from
-/// the [`ff`](https://docs.rs/ff/) crate, which is re-exported as
-/// `p192::elliptic_curve::ff`:
-///
-/// - [`Field`](https://docs.rs/ff/latest/ff/trait.Field.html) -
-///   represents elements of finite fields and provides:
-///   - [`Field::random`](https://docs.rs/ff/latest/ff/trait.Field.html#tymethod.random) -
-///     generate a random scalar
-///   - `double`, `square`, and `invert` operations
-///   - Bounds for [`Add`], [`Sub`], [`Mul`], and [`Neg`] (as well as `*Assign` equivalents)
-///   - Bounds for [`ConditionallySelectable`] from the `subtle` crate
-/// - [`PrimeField`](https://docs.rs/ff/latest/ff/trait.PrimeField.html) -
-///   represents elements of prime fields and provides:
-///   - `from_repr`/`to_repr` for converting field elements from/to big integers.
-///   - `multiplicative_generator` and `root_of_unity` constants.
-/// - [`PrimeFieldBits`](https://docs.rs/ff/latest/ff/trait.PrimeFieldBits.html) -
-///   operations over field elements represented as bits (requires `bits` feature)
-///
-/// Please see the documentation for the relevant traits for more information.
-#[derive(Clone, Copy, PartialOrd, Ord)]
-pub struct Scalar(primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
-
-primefield::monty_field_element!(Scalar, ScalarParams, U192);
+primefield::monty_field_element! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U192,
+    doc: "Element in the NIST P-192 scalar field modulo `n`."
+}
 
 primefield::monty_field_fiat_arithmetic!(
     Scalar,

--- a/p224/src/arithmetic/field.rs
+++ b/p224/src/arithmetic/field.rs
@@ -35,23 +35,21 @@ const MODULUS_HEX: &str = "ffffffffffffffffffffffffffffffff000000000000000000000
 #[cfg(target_pointer_width = "64")]
 const MODULUS_HEX: &str = "00000000ffffffffffffffffffffffffffffffff000000000000000000000001";
 
-primefield::monty_field_params!(
+primefield::monty_field_params! {
     name: FieldParams,
     modulus: MODULUS_HEX,
     uint: Uint,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 22,
-    fe_name: "FieldElement",
-    doc: "P-224 field modulus"
-);
+    doc: "Montgomery parameters for the NIST P-224 field modulus: `p = 2^{224} − 2^{96} + 1`."
+}
 
-/// Element of the secp224r1 base field used for curve coordinates.
-#[derive(Clone, Copy)]
-pub struct FieldElement(
-    pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
-);
-
-primefield::monty_field_element!(FieldElement, FieldParams, Uint);
+primefield::monty_field_element! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: Uint,
+    doc: "Element in the finite field modulo `p = 2^{224} − 2^{96} + 1`."
+}
 
 primefield::monty_field_fiat_arithmetic!(
     FieldElement,

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -40,51 +40,21 @@ use {
 #[cfg(doc)]
 use core::ops::{Add, Mul, Neg, Sub};
 
-primefield::monty_field_params!(
+primefield::monty_field_params! {
     name: ScalarParams,
     modulus: ORDER_HEX,
     uint: Uint,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 2,
-    fe_name: "Scalar",
-    doc: "P-224 scalar modulus"
-);
+    doc: "Montgomery parameters for the NIST P-224 scalar modulus `n`."
+}
 
-/// Scalars are elements in the finite field modulo `n`.
-///
-/// # Trait impls
-///
-/// Much of the important functionality of scalars is provided by traits from
-/// the [`ff`](https://docs.rs/ff/) crate, which is re-exported as
-/// `p224::elliptic_curve::ff`:
-///
-/// - [`Field`](https://docs.rs/ff/latest/ff/trait.Field.html) -
-///   represents elements of finite fields and provides:
-///   - [`Field::random`](https://docs.rs/ff/latest/ff/trait.Field.html#tymethod.random) -
-///     generate a random scalar
-///   - `double`, `square`, and `invert` operations
-///   - Bounds for [`Add`], [`Sub`], [`Mul`], and [`Neg`] (as well as `*Assign` equivalents)
-///   - Bounds for [`ConditionallySelectable`] from the `subtle` crate
-/// - [`PrimeField`](https://docs.rs/ff/latest/ff/trait.PrimeField.html) -
-///   represents elements of prime fields and provides:
-///   - `from_repr`/`to_repr` for converting field elements from/to big integers.
-///   - `multiplicative_generator` and `root_of_unity` constants.
-/// - [`PrimeFieldBits`](https://docs.rs/ff/latest/ff/trait.PrimeFieldBits.html) -
-///   operations over field elements represented as bits (requires `bits` feature)
-///
-/// Please see the documentation for the relevant traits for more information.
-///
-/// # Warning: `sqrt` unimplemented!
-///
-/// `Scalar::sqrt` has not been implemented and will panic if invoked!
-///
-/// See [RustCrypto/elliptic-curves#847] for more info.
-///
-/// [RustCrypto/elliptic-curves#847]: https://github.com/RustCrypto/elliptic-curves/issues/847
-#[derive(Clone, Copy, PartialOrd, Ord)]
-pub struct Scalar(primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
-
-primefield::monty_field_element!(Scalar, ScalarParams, Uint);
+primefield::monty_field_element! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: Uint,
+    doc: "Element in the NIST P-224 scalar field modulo `n`."
+}
 
 primefield::monty_field_fiat_arithmetic!(
     Scalar,

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -13,6 +13,18 @@ use elliptic_curve::{
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
+#[cfg(doc)]
+use {
+    core::ops::{Add, Neg, Sub},
+    elliptic_curve::{
+        ff::{self, Field},
+        subtle::ConditionallySelectable,
+    },
+};
+
+#[cfg(all(doc, feature = "bits"))]
+use elliptic_curve::ff::PrimeFieldBits;
+
 /// Constant representing the modulus: p = 2^{224}(2^{32} − 1) + 2^{192} + 2^{96} − 1
 const MODULUS_HEX: &str = "ffffffff00000001000000000000000000000000ffffffffffffffffffffffff";
 
@@ -22,20 +34,15 @@ primefield::monty_field_params!(
     uint: U256,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 6,
-    fe_name: "FieldElement",
-    doc: "Bign P-256 field modulus"
+    doc: "Montgomery parameters for the NIST P-256 field modulus: p = 2^{224}(2^{32} − 1) + 2^{192} + 2^{96} − 1."
 );
 
-/// An element in the finite field modulo p = 2^{224}(2^{32} − 1) + 2^{192} + 2^{96} − 1.
-///
-/// The internal representation is in little-endian order. Elements are always in
-/// Montgomery form; i.e., FieldElement(a) = aR mod p, with R = 2^256.
-#[derive(Clone, Copy)]
-pub struct FieldElement(
-    pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
+primefield::monty_field_element!(
+    name: FieldElement,
+    params: FieldParams,
+    uint: U256,
+    doc: "Element in the finite field modulo p = 2^{224}(2^{32} − 1) + 2^{192} + 2^{96} − 1."
 );
-
-primefield::monty_field_element!(FieldElement, FieldParams, U256);
 
 impl FieldElement {
     /// Decode [`FieldElement`] from [`U256`] converting it into Montgomery form.

--- a/p256/src/arithmetic/field/field64.rs
+++ b/p256/src/arithmetic/field/field64.rs
@@ -73,11 +73,11 @@ pub(super) const fn to_canonical(a: &U256) -> U256 {
 /// References:
 /// - Handbook of Applied Cryptography, Chapter 14
 ///   Algorithm 14.32
-///   http://cacr.uwaterloo.ca/hac/about/chap14.pdf
+///   <http://cacr.uwaterloo.ca/hac/about/chap14.pdf>
 ///
 /// - Efficient and Secure Elliptic Curve Cryptography Implementation of Curve P-256
 ///   Algorithm 7) Montgomery Word-by-Word Reduction
-///   https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf
+///   <https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf>
 #[inline]
 #[allow(clippy::too_many_arguments)]
 pub(super) const fn montgomery_reduce(lo: &U256, hi: &U256) -> U256 {

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -13,7 +13,7 @@ use core::{
 };
 use elliptic_curve::{
     Curve,
-    bigint::{Limb, Odd, U256, prelude::*},
+    bigint::{Limb, Odd, U256, Uint, prelude::*},
     group::ff::{self, Field, FromUniformBytes, PrimeField},
     ops::{Invert, Reduce, ReduceNonZero},
     rand_core::TryRngCore,
@@ -28,7 +28,6 @@ use elliptic_curve::{
 #[cfg(feature = "bits")]
 use {crate::ScalarBits, elliptic_curve::group::ff::PrimeFieldBits};
 
-use primefield::bigint::Uint;
 #[cfg(feature = "serde")]
 use {
     elliptic_curve::ScalarValue,
@@ -42,37 +41,7 @@ pub(crate) const MODULUS: Odd<U256> = NistP256::ORDER;
 /// `MODULUS / 2`
 const FRAC_MODULUS_2: Scalar = Scalar(MODULUS.as_ref().shr_vartime(1));
 
-/// Scalars are elements in the finite field modulo n.
-///
-/// # Trait impls
-///
-/// Much of the important functionality of scalars is provided by traits from
-/// the [`ff`](https://docs.rs/ff/) crate, which is re-exported as
-/// `p256::elliptic_curve::ff`:
-///
-/// - [`Field`](https://docs.rs/ff/latest/ff/trait.Field.html) -
-///   represents elements of finite fields and provides:
-///   - [`Field::random`](https://docs.rs/ff/latest/ff/trait.Field.html#tymethod.random) -
-///     generate a random scalar
-///   - `double`, `square`, and `invert` operations
-///   - Bounds for [`Add`], [`Sub`], [`Mul`], and [`Neg`] (as well as `*Assign` equivalents)
-///   - Bounds for [`ConditionallySelectable`] from the `subtle` crate
-/// - [`PrimeField`](https://docs.rs/ff/latest/ff/trait.PrimeField.html) -
-///   represents elements of prime fields and provides:
-///   - `from_repr`/`to_repr` for converting field elements from/to big integers.
-///   - `multiplicative_generator` and `root_of_unity` constants.
-/// - [`PrimeFieldBits`](https://docs.rs/ff/latest/ff/trait.PrimeFieldBits.html) -
-///   operations over field elements represented as bits (requires `bits` feature)
-///
-/// Please see the documentation for the relevant traits for more information.
-///
-/// # `serde` support
-///
-/// When the `serde` feature of this crate is enabled, the `Serialize` and
-/// `Deserialize` traits are impl'd for this type.
-///
-/// The serialization is a fixed-width big endian encoding. When used with
-/// textual formats, the binary data is encoded as hexadecimal.
+#[doc = primefield::monty_field_element_doc!("Scalars are elements in the finite field modulo n.")]
 #[derive(Clone, Copy, Default)]
 pub struct Scalar(pub(crate) U256);
 

--- a/p256/src/arithmetic/scalar/scalar64.rs
+++ b/p256/src/arithmetic/scalar/scalar64.rs
@@ -39,11 +39,11 @@ const MU: [Limb; 5] = [
 /// References:
 /// - Handbook of Applied Cryptography, Chapter 14
 ///   Algorithm 14.42
-///   http://cacr.uwaterloo.ca/hac/about/chap14.pdf
+///   <http://cacr.uwaterloo.ca/hac/about/chap14.pdf>
 ///
 /// - Efficient and Secure Elliptic Curve Cryptography Implementation of Curve P-256
 ///   Algorithm 6) Barrett Reduction modulo p
-///   https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf
+///   <https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf>
 #[inline]
 #[allow(clippy::too_many_arguments)]
 pub(super) const fn barrett_reduce(lo: U256, hi: U256) -> U256 {

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -25,23 +25,21 @@ use elliptic_curve::{
 /// p = 2^{384} − 2^{128} − 2^{96} + 2^{32} − 1
 const MODULUS_HEX: &str = "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff";
 
-primefield::monty_field_params!(
+primefield::monty_field_params! {
     name: FieldParams,
     modulus: MODULUS_HEX,
     uint: U384,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 19,
-    fe_name: "FieldElement",
-    doc: "P-384 field modulus"
-);
+    doc: "Montgomery parameters for the NIST P-384 field modulus: `p = 2^{384} − 2^{128} − 2^{96} + 2^{32} − 1`."
+}
 
-/// Element of the secp384r1 base field used for curve coordinates.
-#[derive(Clone, Copy)]
-pub struct FieldElement(
-    pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
-);
-
-primefield::monty_field_element!(FieldElement, FieldParams, U384);
+primefield::monty_field_element! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U384,
+    doc: "Element in the finite field modulo `p = 2^{384} − 2^{128} − 2^{96} + 2^{32} − 1`."
+}
 
 primefield::monty_field_fiat_arithmetic!(
     FieldElement,

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -34,51 +34,21 @@ use {
 #[cfg(doc)]
 use core::ops::{Add, Mul, Neg, Sub};
 
-primefield::monty_field_params!(
+primefield::monty_field_params! {
     name: ScalarParams,
     modulus: ORDER_HEX,
     uint: U384,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 2,
-    fe_name: "Scalar",
-    doc: "P-384 scalar modulus"
-);
+    doc: "Montgomery parameters for the NIST P-384 scalar modulus `n`."
+}
 
-/// Scalars are elements in the finite field modulo `n`.
-///
-/// # Trait impls
-///
-/// Much of the important functionality of scalars is provided by traits from
-/// the [`ff`](https://docs.rs/ff/) crate, which is re-exported as
-/// `p384::elliptic_curve::ff`:
-///
-/// - [`Field`](https://docs.rs/ff/latest/ff/trait.Field.html) -
-///   represents elements of finite fields and provides:
-///   - [`Field::random`](https://docs.rs/ff/latest/ff/trait.Field.html#tymethod.random) -
-///     generate a random scalar
-///   - `double`, `square`, and `invert` operations
-///   - Bounds for [`Add`], [`Sub`], [`Mul`], and [`Neg`] (as well as `*Assign` equivalents)
-///   - Bounds for [`ConditionallySelectable`] from the `subtle` crate
-/// - [`PrimeField`](https://docs.rs/ff/latest/ff/trait.PrimeField.html) -
-///   represents elements of prime fields and provides:
-///   - `from_repr`/`to_repr` for converting field elements from/to big integers.
-///   - `multiplicative_generator` and `root_of_unity` constants.
-/// - [`PrimeFieldBits`](https://docs.rs/ff/latest/ff/trait.PrimeFieldBits.html) -
-///   operations over field elements represented as bits (requires `bits` feature)
-///
-/// Please see the documentation for the relevant traits for more information.
-///
-/// # `serde` support
-///
-/// When the `serde` feature of this crate is enabled, the `Serialize` and
-/// `Deserialize` traits are impl'd for this type.
-///
-/// The serialization is a fixed-width big endian encoding. When used with
-/// textual formats, the binary data is encoded as hexadecimal.
-#[derive(Clone, Copy, PartialOrd, Ord)]
-pub struct Scalar(primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
-
-primefield::monty_field_element!(Scalar, ScalarParams, U384);
+primefield::monty_field_element! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U384,
+    doc: "Element in the NIST P-384 scalar field modulo `n`."
+}
 
 primefield::monty_field_fiat_arithmetic!(
     Scalar,

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -34,20 +34,9 @@ use elliptic_curve::{
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, CtOption},
     zeroize::DefaultIsZeroes,
 };
-use primefield::bigint::modular::MontyParams;
 use primefield::bigint::{Limb, Uint};
 
 const MODULUS_HEX: &str = "00000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
-
-primefield::monty_field_params!(
-    name: FieldParams,
-    modulus: MODULUS_HEX,
-    uint: U576,
-    byte_order: primefield::ByteOrder::BigEndian,
-    multiplicative_generator: 3,
-    fe_name: "FieldElement",
-    doc: "P-521 field modulus"
-);
 
 /// Field modulus: p = 2^{521} − 1
 pub(crate) const MODULUS: U576 = U576::from_be_hex(MODULUS_HEX);
@@ -350,11 +339,6 @@ impl AsRef<fiat_p521_tight_field_element> for FieldElement {
     fn as_ref(&self) -> &fiat_p521_tight_field_element {
         &self.0
     }
-}
-
-impl ConstMontyParams<{ U576::LIMBS }> for FieldElement {
-    const LIMBS: usize = U576::LIMBS;
-    const PARAMS: MontyParams<{ U576::LIMBS }> = FieldParams::PARAMS;
 }
 
 impl Default for FieldElement {

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -62,8 +62,7 @@ primefield::monty_field_params!(
     uint: U576,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 3,
-    fe_name: "Scalar",
-    doc: "P-521 scalar modulus"
+    doc: "Montgomery parameters for the NIST P-521 scalar modulus `n`."
 );
 
 /// Scalars are elements in the finite field modulo `n`.

--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -30,9 +30,6 @@ pub trait MontyFieldParams<const LIMBS: usize>: ConstMontyParams<LIMBS> {
     /// Byte order to use when serializing a field element as byte.
     const BYTE_ORDER: ByteOrder;
 
-    /// Type name to use in the `Debug` impl on elements of this field.
-    const FIELD_ELEMENT_NAME: &'static str;
-
     /// Field modulus as a hexadecimal string.
     const MODULUS_HEX: &'static str;
 
@@ -725,7 +722,12 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let canonical = self.to_canonical();
-        write!(f, "{}(0x{:X})", MOD::FIELD_ELEMENT_NAME, &canonical)
+        write!(
+            f,
+            "MontyFieldElement<p={}>(0x{:X})",
+            MOD::MODULUS_HEX,
+            canonical
+        )
     }
 }
 
@@ -899,7 +901,6 @@ mod tests {
         uint: U256,
         byte_order: ByteOrder::BigEndian,
         multiplicative_generator: 6,
-        fe_name: "FieldElement",
         doc: "P-256 field modulus"
     );
 

--- a/primefield/src/monty/sqrt.rs
+++ b/primefield/src/monty/sqrt.rs
@@ -166,7 +166,6 @@ mod tests {
             uint: U384,
             byte_order: ByteOrder::BigEndian,
             multiplicative_generator: 2,
-            fe_name: "Scalar",
             doc: "brainpoolP384 scalar modulus"
         );
 
@@ -191,7 +190,6 @@ mod tests {
             uint: U256,
             byte_order: ByteOrder::BigEndian,
             multiplicative_generator: 6,
-            fe_name: "FieldElement",
             doc: "P-256 field modulus"
         );
 
@@ -216,7 +214,6 @@ mod tests {
             uint: U192,
             byte_order: ByteOrder::BigEndian,
             multiplicative_generator: 3,
-            fe_name: "Scalar",
             doc: "P-192 scalar modulus"
         );
 

--- a/sm2/src/arithmetic/field.rs
+++ b/sm2/src/arithmetic/field.rs
@@ -24,23 +24,21 @@ use elliptic_curve::{
 /// Constant representing the modulus serialized as hex.
 const MODULUS_HEX: &str = "fffffffeffffffffffffffffffffffffffffffff00000000ffffffffffffffff";
 
-primefield::monty_field_params!(
+primefield::monty_field_params! {
     name: FieldParams,
     modulus: MODULUS_HEX,
     uint: U256,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 13,
-    fe_name: "FieldElement",
-    doc: "SM2 field modulus"
-);
+    doc: "Montgomery parameters for SM2's field modulus `p = 0xfffffffeffffffffffffffffffffffffffffffff00000000ffffffffffffffff`"
+}
 
-/// Element of the SM2 elliptic curve base field used for curve point coordinates.
-#[derive(Clone, Copy)]
-pub struct FieldElement(
-    pub(super) primefield::MontyFieldElement<FieldParams, { FieldParams::LIMBS }>,
-);
-
-primefield::monty_field_element!(FieldElement, FieldParams, U256);
+primefield::monty_field_element! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U256,
+    doc: "Element in the SM2 finite field modulo `p = 0xfffffffeffffffffffffffffffffffffffffffff00000000ffffffffffffffff`"
+}
 
 primefield::monty_field_fiat_arithmetic!(
     FieldElement,

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -34,43 +34,21 @@ use {
 #[cfg(doc)]
 use core::ops::{Add, Mul, Neg, Sub};
 
-primefield::monty_field_params!(
+primefield::monty_field_params! {
     name: ScalarParams,
     modulus: ORDER_HEX,
     uint: U256,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 3,
-    fe_name: "Scalar",
-    doc: "SM2 scalar modulus"
-);
+    doc: "Montgomery parameters for the SM2 scalar modulus `n`."
+}
 
-/// Scalars are elements in the finite field modulo `n`.
-///
-/// # Trait impls
-///
-/// Much of the important functionality of scalars is provided by traits from
-/// the [`ff`](https://docs.rs/ff/) crate, which is re-exported as
-/// `sm2::elliptic_curve::ff`:
-///
-/// - [`Field`](https://docs.rs/ff/latest/ff/trait.Field.html) -
-///   represents elements of finite fields and provides:
-///   - [`Field::random`](https://docs.rs/ff/latest/ff/trait.Field.html#tymethod.random) -
-///     generate a random scalar
-///   - `double`, `square`, and `invert` operations
-///   - Bounds for [`Add`], [`Sub`], [`Mul`], and [`Neg`] (as well as `*Assign` equivalents)
-///   - Bounds for [`ConditionallySelectable`] from the `subtle` crate
-/// - [`PrimeField`](https://docs.rs/ff/latest/ff/trait.PrimeField.html) -
-///   represents elements of prime fields and provides:
-///   - `from_repr`/`to_repr` for converting field elements from/to big integers.
-///   - `multiplicative_generator` and `root_of_unity` constants.
-/// - [`PrimeFieldBits`](https://docs.rs/ff/latest/ff/trait.PrimeFieldBits.html) -
-///   operations over field elements represented as bits (requires `bits` feature)
-///
-/// Please see the documentation for the relevant traits for more information.
-#[derive(Clone, Copy, PartialOrd, Ord)]
-pub struct Scalar(pub(super) primefield::MontyFieldElement<ScalarParams, { ScalarParams::LIMBS }>);
-
-primefield::monty_field_element!(Scalar, ScalarParams, U256);
+primefield::monty_field_element! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U256,
+    doc: "Element in the SM2 scalar field modulo `n`."
+}
 
 primefield::monty_field_fiat_arithmetic!(
     Scalar,


### PR DESCRIPTION
Previously the macro only wrote a series of `impl`s but didn't actually write the struct type. If nothing else, this is inconsistent with `monty_field_params!`.

But also, changes to the definition of the struct lead to tedious field-by-field changes, with a base and scalar field per-curve, for every curve we implement.

This changes `monty_field_element!` to be more consistent with `monty_field_params!`, using named parameters, and having it write the struct definition for the field element newtype.

This follows a similar pattern in `crypto-bigint` with `const_monty_params!` and `const_monty_form!` macros.