### PR TITLE
Replace `dev-dependency` on `rand` with `getrandom`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "der",
  "digest",
  "elliptic-curve",
+ "getrandom 0.4.0-rc.0",
  "hex",
  "hex-literal",
  "hkdf",
@@ -85,7 +86,6 @@ dependencies = [
  "primefield",
  "primeorder",
  "proptest",
- "rand 0.10.0-rc.5",
  "rand_core 0.10.0-rc-3",
  "rfc6979",
  "sec1",
@@ -449,11 +449,11 @@ dependencies = [
  "criterion",
  "ed448",
  "elliptic-curve",
+ "getrandom 0.4.0-rc.0",
  "hash2curve",
  "hex",
  "hex-literal",
  "proptest",
- "rand 0.10.0-rc.5",
  "rand_core 0.10.0-rc-3",
  "serde_bare",
  "serde_json",
@@ -658,6 +658,7 @@ dependencies = [
  "criterion",
  "ecdsa",
  "elliptic-curve",
+ "getrandom 0.4.0-rc.0",
  "hash2curve",
  "hex",
  "hex-literal",
@@ -665,7 +666,6 @@ dependencies = [
  "num-traits",
  "primeorder",
  "proptest",
- "rand 0.10.0-rc.5",
  "serdect",
  "sha2",
  "sha3",
@@ -772,10 +772,10 @@ version = "0.14.0-rc.1"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "getrandom 0.4.0-rc.0",
  "hex-literal",
  "primefield",
  "primeorder",
- "rand 0.10.0-rc.5",
  "serdect",
  "sha2",
 ]
@@ -787,12 +787,12 @@ dependencies = [
  "criterion",
  "ecdsa",
  "elliptic-curve",
+ "getrandom 0.4.0-rc.0",
  "hash2curve",
  "hex-literal",
  "primefield",
  "primeorder",
  "proptest",
- "rand 0.10.0-rc.5",
  "serdect",
  "sha2",
 ]
@@ -805,12 +805,12 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "fiat-crypto",
+ "getrandom 0.4.0-rc.0",
  "hash2curve",
  "hex-literal",
  "primefield",
  "primeorder",
  "proptest",
- "rand 0.10.0-rc.5",
  "serdect",
  "sha2",
 ]
@@ -823,12 +823,12 @@ dependencies = [
  "criterion",
  "ecdsa",
  "elliptic-curve",
+ "getrandom 0.4.0-rc.0",
  "hash2curve",
  "hex-literal",
  "primefield",
  "primeorder",
  "proptest",
- "rand 0.10.0-rc.5",
  "rand_core 0.10.0-rc-3",
  "serdect",
  "sha2",
@@ -935,7 +935,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "proptest-macro",
- "rand 0.9.2",
+ "rand",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -991,16 +991,6 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.0-rc.5"
-source = "git+https://github.com/rust-random/rand#ff07ec205347dd749a586aaee7218cb21590ea4c"
-dependencies = [
- "chacha20",
- "getrandom 0.4.0-rc.0",
- "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -1304,11 +1294,11 @@ dependencies = [
  "der",
  "elliptic-curve",
  "fiat-crypto",
+ "getrandom 0.4.0-rc.0",
  "hex-literal",
  "primefield",
  "primeorder",
  "proptest",
- "rand 0.10.0-rc.5",
  "rand_core 0.10.0-rc-3",
  "rfc6979",
  "serdect",
@@ -1543,7 +1533,7 @@ name = "x448"
 version = "0.14.0-pre.1"
 dependencies = [
  "ed448-goldilocks",
- "rand 0.10.0-rc.5",
+ "getrandom 0.4.0-rc.0",
  "rand_core 0.10.0-rc-3",
  "serdect",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,3 @@ ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
-
-rand = { git = "https://github.com/rust-random/rand" }

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -37,11 +37,11 @@ signature = { version = "3.0.0-rc.6", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
+getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
+hex = { version = "0.4" }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
 proptest = "1"
-rand = "0.10.0-rc.1"
-hex = { version = "0.4" }
 
 [features]
 default = ["ecdh", "ecdsa", "pem", "std"]

--- a/bignp256/src/ecdsa.rs
+++ b/bignp256/src/ecdsa.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(feature = "std", doc = "```")]
 #![cfg_attr(not(feature = "std"), doc = "```ignore")]
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! use rand::{rngs::SysRng, TryRngCore};
+//! use getrandom::{SysRng, rand_core::TryRngCore};
 //! use bignp256::{
 //!     ecdsa::{Signature, SigningKey, signature::Signer},
 //!     SecretKey

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -29,11 +29,11 @@ signature = { version = "3.0.0-rc.6", optional = true, default-features = false,
 
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false, features = ["cargo_bench_support"] }
+getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 hex-literal = "1"
 hex = "0.4"
 proptest = { version = "1", features = ["attr-macro"] }
-rand = "0.10.0-rc.5"
-chacha20 = "0.10.0-rc.6"
+chacha20 = { version = "0.10.0-rc.6", features = ["rng"] }
 serde_bare = "0.5"
 serde_json = "1.0"
 

--- a/ed448-goldilocks/README.md
+++ b/ed448-goldilocks/README.md
@@ -19,8 +19,8 @@ It is intended to be portable, fast, and safe.
 ```rust
 use ed448_goldilocks::{Ed448, EdwardsPoint, CompressedEdwardsY, EdwardsScalar, sha3::Shake256};
 use elliptic_curve::{consts::U84, Field, group::GroupEncoding};
+use getrandom::SysRng;
 use hash2curve::{ExpandMsgXof, GroupDigest};
-use rand::rngs::SysRng;
 
 let secret_key = EdwardsScalar::TWO;
 let public_key = EdwardsPoint::GENERATOR * &secret_key;

--- a/ed448-goldilocks/benches/bench.rs
+++ b/ed448-goldilocks/benches/bench.rs
@@ -2,10 +2,9 @@ use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use ed448_goldilocks::{
     Decaf448, DecafPoint, DecafScalar, Ed448, EdwardsPoint, EdwardsScalar, MontgomeryPoint,
 };
-use elliptic_curve::group::GroupEncoding;
-use elliptic_curve::{Field, Group};
+use elliptic_curve::{Field, Group, group::GroupEncoding};
+use getrandom::{SysRng, rand_core::TryRngCore};
 use hash2curve::GroupDigest;
-use rand::{TryRngCore, rngs::SysRng};
 
 pub fn ed448(c: &mut Criterion) {
     let mut group = c.benchmark_group("Ed448");

--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -783,9 +783,9 @@ where
 mod tests {
     use super::*;
     use elliptic_curve::Field;
+    use getrandom::{SysRng, rand_core::TryRngCore};
     use hex_literal::hex;
     use proptest::{prop_assert_eq, property_test};
-    use rand::{TryRngCore, rngs::SysRng};
 
     fn hex_to_field(hex: &'static str) -> FieldElement {
         assert_eq!(hex.len(), 56 * 2);

--- a/ed448-goldilocks/src/sign.rs
+++ b/ed448-goldilocks/src/sign.rs
@@ -10,7 +10,7 @@
 //!
 //! ```
 //! use ed448_goldilocks::*;
-//! use rand::{rngs::SysRng, TryRngCore};
+//! use getrandom::{SysRng, rand_core::TryRngCore};
 //!
 //! let signing_key = SigningKey::generate(&mut SysRng.unwrap_err());
 //! let signature = signing_key.sign_raw(b"Hello, world!");
@@ -56,7 +56,7 @@
 //! ```
 //! use ed448_goldilocks::*;
 //! use sha3::{Shake256, digest::Update};
-//! use rand::{rngs::SysRng, TryRngCore};
+//! use getrandom::{SysRng, rand_core::TryRngCore};
 //!
 //! let msg = b"Hello World";
 //!

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -39,7 +39,7 @@ hex-literal = "1"
 num-bigint = "0.4"
 num-traits = "0.2"
 proptest = "1.9"
-rand = "0.10.0-rc.1"
+getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 sha3 = { version = "0.11.0-rc.3", default-features = false }
 
 [features]

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -49,7 +49,7 @@ mod tests {
     #[test]
     fn try_from_rng() {
         use crate::SecretKey;
-        use rand::rngs::SysRng;
+        use getrandom::SysRng;
         let key = SecretKey::try_from_rng(&mut SysRng).unwrap();
 
         // Sanity check

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -510,9 +510,9 @@ impl<'a> Product<&'a FieldElement> for FieldElement {
 mod tests {
     use elliptic_curve::ff::{Field, PrimeField};
     use elliptic_curve::ops::BatchInvert;
+    use getrandom::{SysRng, rand_core::TryRngCore};
     use num_bigint::{BigUint, ToBigUint};
     use proptest::prelude::*;
-    use rand::{TryRngCore, rngs::SysRng};
 
     use super::FieldElement;
     use crate::{

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -392,7 +392,7 @@ mod tests {
     use super::*;
     use crate::arithmetic::{ProjectivePoint, Scalar};
     use elliptic_curve::{Field, Group};
-    use rand::{TryRngCore, rngs::SysRng};
+    use getrandom::{SysRng, rand_core::TryRngCore};
 
     #[test]
     fn test_lincomb() {

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -727,7 +727,7 @@ mod tests {
     use elliptic_curve::BatchNormalize;
     use elliptic_curve::group::{ff::PrimeField, prime::PrimeCurveAffine};
     use elliptic_curve::{CurveGroup, Field};
-    use rand::{TryRngCore, rngs::SysRng};
+    use getrandom::{SysRng, rand_core::TryRngCore};
 
     #[cfg(feature = "alloc")]
     use alloc::vec::Vec;

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -906,10 +906,10 @@ mod tests {
         ops::{Invert, Reduce},
         scalar::IsHigh,
     };
+    use getrandom::{SysRng, rand_core::TryRngCore};
     use num_bigint::{BigUint, ToBigUint};
     use num_traits::Zero;
     use proptest::prelude::*;
-    use rand::{TryRngCore, rngs::SysRng};
 
     use elliptic_curve::ops::BatchInvert;
 

--- a/k256/src/ecdh.rs
+++ b/k256/src/ecdh.rs
@@ -10,7 +10,7 @@
 //!
 //! ```
 //! use k256::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use rand::{rngs::SysRng, TryRngCore};
+//! use getrandom::{SysRng, rand_core::TryRngCore};
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -28,7 +28,7 @@
 //!     ecdsa::{SigningKey, Signature, signature::Signer},
 //!     SecretKey,
 //! };
-//! use rand::rngs::SysRng;
+//! use getrandom::SysRng;
 //!
 //! // Signing
 //! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`

--- a/k256/src/schnorr.rs
+++ b/k256/src/schnorr.rs
@@ -35,7 +35,7 @@
 //!     signature::{Signer, Verifier},
 //!     SigningKey, VerifyingKey
 //! };
-//! use rand::rngs::SysRng;
+//! use getrandom::SysRng;
 //!
 //! //
 //! // Signing

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -31,7 +31,7 @@ sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
-rand = "0.10.0-rc.1"
+getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p224/src/ecdh.rs
+++ b/p224/src/ecdh.rs
@@ -10,7 +10,7 @@
 //!
 //! ```
 //! use p224::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use rand::rngs::SysRng;
+//! use getrandom::SysRng;
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();

--- a/p224/src/ecdsa.rs
+++ b/p224/src/ecdsa.rs
@@ -22,7 +22,7 @@
 //! # #[cfg(feature = "ecdsa")]
 //! # {
 //! use p224::ecdsa::{signature::Signer, Signature, SigningKey};
-//! use rand::{rngs::SysRng, TryRngCore};
+//! use getrandom::{SysRng, rand_core::TryRngCore};
 //!
 //! // Signing
 //! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -36,7 +36,7 @@ hex-literal = "1"
 primefield = { version = "0.14.0-rc.1" }
 primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
 proptest = "1"
-rand = "0.10.0-rc.1"
+getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p256/src/ecdh.rs
+++ b/p256/src/ecdh.rs
@@ -10,7 +10,7 @@
 //!
 //! ```
 //! use p256::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use rand::rngs::SysRng;
+//! use getrandom::SysRng;
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -24,7 +24,7 @@
 //! use p256::{
 //!     ecdsa::{SigningKey, Signature, signature::Signer},
 //! };
-//! use rand::rngs::SysRng;
+//! use getrandom::SysRng;
 //!
 //! // Signing
 //! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -38,7 +38,7 @@ ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = f
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
 proptest = "1.9"
-rand = "0.10.0-rc.1"
+getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p384/src/ecdh.rs
+++ b/p384/src/ecdh.rs
@@ -10,7 +10,7 @@
 //!
 //! ```
 //! use p384::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use rand::rngs::SysRng;
+//! use getrandom::SysRng;
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();

--- a/p384/src/ecdsa.rs
+++ b/p384/src/ecdsa.rs
@@ -22,7 +22,7 @@
 //! # #[cfg(feature = "ecdsa")]
 //! # {
 //! use p384::ecdsa::{signature::Signer, Signature, SigningKey};
-//! use rand::{rngs::SysRng, TryRngCore};
+//! use getrandom::{SysRng, rand_core::TryRngCore};
 //!
 //! // Signing
 //! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -36,7 +36,7 @@ ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = f
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.1", features = ["dev"] }
 proptest = "1.9"
-rand = "0.10.0-rc.1"
+getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p521/src/ecdh.rs
+++ b/p521/src/ecdh.rs
@@ -10,7 +10,7 @@
 //!
 //! ```
 //! use p521::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use rand::{rngs::SysRng, TryRngCore};
+//! use getrandom::{SysRng, rand_core::TryRngCore};
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();

--- a/p521/src/ecdsa.rs
+++ b/p521/src/ecdsa.rs
@@ -22,7 +22,7 @@
 //! # #[cfg(feature = "ecdsa")]
 //! # {
 //! use p521::ecdsa::{signature::Signer, Signature, SigningKey};
-//! use rand::rngs::SysRng;
+//! use getrandom::SysRng;
 //!
 //! // Signing
 //! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -34,7 +34,7 @@ der = { version = "0.8.0-rc.10", optional = true }
 [dev-dependencies]
 hex-literal = "1"
 proptest = "1"
-rand = "0.10.0-rc.1"
+getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 
 [features]
 default = ["arithmetic", "dsa", "getrandom", "pke", "pem", "std"]

--- a/sm2/src/dsa.rs
+++ b/sm2/src/dsa.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(feature = "std", doc = "```")]
 #![cfg_attr(not(feature = "std"), doc = "```ignore")]
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! use rand::{rngs::SysRng, TryRngCore};
+//! use getrandom::{SysRng, rand_core::TryRngCore};
 //! use sm2::{
 //!     dsa::{Signature, SigningKey, signature::Signer},
 //!     SecretKey

--- a/sm2/src/pke.rs
+++ b/sm2/src/pke.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(feature = "std", doc = "```")]
 #![cfg_attr(not(feature = "std"), doc = "```ignore")]
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! use rand::rngs::SysRng;
+//! use getrandom::SysRng;
 //! use sm2::{
 //!     pke::{EncryptingKey, Mode},
 //!     {SecretKey, PublicKey}

--- a/sm2/tests/sm2pke.rs
+++ b/sm2/tests/sm2pke.rs
@@ -1,9 +1,9 @@
 #![cfg(feature = "pke")]
 
 use elliptic_curve::{NonZeroScalar, ops::Reduce};
+use getrandom::SysRng;
 use hex_literal::hex;
 use proptest::prelude::*;
-use rand::rngs::SysRng;
 
 use sm2::{FieldBytes, Scalar, Sm2, pke::DecryptingKey};
 

--- a/x448/Cargo.toml
+++ b/x448/Cargo.toml
@@ -26,7 +26,7 @@ default-features = false
 features = ["zeroize_derive"]
 
 [dev-dependencies]
-rand = "0.10.0-rc.1"
+getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 
 [features]
 default = ["getrandom"]

--- a/x448/src/lib.rs
+++ b/x448/src/lib.rs
@@ -271,6 +271,7 @@ mod test {
     use super::*;
     use alloc::vec;
     use core::array::TryFromSliceError;
+    use rand_core::TryRngCore;
 
     /// Helpers to test properties of EphemeralSecret. Those `From` and `TryFrom` are not meant to
     /// be exposed outside tests.
@@ -290,7 +291,7 @@ mod test {
 
     #[test]
     fn test_random_dh() {
-        let mut rng = rand::rng();
+        let mut rng = getrandom::SysRng.unwrap_err();
         let alice_priv = EphemeralSecret::random_from_rng(&mut rng);
         let alice_pub = PublicKey::from(&alice_priv);
 


### PR DESCRIPTION
The main use is `OsRng` => `SysRng`.

Right now the lack of a new compatible `rand` crate release is blocking publishing new versions of these crates, so sourcing it from `rand` is just an impediment.