### PR TITLE
Bump `elliptic-curve` to v0.14.0-rc.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.10"
+version = "0.17.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6378f4db5c3e64d1c0bbde7948849ec7aaa231632a7c0ba1cfca7543e34ce9f5"
+checksum = "569a1f3377df19ab839b2811061095ff7d9fb7ea3c0e500b7a4724343cf6ee3d"
 dependencies = [
  "der",
  "digest",
@@ -477,8 +477,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.18"
-source = "git+https://github.com/RustCrypto/traits#443d4ee719c8a10fa3dedd3878a57fe9074496fc"
+version = "0.14.0-rc.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bfae4ab886ff791e2119cc79402281e35408f22b6b7322acef371d01061054b"
 dependencies = [
  "base16ct 1.0.0",
  "crypto-bigint",
@@ -824,7 +825,7 @@ dependencies = [
 name = "p521"
 version = "0.14.0-rc.2"
 dependencies = [
- "base16ct 0.3.0",
+ "base16ct 1.0.0",
  "criterion",
  "ecdsa",
  "elliptic-curve",
@@ -1186,6 +1187,7 @@ dependencies = [
  "der",
  "hybrid-array",
  "serdect",
+ "subtle",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,3 @@ ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
-
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.18", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.19", features = ["sec1"] }
 
 # optional dependencies
 belt-hash = { version = "0.2.0-rc.0", optional = true, default-features = false }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,10 +14,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.10", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.11", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14.0-rc.2", optional = true }
 primeorder = { version = "0.14.0-rc.2", optional = true }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,10 +14,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.10", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.11", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14.0-rc.2", optional = true }
 primeorder = { version = "0.14.0-rc.2", optional = true }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -16,7 +16,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.18", features = ["arithmetic", "pkcs8"] }
+elliptic-curve = { version = "0.14.0-rc.19", features = ["arithmetic", "pkcs8"] }
 hash2curve = "0.14.0-rc.4"
 rand_core = { version = "0.10.0-rc-3", default-features = false }
 sha3 = { version = "0.11.0-rc.3", default-features = false }

--- a/ed448-goldilocks/src/decaf/affine.rs
+++ b/ed448-goldilocks/src/decaf/affine.rs
@@ -3,7 +3,7 @@ use crate::field::FieldElement;
 use crate::{Decaf448FieldBytes, DecafPoint, DecafScalar, ORDER};
 use core::ops::Mul;
 use elliptic_curve::{
-    Error,
+    Error, ctutils,
     point::{AffineCoordinates, NonIdentity},
     zeroize::DefaultIsZeroes,
 };
@@ -25,6 +25,18 @@ impl ConditionallySelectable for AffinePoint {
             x: FieldElement::conditional_select(&a.0.x, &b.0.x, choice),
             y: FieldElement::conditional_select(&a.0.y, &b.0.y, choice),
         })
+    }
+}
+
+impl ctutils::CtEq for AffinePoint {
+    fn ct_eq(&self, other: &Self) -> ctutils::Choice {
+        ConstantTimeEq::ct_eq(self, other).into()
+    }
+}
+
+impl ctutils::CtSelect for AffinePoint {
+    fn ct_select(&self, other: &Self, choice: ctutils::Choice) -> Self {
+        ConditionallySelectable::conditional_select(self, other, choice.into())
     }
 }
 

--- a/ed448-goldilocks/src/decaf/points.rs
+++ b/ed448-goldilocks/src/decaf/points.rs
@@ -6,6 +6,7 @@ use elliptic_curve::{
     CurveGroup, Error, Group,
     array::Array,
     consts::U56,
+    ctutils,
     group::{GroupEncoding, cofactor::CofactorGroup, prime::PrimeGroup},
     ops::LinearCombination,
     point::NonIdentity,
@@ -74,6 +75,18 @@ impl ConditionallySelectable for DecafPoint {
             Z: FieldElement::conditional_select(&a.0.Z, &b.0.Z, choice),
             T: FieldElement::conditional_select(&a.0.T, &b.0.T, choice),
         })
+    }
+}
+
+impl ctutils::CtEq for DecafPoint {
+    fn ct_eq(&self, other: &Self) -> ctutils::Choice {
+        ConstantTimeEq::ct_eq(self, other).into()
+    }
+}
+
+impl ctutils::CtSelect for DecafPoint {
+    fn ct_select(&self, other: &Self, choice: ctutils::Choice) -> Self {
+        ConditionallySelectable::conditional_select(self, other, choice.into())
     }
 }
 

