### PR TITLE
primefield: use named params for `monty_field_fiat_arithmetic!`

### DIFF
--- a/bignp256/src/arithmetic/field.rs
+++ b/bignp256/src/arithmetic/field.rs
@@ -53,24 +53,24 @@ primefield::monty_field_element! {
     doc: "Element in the bign-curve256v1 finite field modulo p = 2^{256} − 189"
 }
 
-primefield::monty_field_fiat_arithmetic!(
-    FieldElement,
-    FieldParams,
-    U256,
-    fiat_bignp256_non_montgomery_domain_field_element,
-    fiat_bignp256_montgomery_domain_field_element,
-    fiat_bignp256_from_montgomery,
-    fiat_bignp256_to_montgomery,
-    fiat_bignp256_add,
-    fiat_bignp256_sub,
-    fiat_bignp256_mul,
-    fiat_bignp256_opp,
-    fiat_bignp256_square,
-    fiat_bignp256_divstep_precomp,
-    fiat_bignp256_divstep,
-    fiat_bignp256_msat,
-    fiat_bignp256_selectznz
-);
+primefield::monty_field_fiat_arithmetic! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U256,
+    non_mont: fiat_bignp256_non_montgomery_domain_field_element,
+    mont: fiat_bignp256_montgomery_domain_field_element,
+    from_mont: fiat_bignp256_from_montgomery,
+    to_mont: fiat_bignp256_to_montgomery,
+    add: fiat_bignp256_add,
+    sub: fiat_bignp256_sub,
+    mul: fiat_bignp256_mul,
+    neg: fiat_bignp256_opp,
+    square: fiat_bignp256_square,
+    divstep_precomp: fiat_bignp256_divstep_precomp,
+    divstep: fiat_bignp256_divstep,
+    msat: fiat_bignp256_msat,
+    selectnz: fiat_bignp256_selectznz
+}
 
 #[cfg(test)]
 mod tests {

--- a/bignp256/src/arithmetic/scalar.rs
+++ b/bignp256/src/arithmetic/scalar.rs
@@ -30,14 +30,14 @@ use elliptic_curve::{
 #[cfg(doc)]
 use core::ops::{Add, Mul, Neg, Sub};
 
-primefield::monty_field_params!(
+primefield::monty_field_params! {
     name: ScalarParams,
     modulus: ORDER_HEX,
     uint: U256,
     byte_order: primefield::ByteOrder::BigEndian,
     multiplicative_generator: 3,
     doc: "Montgomery parameters for the bign-curve256v1 scalar modulus"
-);
+}
 
 primefield::monty_field_element! {
     name: Scalar,
@@ -46,24 +46,24 @@ primefield::monty_field_element! {
     doc: "Element in the bign-curve256v1 scalar field modulo n"
 }
 
-primefield::monty_field_fiat_arithmetic!(
-    Scalar,
-    ScalarParams,
-    U256,
-    fiat_bignp256_scalar_non_montgomery_domain_field_element,
-    fiat_bignp256_scalar_montgomery_domain_field_element,
-    fiat_bignp256_scalar_from_montgomery,
-    fiat_bignp256_scalar_to_montgomery,
-    fiat_bignp256_scalar_add,
-    fiat_bignp256_scalar_sub,
-    fiat_bignp256_scalar_mul,
-    fiat_bignp256_scalar_opp,
-    fiat_bignp256_scalar_square,
-    fiat_bignp256_scalar_divstep_precomp,
-    fiat_bignp256_scalar_divstep,
-    fiat_bignp256_scalar_msat,
-    fiat_bignp256_scalar_selectznz
-);
+primefield::monty_field_fiat_arithmetic! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U256,
+    non_mont: fiat_bignp256_scalar_non_montgomery_domain_field_element,
+    mont: fiat_bignp256_scalar_montgomery_domain_field_element,
+    from_mont: fiat_bignp256_scalar_from_montgomery,
+    to_mont: fiat_bignp256_scalar_to_montgomery,
+    add: fiat_bignp256_scalar_add,
+    sub: fiat_bignp256_scalar_sub,
+    mul: fiat_bignp256_scalar_mul,
+    neg: fiat_bignp256_scalar_opp,
+    square: fiat_bignp256_scalar_square,
+    divstep_precomp: fiat_bignp256_scalar_divstep_precomp,
+    divstep: fiat_bignp256_scalar_divstep,
+    msat: fiat_bignp256_scalar_msat,
+    selectnz: fiat_bignp256_scalar_selectznz
+}
 
 elliptic_curve::scalar_impls!(BignP256, Scalar);
 

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -47,24 +47,24 @@ primefield::monty_field_element! {
     doc: "Element in the brainpoolP256 finite field modulo p"
 }
 
-primefield::monty_field_fiat_arithmetic!(
-    FieldElement,
-    FieldParams,
-    U256,
-    fiat_bp256_non_montgomery_domain_field_element,
-    fiat_bp256_montgomery_domain_field_element,
-    fiat_bp256_from_montgomery,
-    fiat_bp256_to_montgomery,
-    fiat_bp256_add,
-    fiat_bp256_sub,
-    fiat_bp256_mul,
-    fiat_bp256_opp,
-    fiat_bp256_square,
-    fiat_bp256_divstep_precomp,
-    fiat_bp256_divstep,
-    fiat_bp256_msat,
-    fiat_bp256_selectznz
-);
+primefield::monty_field_fiat_arithmetic! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U256,
+    non_mont: fiat_bp256_non_montgomery_domain_field_element,
+    mont: fiat_bp256_montgomery_domain_field_element,
+    from_mont: fiat_bp256_from_montgomery,
+    to_mont: fiat_bp256_to_montgomery,
+    add: fiat_bp256_add,
+    sub: fiat_bp256_sub,
+    mul: fiat_bp256_mul,
+    neg: fiat_bp256_opp,
+    square: fiat_bp256_square,
+    divstep_precomp: fiat_bp256_divstep_precomp,
+    divstep: fiat_bp256_divstep,
+    msat: fiat_bp256_msat,
+    selectnz: fiat_bp256_selectznz
+}
 
 #[cfg(test)]
 mod tests {

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -50,24 +50,24 @@ primefield::monty_field_element! {
     doc: "Element in the brainpoolP256 scalar field modulo n"
 }
 
-primefield::monty_field_fiat_arithmetic!(
-    Scalar,
-    ScalarParams,
-    U256,
-    fiat_bp256_scalar_non_montgomery_domain_field_element,
-    fiat_bp256_scalar_montgomery_domain_field_element,
-    fiat_bp256_scalar_from_montgomery,
-    fiat_bp256_scalar_to_montgomery,
-    fiat_bp256_scalar_add,
-    fiat_bp256_scalar_sub,
-    fiat_bp256_scalar_mul,
-    fiat_bp256_scalar_opp,
-    fiat_bp256_scalar_square,
-    fiat_bp256_scalar_divstep_precomp,
-    fiat_bp256_scalar_divstep,
-    fiat_bp256_scalar_msat,
-    fiat_bp256_scalar_selectznz
-);
+primefield::monty_field_fiat_arithmetic! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U256,
+    non_mont: fiat_bp256_scalar_non_montgomery_domain_field_element,
+    mont: fiat_bp256_scalar_montgomery_domain_field_element,
+    from_mont: fiat_bp256_scalar_from_montgomery,
+    to_mont: fiat_bp256_scalar_to_montgomery,
+    add: fiat_bp256_scalar_add,
+    sub: fiat_bp256_scalar_sub,
+    mul: fiat_bp256_scalar_mul,
+    neg: fiat_bp256_scalar_opp,
+    square: fiat_bp256_scalar_square,
+    divstep_precomp: fiat_bp256_scalar_divstep_precomp,
+    divstep: fiat_bp256_scalar_divstep,
+    msat: fiat_bp256_scalar_msat,
+    selectnz: fiat_bp256_scalar_selectznz
+}
 
 elliptic_curve::scalar_impls!(BrainpoolP256r1, Scalar);
 elliptic_curve::scalar_impls!(BrainpoolP256t1, Scalar);

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -47,24 +47,24 @@ primefield::monty_field_element! {
     doc: "Element in the brainpoolP256 finite field modulo p"
 }
 
-primefield::monty_field_fiat_arithmetic!(
-    FieldElement,
-    FieldParams,
-    U384,
-    fiat_bp384_non_montgomery_domain_field_element,
-    fiat_bp384_montgomery_domain_field_element,
-    fiat_bp384_from_montgomery,
-    fiat_bp384_to_montgomery,
-    fiat_bp384_add,
-    fiat_bp384_sub,
-    fiat_bp384_mul,
-    fiat_bp384_opp,
-    fiat_bp384_square,
-    fiat_bp384_divstep_precomp,
-    fiat_bp384_divstep,
-    fiat_bp384_msat,
-    fiat_bp384_selectznz
-);
+primefield::monty_field_fiat_arithmetic! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U384,
+    non_mont: fiat_bp384_non_montgomery_domain_field_element,
+    mont: fiat_bp384_montgomery_domain_field_element,
+    from_mont: fiat_bp384_from_montgomery,
+    to_mont: fiat_bp384_to_montgomery,
+    add: fiat_bp384_add,
+    sub: fiat_bp384_sub,
+    mul: fiat_bp384_mul,
+    neg: fiat_bp384_opp,
+    square: fiat_bp384_square,
+    divstep_precomp: fiat_bp384_divstep_precomp,
+    divstep: fiat_bp384_divstep,
+    msat: fiat_bp384_msat,
+    selectnz: fiat_bp384_selectznz
+}
 
 #[cfg(test)]
 mod tests {

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -50,24 +50,24 @@ primefield::monty_field_element! {
     doc: "Element in the brainpoolP256 scalar field modulo n"
 }
 
-primefield::monty_field_fiat_arithmetic!(
-    Scalar,
-    ScalarParams,
-    U384,
-    fiat_bp384_scalar_non_montgomery_domain_field_element,
-    fiat_bp384_scalar_montgomery_domain_field_element,
-    fiat_bp384_scalar_from_montgomery,
-    fiat_bp384_scalar_to_montgomery,
-    fiat_bp384_scalar_add,
-    fiat_bp384_scalar_sub,
-    fiat_bp384_scalar_mul,
-    fiat_bp384_scalar_opp,
-    fiat_bp384_scalar_square,
-    fiat_bp384_scalar_divstep_precomp,
-    fiat_bp384_scalar_divstep,
-    fiat_bp384_scalar_msat,
-    fiat_bp384_scalar_selectznz
-);
+primefield::monty_field_fiat_arithmetic! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U384,
+    non_mont: fiat_bp384_scalar_non_montgomery_domain_field_element,
+    mont: fiat_bp384_scalar_montgomery_domain_field_element,
+    from_mont: fiat_bp384_scalar_from_montgomery,
+    to_mont: fiat_bp384_scalar_to_montgomery,
+    add: fiat_bp384_scalar_add,
+    sub: fiat_bp384_scalar_sub,
+    mul: fiat_bp384_scalar_mul,
+    neg: fiat_bp384_scalar_opp,
+    square: fiat_bp384_scalar_square,
+    divstep_precomp: fiat_bp384_scalar_divstep_precomp,
+    divstep: fiat_bp384_scalar_divstep,
+    msat: fiat_bp384_scalar_msat,
+    selectnz: fiat_bp384_scalar_selectznz
+}
 
 elliptic_curve::scalar_impls!(BrainpoolP384r1, Scalar);
 elliptic_curve::scalar_impls!(BrainpoolP384t1, Scalar);

