### PR TITLE
sm2: avoid `Vec` reallocations in `decrypt` and `decrypt_der_digest`

### DIFF
--- a/sm2/src/pke/decrypting.rs
+++ b/sm2/src/pke/decrypting.rs
@@ -116,7 +116,7 @@ impl DecryptingKey {
             Mode::C1C3C2 => [prefix, &x, &y, cipher.digest, cipher.cipher].concat(),
         };
 
-        Ok(self.decrypt_digest::<D>(&cipher)?.to_vec())
+        self.decrypt_digest::<D>(&cipher)
     }
 }
 
@@ -212,5 +212,5 @@ fn decrypt(
     }
 
     // B7: output the plaintext 𝑀′.
-    Ok(c2.to_vec())
+    Ok(c2)
 }


### PR DESCRIPTION
This change removes two unnecessary Vec allocations and copies in the SM2 PKE decryption path. In decrypt_der_digest, the result from decrypt_digest already returns a Vec and was being cloned before returning; returning it directly avoids a full plaintext copy. In decrypt, the local buffer c2 was cloned with to_vec right before return; returning c2 directly preserves behavior while eliminating an allocation. These adjustments reduce overhead without altering functionality or public APIs.