### PR TITLE
p384: add `cfg(p384_backend = "bignum")`

### DIFF
--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -100,6 +100,10 @@ jobs:
       - run: cargo test --release --target ${{ matrix.target }} --no-default-features
       - run: cargo test --release --target ${{ matrix.target }}
       - run: cargo test --release --target ${{ matrix.target }} --all-features
+      - env:
+          RUSTFLAGS: '--cfg p384_backend="bignum"'
+          RUSTDOCFLAGS: '--cfg p384_backend="bignum"'
+        run: cargo test --release --target ${{ matrix.target }} --all-features
 
   cross:
     strategy:

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -19,7 +19,6 @@ rust-version = "1.85"
 
 [dependencies]
 elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
-fiat-crypto = { version = "0.3", default-features = false }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
@@ -29,6 +28,9 @@ primefield = { version = "0.14.0-rc.1", optional = true }
 primeorder = { version = "0.14.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
+
+[target.'cfg(not(p384_backend = "bignum"))'.dependencies]
+fiat-crypto = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
@@ -75,3 +77,7 @@ required-features = ["expose-field"]
 [[bench]]
 name = "scalar"
 harness = false
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(p384_backend, values("bignum", "fiat"))'] # default: "fiat"

--- a/p384/benches/field.rs
+++ b/p384/benches/field.rs
@@ -1,5 +1,6 @@
 //! secp384r1 field element benchmarks
 
+use core::hint::black_box;
 use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
@@ -7,10 +8,10 @@ use hex_literal::hex;
 use p384::{FieldElement, elliptic_curve::ff::Field};
 
 fn test_field_element_x() -> FieldElement {
-    FieldElement::from_bytes(
+    black_box(FieldElement::from_bytes(
         &hex!("c2b47944fb5de342d03285880177ca5f7d0f2fcad7678cce4229d6e1932fcac11bfc3c3e97d942a3c56bf34123013dbf").into()
     )
-    .unwrap()
+    .unwrap())
 }
 
 fn test_field_element_y() -> FieldElement {

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -10,9 +10,10 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
-#[cfg(target_pointer_width = "32")]
+// Default backend: fiat-crypto
+#[cfg(all(not(p384_backend = "bignum"), target_pointer_width = "32"))]
 use fiat_crypto::p384_32::*;
-#[cfg(target_pointer_width = "64")]
+#[cfg(all(not(p384_backend = "bignum"), target_pointer_width = "64"))]
 use fiat_crypto::p384_64::*;
 
 use elliptic_curve::{
@@ -41,6 +42,14 @@ primefield::monty_field_element! {
     doc: "Element in the finite field modulo `p = 2^{384} − 2^{128} − 2^{96} + 2^{32} − 1`."
 }
 
+#[cfg(p384_backend = "bignum")]
+primefield::monty_field_arithmetic! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U384
+}
+
+#[cfg(not(p384_backend = "bignum"))]
 primefield::monty_field_fiat_arithmetic! {
     name: FieldElement,
     params: FieldParams,

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -10,9 +10,9 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(not(p384_backend = "bignum"), target_pointer_width = "32"))]
 use fiat_crypto::p384_scalar_32::*;
-#[cfg(target_pointer_width = "64")]
+#[cfg(all(not(p384_backend = "bignum"), target_pointer_width = "64"))]
 use fiat_crypto::p384_scalar_64::*;
 
 use crate::{FieldBytes, NistP384, ORDER_HEX, U384};
@@ -50,6 +50,14 @@ primefield::monty_field_element! {
     doc: "Element in the NIST P-384 scalar field modulo `n`."
 }
 
+#[cfg(p384_backend = "bignum")]
+primefield::monty_field_arithmetic! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U384
+}
+
+#[cfg(not(p384_backend = "bignum"))]
 primefield::monty_field_fiat_arithmetic! {
     name: Scalar,
     params: ScalarParams,

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -8,6 +8,32 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc = include_str!("../README.md")]
 
+//! ## Backends
+//!
+//! This crate has support for two different field arithmetic backends which can be selected using
+//! `cfg(p384_backend)`, e.g. to select the `bignum` backend:
+//!
+//! ```console
+//! $ RUSTFLAGS='--cfg p384_backend="bignum"' cargo test
+//! ```
+//!
+//! Or it can be set through [`.cargo/config`][buildrustflags]:
+//!
+//! ```toml
+//! [build]
+//! rustflags = ['--cfg', 'p384_backend="bignum"']
+//! ```
+//!
+//! The available backends are:
+//! - `bignum`: experimental backend provided by [crypto-bigint]. May offer better performance in
+//!   some cases along with smaller code size, but might also have bugs.
+//! - `fiat` (default): formally verified implementation synthesized by [fiat-crypto] which should
+//!   be correct for all inputs (though there's a possibility of bugs in the code which glues to it)
+//!
+//! [buildrustflags]: https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags
+//! [crypto-bigint]: https://github.com/RustCrypto/crypto-bigint
+//! [fiat-crypto]: https://github.com/mit-plv/fiat-crypto
+//!
 //! ## `serde` support
 //!
 //! When the `serde` feature of this crate is enabled, `Serialize` and


### PR DESCRIPTION
Adds support for an experimental backend which uses `crypto-bigint` as the field element representation, as an off-by-default alternative to `fiat-crypto`.

This uses the `monty_field_arithmetic!` macro introduced in #1547 which in turn builds on the `MontyFieldElement` type introduced in #1311, which builds on `crypto-bigint`'s `ConstMontyForm` type, which implements Montgomery form modular arithmetic.