### PR TITLE
[WIP] primeorder: `LookupTable` and `BasepointTable`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,6 @@ dependencies = [
  "hex-literal",
  "num-bigint 0.4.6",
  "num-traits",
- "once_cell",
  "primeorder",
  "proptest",
  "rand_core",
@@ -899,6 +898,7 @@ name = "primeorder"
 version = "0.14.0-pre.9"
 dependencies = [
  "elliptic-curve",
+ "once_cell",
  "serdect",
 ]
 

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -24,7 +24,6 @@ elliptic-curve = { version = "0.14.0-rc.14", default-features = false, features 
 hash2curve = { version = "0.14.0-rc.2", optional = true }
 
 # optional dependencies
-once_cell = { version = "1.21", optional = true, default-features = false }
 ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primeorder = { version = "=0.14.0-pre.9", optional = true }
@@ -47,11 +46,11 @@ sha3 = { version = "0.11.0-rc.3", default-features = false }
 [features]
 default = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "schnorr", "std"]
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc"]
-std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std", "once_cell?/std"]
+std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std", "primeorder?/std"]
 
 arithmetic = ["elliptic-curve/arithmetic"]
 bits = ["arithmetic", "elliptic-curve/bits"]
-critical-section = ["once_cell/critical-section", "precomputed-tables"]
+critical-section = ["precomputed-tables", "primeorder/critical-section"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/signing", "ecdsa-core/verifying", "sha256"]
@@ -60,7 +59,7 @@ hash2curve = ["arithmetic", "dep:hash2curve", "dep:primeorder", "primeorder/hash
 group-digest = ["hash2curve", "sha2"]
 pem = ["ecdsa-core/pem", "elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa-core/pkcs8", "elliptic-curve/pkcs8"]
-precomputed-tables = ["arithmetic"]
+precomputed-tables = ["arithmetic", "primeorder/basepoint-table"]
 schnorr = ["arithmetic", "sha256", "signature"]
 serde = ["ecdsa-core/serde", "elliptic-curve/serde", "pkcs8", "serdect"]
 sha256 = ["digest", "sha2"]

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -46,11 +46,7 @@ use crate::arithmetic::{
 };
 
 use core::ops::{Mul, MulAssign};
-use elliptic_curve::{
-    ops::LinearCombination,
-    scalar::IsHigh,
-    subtle::{Choice, ConditionallySelectable, ConstantTimeEq},
-};
+use elliptic_curve::{ops::LinearCombination, scalar::IsHigh, subtle::ConditionallySelectable};
 
 #[cfg(all(feature = "precomputed-tables", feature = "critical-section"))]
 use once_cell::sync::Lazy as LazyLock;
@@ -61,44 +57,10 @@ use once_cell::sync::Lazy as LazyLock;
 use std::sync::LazyLock;
 
 /// Lookup table containing precomputed values `[p, 2p, 3p, ..., 8p]`
-#[derive(Copy, Clone, Default)]
-struct LookupTable([ProjectivePoint; 8]);
+type LookupTable = primeorder::LookupTable<ProjectivePoint>;
 
-impl From<&ProjectivePoint> for LookupTable {
-    fn from(p: &ProjectivePoint) -> Self {
-        let mut points = [*p; 8];
-        for j in 0..7 {
-            points[j + 1] = p + &points[j];
-        }
-        LookupTable(points)
-    }
-}
-
-impl LookupTable {
-    /// Given -8 <= x <= 8, returns x * p in constant time.
-    fn select(&self, x: i8) -> ProjectivePoint {
-        debug_assert!(x >= -8);
-        debug_assert!(x <= 8);
-
-        // Compute xabs = |x|
-        let xmask = x >> 7;
-        let xabs = (x + xmask) ^ xmask;
-
-        // Get an array element in constant time
-        let mut t = ProjectivePoint::IDENTITY;
-        for j in 1..9 {
-            let c = (xabs as u8).ct_eq(&(j as u8));
-            t.conditional_assign(&self.0[j - 1], c);
-        }
-        // Now t == |x| * p.
-
-        let neg_mask = Choice::from((xmask & 1) as u8);
-        t.conditional_assign(&-t, neg_mask);
-        // Now t == x * p.
-
-        t
-    }
-}
+/// Basepoint table for multiples of secp256k1's generator.
+type BasepointTable = primeorder::BasepointTable<ProjectivePoint, 33>;
 
 const MINUS_LAMBDA: Scalar = Scalar::from_bytes_unchecked(&[
     0xac, 0x9c, 0x52, 0xb3, 0x3f, 0xa3, 0xcf, 0x1f, 0x5a, 0xd9, 0xe3, 0xfd, 0x77, 0xed, 0x9b, 0xa4,
@@ -329,8 +291,8 @@ fn lincomb(
         );
 
         tables[i] = (
-            LookupTable::from(&ProjectivePoint::conditional_select(x, &-*x, r1_sign)),
-            LookupTable::from(&ProjectivePoint::conditional_select(
+            LookupTable::new(ProjectivePoint::conditional_select(x, &-*x, r1_sign)),
+            LookupTable::new(ProjectivePoint::conditional_select(
                 &x_beta, &-x_beta, r2_sign,
             )),
         );
@@ -368,23 +330,7 @@ fn lincomb(
 
 /// Lazily computed basepoint table.
 #[cfg(feature = "precomputed-tables")]
-static GEN_LOOKUP_TABLE: LazyLock<[LookupTable; 33]> = LazyLock::new(precompute_gen_lookup_table);
-
-#[cfg(feature = "precomputed-tables")]
-fn precompute_gen_lookup_table() -> [LookupTable; 33] {
-    let mut generator = ProjectivePoint::GENERATOR;
-    let mut res = [LookupTable::default(); 33];
-
-    for i in 0..33 {
-        res[i] = LookupTable::from(&generator);
-        // We are storing tables spaced by two radix steps,
-        // to decrease the size of the precomputed data.
-        for _ in 0..8 {
-            generator = generator.double();
-        }
-    }
-    res
-}
+static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
 
 impl ProjectivePoint {
     /// Calculates `k * G`, where `G` is the generator.
@@ -397,7 +343,7 @@ impl ProjectivePoint {
     #[cfg(feature = "precomputed-tables")]
     pub(super) fn mul_by_generator(k: &Scalar) -> ProjectivePoint {
         let digits = Radix16Decomposition::<65>::new(k);
-        let table = *GEN_LOOKUP_TABLE;
+        let table = *BASEPOINT_TABLE;
         let mut acc = table[32].select(digits.0[64]);
         let mut acc2 = ProjectivePoint::IDENTITY;
         for i in (0..32).rev() {

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -21,14 +21,17 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.0-rc.14", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
+once_cell = { version = "1.21", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [features]
 alloc = ["elliptic-curve/alloc"]
-hash2curve = []
-std = ["alloc", "elliptic-curve/std"]
+std = ["alloc", "elliptic-curve/std", "once_cell?/std"]
 
+basepoint-table = []
+critical-section = ["once_cell?/critical-section"]
 dev = []
+hash2curve = []
 serde = ["elliptic-curve/serde", "serdect"]
 
 [package.metadata.docs.rs]

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -12,6 +12,9 @@
 #[macro_use]
 extern crate alloc;
 
+#[cfg(feature = "std")]
+extern crate std;
+
 #[cfg(feature = "hash2curve")]
 pub mod osswu;
 pub mod point_arithmetic;
@@ -19,9 +22,14 @@ pub mod point_arithmetic;
 mod affine;
 #[cfg(feature = "dev")]
 mod dev;
+mod lookup_table;
 mod projective;
 
-pub use crate::{affine::AffinePoint, projective::ProjectivePoint};
+pub use crate::{
+    affine::AffinePoint,
+    lookup_table::{BasepointTable, LookupTable},
+    projective::ProjectivePoint,
+};
 pub use elliptic_curve::{self, Field, FieldBytes, PrimeCurve, PrimeField, array, point::Double};
 
 use elliptic_curve::{CurveArithmetic, ops::Invert, subtle::CtOption};

--- a/primeorder/src/lookup_table.rs
+++ b/primeorder/src/lookup_table.rs
@@ -1,0 +1,122 @@
+use elliptic_curve::{
+    Group,
+    subtle::{Choice, ConditionallySelectable, ConstantTimeEq},
+};
+
+#[cfg(all(
+    feature = "basepoint-table",
+    not(any(feature = "critical-section", feature = "std"))
+))]
+compile_error!("`basepoint-table` feature requires either `critical-section` or `std`");
+
+#[cfg(feature = "basepoint-table")]
+use core::ops::Deref;
+
+#[cfg(all(feature = "basepoint-table", feature = "critical-section"))]
+use once_cell::sync::Lazy as LazyLock;
+#[cfg(all(
+    feature = "basepoint-table",
+    all(feature = "std", not(feature = "critical-section"))
+))]
+use std::sync::LazyLock;
+
+/// Internal constant for the number of entries in a [`LookupTable`].
+const LUT_SIZE: usize = 8;
+
+/// Lookup table containing precomputed values `[p, 2p, 3p, ..., 8p]`
+#[derive(Clone, Copy, Debug, Default)]
+pub struct LookupTable<Point> {
+    points: [Point; LUT_SIZE],
+}
+
+impl<Point> LookupTable<Point>
+where
+    Point: ConditionallySelectable + Group,
+{
+    /// Compute a new lookup table from the given point.
+    pub fn new(p: Point) -> Self {
+        let mut points = [p; 8];
+
+        for j in 0..(LUT_SIZE - 1) {
+            points[j + 1] = p + &points[j];
+        }
+
+        Self { points }
+    }
+
+    /// Given -8 <= x <= 8, returns x * p in constant time.
+    pub fn select(&self, x: i8) -> Point {
+        debug_assert!((-8..=8).contains(&x));
+
+        // Compute xabs = |x|
+        let xmask = x >> 7;
+        let xabs = (x + xmask) ^ xmask;
+
+        // Get an array element in constant time
+        let mut t = Point::identity();
+
+        for j in 1..(8 + 1) {
+            let c = (xabs as u8).ct_eq(&(j as u8));
+            t.conditional_assign(&self.points[j - 1], c);
+        }
+        // Now t == |x| * p.
+
+        let neg_mask = Choice::from((xmask & 1) as u8);
+        t.conditional_assign(&-t, neg_mask);
+        // Now t == x * p.
+
+        t
+    }
+}
+
+/// Precomputed lookup table of multiples of a base point, a.k.a. generator.
+#[cfg(feature = "basepoint-table")]
+pub struct BasepointTable<Point, const N: usize> {
+    tables: LazyLock<[LookupTable<Point>; N]>,
+}
+
+#[cfg(feature = "basepoint-table")]
+impl<Point, const N: usize> BasepointTable<Point, N>
+where
+    Point: ConditionallySelectable + Default + Group,
+{
+    /// Create a new [`BasepointTable`] which is lazily initialized on first use and can be bound
+    /// to a constant.
+    ///
+    /// Computed using [`Point::generator()`] as the base point.
+    pub const fn new() -> Self {
+        /// Inner function to initialize the table.
+        fn init_table<Point, const N: usize>() -> [LookupTable<Point>; N]
+        where
+            Point: ConditionallySelectable + Default + Group,
+        {
+            let mut generator = Point::generator();
+            let mut res = [LookupTable::<Point>::default(); N];
+
+            for i in 0..N {
+                res[i] = LookupTable::new(generator);
+                // We are storing tables spaced by two radix steps,
+                // to decrease the size of the precomputed data.
+                for _ in 0..8 {
+                    generator = generator.double();
+                }
+            }
+
+            res
+        }
+
+        Self {
+            tables: LazyLock::new(init_table),
+        }
+    }
+}
+
+#[cfg(feature = "basepoint-table")]
+impl<Point, const N: usize> Deref for BasepointTable<Point, N> {
+    type Target = [LookupTable<Point>; N];
+
+    #[inline]
+    fn deref(&self) -> &[LookupTable<Point>; N] {
+        &self.tables
+    }
+}


### PR DESCRIPTION
Extracts the `LookupTable` type from `k256`, and the code for calculating basepoint tables and storing them in lazily computed statics.

Notably this retains support for either using `std::sync::LazyLock` with no additional dependencies, or leveraging the `critical-section` feature of `once_cell` on `no_std` targets.