--- a/ed448-goldilocks/src/edwards/affine.rs
+++ b/ed448-goldilocks/src/edwards/affine.rs
@@ -2,7 +2,7 @@ use crate::field::FieldElement;
 use crate::*;
 use core::fmt::{Display, Formatter, LowerHex, Result as FmtResult, UpperHex};
 use core::ops::Mul;
-use elliptic_curve::{Error, point::NonIdentity, zeroize::DefaultIsZeroes};
+use elliptic_curve::{Error, ctutils, point::NonIdentity, zeroize::DefaultIsZeroes};
 use rand_core::TryRngCore;
 use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq, CtOption};
 
@@ -30,6 +30,21 @@ impl ConditionallySelectable for AffinePoint {
         Self {
             x: FieldElement::conditional_select(&a.x, &b.x, choice),
             y: FieldElement::conditional_select(&a.y, &b.y, choice),
+        }
+    }
+}
+
+impl ctutils::CtEq for AffinePoint {
+    fn ct_eq(&self, other: &Self) -> ctutils::Choice {
+        (self.x.ct_eq(&other.x) & self.y.ct_eq(&other.y)).into()
+    }
+}
+
+impl ctutils::CtSelect for AffinePoint {
+    fn ct_select(&self, other: &Self, choice: ctutils::Choice) -> Self {
+        Self {
+            x: FieldElement::conditional_select(&self.x, &other.x, choice.into()),
+            y: FieldElement::conditional_select(&self.y, &other.y, choice.into()),
         }
     }
 }

--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -12,6 +12,7 @@ use crate::*;
 use elliptic_curve::{
     BatchNormalize, CurveGroup, Error,
     array::Array,
+    ctutils,
     group::{Group, GroupEncoding, cofactor::CofactorGroup, prime::PrimeGroup},
     ops::{BatchInvert, LinearCombination},
     point::NonIdentity,
@@ -88,6 +89,18 @@ impl ConstantTimeEq for EdwardsPoint {
         let ZY = self.Z * other.Y;
 
         (XZ.ct_eq(&ZX)) & (YZ.ct_eq(&ZY))
+    }
+}
+
+impl ctutils::CtEq for EdwardsPoint {
+    fn ct_eq(&self, other: &Self) -> ctutils::Choice {
+        ConstantTimeEq::ct_eq(self, other).into()
+    }
+}
+
+impl ctutils::CtSelect for EdwardsPoint {
+    fn ct_select(&self, other: &Self, choice: ctutils::Choice) -> Self {
+        ConditionallySelectable::conditional_select(self, other, choice.into())
     }
 }
 

--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -13,8 +13,9 @@ use elliptic_curve::{
         Array, ArraySize,
         typenum::{Prod, Unsigned},
     },
-    bigint::{CtSelect, Integer, Limb, U448, U896, Word},
+    bigint::{Integer, Limb, U448, U896, Word},
     consts::U2,
+    ctutils::{self, CtSelect},
     ff::{Field, helpers},
     ops::{Invert, Reduce, ReduceNonZero},
     scalar::{FromUintUnchecked, IsHigh},
