### PR TITLE
CI: bump `cargo-audit` to v0.22.0

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-audit-v0.20.1
+          key: ${{ runner.os }}-cargo-audit-v0.22.0
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is the minimum version supported by the current database.