### PR TITLE
Bump `crypto-bigint` to v0.7.0-rc.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
  "primeorder",
  "proptest",
  "rand 0.10.0-rc.5",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "rfc6979",
  "sec1",
  "signature",
@@ -182,14 +182,14 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.5"
+version = "0.10.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cbf41c6ec3c4b9eaf7f8f5c11a72cd7d3aa0428125c20d5ef4d09907a0f019"
+checksum = "f895fb33c1ad22da4bc79d37c0bddff8aee2ba4575705345eb73b8ffbc386074"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -254,6 +254,12 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "cmov"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11ed919bd3bae4af5ab56372b627dfc32622aba6cec36906e8ab46746037c9d"
 
 [[package]]
 name = "const-oid"
@@ -351,24 +357,34 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6715836b4946e8585016e80b79c7561476aff3b22f7b756778e7b109d86086c6"
+version = "0.7.0-rc.12"
+source = "git+https://github.com/RustCrypto/crypto-bigint#f8f09a143353de02dc97223e449620dc2d7879c9"
 dependencies = [
+ "ctutils",
  "hybrid-array",
  "num-traits",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
+checksum = "e6165b8029cdc3e765b74d3548f85999ee799d5124877ce45c2c85ca78e4d4aa"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0d4ebbcf0ee8b260dd060b79b7449973fffccdbaa5c871c9867c7b44445e75"
+dependencies = [
+ "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -384,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
+checksum = "ebf9423bafb058e4142194330c52273c343f8a5beb7176d052f0e73b17dd35b9"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -436,7 +452,7 @@ dependencies = [
  "hex-literal",
  "proptest",
  "rand 0.10.0-rc.5",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "serde_bare",
  "serde_json",
  "serdect",
@@ -454,20 +470,19 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ecd2903524729de5d0cba7589121744513feadd56d71980cb480c48caceb11"
+source = "git+https://github.com/RustCrypto/traits#96a144dc17c39d58cf31c36d1857e0185425842a"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest",
- "getrandom",
+ "getrandom 0.4.0-rc.0",
  "hex-literal",
  "hkdf",
  "hybrid-array",
  "once_cell",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "rustcrypto-ff",
  "rustcrypto-group",
  "sec1",
@@ -519,6 +534,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b99f0d993a2b9b97b9a201193aa8ad21305cde06a3be9a7e1f8f4201e5cc27e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.0-rc-3",
  "wasip2",
 ]
 
@@ -798,7 +826,7 @@ dependencies = [
  "primeorder",
  "proptest",
  "rand 0.10.0-rc.5",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "serdect",
  "sha2",
 ]
@@ -870,7 +898,7 @@ name = "primefield"
 version = "0.14.0-rc.1"
 dependencies = [
  "crypto-bigint",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "rustcrypto-ff",
  "subtle",
  "zeroize",
@@ -965,12 +993,11 @@ dependencies = [
 [[package]]
 name = "rand"
 version = "0.10.0-rc.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be866deebbade98028b705499827ad6967c8bb1e21f96a2609913c8c076e9307"
+source = "git+https://github.com/rust-random/rand#ff07ec205347dd749a586aaee7218cb21590ea4c"
 dependencies = [
  "chacha20",
- "getrandom",
- "rand_core 0.10.0-rc-2",
+ "getrandom 0.4.0-rc.0",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -989,14 +1016,14 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-2"
+version = "0.10.0-rc-3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a23e4e8b77312a823b6b5613edbac78397e2f34320bc7ac4277013ec4478e"
+checksum = "f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05"
 
 [[package]]
 name = "rand_xorshift"
@@ -1073,7 +1100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9cd37111549306f79b09aa2618e15b1e8241b7178c286821e3dd71579db4db"
 dependencies = [
  "bitvec",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "rustcrypto-ff_derive",
  "subtle",
 ]
@@ -1099,7 +1126,7 @@ version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e394cd734b5f97dfc3484fa42aad7acd912961c2bcd96c99aa05b3d6cab7cafd"
 dependencies = [
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "rustcrypto-ff",
  "subtle",
 ]
@@ -1259,12 +1286,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.5"
+version = "3.0.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0251c9d6468f4ba853b6352b190fb7c1e405087779917c238445eb03993826"
+checksum = "597a96996ccff7dfa16f052bd995b4cecc72af22c35138738dc029f0ead6608d"
 dependencies = [
  "digest",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -1279,7 +1306,7 @@ dependencies = [
  "primeorder",
  "proptest",
  "rand 0.10.0-rc.5",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "rfc6979",
  "serdect",
  "signature",
@@ -1346,7 +1373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1514,7 +1541,7 @@ version = "0.14.0-pre.1"
 dependencies = [
  "ed448-goldilocks",
  "rand 0.10.0-rc.5",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "serdect",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,7 @@ ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
+
+crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint" }
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
+rand = { git = "https://github.com/rust-random/rand" }

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -27,13 +27,13 @@ digest = { version = "0.11.0-rc.4", optional = true }
 hex-literal = { version = "1", optional = true }
 hkdf = { version = "0.13.0-rc.3", optional = true }
 hmac = { version = "0.13.0-rc.3", optional = true }
-rand_core = "0.10.0-rc-2"
+rand_core = "0.10.0-rc-3"
 rfc6979 = { version = "0.5.0-rc.3", optional = true }
 pkcs8 = { version = "0.11.0-rc.8", optional = true }
 primefield = { version = "0.14.0-rc.1", optional = true }
 primeorder = { version = "0.14.0-rc.1", optional = true }
 sec1 = { version = "0.8.0-rc.10", optional = true }
-signature = { version = "3.0.0-rc.5", optional = true }
+signature = { version = "3.0.0-rc.6", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"

--- a/bignp256/src/ecdsa.rs
+++ b/bignp256/src/ecdsa.rs
@@ -7,14 +7,14 @@
 #![cfg_attr(feature = "std", doc = "```")]
 #![cfg_attr(not(feature = "std"), doc = "```ignore")]
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! use rand::{rngs::OsRng, TryRngCore};
+//! use rand::{rngs::SysRng, TryRngCore};
 //! use bignp256::{
 //!     ecdsa::{Signature, SigningKey, signature::Signer},
 //!     SecretKey
 //! };
 //!
 //! // Signing
-//! let secret_key = SecretKey::try_from_rng(&mut OsRng).unwrap(); // serialize with `::to_bytes()`
+//! let secret_key = SecretKey::try_from_rng(&mut SysRng).unwrap(); // serialize with `::to_bytes()`
 //! let signing_key = SigningKey::new(&secret_key)?;
 //! let verifying_key_bytes = signing_key.verifying_key().to_bytes();
 //! let message = b"test message";

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -18,22 +18,22 @@ This crate also includes signing and verifying of Ed448 signatures.
 [dependencies]
 elliptic-curve = { version = "0.14.0-rc.17", features = ["arithmetic", "pkcs8"] }
 hash2curve = "0.14.0-rc.4"
-rand_core = { version = "0.10.0-rc-2", default-features = false }
+rand_core = { version = "0.10.0-rc-3", default-features = false }
 sha3 = { version = "0.11.0-rc.3", default-features = false }
 subtle = { version = "2.6", default-features = false }
 
 # optional dependencies
 ed448 = { version = "0.5.0-rc.2", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true }
-signature = { version = "3.0.0-rc.5", optional = true, default-features = false, features = ["digest", "rand_core"] }
+signature = { version = "3.0.0-rc.6", optional = true, default-features = false, features = ["digest", "rand_core"] }
 
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false, features = ["cargo_bench_support"] }
 hex-literal = "1"
 hex = "0.4"
 proptest = { version = "1", features = ["attr-macro"] }
-rand = "0.10.0-rc.1"
-chacha20 = "0.10.0-rc.3"
+rand = "0.10.0-rc.5"
+chacha20 = "0.10.0-rc.6"
 serde_bare = "0.5"
 serde_json = "1.0"
 

--- a/ed448-goldilocks/README.md
+++ b/ed448-goldilocks/README.md
@@ -20,14 +20,14 @@ It is intended to be portable, fast, and safe.
 use ed448_goldilocks::{Ed448, EdwardsPoint, CompressedEdwardsY, EdwardsScalar, sha3::Shake256};
 use elliptic_curve::{consts::U84, Field, group::GroupEncoding};
 use hash2curve::{ExpandMsgXof, GroupDigest};
-use rand::rngs::OsRng;
+use rand::rngs::SysRng;
 
 let secret_key = EdwardsScalar::TWO;
 let public_key = EdwardsPoint::GENERATOR * &secret_key;
 
 assert_eq!(public_key, EdwardsPoint::GENERATOR + EdwardsPoint::GENERATOR);
 
-let secret_key = EdwardsScalar::try_from_rng(&mut OsRng).unwrap();
+let secret_key = EdwardsScalar::try_from_rng(&mut SysRng).unwrap();
 let public_key = EdwardsPoint::GENERATOR * &secret_key;
 let compressed_public_key = public_key.to_bytes();
 

--- a/ed448-goldilocks/benches/bench.rs
+++ b/ed448-goldilocks/benches/bench.rs
@@ -5,7 +5,7 @@ use ed448_goldilocks::{
 use elliptic_curve::group::GroupEncoding;
 use elliptic_curve::{Field, Group};
 use hash2curve::GroupDigest;
-use rand::{TryRngCore, rngs::OsRng};
+use rand::{TryRngCore, rngs::SysRng};
 
 pub fn ed448(c: &mut Criterion) {
     let mut group = c.benchmark_group("Ed448");
@@ -13,8 +13,8 @@ pub fn ed448(c: &mut Criterion) {
     group.bench_function("scalar multiplication", |b| {
         b.iter_batched(
             || {
-                let point = EdwardsPoint::try_from_rng(&mut OsRng).unwrap();
-                let scalar = EdwardsScalar::try_from_rng(&mut OsRng).unwrap();
+                let point = EdwardsPoint::try_from_rng(&mut SysRng).unwrap();
+                let scalar = EdwardsScalar::try_from_rng(&mut SysRng).unwrap();
                 (point, scalar)
             },
             |(point, scalar)| point * scalar,
@@ -25,8 +25,8 @@ pub fn ed448(c: &mut Criterion) {
     group.bench_function("point addition", |b| {
         b.iter_batched(
             || {
-                let p1 = EdwardsPoint::try_from_rng(&mut OsRng).unwrap();
-                let p2 = EdwardsPoint::try_from_rng(&mut OsRng).unwrap();
+                let p1 = EdwardsPoint::try_from_rng(&mut SysRng).unwrap();
+                let p2 = EdwardsPoint::try_from_rng(&mut SysRng).unwrap();
                 (p1, p2)
             },
             |(p1, p2)| p1 + p2,
@@ -38,7 +38,7 @@ pub fn ed448(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let mut msg = [0; 64];
-                OsRng.try_fill_bytes(&mut msg).unwrap();
+                SysRng.try_fill_bytes(&mut msg).unwrap();
                 msg
             },
             |msg| Ed448::encode_from_bytes(&msg, b"test DST"),
@@ -48,7 +48,7 @@ pub fn ed448(c: &mut Criterion) {
 
     group.bench_function("compress", |b| {
         b.iter_batched(
-            || EdwardsPoint::try_from_rng(&mut OsRng).unwrap(),
+            || EdwardsPoint::try_from_rng(&mut SysRng).unwrap(),
             |point| point.to_bytes(),
             BatchSize::SmallInput,
         )
@@ -56,7 +56,7 @@ pub fn ed448(c: &mut Criterion) {
 
     group.bench_function("decompress", |b| {
         b.iter_batched(
-            || EdwardsPoint::try_from_rng(&mut OsRng).unwrap().to_bytes(),
+            || EdwardsPoint::try_from_rng(&mut SysRng).unwrap().to_bytes(),
             |bytes| EdwardsPoint::from_bytes(&bytes).unwrap(),
             BatchSize::SmallInput,
         )
@@ -71,8 +71,8 @@ pub fn decaf448(c: &mut Criterion) {
     group.bench_function("scalar multiplication", |b| {
         b.iter_batched(
             || {
-                let point = DecafPoint::try_from_rng(&mut OsRng).unwrap();
-                let scalar = DecafScalar::try_from_rng(&mut OsRng).unwrap();
+                let point = DecafPoint::try_from_rng(&mut SysRng).unwrap();
+                let scalar = DecafScalar::try_from_rng(&mut SysRng).unwrap();
                 (point, scalar)
             },
             |(point, scalar)| point * scalar,
@@ -83,8 +83,8 @@ pub fn decaf448(c: &mut Criterion) {
     group.bench_function("point addition", |b| {
         b.iter_batched(
             || {
-                let p1 = DecafPoint::try_from_rng(&mut OsRng).unwrap();
-                let p2 = DecafPoint::try_from_rng(&mut OsRng).unwrap();
+                let p1 = DecafPoint::try_from_rng(&mut SysRng).unwrap();
+                let p2 = DecafPoint::try_from_rng(&mut SysRng).unwrap();
                 (p1, p2)
             },
             |(p1, p2)| p1 + p2,
@@ -96,7 +96,7 @@ pub fn decaf448(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let mut msg = [0; 64];
-                OsRng.try_fill_bytes(&mut msg).unwrap();
+                SysRng.try_fill_bytes(&mut msg).unwrap();
                 msg
             },
             |msg| Decaf448::encode_from_bytes(&msg, b"test DST"),
@@ -106,7 +106,7 @@ pub fn decaf448(c: &mut Criterion) {
 
     group.bench_function("encode", |b| {
         b.iter_batched(
-            || DecafPoint::try_from_rng(&mut OsRng).unwrap(),
+            || DecafPoint::try_from_rng(&mut SysRng).unwrap(),
             |point| point.to_bytes(),
             BatchSize::SmallInput,
         )
@@ -114,7 +114,7 @@ pub fn decaf448(c: &mut Criterion) {
 
     group.bench_function("decode", |b| {
         b.iter_batched(
-            || DecafPoint::try_from_rng(&mut OsRng).unwrap().to_bytes(),
+            || DecafPoint::try_from_rng(&mut SysRng).unwrap().to_bytes(),
             |bytes| DecafPoint::from_bytes(&bytes).unwrap(),
             BatchSize::SmallInput,
         )
@@ -130,8 +130,8 @@ pub fn x448(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let mut point = MontgomeryPoint::default();
-                OsRng.try_fill_bytes(&mut point.0).unwrap();
-                let scalar = EdwardsScalar::try_from_rng(&mut OsRng).unwrap();
+                SysRng.try_fill_bytes(&mut point.0).unwrap();
+                let scalar = EdwardsScalar::try_from_rng(&mut SysRng).unwrap();
                 (point, scalar)
             },
             |(point, scalar)| &point * &scalar,

--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -785,7 +785,7 @@ mod tests {
     use elliptic_curve::Field;
     use hex_literal::hex;
     use proptest::{prop_assert_eq, property_test};
-    use rand::{TryRngCore, rngs::OsRng};
+    use rand::{TryRngCore, rngs::SysRng};
 
     fn hex_to_field(hex: &'static str) -> FieldElement {
         assert_eq!(hex.len(), 56 * 2);
@@ -966,7 +966,7 @@ mod tests {
     fn hash_fuzzing() {
         for _ in 0..25 {
             let mut msg = [0u8; 64];
-            OsRng.try_fill_bytes(&mut msg).unwrap();
+            SysRng.try_fill_bytes(&mut msg).unwrap();
             let p = Ed448::hash_from_bytes(&msg, b"test DST").unwrap();
             assert_eq!(p.is_on_curve().unwrap_u8(), 1u8);
             assert_eq!(p.is_torsion_free().unwrap_u8(), 1u8);
@@ -1089,8 +1089,8 @@ mod tests {
     #[test]
     fn batch_normalize() {
         let points: [EdwardsPoint; 2] = [
-            EdwardsPoint::try_from_rng(&mut OsRng).unwrap(),
-            EdwardsPoint::try_from_rng(&mut OsRng).unwrap(),
+            EdwardsPoint::try_from_rng(&mut SysRng).unwrap(),
+            EdwardsPoint::try_from_rng(&mut SysRng).unwrap(),
         ];
 
         let affine_points = <EdwardsPoint as BatchNormalize<_>>::batch_normalize(&points);
@@ -1104,8 +1104,8 @@ mod tests {
     #[cfg(feature = "alloc")]
     fn batch_normalize_alloc() {
         let points = alloc::vec![
-            EdwardsPoint::try_from_rng(&mut OsRng).unwrap(),
-            EdwardsPoint::try_from_rng(&mut OsRng).unwrap(),
+            EdwardsPoint::try_from_rng(&mut SysRng).unwrap(),
+            EdwardsPoint::try_from_rng(&mut SysRng).unwrap(),
         ];
 
         let affine_points = <EdwardsPoint as BatchNormalize<_>>::batch_normalize(points.as_slice());

--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -306,16 +306,16 @@ impl FieldElement {
     pub const ZERO: Self = Self(ConstMontyType::new(&U448::ZERO));
 
     pub fn is_negative(&self) -> Choice {
-        self.0.retrieve().is_odd()
+        self.0.retrieve().is_odd().into()
     }
 
     pub fn is_zero(&self) -> Choice {
-        self.0.is_zero()
+        self.0.is_zero().into()
     }
 
     /// Inverts a field element
     pub fn invert(&self) -> Self {
-        Self(self.0.invert().unwrap_or(ConstMontyType::default()))
+        Self(self.0.invert().unwrap_or_default())
     }
 
     pub fn square(&self) -> Self {

--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -13,7 +13,7 @@ use elliptic_curve::{
         Array, ArraySize,
         typenum::{Prod, Unsigned},
     },
-    bigint::{Integer, Limb, U448, U896, Word, Zero},
+    bigint::{CtSelect, Integer, Limb, U448, U896, Word},
     consts::U2,
     ff::{Field, helpers},
     ops::{Invert, Reduce, ReduceNonZero},
@@ -655,7 +655,7 @@ impl<C: CurveWithScalar> Scalar<C> {
 
     /// Is this scalar equal to zero?
     pub fn is_zero(&self) -> Choice {
-        self.scalar.is_zero()
+        self.scalar.is_zero().into()
     }
 
     // This method was modified from Curve25519-Dalek codebase. [scalar.rs]
@@ -774,7 +774,7 @@ impl<C: CurveWithScalar> Scalar<C> {
     pub fn div_by_2(&self) -> Self {
         let is_odd = self.scalar.is_odd();
         let if_odd = self.scalar + *ORDER;
-        let scalar = U448::conditional_select(&self.scalar, &if_odd, is_odd);
+        let scalar = U448::ct_select(&self.scalar, &if_odd, is_odd);
 
         Self::new(scalar >> 1)
     }

--- a/ed448-goldilocks/src/sign.rs
+++ b/ed448-goldilocks/src/sign.rs
@@ -10,9 +10,9 @@
 //!
 //! ```
 //! use ed448_goldilocks::*;
-//! use rand::{rngs::OsRng, TryRngCore};
+//! use rand::{rngs::SysRng, TryRngCore};
 //!
-//! let signing_key = SigningKey::generate(&mut OsRng.unwrap_err());
+//! let signing_key = SigningKey::generate(&mut SysRng.unwrap_err());
 //! let signature = signing_key.sign_raw(b"Hello, world!");
 //! let verifying_key = signing_key.verifying_key();
 //!
@@ -56,11 +56,11 @@
 //! ```
 //! use ed448_goldilocks::*;
 //! use sha3::{Shake256, digest::Update};
-//! use rand::{rngs::OsRng, TryRngCore};
+//! use rand::{rngs::SysRng, TryRngCore};
 //!
 //! let msg = b"Hello World";
 //!
-//! let signing_key = SigningKey::generate(&mut OsRng.unwrap_err());
+//! let signing_key = SigningKey::generate(&mut SysRng.unwrap_err());
 //! let signature = signing_key.sign_prehashed::<PreHasherXof<Shake256>>(
 //!     None,
 //!     Shake256::default().chain(msg).into(),

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -29,7 +29,7 @@ hex-literal = { version = "1", optional = true }
 primeorder = { version = "0.14.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
-signature = { version = "3.0.0-rc.5", optional = true }
+signature = { version = "3.0.0-rc.6", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -49,8 +49,8 @@ mod tests {
     #[test]
     fn try_from_rng() {
         use crate::SecretKey;
-        use rand::rngs::OsRng;
-        let key = SecretKey::try_from_rng(&mut OsRng).unwrap();
+        use rand::rngs::SysRng;
+        let key = SecretKey::try_from_rng(&mut SysRng).unwrap();
 
         // Sanity check
         assert!(!key.to_bytes().iter().all(|b| *b == 0))

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -512,7 +512,7 @@ mod tests {
     use elliptic_curve::ops::BatchInvert;
     use num_bigint::{BigUint, ToBigUint};
     use proptest::prelude::*;
-    use rand::{TryRngCore, rngs::OsRng};
+    use rand::{TryRngCore, rngs::SysRng};
 
     use super::FieldElement;
     use crate::{
@@ -696,8 +696,8 @@ mod tests {
 
     #[test]
     fn batch_invert_array() {
-        let k: FieldElement = FieldElement::random(&mut OsRng.unwrap_mut());
-        let l: FieldElement = FieldElement::random(&mut OsRng.unwrap_mut());
+        let k: FieldElement = FieldElement::random(&mut SysRng.unwrap_mut());
+        let l: FieldElement = FieldElement::random(&mut SysRng.unwrap_mut());
 
         let expected = [k.invert().unwrap(), l.invert().unwrap()];
         let actual = <FieldElement as BatchInvert<_>>::batch_invert([k, l]).unwrap();
@@ -709,8 +709,8 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn batch_invert() {
-        let k: FieldElement = FieldElement::random(&mut OsRng.unwrap_mut());
-        let l: FieldElement = FieldElement::random(&mut OsRng.unwrap_mut());
+        let k: FieldElement = FieldElement::random(&mut SysRng.unwrap_mut());
+        let l: FieldElement = FieldElement::random(&mut SysRng.unwrap_mut());
 
         let expected = vec![k.invert().unwrap(), l.invert().unwrap()];
         let field_elements = vec![k, l]; // to test impl of `BatchInvert` for `Vec`

--- a/k256/src/arithmetic/field/field_5x52.rs
+++ b/k256/src/arithmetic/field/field_5x52.rs
@@ -3,7 +3,7 @@
 
 use crate::FieldBytes;
 use elliptic_curve::{
-    bigint::U256,
+    bigint::{ArrayEncoding, U256},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::Zeroize,
 };
@@ -35,7 +35,7 @@ impl FieldElement5x52 {
     /// [0, p).
     #[inline]
     pub fn from_bytes(bytes: &FieldBytes) -> CtOption<Self> {
-        Self::from_u256(U256::from_be_slice(bytes))
+        Self::from_u256(U256::from_be_byte_array(*bytes))
     }
 
     pub const fn from_u64(val: u64) -> Self {
@@ -46,7 +46,7 @@ impl FieldElement5x52 {
 
     /// Returns the SEC1 encoding of this field element.
     pub fn to_bytes(self) -> FieldBytes {
-        self.to_u256().to_be_bytes().into()
+        self.to_u256().to_be_byte_array()
     }
 
     #[inline(always)]

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -392,14 +392,14 @@ mod tests {
     use super::*;
     use crate::arithmetic::{ProjectivePoint, Scalar};
     use elliptic_curve::{Field, Group};
-    use rand::{TryRngCore, rngs::OsRng};
+    use rand::{TryRngCore, rngs::SysRng};
 
     #[test]
     fn test_lincomb() {
-        let x = ProjectivePoint::random(&mut OsRng.unwrap_mut());
-        let y = ProjectivePoint::random(&mut OsRng.unwrap_mut());
-        let k = Scalar::random(&mut OsRng.unwrap_mut());
-        let l = Scalar::random(&mut OsRng.unwrap_mut());
+        let x = ProjectivePoint::random(&mut SysRng.unwrap_mut());
+        let y = ProjectivePoint::random(&mut SysRng.unwrap_mut());
+        let k = Scalar::random(&mut SysRng.unwrap_mut());
+        let l = Scalar::random(&mut SysRng.unwrap_mut());
 
         let reference = x * k + y * l;
         let test = ProjectivePoint::lincomb(&[(x, k), (y, l)]);
@@ -408,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_mul_by_generator() {
-        let k = Scalar::random(&mut OsRng.unwrap_mut());
+        let k = Scalar::random(&mut SysRng.unwrap_mut());
         let reference = ProjectivePoint::GENERATOR * k;
         let test = ProjectivePoint::mul_by_generator(&k);
         assert_eq!(reference, test);
@@ -417,10 +417,10 @@ mod tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn test_lincomb_slice() {
-        let x = ProjectivePoint::random(&mut OsRng.unwrap_mut());
-        let y = ProjectivePoint::random(&mut OsRng.unwrap_mut());
-        let k = Scalar::random(&mut OsRng.unwrap_mut());
-        let l = Scalar::random(&mut OsRng.unwrap_mut());
+        let x = ProjectivePoint::random(&mut SysRng.unwrap_mut());
+        let y = ProjectivePoint::random(&mut SysRng.unwrap_mut());
+        let k = Scalar::random(&mut SysRng.unwrap_mut());
+        let l = Scalar::random(&mut SysRng.unwrap_mut());
 
         let reference = x * k + y * l;
         let points_and_scalars = vec![(x, k), (y, l)];

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -727,7 +727,7 @@ mod tests {
     use elliptic_curve::BatchNormalize;
     use elliptic_curve::group::{ff::PrimeField, prime::PrimeCurveAffine};
     use elliptic_curve::{CurveGroup, Field};
-    use rand::{TryRngCore, rngs::OsRng};
+    use rand::{TryRngCore, rngs::SysRng};
 
     #[cfg(feature = "alloc")]
     use alloc::vec::Vec;
@@ -751,8 +751,8 @@ mod tests {
 
     #[test]
     fn batch_normalize_array() {
-        let k: Scalar = Scalar::random(&mut OsRng.unwrap_mut());
-        let l: Scalar = Scalar::random(&mut OsRng.unwrap_mut());
+        let k: Scalar = Scalar::random(&mut SysRng.unwrap_mut());
+        let l: Scalar = Scalar::random(&mut SysRng.unwrap_mut());
         let g = ProjectivePoint::mul_by_generator(&k);
         let h = ProjectivePoint::mul_by_generator(&l);
 
@@ -768,7 +768,7 @@ mod tests {
 
         let mut res = [AffinePoint::IDENTITY; 3];
         let non_normalized_identity =
-            ProjectivePoint::IDENTITY * Scalar::random(&mut OsRng.unwrap_mut());
+            ProjectivePoint::IDENTITY * Scalar::random(&mut SysRng.unwrap_mut());
         let expected = [g.to_affine(), AffinePoint::IDENTITY, AffinePoint::IDENTITY];
         assert_eq!(
             <ProjectivePoint as BatchNormalize<_>>::batch_normalize(&[
@@ -789,8 +789,8 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn batch_normalize_slice() {
-        let k: Scalar = Scalar::random(&mut OsRng.unwrap_mut());
-        let l: Scalar = Scalar::random(&mut OsRng.unwrap_mut());
+        let k: Scalar = Scalar::random(&mut SysRng.unwrap_mut());
+        let l: Scalar = Scalar::random(&mut SysRng.unwrap_mut());
         let g = ProjectivePoint::mul_by_generator(&k);
         let h = ProjectivePoint::mul_by_generator(&l);
 

--- a/k256/src/ecdh.rs
+++ b/k256/src/ecdh.rs
@@ -10,14 +10,14 @@
 //!
 //! ```
 //! use k256::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use rand::{rngs::OsRng, TryRngCore};
+//! use rand::{rngs::SysRng, TryRngCore};
 //!
 //! // Alice
-//! let alice_secret = EphemeralSecret::try_from_rng(&mut OsRng).unwrap();
+//! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
 //! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
 //!
 //! // Bob
-//! let bob_secret = EphemeralSecret::try_from_rng(&mut OsRng).unwrap();
+//! let bob_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
 //! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -28,10 +28,10 @@
 //!     ecdsa::{SigningKey, Signature, signature::Signer},
 //!     SecretKey,
 //! };
-//! use rand::rngs::OsRng;
+//! use rand::rngs::SysRng;
 //!
 //! // Signing
-//! let signing_key = SigningKey::try_from_rng(&mut OsRng).unwrap(); // Serialize with `::to_bytes()`
+//! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //!
 //! // Note: The signature type must be annotated or otherwise inferable as

--- a/k256/src/schnorr.rs
+++ b/k256/src/schnorr.rs
@@ -35,12 +35,12 @@
 //!     signature::{Signer, Verifier},
 //!     SigningKey, VerifyingKey
 //! };
-//! use rand::rngs::OsRng;
+//! use rand::rngs::SysRng;
 //!
 //! //
 //! // Signing
 //! //
-//! let signing_key = SigningKey::try_from_rng(&mut OsRng).unwrap(); // serialize with `.to_bytes()`
+//! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // serialize with `.to_bytes()`
 //! let verifying_key_bytes = signing_key.verifying_key().to_bytes(); // 32-bytes
 //!
 //! let message = b"Schnorr signatures prove knowledge of a secret in the random oracle model";

--- a/p224/src/ecdh.rs
+++ b/p224/src/ecdh.rs
@@ -10,14 +10,14 @@
 //!
 //! ```
 //! use p224::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use rand::rngs::OsRng;
+//! use rand::rngs::SysRng;
 //!
 //! // Alice
-//! let alice_secret = EphemeralSecret::try_from_rng(&mut OsRng).unwrap();
+//! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
 //! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
 //!
 //! // Bob
-//! let bob_secret = EphemeralSecret::try_from_rng(&mut OsRng).unwrap();
+//! let bob_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
 //! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it

--- a/p224/src/ecdsa.rs
+++ b/p224/src/ecdsa.rs
@@ -22,10 +22,10 @@
 //! # #[cfg(feature = "ecdsa")]
 //! # {
 //! use p224::ecdsa::{signature::Signer, Signature, SigningKey};
-//! use rand::{rngs::OsRng, TryRngCore};
+//! use rand::{rngs::SysRng, TryRngCore};
 //!
 //! // Signing
-//! let signing_key = SigningKey::try_from_rng(&mut OsRng).unwrap(); // Serialize with `::to_bytes()`
+//! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature: Signature = signing_key.sign(message);
 //!

--- a/p256/src/ecdh.rs
+++ b/p256/src/ecdh.rs
@@ -10,14 +10,14 @@
 //!
 //! ```
 //! use p256::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use rand::rngs::OsRng;
+//! use rand::rngs::SysRng;
 //!
 //! // Alice
-//! let alice_secret = EphemeralSecret::try_from_rng(&mut OsRng).unwrap();
+//! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
 //! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
 //!
 //! // Bob
-//! let bob_secret = EphemeralSecret::try_from_rng(&mut OsRng).unwrap();
+//! let bob_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
 //! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -24,10 +24,10 @@
 //! use p256::{
 //!     ecdsa::{SigningKey, Signature, signature::Signer},
 //! };
-//! use rand::rngs::OsRng;
+//! use rand::rngs::SysRng;
 //!
 //! // Signing
-//! let signing_key = SigningKey::try_from_rng(&mut OsRng).unwrap(); // Serialize with `::to_bytes()`
+//! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature: Signature = signing_key.sign(message);
 //!

--- a/p384/src/ecdh.rs
+++ b/p384/src/ecdh.rs
@@ -10,14 +10,14 @@
 //!
 //! ```
 //! use p384::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use rand::rngs::OsRng;
+//! use rand::rngs::SysRng;
 //!
 //! // Alice
-//! let alice_secret = EphemeralSecret::try_from_rng(&mut OsRng).unwrap();
+//! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
 //! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
 //!
 //! // Bob
-//! let bob_secret = EphemeralSecret::try_from_rng(&mut OsRng).unwrap();
+//! let bob_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
 //! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it

--- a/p384/src/ecdsa.rs
+++ b/p384/src/ecdsa.rs
@@ -22,10 +22,10 @@
 //! # #[cfg(feature = "ecdsa")]
 //! # {
 //! use p384::ecdsa::{signature::Signer, Signature, SigningKey};
-//! use rand::{rngs::OsRng, TryRngCore};
+//! use rand::{rngs::SysRng, TryRngCore};
 //!
 //! // Signing
-//! let signing_key = SigningKey::try_from_rng(&mut OsRng).unwrap(); // Serialize with `::to_bytes()`
+//! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature: Signature = signing_key.sign(message);
 //!

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -26,7 +26,7 @@ hash2curve = { version = "0.14.0-rc.4", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.1", optional = true }
 primeorder = { version = "0.14.0-rc.1", optional = true }
-rand_core = { version = "0.10.0-rc-2", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-3", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -134,7 +134,7 @@ impl FieldElement {
 
         // Extract the first 66-bytes of the 72-byte (576-bit) little endian serialized value
         while i < le_bytes.len() {
-            le_bytes[i] = le_bytes_wide[i];
+            le_bytes[i] = le_bytes_wide.as_slice()[i];
             i += 1;
         }
 

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -192,7 +192,7 @@ impl Scalar {
     ///
     /// If odd, return `Choice(1)`.  Otherwise, return `Choice(0)`.
     pub fn is_odd(&self) -> Choice {
-        self.to_canonical().is_odd()
+        self.to_canonical().is_odd().into()
     }
 
     /// Determine if this [`Scalar`] is even in the SEC1 sense: `self mod 2 == 0`.

--- a/p521/src/ecdh.rs
+++ b/p521/src/ecdh.rs
@@ -10,14 +10,14 @@
 //!
 //! ```
 //! use p521::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use rand::{rngs::OsRng, TryRngCore};
+//! use rand::{rngs::SysRng, TryRngCore};
 //!
 //! // Alice
-//! let alice_secret = EphemeralSecret::try_from_rng(&mut OsRng).unwrap();
+//! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
 //! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
 //!
 //! // Bob
-//! let bob_secret = EphemeralSecret::try_from_rng(&mut OsRng).unwrap();
+//! let bob_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
 //! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it

--- a/p521/src/ecdsa.rs
+++ b/p521/src/ecdsa.rs
@@ -22,10 +22,10 @@
 //! # #[cfg(feature = "ecdsa")]
 //! # {
 //! use p521::ecdsa::{signature::Signer, Signature, SigningKey};
-//! use rand::rngs::OsRng;
+//! use rand::rngs::SysRng;
 //!
 //! // Signing
-//! let signing_key = SigningKey::try_from_rng(&mut OsRng).unwrap(); // Serialize with `::to_bytes()`
+//! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature: Signature = signing_key.sign(message);
 //!

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-bigint = { package = "crypto-bigint", version = "0.7.0-rc.10", default-features = false, features = ["hybrid-array"] }
+bigint = { package = "crypto-bigint", version = "0.7.0-rc.12", default-features = false, features = ["hybrid-array", "subtle"] }
 ff = { version = "=0.14.0-pre.0", package = "rustcrypto-ff", default-features = false }
 subtle = { version = "2.6", default-features = false, features = ["const-generics"] }
-rand_core = { version = "0.10.0-rc-2", default-features = false }
+rand_core = { version = "0.10.0-rc-3", default-features = false }
 zeroize = { version = "1.7", default-features = false }

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -10,6 +10,7 @@ use core::{
 use elliptic_curve::{
     Error, FieldBytes, FieldBytesEncoding, FieldBytesSize, PublicKey, Result, Scalar,
     array::ArraySize,
+    bigint::CtGt,
     ff::{Field, PrimeField},
     group::{GroupEncoding, prime::PrimeCurveAffine},
     point::{AffineCoordinates, DecompactPoint, DecompressPoint, Double, NonIdentity},
@@ -18,7 +19,7 @@ use elliptic_curve::{
         self, CompressedPoint, EncodedPoint, FromEncodedPoint, ModulusSize, ToCompactEncodedPoint,
         ToEncodedPoint, UncompressedPointSize,
     },
-    subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, CtOption},
+    subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
 };
 
@@ -72,7 +73,7 @@ where
 
         Self {
             x: self.x,
-            y: C::FieldElement::conditional_select(&self.y, &neg_self.y, choice),
+            y: C::FieldElement::conditional_select(&self.y, &neg_self.y, choice.into()),
             infinity: self.infinity,
         }
     }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -20,14 +20,14 @@ rust-version = "1.85"
 [dependencies]
 elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
-rand_core = { version = "0.10.0-rc-2", default-features = false }
+rand_core = { version = "0.10.0-rc-3", default-features = false }
 
 # optional dependencies
 primefield = { version = "0.14.0-rc.1", optional = true }
 primeorder = { version = "0.14.0-rc.1", optional = true }
 rfc6979 = { version = "0.5.0-rc.3", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-signature = { version = "3.0.0-rc.5", optional = true, features = ["rand_core"] }
+signature = { version = "3.0.0-rc.6", optional = true, features = ["rand_core"] }
 sm3 = { version = "0.5.0-rc.3", optional = true, default-features = false }
 der = { version = "0.8.0-rc.10", optional = true }
 

--- a/sm2/src/dsa.rs
+++ b/sm2/src/dsa.rs
@@ -8,14 +8,14 @@
 #![cfg_attr(feature = "std", doc = "```")]
 #![cfg_attr(not(feature = "std"), doc = "```ignore")]
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! use rand::{rngs::OsRng, TryRngCore};
+//! use rand::{rngs::SysRng, TryRngCore};
 //! use sm2::{
 //!     dsa::{Signature, SigningKey, signature::Signer},
 //!     SecretKey
 //! };
 //!
 //! // Signing
-//! let secret_key = SecretKey::try_from_rng(&mut OsRng).unwrap(); // serialize with `::to_bytes()`
+//! let secret_key = SecretKey::try_from_rng(&mut SysRng).unwrap(); // serialize with `::to_bytes()`
 //! let distid = "example@rustcrypto.org"; // distinguishing identifier
 //! let signing_key = SigningKey::new(distid, &secret_key)?;
 //! let verifying_key_bytes = signing_key.verifying_key().to_sec1_bytes();

--- a/sm2/src/pke/decrypting.rs
+++ b/sm2/src/pke/decrypting.rs
@@ -8,7 +8,7 @@ use crate::{
 use alloc::{borrow::ToOwned, vec::Vec};
 use elliptic_curve::{
     Error, Group, Result,
-    bigint::U256,
+    bigint::{ArrayEncoding, U256},
     ops::Reduce,
     pkcs8::der::Decode,
     sec1::{FromEncodedPoint, ToEncodedPoint},
@@ -109,8 +109,8 @@ impl DecryptingKey {
     {
         let cipher = Cipher::from_der(ciphertext).map_err(elliptic_curve::pkcs8::Error::from)?;
         let prefix: &[u8] = &[0x04];
-        let x: [u8; 32] = cipher.x.to_be_bytes();
-        let y: [u8; 32] = cipher.y.to_be_bytes();
+        let x: [u8; 32] = cipher.x.to_be_byte_array().into();
+        let y: [u8; 32] = cipher.y.to_be_byte_array().into();
         let cipher = match self.mode {
             Mode::C1C2C3 => [prefix, &x, &y, cipher.cipher, cipher.digest].concat(),
             Mode::C1C3C2 => [prefix, &x, &y, cipher.digest, cipher.cipher].concat(),

--- a/sm2/src/pke/encrypting.rs
+++ b/sm2/src/pke/encrypting.rs
@@ -10,7 +10,7 @@ use crate::{
 use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
 use elliptic_curve::{
     Curve, Error, Group, Result,
-    bigint::{RandomBits, U256, Uint, Zero},
+    bigint::{RandomBits, U256, Uint},
     ops::Reduce,
     pkcs8::der::Encode,
     rand_core::TryCryptoRng,

--- a/sm2/tests/sm2pke.rs
+++ b/sm2/tests/sm2pke.rs
@@ -3,7 +3,7 @@
 use elliptic_curve::{NonZeroScalar, ops::Reduce};
 use hex_literal::hex;
 use proptest::prelude::*;
-use rand::rngs::OsRng;
+use rand::rngs::SysRng;
 
 use sm2::{FieldBytes, Scalar, Sm2, pke::DecryptingKey};
 
@@ -70,21 +70,21 @@ proptest! {
     #[test]
     fn encrypt_and_decrypt_der(dk in decrypting_key()) {
         let ek = dk.encrypting_key();
-        let cipher_bytes = ek.encrypt_der(&mut OsRng, MSG).unwrap();
+        let cipher_bytes = ek.encrypt_der(&mut SysRng, MSG).unwrap();
         prop_assert!(dk.decrypt_der(&cipher_bytes).is_ok());
     }
 
     #[test]
     fn encrypt_and_decrypt(dk in decrypting_key()) {
         let ek = dk.encrypting_key();
-        let cipher_bytes = ek.encrypt(&mut OsRng, MSG).unwrap();
+        let cipher_bytes = ek.encrypt(&mut SysRng, MSG).unwrap();
         assert_eq!(dk.decrypt(&cipher_bytes).unwrap(), MSG);
     }
 
     #[test]
     fn encrypt_and_decrypt_mode(dk in decrypting_key_c1c2c3()) {
         let ek = dk.encrypting_key();
-        let cipher_bytes = ek.encrypt(&mut OsRng, MSG).unwrap();
+        let cipher_bytes = ek.encrypt(&mut SysRng, MSG).unwrap();
         assert_eq!(
             dk.decrypt(&cipher_bytes)
                 .unwrap(),

--- a/x448/Cargo.toml
+++ b/x448/Cargo.toml
@@ -15,7 +15,7 @@ description = "Pure Rust implementation of X448, an elliptic curve Diffie-Hellma
 
 [dependencies]
 ed448-goldilocks = { version = "0.14.0-pre.4", default-features = false }
-rand_core = { version = "0.10.0-rc-2", default-features = false }
+rand_core = { version = "0.10.0-rc-3", default-features = false }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true }


### PR DESCRIPTION
Also includes a `rand_core` v0.10.0-rc-3 bump

This notably begins an initial migration from `subtle` to the new `ctutils` crate. Both are currently supported, leading to some ambiguity around same-named methods like `ct_eq` that has been disambiguated here using UFCS, which can hopefully be converted back into the simpler more readable form if we ever fully migrate from one to the other.