### PR TITLE
Cargo.toml(s): remove `rustdoc-args`

### DIFF
--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -64,3 +64,6 @@ harness = false
 [[bench]]
 name = "scalar"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -36,4 +36,3 @@ sha256 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -36,4 +36,3 @@ sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -50,3 +50,6 @@ serde_json = "1.0"
 [[bench]]
 harness = false
 name = "bench"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -66,7 +66,6 @@ test-vectors = ["hex-literal"]
 
 [package.metadata.docs.rs]
 features = ["ecdh", "ecdsa", "schnorr"]
-rustdoc-args = ["--cfg", "docsrs"]
 
 [[bench]]
 name = "ecdsa"

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -47,4 +47,3 @@ test-vectors = ["hex-literal"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -51,4 +51,3 @@ test-vectors = ["dep:hex-literal"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -60,7 +60,6 @@ test-vectors = ["dep:hex-literal"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [[bench]]
 name = "field"

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -65,7 +65,6 @@ test-vectors = ["hex-literal"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [[bench]]
 name = "field"

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -60,7 +60,6 @@ test-vectors = ["dep:hex-literal"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [[bench]]
 name = "field"

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -25,12 +25,11 @@ serdect = { version = "0.4", optional = true, default-features = false }
 
 [features]
 alloc = ["elliptic-curve/alloc"]
-hash2curve = []
 std = ["alloc", "elliptic-curve/std"]
 
 dev = []
+hash2curve = []
 serde = ["elliptic-curve/serde", "serdect"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -51,4 +51,3 @@ serde = ["elliptic-curve/serde", "primeorder?/serde", "serdect"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/x448/Cargo.toml
+++ b/x448/Cargo.toml
@@ -30,3 +30,6 @@ rand = "0.9"
 [features]
 static_secrets = []
 serde = ["dep:serdect", "ed448-goldilocks/serde"]
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
For docs.rs: the `docsrs` cfg is now set implicitly