### PR TITLE
Bump `ecdsa` to v0.17.0-rc.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,8 +373,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.7"
-source = "git+https://github.com/RustCrypto/signatures.git#305bad5a0067712634089e2aa948aaf1f75bd023"
+version = "0.17.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b56e025680b64794fad81dd46019037773eeb5268a990c5d4cca05bf351c7f0f"
 dependencies = [
  "der",
  "digest",
@@ -1056,8 +1057,9 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-rc.1"
-source = "git+https://github.com/RustCrypto/signatures.git#305bad5a0067712634089e2aa948aaf1f75bd023"
+version = "0.5.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a165e1723c68a5c6c3746322ba13f0e167206be428305bc9c76e204eacc639c"
 dependencies = [
  "hmac",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,3 @@ ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
-
-ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
-rfc6979 = { git = "https://github.com/RustCrypto/signatures.git" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.7", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.8", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "=0.14.0-pre.6", optional = true }
 primeorder = { version = "=0.14.0-pre.9", optional = true }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.7", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.8", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "=0.14.0-pre.6", optional = true }
 primeorder = { version = "=0.14.0-pre.9", optional = true }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -24,7 +24,7 @@ elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features 
 hash2curve = { version = "0.14.0-rc.2", optional = true }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primeorder = { version = "=0.14.0-pre.9", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
@@ -33,7 +33,7 @@ signature = { version = "3.0.0-rc.4", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4.3"
 hex-literal = "1"
 num-bigint = "0.4"

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -20,14 +20,14 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.6", optional = true }
 primeorder = { version = "=0.14.0-pre.9", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "=0.14.0-pre.9", features = ["dev"] }
 

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.6", optional = true }
 primeorder = { version = "=0.14.0-pre.9", optional = true }
@@ -28,7 +28,7 @@ serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "=0.14.0-pre.9", features = ["dev"] }
 rand_core = { version = "0.9", features = ["os_rng"] }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.2", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.6", optional = true }
@@ -31,7 +31,7 @@ sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primefield = { version = "=0.14.0-pre.6" }
 primeorder = { version = "=0.14.0-pre.9", features = ["dev"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -22,7 +22,7 @@ elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features 
 fiat-crypto = { version = "0.3", default-features = false }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.2", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.6", optional = true }
@@ -32,7 +32,7 @@ sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "=0.14.0-pre.9", features = ["dev"] }
 proptest = "1.7"

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -21,7 +21,7 @@ base16ct = "0.3"
 elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.2", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "=0.14.0-pre.6", optional = true }
@@ -32,7 +32,7 @@ sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.7", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "=0.14.0-pre.9", features = ["dev"] }
 proptest = "1.7"


### PR DESCRIPTION
~~Notably this includes changes to the blobby format, which haven't been performed in this PR.~~ Fixed in #1484

Closes #1492