### PR TITLE
p521: fix sqn(0) off-by-one

### DIFF
--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -256,13 +256,7 @@ impl FieldElement {
 
     /// Returns self^(2^n) mod p
     const fn sqn(&self, n: usize) -> Self {
-        let mut x = self.square();
-        let mut i = 1;
-        while i < n {
-            x = x.square();
-            i += 1;
-        }
-        x
+        self.sqn_vartime(n)
     }
 
     /// Returns `self^exp`, where `exp` is a little-endian integer exponent.
@@ -715,5 +709,13 @@ mod tests {
         );
         let ct_option = FieldElement::from_bytes(&overflowing_bytes.into());
         assert!(bool::from(ct_option.is_none()));
+    }
+
+    #[test]
+    fn sqn_edge_cases() {
+        let a = FieldElement::from_u64(5);
+        assert_eq!(a.sqn(0), a);
+        assert_eq!(a.sqn(1), a.square());
+        assert_eq!(a.sqn(2), a.square().square());
     }
 }


### PR DESCRIPTION
fixed an off-by-one edge case in FieldElement::sqn() in p521/src/arithmetic/field.rs which incorrectly returned self.square() for n=0 despite the function’s contract promising self^(2^n). The fix delegates to the already-correct sqn_vartime(n), ensuring sqn(0) returns self, matching both the documented semantics and the implementation pattern used by p256. Although current call sites never pass n=0, correcting this now prevents future misuse and improves internal consistency. A unit test sqn_edge_cases is added to verify n=0/1/2 behavior.