### PR TITLE
fix: Use CurveWithScalar::to_repr in serde for Scalar and read full ReprSize

### DIFF
--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -430,7 +430,8 @@ impl<C: CurveWithScalar> serdect::serde::Serialize for Scalar<C> {
     where
         S: serdect::serde::Serializer,
     {
-        serdect::slice::serialize_hex_lower_or_bin(&self.to_bytes(), s)
+        let repr = C::to_repr(self);
+        serdect::slice::serialize_hex_lower_or_bin(repr.as_slice(), s)
     }
 }
 
@@ -441,7 +442,7 @@ impl<'de, C: CurveWithScalar> serdect::serde::Deserialize<'de> for Scalar<C> {
         D: serdect::serde::Deserializer<'de>,
     {
         let mut buffer = ScalarBytes::<C>::default();
-        serdect::array::deserialize_hex_or_bin(&mut buffer[..56], d)?;
+        serdect::array::deserialize_hex_or_bin(&mut buffer[..], d)?;
         Option::from(Self::from_canonical_bytes(&buffer)).ok_or(serdect::serde::de::Error::custom(
             "scalar was not canonically encoded",
         ))


### PR DESCRIPTION
Switch Scalar serde to use the curve-specific canonical representation by serializing C::to_repr(self) and deserializing into the full ScalarBytes buffer instead of a hardcoded 56-byte slice. This aligns serde with PrimeField::to_repr, LowerHex/UpperHex, and Vec conversions, and fixes the Ed448 case where the canonical representation is 57 bytes per RFC 8032. The Edwards serde_bare test is adjusted to expect 58 bytes due to the 57-byte payload plus the slice length prefix, while Decaf remains unchanged.