### PR TITLE
k256: use `crypto-bigint` to implement field inversions

### DIFF
--- a/k256/src/arithmetic/field/field_impl.rs
+++ b/k256/src/arithmetic/field/field_impl.rs
@@ -4,6 +4,7 @@
 
 use crate::FieldBytes;
 use elliptic_curve::{
+    bigint::U256,
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::Zeroize,
 };
@@ -75,9 +76,23 @@ impl FieldElementImpl {
         CtOption::map(value, |x| Self::new_normalized(&x))
     }
 
+    pub const fn from_u256_unchecked(value: U256) -> Self {
+        Self {
+            value: FieldElementUnsafeImpl::from_u256_unchecked(value),
+            magnitude: 1,
+            normalized: true,
+        }
+    }
+
     pub fn to_bytes(self) -> FieldBytes {
         debug_assert!(self.normalized);
         self.value.to_bytes()
+    }
+
+    #[inline]
+    pub const fn to_u256(self) -> U256 {
+        debug_assert!(self.normalized);
+        self.value.to_u256()
     }
 
     pub fn normalize_weak(&self) -> Self {


### PR DESCRIPTION
Leverages the safegcd-bounds implementation from `crypto-bigint`, using the `U256` conversions introduced in #1552, and then invoking `invert_odd_mod` on the resulting value.

Also adds `FieldElement::invert_vartime` which can leverage the variable-time inversion implementation via `invert_odd_mod_vartime`.

Improves performance by ~2X:

    field element operations/invert
                        time:   [2.3716 µs 2.3946 µs 2.4311 µs]
                        change: [−52.351% −50.978% −48.923%] (p = 0.00 < 0.05)
                        Performance has improved.