### PR TITLE
primefield: better field element hex parsing

### DIFF
--- a/p224/src/arithmetic.rs
+++ b/p224/src/arithmetic.rs
@@ -41,41 +41,17 @@ impl PrimeCurveParams for NistP224 {
     const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();
 
     /// b = 0xb4050a85 0c04b3ab f5413256 5044b0b7 d7bfd8ba 270b3943 2355ffb4
-    #[cfg(target_pointer_width = "32")]
     const EQUATION_B: FieldElement =
         FieldElement::from_hex_vartime("b4050a850c04b3abf54132565044b0b7d7bfd8ba270b39432355ffb4");
 
-    /// b = 0xb4050a85 0c04b3ab f5413256 5044b0b7 d7bfd8ba 270b3943 2355ffb4
-    #[cfg(target_pointer_width = "64")]
-    const EQUATION_B: FieldElement = FieldElement::from_hex_vartime(
-        "00000000b4050a850c04b3abf54132565044b0b7d7bfd8ba270b39432355ffb4",
-    );
-
     /// Base point of P-224.
     ///
     /// ```text
     /// Gₓ = 0xb70e0cbd 6bb4bf7f 321390b9 4a03c1d3 56c21122 343280d6 115c1d21
     /// Gᵧ = 0xbd376388 b5f723fb 4c22dfe6 cd4375a0 5a074764 44d58199 85007e34
     /// ```
-    #[cfg(target_pointer_width = "32")]
     const GENERATOR: (FieldElement, FieldElement) = (
         FieldElement::from_hex_vartime("b70e0cbd6bb4bf7f321390b94a03c1d356c21122343280d6115c1d21"),
         FieldElement::from_hex_vartime("bd376388b5f723fb4c22dfe6cd4375a05a07476444d5819985007e34"),
-    );
-
-    /// Base point of P-224.
-    ///
-    /// ```text
-    /// Gₓ = 0xb70e0cbd 6bb4bf7f 321390b9 4a03c1d3 56c21122 343280d6 115c1d21
-    /// Gᵧ = 0xbd376388 b5f723fb 4c22dfe6 cd4375a0 5a074764 44d58199 85007e34
-    /// ```
-    #[cfg(target_pointer_width = "64")]
-    const GENERATOR: (FieldElement, FieldElement) = (
-        FieldElement::from_hex_vartime(
-            "00000000b70e0cbd6bb4bf7f321390b94a03c1d356c21122343280d6115c1d21",
-        ),
-        FieldElement::from_hex_vartime(
-            "00000000bd376388b5f723fb4c22dfe6cd4375a05a07476444d5819985007e34",
-        ),
     );
 }


### PR DESCRIPTION
Ensures hex strings are always sized appropriately to the modulus, which also ensures the size is consistent on 32-bit and 64-bit targets.

Notably this impacts P-224 where there was previously some special casing on `target_pointer_width`.