### PR TITLE
Bump `elliptic-curve` dependency to v0.14.0-rc.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,8 +397,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.8"
-source = "git+https://github.com/RustCrypto/signatures#9fe087a8e90156e08cc8a1b68872f123fb2ee189"
+version = "0.17.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e914ecb8e11a02f42cc05f6b43675d1e5aa4d446cd207f9f818903a1ab34f19f"
 dependencies = [
  "der",
  "digest",
@@ -452,15 +453,14 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.16"
-source = "git+https://github.com/RustCrypto/traits#a8701a4463d78a5fbb3cc8bb7f2c6af37a5d4f69"
+version = "0.14.0-rc.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ecd2903524729de5d0cba7589121744513feadd56d71980cb480c48caceb11"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest",
- "ff",
  "getrandom",
- "group",
  "hex-literal",
  "hkdf",
  "hybrid-array",
@@ -468,6 +468,8 @@ dependencies = [
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.10.0-rc-2",
+ "rustcrypto-ff",
+ "rustcrypto-group",
  "sec1",
  "serdect",
  "subtle",
@@ -493,26 +495,11 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "ff"
 version = "0.14.0-pre.0"
-source = "git+https://github.com/tarcieri/ff?branch=rand_core%2Fv0.10.0-rc-2#80d58e19c3649824c009b3c77cd15f969bb58ca0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
 dependencies = [
- "bitvec",
- "ff_derive",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.9.3",
  "subtle",
-]
-
-[[package]]
-name = "ff_derive"
-version = "0.14.0-pre.0"
-source = "git+https://github.com/tarcieri/ff?branch=rand_core%2Fv0.10.0-rc-2#80d58e19c3649824c009b3c77cd15f969bb58ca0"
-dependencies = [
- "addchain",
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -543,16 +530,6 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi",
-]
-
-[[package]]
-name = "group"
-version = "0.14.0-pre.0"
-source = "git+https://github.com/tarcieri/group?branch=rand_core%2Fv0.10.0-rc-2#642bee5b41b93c11496ca667fd99eacb6eb4a147"
-dependencies = [
- "ff",
- "rand_core 0.10.0-rc-2",
- "subtle",
 ]
 
 [[package]]
@@ -910,8 +887,8 @@ name = "primefield"
 version = "0.14.0-rc.0"
 dependencies = [
  "crypto-bigint",
- "ff",
  "rand_core 0.10.0-rc-2",
+ "rustcrypto-ff",
  "subtle",
  "zeroize",
 ]
@@ -1103,6 +1080,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8e2323084c987a72875b2fd682b7307d5cf14d47e3875bb5e89948e8809d4"
 dependencies = [
  "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "rustcrypto-ff"
+version = "0.14.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9cd37111549306f79b09aa2618e15b1e8241b7178c286821e3dd71579db4db"
+dependencies = [
+ "bitvec",
+ "rand_core 0.10.0-rc-2",
+ "rustcrypto-ff_derive",
+ "subtle",
+]
+
+[[package]]
+name = "rustcrypto-ff_derive"
+version = "0.14.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2aef88cb4ddb3b1c83beff963f9197607dac780cc39a09f19c041dacbb0b6a5"
+dependencies = [
+ "addchain",
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rustcrypto-group"
+version = "0.14.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e394cd734b5f97dfc3484fa42aad7acd912961c2bcd96c99aa05b3d6cab7cafd"
+dependencies = [
+ "rand_core 0.10.0-rc-2",
+ "rustcrypto-ff",
  "subtle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,3 @@ ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
-
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
-ecdsa = { git = "https://github.com/RustCrypto/signatures" }
-ff = { git = "https://github.com/tarcieri/ff", branch = "rand_core/v0.10.0-rc-2" }
-group = { git = "https://github.com/tarcieri/group", branch = "rand_core/v0.10.0-rc-2" }

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.16", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.17", features = ["sec1"] }
 
 # optional dependencies
 belt-hash = { version = "0.2.0-rc.0", optional = true, default-features = false }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,10 +14,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.8", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.9", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14.0-rc.0", optional = true }
 primeorder = { version = "0.14.0-rc.0", optional = true }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,10 +14,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.8", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.9", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14.0-rc.0", optional = true }
 primeorder = { version = "0.14.0-rc.0", optional = true }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -16,7 +16,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.16", features = ["arithmetic", "pkcs8"] }
+elliptic-curve = { version = "0.14.0-rc.17", features = ["arithmetic", "pkcs8"] }
 hash2curve = "0.14.0-rc.3"
 rand_core = { version = "0.10.0-rc-2", default-features = false }
 sha3 = { version = "0.11.0-rc.3", default-features = false }

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = { version = "0.11.0-rc.4" }
-elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["arithmetic"] }
 ff = { version = "=0.14.0-pre.0", default-features = false }
 subtle = { version = "2.6", default-features = false }
 

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,11 +20,11 @@ rust-version = "1.85"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
 hash2curve = { version = "0.14.0-rc.3", optional = true }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primeorder = { version = "0.14.0-rc.0", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
@@ -33,7 +33,7 @@ signature = { version = "3.0.0-rc.5", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4.3"
 hex-literal = "1"
 num-bigint = "0.4"

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.0", optional = true }
 primeorder = { version = "0.14.0-rc.0", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.0", features = ["dev"] }
 

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,10 +17,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.0", optional = true }
 primeorder = { version = "0.14.0-rc.0", optional = true }
@@ -28,7 +28,7 @@ serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.0", features = ["dev"] }
 rand = "0.10.0-rc.1"

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,10 +18,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.3", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.0", optional = true }
@@ -31,7 +31,7 @@ sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primefield = { version = "0.14.0-rc.0" }
 primeorder = { version = "0.14.0-rc.0", features = ["dev"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,11 +18,11 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.3", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.0", optional = true }
@@ -32,7 +32,7 @@ sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.0", features = ["dev"] }
 proptest = "1.9"

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -18,10 +18,10 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "0.3"
-elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.3", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.0", optional = true }
@@ -32,7 +32,7 @@ sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.8", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.0", features = ["dev"] }
 proptest = "1.9"

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 bigint = { package = "crypto-bigint", version = "0.7.0-rc.10", default-features = false, features = ["hybrid-array"] }
-ff = { version = "=0.14.0-pre.0", default-features = false }
+ff = { version = "=0.14.0-pre.0", package = "rustcrypto-ff", default-features = false }
 subtle = { version = "2.6", default-features = false, features = ["const-generics"] }
 rand_core = { version = "0.10.0-rc-2", default-features = false }
 zeroize = { version = "1.7", default-features = false }

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true, default-features = false }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.16", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
 rand_core = { version = "0.10.0-rc-2", default-features = false }
 


### PR DESCRIPTION
This uses the `rustcrypto-ff` and `rustcrypto-group` crate releases

Also bumps `ecdsa` to v0.17.0-rc.9