--- a/p192/src/arithmetic/field.rs
+++ b/p192/src/arithmetic/field.rs
@@ -48,24 +48,24 @@ primefield::monty_field_element! {
     doc: "Element in the finite field modulo `p = 2^{192} − 2^{64} - 1`."
 }
 
-primefield::monty_field_fiat_arithmetic!(
-    FieldElement,
-    FieldParams,
-    U192,
-    fiat_p192_non_montgomery_domain_field_element,
-    fiat_p192_montgomery_domain_field_element,
-    fiat_p192_from_montgomery,
-    fiat_p192_to_montgomery,
-    fiat_p192_add,
-    fiat_p192_sub,
-    fiat_p192_mul,
-    fiat_p192_opp,
-    fiat_p192_square,
-    fiat_p192_divstep_precomp,
-    fiat_p192_divstep,
-    fiat_p192_msat,
-    fiat_p192_selectznz
-);
+primefield::monty_field_fiat_arithmetic! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U192,
+    non_mont: fiat_p192_non_montgomery_domain_field_element,
+    mont: fiat_p192_montgomery_domain_field_element,
+    from_mont: fiat_p192_from_montgomery,
+    to_mont: fiat_p192_to_montgomery,
+    add: fiat_p192_add,
+    sub: fiat_p192_sub,
+    mul: fiat_p192_mul,
+    neg: fiat_p192_opp,
+    square: fiat_p192_square,
+    divstep_precomp: fiat_p192_divstep_precomp,
+    divstep: fiat_p192_divstep,
+    msat: fiat_p192_msat,
+    selectnz: fiat_p192_selectznz
+}
 
 #[cfg(test)]
 mod tests {

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -57,24 +57,24 @@ primefield::monty_field_element! {
     doc: "Element in the NIST P-192 scalar field modulo `n`."
 }
 
-primefield::monty_field_fiat_arithmetic!(
-    Scalar,
-    ScalarParams,
-    U192,
-    fiat_p192_scalar_non_montgomery_domain_field_element,
-    fiat_p192_scalar_montgomery_domain_field_element,
-    fiat_p192_scalar_from_montgomery,
-    fiat_p192_scalar_to_montgomery,
-    fiat_p192_scalar_add,
-    fiat_p192_scalar_sub,
-    fiat_p192_scalar_mul,
-    fiat_p192_scalar_opp,
-    fiat_p192_scalar_square,
-    fiat_p192_scalar_divstep_precomp,
-    fiat_p192_scalar_divstep,
-    fiat_p192_scalar_msat,
-    fiat_p192_scalar_selectznz
-);
+primefield::monty_field_fiat_arithmetic! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U192,
+    non_mont: fiat_p192_scalar_non_montgomery_domain_field_element,
+    mont: fiat_p192_scalar_montgomery_domain_field_element,
+    from_mont: fiat_p192_scalar_from_montgomery,
+    to_mont: fiat_p192_scalar_to_montgomery,
+    add: fiat_p192_scalar_add,
+    sub: fiat_p192_scalar_sub,
+    mul: fiat_p192_scalar_mul,
+    neg: fiat_p192_scalar_opp,
+    square: fiat_p192_scalar_square,
+    divstep_precomp: fiat_p192_scalar_divstep_precomp,
+    divstep: fiat_p192_scalar_divstep,
+    msat: fiat_p192_scalar_msat,
+    selectnz: fiat_p192_scalar_selectznz
+}
 
 elliptic_curve::scalar_impls!(NistP192, Scalar);
 

