### PR TITLE
k256: use `crypto-bigint` to implement field inversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,7 @@ dependencies = [
  "hex-literal",
  "num-bigint 0.4.6",
  "num-traits",
+ "primefield",
  "primeorder",
  "proptest",
  "rand 0.10.0-rc.5",

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -26,6 +26,7 @@ hash2curve = { version = "0.14.0-rc.4", optional = true }
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
+primefield = { version = "0.14.0-rc.1", optional = true }
 primeorder = { version = "0.14.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
@@ -47,14 +48,14 @@ default = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "schnorr", "std
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std", "getrandom"]
 
-arithmetic = ["elliptic-curve/arithmetic"]
+arithmetic = ["elliptic-curve/arithmetic", "dep:primefield"]
 bits = ["arithmetic", "elliptic-curve/bits"]
 critical-section = ["elliptic-curve/critical-section", "precomputed-tables"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm", "sha256"]
 expose-field = ["arithmetic"]
-hash2curve = ["arithmetic", "dep:hash2curve", "dep:primeorder", "primeorder/hash2curve"]
+hash2curve = ["arithmetic", "primeorder/hash2curve", "dep:hash2curve", "dep:primeorder"]
 group-digest = ["hash2curve", "sha2"]
 getrandom = ["ecdsa-core?/getrandom", "elliptic-curve/getrandom"]
 pem = ["ecdsa-core/pem", "elliptic-curve/pem", "pkcs8"]


### PR DESCRIPTION
Leverages the safegcd-bounds implementation from `crypto-bigint`. This adds a hard dependency on `primefield` in order to use `primefield::monty_field_params!` and `MontyFieldElement`.

Inversions are implemented by first converting from `FieldElement` to its canonical representative (i.e. big endian byte serialization), then parsing those bytes as a `MontyFieldElement`, which converts to a saturated Montgomery form representation. Once the inversion is complete, it uses a similar process to convert back.

Despite the circuitous conversions, safegcd-bounds is so fast it's still a fairly significant win, doubling performance:

    field element operations/invert
                        time:   [2.5839 µs 2.5915 µs 2.5993 µs]
                        change: [−51.091% −50.749% −50.449%] (p = 0.00 < 0.05)

See also: #1549 a similar change to `p256`