### PR TITLE
fix(ed448): set Scalar PrimeField::NUM_BITS to 446

### DIFF
--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -339,7 +339,7 @@ impl<C: CurveWithScalar> PrimeField for Scalar<C> {
         Choice::from((self.scalar.to_words()[0] & 1) as u8)
     }
     const MODULUS: &'static str = "3fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f3";
-    const NUM_BITS: u32 = 448;
+    const NUM_BITS: u32 = 446;
     const CAPACITY: u32 = Self::NUM_BITS - 1;
     const TWO_INV: Self = Self::new(U448::from_be_hex(
         "1fffffffffffffffffffffffffffffffffffffffffffffffffffffffbe6511f4e2276da4d76b1b4810b6613946e2c7aa91bc614955ac227a",


### PR DESCRIPTION
Align PrimeField::NUM_BITS with the actual bit length of the scalar field modulus (order l) for Ed448, which is 446 bits (modulus starts with 0x3...). Previously set to 448, which incorrectly inflated CAPACITY and could break consumers relying on accurate NUM_BITS/CAPACITY. CAPACITY remains defined as NUM_BITS - 1 and now evaluates to 445 as intended.