--- a/p224/src/arithmetic/field.rs
+++ b/p224/src/arithmetic/field.rs
@@ -51,24 +51,24 @@ primefield::monty_field_element! {
     doc: "Element in the finite field modulo `p = 2^{224} − 2^{96} + 1`."
 }
 
-primefield::monty_field_fiat_arithmetic!(
-    FieldElement,
-    FieldParams,
-    Uint,
-    fiat_p224_non_montgomery_domain_field_element,
-    fiat_p224_montgomery_domain_field_element,
-    fiat_p224_from_montgomery,
-    fiat_p224_to_montgomery,
-    fiat_p224_add,
-    fiat_p224_sub,
-    fiat_p224_mul,
-    fiat_p224_opp,
-    fiat_p224_square,
-    fiat_p224_divstep_precomp,
-    fiat_p224_divstep,
-    fiat_p224_msat,
-    fiat_p224_selectznz
-);
+primefield::monty_field_fiat_arithmetic! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: Uint,
+    non_mont: fiat_p224_non_montgomery_domain_field_element,
+    mont: fiat_p224_montgomery_domain_field_element,
+    from_mont: fiat_p224_from_montgomery,
+    to_mont: fiat_p224_to_montgomery,
+    add: fiat_p224_add,
+    sub: fiat_p224_sub,
+    mul: fiat_p224_mul,
+    neg: fiat_p224_opp,
+    square: fiat_p224_square,
+    divstep_precomp: fiat_p224_divstep_precomp,
+    divstep: fiat_p224_divstep,
+    msat: fiat_p224_msat,
+    selectnz: fiat_p224_selectznz
+}
 
 #[cfg(test)]
 mod tests {

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -56,24 +56,24 @@ primefield::monty_field_element! {
     doc: "Element in the NIST P-224 scalar field modulo `n`."
 }
 
-primefield::monty_field_fiat_arithmetic!(
-    Scalar,
-    ScalarParams,
-    Uint,
-    fiat_p224_scalar_non_montgomery_domain_field_element,
-    fiat_p224_scalar_montgomery_domain_field_element,
-    fiat_p224_scalar_from_montgomery,
-    fiat_p224_scalar_to_montgomery,
-    fiat_p224_scalar_add,
-    fiat_p224_scalar_sub,
-    fiat_p224_scalar_mul,
-    fiat_p224_scalar_opp,
-    fiat_p224_scalar_square,
-    fiat_p224_scalar_divstep_precomp,
-    fiat_p224_scalar_divstep,
-    fiat_p224_scalar_msat,
-    fiat_p224_scalar_selectznz
-);
+primefield::monty_field_fiat_arithmetic! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: Uint,
+    non_mont: fiat_p224_scalar_non_montgomery_domain_field_element,
+    mont: fiat_p224_scalar_montgomery_domain_field_element,
+    from_mont: fiat_p224_scalar_from_montgomery,
+    to_mont: fiat_p224_scalar_to_montgomery,
+    add: fiat_p224_scalar_add,
+    sub: fiat_p224_scalar_sub,
+    mul: fiat_p224_scalar_mul,
+    neg: fiat_p224_scalar_opp,
+    square: fiat_p224_scalar_square,
+    divstep_precomp: fiat_p224_scalar_divstep_precomp,
+    divstep: fiat_p224_scalar_divstep,
+    msat: fiat_p224_scalar_msat,
+    selectnz: fiat_p224_scalar_selectznz
+}
 
 elliptic_curve::scalar_impls!(NistP224, Scalar);
 

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -41,24 +41,24 @@ primefield::monty_field_element! {
     doc: "Element in the finite field modulo `p = 2^{384} − 2^{128} − 2^{96} + 2^{32} − 1`."
 }
 
