### PR TITLE
chore: remove unnecessary Default bound on T in hash_to_field

### DIFF
--- a/hash2curve/src/hash2field.rs
+++ b/hash2curve/src/hash2field.rs
@@ -29,7 +29,7 @@ pub fn hash_to_field<const N: usize, E, K, T, L>(
 ) -> Result<[T; N], E::Error>
 where
     E: ExpandMsg<K>,
-    T: Reduce<Array<u8, L>> + Default,
+    T: Reduce<Array<u8, L>>,
     L: ArraySize + NonZero,
 {
     // Completely degenerate case; `N` and `L` would need to be extremely large.


### PR DESCRIPTION
Drop the T: Default bound from hash2curve/src/hash2field.rs::hash_to_field(), since T is only used via Reduce<Array<u8, L>> (T::reduce(&tmp)) and never instantiated with T::default(). The Reduce trait from elliptic_curve::ops does not require Default, and call sites rely solely on reduction from expanded message bytes. This change relaxes the generic constraints without altering behavior or API semantics. The Default bound in hash2curve/src/map2curve.rs is intentionally preserved because mapping implementations construct Array::<FieldElement, N>::default(), which requires FieldElement: Default.