### PR TITLE
fix: correct curve equation sign in AffinePoint::is_on_curve

### DIFF
--- a/ed448-goldilocks/src/curve/twedwards/affine.rs
+++ b/ed448-goldilocks/src/curve/twedwards/affine.rs
@@ -35,7 +35,7 @@ impl AffinePoint {
         let xx = self.x.square();
         let yy = self.y.square();
 
-        (yy - xx).ct_eq(&(FieldElement::ONE + (FieldElement::TWISTED_D * xx * yy)))
+        (yy - xx).ct_eq(&(FieldElement::ONE - (FieldElement::TWISTED_D * xx * yy)))
     }
 
     // Negates an AffinePoint


### PR DESCRIPTION
Fix the sign in the twisted Edwards curve equation check. 
The formula was using addition instead of subtraction, which didn't match thedocumented curve equation y^2 - x^2 = 1 - d*x^2*y^2.

Changed FieldElement::ONE + to FieldElement::ONE - in the is_on_curve method to correctly validate points on the curve.