### PR TITLE
p521: remove unnecessary `allow(dead_code)` from `Scalar::from_hex_unchecked`

### DIFF
--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -122,7 +122,6 @@ impl Scalar {
     /// Does *not* perform a check that the field element does not overflow the order.
     ///
     /// This method is primarily intended for defining internal constants.
-    #[allow(dead_code)]
     pub(crate) const fn from_hex_unchecked(hex: &str) -> Self {
         Self::from_uint_unchecked(Uint::from_be_hex(hex))
     }


### PR DESCRIPTION
Remove #[allow(dead_code)] above from_hex_unchecked in p521/src/arithmetic/scalar.rs.
The function is referenced by PrimeField::ROOT_OF_UNITY (#[cfg(target_pointer_width = "32/64")]) and by hash2curve constants, ensuring it is used