-primefield::monty_field_fiat_arithmetic!(
-    FieldElement,
-    FieldParams,
-    U384,
-    fiat_p384_non_montgomery_domain_field_element,
-    fiat_p384_montgomery_domain_field_element,
-    fiat_p384_from_montgomery,
-    fiat_p384_to_montgomery,
-    fiat_p384_add,
-    fiat_p384_sub,
-    fiat_p384_mul,
-    fiat_p384_opp,
-    fiat_p384_square,
-    fiat_p384_divstep_precomp,
-    fiat_p384_divstep,
-    fiat_p384_msat,
-    fiat_p384_selectznz
-);
+primefield::monty_field_fiat_arithmetic! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U384,
+    non_mont: fiat_p384_non_montgomery_domain_field_element,
+    mont: fiat_p384_montgomery_domain_field_element,
+    from_mont: fiat_p384_from_montgomery,
+    to_mont: fiat_p384_to_montgomery,
+    add: fiat_p384_add,
+    sub: fiat_p384_sub,
+    mul: fiat_p384_mul,
+    neg: fiat_p384_opp,
+    square: fiat_p384_square,
+    divstep_precomp: fiat_p384_divstep_precomp,
+    divstep: fiat_p384_divstep,
+    msat: fiat_p384_msat,
+    selectnz: fiat_p384_selectznz
+}
 
 #[cfg(test)]
 mod tests {

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -50,24 +50,24 @@ primefield::monty_field_element! {
     doc: "Element in the NIST P-384 scalar field modulo `n`."
 }
 
-primefield::monty_field_fiat_arithmetic!(
-    Scalar,
-    ScalarParams,
-    U384,
-    fiat_p384_scalar_non_montgomery_domain_field_element,
-    fiat_p384_scalar_montgomery_domain_field_element,
-    fiat_p384_scalar_from_montgomery,
-    fiat_p384_scalar_to_montgomery,
-    fiat_p384_scalar_add,
-    fiat_p384_scalar_sub,
-    fiat_p384_scalar_mul,
-    fiat_p384_scalar_opp,
-    fiat_p384_scalar_square,
-    fiat_p384_scalar_divstep_precomp,
-    fiat_p384_scalar_divstep,
-    fiat_p384_scalar_msat,
-    fiat_p384_scalar_selectznz
-);
+primefield::monty_field_fiat_arithmetic! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U384,
+    non_mont: fiat_p384_scalar_non_montgomery_domain_field_element,
+    mont: fiat_p384_scalar_montgomery_domain_field_element,
+    from_mont: fiat_p384_scalar_from_montgomery,
+    to_mont: fiat_p384_scalar_to_montgomery,
+    add: fiat_p384_scalar_add,
+    sub: fiat_p384_scalar_sub,
+    mul: fiat_p384_scalar_mul,
+    neg: fiat_p384_scalar_opp,
+    square: fiat_p384_scalar_square,
+    divstep_precomp: fiat_p384_scalar_divstep_precomp,
+    divstep: fiat_p384_scalar_divstep,
+    msat: fiat_p384_scalar_msat,
+    selectnz: fiat_p384_scalar_selectznz
+}
 
 elliptic_curve::scalar_impls!(NistP384, Scalar);
 