@@ -109,6 +110,18 @@ impl<C: CurveWithScalar> ConstantTimeEq for Scalar<C> {
 impl<C: CurveWithScalar> ConditionallySelectable for Scalar<C> {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self::new(U448::conditional_select(&a.scalar, &b.scalar, choice))
+    }
+}
+
+impl<C: CurveWithScalar> ctutils::CtEq for Scalar<C> {
+    fn ct_eq(&self, other: &Self) -> ctutils::Choice {
+        ConstantTimeEq::ct_eq(self, other).into()
+    }
+}
+
+impl<C: CurveWithScalar> ctutils::CtSelect for Scalar<C> {
+    fn ct_select(&self, other: &Self, choice: ctutils::Choice) -> Self {
+        ConditionallySelectable::conditional_select(self, other, choice.into())
     }
 }
 

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = { version = "0.11.0-rc.5" }
-elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["arithmetic"] }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,11 +20,11 @@ rust-version = "1.85"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
 hash2curve = { version = "0.14.0-rc.4", optional = true }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primeorder = { version = "0.14.0-rc.2", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
@@ -33,7 +33,7 @@ signature = { version = "3.0.0-rc.6", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4.3"
 hex-literal = "1"
 num-bigint = "0.4"

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -388,6 +388,18 @@ impl ConstantTimeEq for ProjectivePoint {
     }
 }
 
+impl ctutils::CtEq for ProjectivePoint {
+    fn ct_eq(&self, other: &Self) -> ctutils::Choice {
+        ConstantTimeEq::ct_eq(self, other).into()
+    }
+}
+
+impl ctutils::CtSelect for ProjectivePoint {
+    fn ct_select(&self, other: &Self, choice: ctutils::Choice) -> Self {
+        ConditionallySelectable::conditional_select(self, other, choice.into())
+    }
+}
+
 impl Default for ProjectivePoint {
     fn default() -> Self {
         Self::IDENTITY

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -16,7 +16,8 @@ use core::{
 };
 use elliptic_curve::{
     Curve, Error, ScalarValue,
-    bigint::{Limb, U256, U512, Word, prelude::*},
+    bigint::{ArrayEncoding, Integer, Limb, U256, U512, Word},
+    ctutils,
     ff::{self, Field, FromUniformBytes, PrimeField},
     ops::{Invert, Reduce, ReduceNonZero},
     rand_core::{CryptoRng, TryCryptoRng, TryRngCore},
@@ -545,6 +546,18 @@ impl ConditionallySelectable for Scalar {
 impl ConstantTimeEq for Scalar {
     fn ct_eq(&self, other: &Self) -> Choice {
         ConstantTimeEq::ct_eq(&self.0, &other.0)
+    }
+}
+
+impl ctutils::CtEq for Scalar {
+    fn ct_eq(&self, other: &Self) -> ctutils::Choice {
+        ConstantTimeEq::ct_eq(self, other).into()
+    }
+}
+
+impl ctutils::CtSelect for Scalar {
+    fn ct_select(&self, other: &Self, choice: ctutils::Choice) -> Self {
+        ConditionallySelectable::conditional_select(self, other, choice.into())
     }
 }
 

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.2", optional = true }
 primeorder = { version = "0.14.0-rc.2", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.2", features = ["dev"] }
 

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,10 +17,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.2", optional = true }
 primeorder = { version = "0.14.0-rc.2", optional = true }
@@ -28,7 +28,7 @@ serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.2", features = ["dev"] }
 getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,10 +18,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.4", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.2", optional = true }
@@ -31,7 +31,7 @@ sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primefield = { version = "0.14.0-rc.2" }
 primeorder = { version = "0.14.0-rc.2", features = ["dev"] }

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -13,7 +13,8 @@ use core::{
 };
 use elliptic_curve::{
     Curve,
-    bigint::{Limb, Odd, U256, Uint, prelude::*},
+    bigint::{ArrayEncoding, Integer, Limb, Odd, U256, Uint},
+    ctutils,
     group::ff::{self, Field, FromUniformBytes, PrimeField},
     ops::{Invert, Reduce, ReduceNonZero},
     rand_core::TryRngCore,
@@ -679,6 +680,18 @@ impl ConditionallySelectable for Scalar {
 impl ConstantTimeEq for Scalar {
     fn ct_eq(&self, other: &Self) -> Choice {
         ConstantTimeEq::ct_eq(&self.0, &other.0)
+    }
+}
+
+impl ctutils::CtEq for Scalar {
+    fn ct_eq(&self, other: &Self) -> ctutils::Choice {
+        ConstantTimeEq::ct_eq(self, other).into()
+    }
+}
+
+impl ctutils::CtSelect for Scalar {
+    fn ct_select(&self, other: &Self, choice: ctutils::Choice) -> Self {
+        ConditionallySelectable::conditional_select(self, other, choice.into())
     }
 }
 

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,10 +18,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.4", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.2", optional = true }
@@ -34,7 +34,7 @@ fiat-crypto = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.2", features = ["dev"] }
 proptest = "1.9"

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -17,11 +17,11 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-base16ct = "0.3"
-elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
+base16ct = "1"
+elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.4", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.2", optional = true }
@@ -32,7 +32,7 @@ sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.10", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.2", features = ["dev"] }
 proptest = "1.9"

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -32,6 +32,7 @@ use core::{
 use elliptic_curve::{
     Curve as _, Error, FieldBytesEncoding, Result,
     bigint::{self, Integer, Limb, NonZero, modular::MontyParams},
+    ctutils,
     ff::{self, Field, PrimeField},
     ops::{Invert, Reduce, ReduceNonZero},
     rand_core::TryRngCore,
@@ -412,6 +413,18 @@ impl ConditionallySelectable for Scalar {
 impl ConstantTimeEq for Scalar {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.as_limbs().ct_eq(other.as_limbs())
+    }
+}
+
+impl ctutils::CtEq for Scalar {
+    fn ct_eq(&self, other: &Self) -> ctutils::Choice {
+        ConstantTimeEq::ct_eq(self, other).into()
+    }
+}
+
+impl ctutils::CtSelect for Scalar {
+    fn ct_select(&self, other: &Self, choice: ctutils::Choice) -> Self {
+        ConditionallySelectable::conditional_select(self, other, choice.into())
     }
 }
 

--- a/primefield/src/macros.rs
+++ b/primefield/src/macros.rs
@@ -100,6 +100,8 @@ macro_rules! monty_field_params_with_root_of_unity {
 /// - `ConstantTimeEq`
 /// - `ConstantTimeGreater`
 /// - `ConstantTimeLess`
+/// - `CtEq`
+/// - `CtSelect`
 /// - `Default`
 /// - `DefaultIsZeroes`
 /// - `Eq`
@@ -602,6 +604,34 @@ macro_rules! monty_field_element {
         impl $crate::subtle::ConstantTimeLess for $fe {
             fn ct_lt(&self, other: &Self) -> $crate::subtle::Choice {
                 self.0.ct_lt(&other.0)
+            }
+        }
+
+        impl $crate::bigint::ctutils::CtSelect for $fe {
+            fn ct_select(&self, other: &Self, choice: $crate::bigint::ctutils::Choice) -> Self {
+                Self(
+                    $crate::bigint::ctutils::CtSelect::ct_select(
+                        &self.0, &other.0, choice,
+                    ),
+                )
+            }
+        }
+
+        impl $crate::bigint::ctutils::CtEq for $fe {
+            fn ct_eq(&self, other: &Self) -> $crate::bigint::ctutils::Choice {
+                $crate::bigint::ctutils::CtEq::ct_eq(&self.0, &other.0)
+            }
+        }
+
+        impl $crate::bigint::ctutils::CtGt for $fe {
+            fn ct_gt(&self, other: &Self) -> $crate::bigint::ctutils::Choice {
+                $crate::bigint::ctutils::CtGt::ct_gt(&self.0, &other.0)
+            }
+        }
+
+        impl $crate::bigint::ctutils::CtLt for $fe {
+            fn ct_lt(&self, other: &Self) -> $crate::bigint::ctutils::Choice {
+                $crate::bigint::ctutils::CtLt::ct_lt(&self.0, &other.0)
             }
         }
 

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true, default-features = false }

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -10,7 +10,7 @@ use core::{
 use elliptic_curve::{
     Error, FieldBytes, FieldBytesEncoding, FieldBytesSize, PublicKey, Result, Scalar,
     array::ArraySize,
-    ctutils::{self, CtGt, CtSelect},
+    ctutils::{self, CtGt as _, CtSelect as _},
     ff::{Field, PrimeField},
     group::{GroupEncoding, prime::PrimeCurveAffine},
     point::{AffineCoordinates, DecompactPoint, DecompressPoint, Double, NonIdentity},
@@ -155,6 +155,24 @@ where
 {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.x.ct_eq(&other.x) & self.y.ct_eq(&other.y) & self.infinity.ct_eq(&other.infinity)
+    }
+}
+
+impl<C> ctutils::CtEq for AffinePoint<C>
+where
+    C: PrimeCurveParams,
+{
+    fn ct_eq(&self, other: &Self) -> ctutils::Choice {
+        ConstantTimeEq::ct_eq(self, other).into()
+    }
+}
+
+impl<C> ctutils::CtSelect for AffinePoint<C>
+where
+    C: PrimeCurveParams,
+{
+    fn ct_select(&self, other: &Self, choice: ctutils::Choice) -> Self {
+        ConditionallySelectable::conditional_select(self, other, choice.into())
     }
 }
 

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -142,6 +142,24 @@ where
     }
 }
 
+impl<C> ctutils::CtEq for ProjectivePoint<C>
+where
+    C: PrimeCurveParams,
+{
+    fn ct_eq(&self, other: &Self) -> ctutils::Choice {
+        ConstantTimeEq::ct_eq(self, other).into()
+    }
+}
+
+impl<C> ctutils::CtSelect for ProjectivePoint<C>
+where
+    C: PrimeCurveParams,
+{
+    fn ct_select(&self, other: &Self, choice: ctutils::Choice) -> Self {
+        ConditionallySelectable::conditional_select(self, other, choice.into())
+    }
+}
+
 impl<C> Default for ProjectivePoint<C>
 where
     C: PrimeCurveParams,

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.18", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
 rand_core = { version = "0.10.0-rc-3", default-features = false }
 


### PR DESCRIPTION
Notably this adds `ctutils::{CtEq, CtSelect}` requirements to affine points, projective points, and scalar types, in addition to the existing `subtle` requirements.

This shouldn't affect existing `subtle` users but gives people the option to directly use `ctutils` traits on these types instead if they so desire.