### PR TITLE
Bump `crypto-bigint` to v0.7.0-rc.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,8 +351,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.9"
-source = "git+https://github.com/RustCrypto/crypto-bigint?branch=rand_core%2Fv0.10.0-rc-2#896b26cc24c96cad5edf957528d0e9558b13dc75"
+version = "0.7.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6715836b4946e8585016e80b79c7561476aff3b22f7b756778e7b109d86086c6"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -452,7 +453,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.16"
-source = "git+https://github.com/RustCrypto/traits#166903b30642b3b3054593f8500f37943c1d88c7"
+source = "git+https://github.com/RustCrypto/traits#e8af70d7513422157590f3f764ddc8f8ca55bf72"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
 
 elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
-crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint", branch = "rand_core/v0.10.0-rc-2" }
 ecdsa = { git = "https://github.com/RustCrypto/signatures" }
 ff = { git = "https://github.com/tarcieri/ff", branch = "rand_core/v0.10.0-rc-2" }
 group = { git = "https://github.com/tarcieri/group", branch = "rand_core/v0.10.0-rc-2" }

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-bigint = { package = "crypto-bigint", version = "0.7.0-rc.9", default-features = false, features = ["hybrid-array"] }
+bigint = { package = "crypto-bigint", version = "0.7.0-rc.10", default-features = false, features = ["hybrid-array"] }
 ff = { version = "=0.14.0-pre.0", default-features = false }
 subtle = { version = "2.6", default-features = false, features = ["const-generics"] }
 rand_core = { version = "0.10.0-rc-2", default-features = false }


### PR DESCRIPTION
This includes the `rand_core` v0.10-rc* upgrade