### PR TITLE
Bump `elliptic-curve` to v0.14.0-rc.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,10 +357,12 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.12"
-source = "git+https://github.com/RustCrypto/crypto-bigint#f8f09a143353de02dc97223e449620dc2d7879c9"
+version = "0.7.0-rc.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bb4138de6db76c8155b4423e967049fbef2cf84ad6af7f552f73a161941b72"
 dependencies = [
  "ctutils",
+ "getrandom 0.4.0-rc.0",
  "hybrid-array",
  "num-traits",
  "rand_core 0.10.0-rc-3",
@@ -379,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0d4ebbcf0ee8b260dd060b79b7449973fffccdbaa5c871c9867c7b44445e75"
+checksum = "130ffe18bdf7a4926e57ed19d404995244e6c8d6a97abf4eddde1f892bf1ce0c"
 dependencies = [
  "cmov",
  "subtle",
@@ -413,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.9"
+version = "0.17.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e914ecb8e11a02f42cc05f6b43675d1e5aa4d446cd207f9f818903a1ab34f19f"
+checksum = "6378f4db5c3e64d1c0bbde7948849ec7aaa231632a7c0ba1cfca7543e34ce9f5"
 dependencies = [
  "der",
  "digest",
@@ -469,8 +471,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.17"
-source = "git+https://github.com/RustCrypto/traits#96a144dc17c39d58cf31c36d1857e0185425842a"
+version = "0.14.0-rc.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8119dc256cd897f759f5b9d45dfd9b066af1c79e71688b7f0a6be989e8fbfbf"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,4 @@ hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
 
-crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint" }
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
 rand = { git = "https://github.com/rust-random/rand" }

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.17", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.18", features = ["sec1"] }
 
 # optional dependencies
 belt-hash = { version = "0.2.0-rc.0", optional = true, default-features = false }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,10 +14,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.9", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.10", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14.0-rc.1", optional = true }
 primeorder = { version = "0.14.0-rc.1", optional = true }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,10 +14,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.9", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.10", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14.0-rc.1", optional = true }
 primeorder = { version = "0.14.0-rc.1", optional = true }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -16,7 +16,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.17", features = ["arithmetic", "pkcs8"] }
+elliptic-curve = { version = "0.14.0-rc.18", features = ["arithmetic", "pkcs8"] }
 hash2curve = "0.14.0-rc.4"
 rand_core = { version = "0.10.0-rc-3", default-features = false }
 sha3 = { version = "0.11.0-rc.3", default-features = false }

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = { version = "0.11.0-rc.4" }
-elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["arithmetic"] }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,11 +20,11 @@ rust-version = "1.85"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
 hash2curve = { version = "0.14.0-rc.4", optional = true }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primeorder = { version = "0.14.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
@@ -33,7 +33,7 @@ signature = { version = "3.0.0-rc.6", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4.3"
 hex-literal = "1"
 num-bigint = "0.4"

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.1", optional = true }
 primeorder = { version = "0.14.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
 

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,10 +17,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.1", optional = true }
 primeorder = { version = "0.14.0-rc.1", optional = true }
@@ -28,7 +28,7 @@ serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
 rand = "0.10.0-rc.1"

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,10 +18,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.4", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.1", optional = true }
@@ -31,7 +31,7 @@ sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primefield = { version = "0.14.0-rc.1" }
 primeorder = { version = "0.14.0-rc.1", features = ["dev"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,10 +18,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.4", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.1", optional = true }
@@ -34,7 +34,7 @@ fiat-crypto = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
 proptest = "1.9"

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -18,10 +18,10 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "0.3"
-elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.4", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.1", optional = true }
@@ -32,7 +32,7 @@ sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.9", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
 proptest = "1.9"

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "primefield"
 version = "0.14.0-rc.1"
-description = "Macros for generating prime field implementations"
+description = """
+Generic implementation of prime fields built on `crypto-bigint`, along with macros for writing
+field element newtypes including ones with formally verified arithmetic using `fiat-crypto`
+"""
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/primefield"
@@ -14,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-bigint = { package = "crypto-bigint", version = "0.7.0-rc.12", default-features = false, features = ["hybrid-array", "subtle"] }
+bigint = { package = "crypto-bigint", version = "0.7.0-rc.13", default-features = false, features = ["hybrid-array", "subtle"] }
 ff = { version = "=0.14.0-pre.0", package = "rustcrypto-ff", default-features = false }
 subtle = { version = "2.6", default-features = false, features = ["const-generics"] }
 rand_core = { version = "0.10.0-rc-3", default-features = false }

--- a/primefield/README.md
+++ b/primefield/README.md
@@ -8,7 +8,7 @@
 [![Project Chat][chat-image]][chat-link]
 
 Generic implementation of prime fields built on [`crypto-bigint`], along with macros for writing
-field element newtypes including ones with arithmetic backed by [`fiat-crypto`].
+field element newtypes including ones with formally verified arithmetic using [`fiat-crypto`].
 
 [Documentation][docs-link]
 

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true, default-features = false }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
 rand_core = { version = "0.10.0-rc-3", default-features = false }
 


### PR DESCRIPTION
This also bumps:
- `crypto-bigint` v0.7.0-rc.13
- `ctutils` v0.3.0
- `ecdsa` v0.17.0-rc.10