### PR TITLE
x448: clamp StaticSecret on serde deserialization

### DIFF
--- a/x448/src/lib.rs
+++ b/x448/src/lib.rs
@@ -260,7 +260,7 @@ impl<'de> serdect::serde::Deserialize<'de> for StaticSecret {
     {
         let mut bytes = Array::default();
         serdect::array::deserialize_hex_or_bin(&mut bytes, d)?;
-        Ok(Self(bytes))
+        Ok(StaticSecret::new(bytes))
     }
 }
 


### PR DESCRIPTION
Ensure StaticSecret constructed via serde Deserialize is clamped according to RFC7748 by creating it through StaticSecret::new(bytes). Previously the Deserialize impl returned Self(bytes), bypassing clamp() and breaking the scalar invariant only when both static_secrets and serde features were enabled. This change aligns serde behavior with other constructors (From<[u8;56]>, random_from_rng) and with the repository-wide pattern of enforcing invariants during deserialization, preventing malformed or non-standard secrets and preserving interoperability.