### PR TITLE
Cut v0.14.0-rc.1 releases

### DIFF
--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bignp256"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 description = """
 Pure Rust implementation of the Bign P-256 (a.k.a. bign-curve256v1)
 elliptic curve as defined in STB 34.101.45-2013, with
@@ -30,15 +30,15 @@ hmac = { version = "0.13.0-rc.3", optional = true }
 rand_core = "0.10.0-rc-2"
 rfc6979 = { version = "0.5.0-rc.3", optional = true }
 pkcs8 = { version = "0.11.0-rc.8", optional = true }
-primefield = { version = "0.14.0-rc.0", optional = true }
-primeorder = { version = "0.14.0-rc.0", optional = true }
+primefield = { version = "0.14.0-rc.1", optional = true }
+primeorder = { version = "0.14.0-rc.1", optional = true }
 sec1 = { version = "0.8.0-rc.10", optional = true }
 signature = { version = "3.0.0-rc.5", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.0", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
 proptest = "1"
 rand = "0.10.0-rc.1"
 hex = { version = "0.4" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp256"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 description = "Brainpool P-256 (brainpoolP256r1 and brainpoolP256t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -18,8 +18,8 @@ elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features 
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.9", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "0.14.0-rc.0", optional = true }
-primeorder = { version = "0.14.0-rc.0", optional = true }
+primefield = { version = "0.14.0-rc.1", optional = true }
+primeorder = { version = "0.14.0-rc.1", optional = true }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [features]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp384"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -18,8 +18,8 @@ elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features 
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.9", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "0.14.0-rc.0", optional = true }
-primeorder = { version = "0.14.0-rc.0", optional = true }
+primefield = { version = "0.14.0-rc.1", optional = true }
+primeorder = { version = "0.14.0-rc.1", optional = true }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [features]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification/public-key recovery, Taproot Schnorr signatures (BIP340),
@@ -26,7 +26,7 @@ hash2curve = { version = "0.14.0-rc.4", optional = true }
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primeorder = { version = "0.14.0-rc.0", optional = true }
+primeorder = { version = "0.14.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 signature = { version = "3.0.0-rc.5", optional = true }

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p192"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 description = """
 Pure Rust implementation of the NIST P-192 (a.k.a. secp192r1) elliptic curve
 as defined in SP 800-186
@@ -22,14 +22,14 @@ elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.0", optional = true }
-primeorder = { version = "0.14.0-rc.0", optional = true }
+primefield = { version = "0.14.0-rc.1", optional = true }
+primeorder = { version = "0.14.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
 ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.0", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p224"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 description = """
 Pure Rust implementation of the NIST P-224 (a.k.a. secp224r1) elliptic curve
 as defined in SP 800-186
@@ -22,15 +22,15 @@ elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.0", optional = true }
-primeorder = { version = "0.14.0-rc.0", optional = true }
+primefield = { version = "0.14.0-rc.1", optional = true }
+primeorder = { version = "0.14.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.0", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
 rand = "0.10.0-rc.1"
 
 [features]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve as defined in SP 800-186, with support for ECDH, ECDSA
@@ -24,8 +24,8 @@ elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features 
 ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.4", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.0", optional = true }
-primeorder = { version = "0.14.0-rc.0", optional = true }
+primefield = { version = "0.14.0-rc.1", optional = true }
+primeorder = { version = "0.14.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
@@ -33,8 +33,8 @@ sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 criterion = "0.7"
 ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primefield = { version = "0.14.0-rc.0" }
-primeorder = { version = "0.14.0-rc.0", features = ["dev"] }
+primefield = { version = "0.14.0-rc.1" }
+primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
 proptest = "1"
 rand = "0.10.0-rc.1"
 

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p384"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 description = """
 Pure Rust implementation of the NIST P-384 (a.k.a. secp384r1) elliptic curve
 as defined in SP 800-186 with support for ECDH, ECDSA signing/verification,
@@ -25,8 +25,8 @@ fiat-crypto = { version = "0.3", default-features = false }
 ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.4", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.0", optional = true }
-primeorder = { version = "0.14.0-rc.0", optional = true }
+primefield = { version = "0.14.0-rc.1", optional = true }
+primeorder = { version = "0.14.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
@@ -34,7 +34,7 @@ sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 criterion = "0.7"
 ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.0", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
 proptest = "1.9"
 rand = "0.10.0-rc.1"
 

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p521"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 description = """
 Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve
 as defined in SP 800-186
@@ -24,8 +24,8 @@ elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features 
 ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.4", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.0", optional = true }
-primeorder = { version = "0.14.0-rc.0", optional = true }
+primefield = { version = "0.14.0-rc.1", optional = true }
+primeorder = { version = "0.14.0-rc.1", optional = true }
 rand_core = { version = "0.10.0-rc-2", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
@@ -34,7 +34,7 @@ sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 criterion = "0.7"
 ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.0", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
 proptest = "1.9"
 rand = "0.10.0-rc.1"
 

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primefield"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 description = "Macros for generating prime field implementations"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm2"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 description = """
 Pure Rust implementation of the SM2 elliptic curve as defined in the Chinese
 national standard GM/T 0003-2012 as well as ISO/IEC 14888. Includes support for
@@ -23,8 +23,8 @@ fiat-crypto = { version = "0.3", default-features = false }
 rand_core = { version = "0.10.0-rc-2", default-features = false }
 
 # optional dependencies
-primefield = { version = "0.14.0-rc.0", optional = true }
-primeorder = { version = "0.14.0-rc.0", optional = true }
+primefield = { version = "0.14.0-rc.1", optional = true }
+primeorder = { version = "0.14.0-rc.1", optional = true }
 rfc6979 = { version = "0.5.0-rc.3", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 signature = { version = "3.0.0-rc.5", optional = true, features = ["rand_core"] }


### PR DESCRIPTION
Cuts releases of the following with an rc.1 version number:
- `bignp256`
- `bp256`
- `bp384`
- `k256`
- `p192`
- `p224`
- `p256`
- `p384`
- `p521`
- `primefield`
- `primeorder`
- `sm2`