--- a/primefield/src/macros/fiat.rs
+++ b/primefield/src/macros/fiat.rs
@@ -10,22 +10,22 @@
 #[macro_export]
 macro_rules! monty_field_fiat_arithmetic {
     (
-        $fe:tt,
-        $params:ty,
-        $uint:ty,
-        $non_mont_type: expr,
-        $mont_type: expr,
-        $from_mont:ident,
-        $to_mont:ident,
-        $add:ident,
-        $sub:ident,
-        $mul:ident,
-        $neg:ident,
-        $square:ident,
-        $divstep_precomp:ident,
-        $divstep:ident,
-        $msat:ident,
-        $selectznz:ident
+        name: $fe:tt,
+        params: $params:ty,
+        uint: $uint:ty,
+        non_mont: $non_mont_type:expr,
+        mont: $mont_type:expr,
+        from_mont: $from_mont:ident,
+        to_mont: $to_mont:ident,
+        add: $add:ident,
+        sub: $sub:ident,
+        mul: $mul:ident,
+        neg: $neg:ident,
+        square: $square:ident,
+        divstep_precomp: $divstep_precomp:ident,
+        divstep: $divstep:ident,
+        msat: $msat:ident,
+        selectnz: $selectznz:ident
     ) => {
         impl $fe {
             /// Decode [`

--- a/sm2/src/arithmetic/field.rs
+++ b/sm2/src/arithmetic/field.rs
@@ -40,24 +40,24 @@ primefield::monty_field_element! {
     doc: "Element in the SM2 finite field modulo `p = 0xfffffffeffffffffffffffffffffffffffffffff00000000ffffffffffffffff`"
 }
 
-primefield::monty_field_fiat_arithmetic!(
-    FieldElement,
-    FieldParams,
-    U256,
-    fiat_sm2_non_montgomery_domain_field_element,
-    fiat_sm2_montgomery_domain_field_element,
-    fiat_sm2_from_montgomery,
-    fiat_sm2_to_montgomery,
-    fiat_sm2_add,
-    fiat_sm2_sub,
-    fiat_sm2_mul,
-    fiat_sm2_opp,
-    fiat_sm2_square,
-    fiat_sm2_divstep_precomp,
-    fiat_sm2_divstep,
-    fiat_sm2_msat,
-    fiat_sm2_selectznz
-);
+primefield::monty_field_fiat_arithmetic! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U256,
+    non_mont: fiat_sm2_non_montgomery_domain_field_element,
+    mont: fiat_sm2_montgomery_domain_field_element,
+    from_mont: fiat_sm2_from_montgomery,
+    to_mont: fiat_sm2_to_montgomery,
+    add: fiat_sm2_add,
+    sub: fiat_sm2_sub,
+    mul: fiat_sm2_mul,
+    neg: fiat_sm2_opp,
+    square: fiat_sm2_square,
+    divstep_precomp: fiat_sm2_divstep_precomp,
+    divstep: fiat_sm2_divstep,
+    msat: fiat_sm2_msat,
+    selectnz: fiat_sm2_selectznz
+}
 
 #[cfg(test)]
 mod tests {

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -50,24 +50,24 @@ primefield::monty_field_element! {
     doc: "Element in the SM2 scalar field modulo `n`."
 }
 
-primefield::monty_field_fiat_arithmetic!(
-    Scalar,
-    ScalarParams,
-    U256,
-    fiat_sm2_scalar_non_montgomery_domain_field_element,
-    fiat_sm2_scalar_montgomery_domain_field_element,
-    fiat_sm2_scalar_from_montgomery,
-    fiat_sm2_scalar_to_montgomery,
-    fiat_sm2_scalar_add,
-    fiat_sm2_scalar_sub,
-    fiat_sm2_scalar_mul,
-    fiat_sm2_scalar_opp,
-    fiat_sm2_scalar_square,
-    fiat_sm2_scalar_divstep_precomp,
-    fiat_sm2_scalar_divstep,
-    fiat_sm2_scalar_msat,
-    fiat_sm2_scalar_selectznz
-);
+primefield::monty_field_fiat_arithmetic! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U256,
+    non_mont: fiat_sm2_scalar_non_montgomery_domain_field_element,
+    mont: fiat_sm2_scalar_montgomery_domain_field_element,
+    from_mont: fiat_sm2_scalar_from_montgomery,
+    to_mont: fiat_sm2_scalar_to_montgomery,
+    add: fiat_sm2_scalar_add,
+    sub: fiat_sm2_scalar_sub,
+    mul: fiat_sm2_scalar_mul,
+    neg: fiat_sm2_scalar_opp,
+    square: fiat_sm2_scalar_square,
+    divstep_precomp: fiat_sm2_scalar_divstep_precomp,
+    divstep: fiat_sm2_scalar_divstep,
+    msat: fiat_sm2_scalar_msat,
+    selectnz: fiat_sm2_scalar_selectznz
+}
 
 elliptic_curve::scalar_impls!(Sm2, Scalar);
 


### PR DESCRIPTION
Follows the argument style from #1458, which is particularly helpful with the excessively large (16) parameters this macro takes.

Using named parameters should make it much easier to figure out what needs to be changed if macro arguments are added/removed.