### PR TITLE
chore(k256): replace single-iteration loop with direct assignment in isogeny

### DIFF
--- a/k256/src/arithmetic/hash2curve.rs
+++ b/k256/src/arithmetic/hash2curve.rs
@@ -257,9 +257,7 @@ fn isogeny(x: FieldElement, y: FieldElement) -> (FieldElement, FieldElement) {
     xs[0] = FieldElement::ONE;
     xs[1] = x;
     xs[2] = x.square();
-    for i in 3..4 {
-        xs[i] = xs[i - 1] * x;
-    }
+    xs[3] = xs[2] * x;
     let x_num = compute_iso(&xs, &XNUM);
     let x_den = compute_iso(&xs, &XDEN).invert().unwrap();
     let y_num = compute_iso(&xs, &YNUM) * y;


### PR DESCRIPTION
Simplify the computation of xs[3] in isogeny() by replacing a one-iteration loop with xs[3] = xs[2] * x. This clarifies intent, avoids constructing a Range for a single step, and keeps the faster square() for x^2. No functional impact; tests should behave identically.