### PR TITLE
primefield: support precomputed `ROOT_OF_UNITY` constant

### DIFF
--- a/primefield/src/macros.rs
+++ b/primefield/src/macros.rs
@@ -35,6 +35,30 @@ macro_rules! monty_field_params {
         multiplicative_generator: $multiplicative_generator:expr,
         doc: $doc:expr
     ) => {
+        $crate::monty_field_params_with_root_of_unity! {
+            name: $name,
+            modulus: $modulus_hex,
+            uint: $uint,
+            byte_order: $byte_order,
+            multiplicative_generator: $multiplicative_generator,
+            root_of_unity: None,
+            doc: $doc
+        }
+    };
+}
+
+/// Same as [`monty_field_params!`], but with a precomputed `ROOT_OF_UNITY` constant.
+#[macro_export]
+macro_rules! monty_field_params_with_root_of_unity {
+    (
+        name: $name:ident,
+        modulus: $modulus_hex:expr,
+        uint: $uint:ty,
+        byte_order: $byte_order:expr,
+        multiplicative_generator: $multiplicative_generator:expr,
+        root_of_unity: $root_of_unity:expr,
+        doc: $doc:expr
+    ) => {
         use $crate::bigint::modular::ConstMontyParams;
 
         $crate::bigint::const_monty_params!($name, $uint, $modulus_hex, $doc);
@@ -47,6 +71,7 @@ macro_rules! monty_field_params {
             const MODULUS_HEX: &'static str = $modulus_hex;
             const MULTIPLICATIVE_GENERATOR: u64 = $multiplicative_generator;
             const T: $uint = $crate::compute_t($name::PARAMS.modulus().as_ref());
+            const ROOT_OF_UNITY: Option<$uint> = $root_of_unity;
         }
     };
 }

--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -38,8 +38,11 @@ pub trait MontyFieldParams<const LIMBS: usize>: ConstMontyParams<LIMBS> {
     /// This element must also be a quadratic nonresidue.
     const MULTIPLICATIVE_GENERATOR: u64;
 
-    /// `t = (modulus - 1) >> s`, where `S = (modulus - 1).trailing_zeros()`
+    /// `T = (modulus - 1) >> S`, where `S = (modulus - 1).trailing_zeros()`
     const T: Uint<LIMBS>;
+
+    /// Optional precomputed `ROOT_OF_UNITY`, otherwise will be computed at compile-time.
+    const ROOT_OF_UNITY: Option<Uint<LIMBS>>;
 }
 
 /// Serialized representation of a field element.
@@ -455,7 +458,10 @@ where
     const TWO_INV: Self = Self::from_u64(2).const_invert();
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(MOD::MULTIPLICATIVE_GENERATOR);
     const S: u32 = compute_s(MOD::PARAMS.modulus().as_ref());
-    const ROOT_OF_UNITY: Self = Self::MULTIPLICATIVE_GENERATOR.pow_vartime(&MOD::T);
+    const ROOT_OF_UNITY: Self = match MOD::ROOT_OF_UNITY {
+        Some(root_of_unity) => Self::from_uint_reduced(&root_of_unity),
+        None => Self::MULTIPLICATIVE_GENERATOR.pow_vartime(&MOD::T),
+    };
     const ROOT_OF_UNITY_INV: Self = Self::ROOT_OF_UNITY.const_invert();
     const DELTA: Self = Self::MULTIPLICATIVE_GENERATOR.sqn_vartime(Self::S as usize);
 


### PR DESCRIPTION
Being able to compute `ROOT_OF_UNITY` at compile time is super cool! The only problem is we're running `modpow` at compile time, and miri is slow. For large fields, it may be impractically slow.

This makes it possible to define field parameters that include a precomputed `ROOT_OF_UNITY` constant.