### PR TITLE
subtle: enable `const-generics` feature

### DIFF
--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -16,6 +16,6 @@ rust-version = "1.85"
 [dependencies]
 bigint = { package = "crypto-bigint", version = "0.7.0-rc.6", default-features = false, features = ["hybrid-array"] }
 ff = { version = "=0.14.0-pre.0", default-features = false }
-subtle = { version = "2.6", default-features = false }
+subtle = { version = "2.6", default-features = false, features = ["const-generics"] }
 rand_core = { version = "0.9", default-features = false }
 zeroize = { version = "1.7", default-features = false }


### PR DESCRIPTION
Our 1.85 MSRV amply supports it, and it's useful for downstream crates e.g. #1467