### PR TITLE
primefield: add `test_fiat_monty_field_arithmetic!` macro

### DIFF
--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -72,5 +72,22 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U384};
+    #[cfg(not(p384_backend = "bignum"))]
+    use super::{
+        FieldParams, fiat_p384_montgomery_domain_field_element, fiat_p384_msat,
+        fiat_p384_non_montgomery_domain_field_element, fiat_p384_to_montgomery,
+    };
+
     primefield::test_primefield!(FieldElement, U384);
+
+    #[cfg(not(p384_backend = "bignum"))]
+    primefield::test_fiat_monty_field_arithmetic!(
+        name: FieldElement,
+        params: FieldParams,
+        uint: U384,
+        non_mont: fiat_p384_non_montgomery_domain_field_element,
+        mont: fiat_p384_montgomery_domain_field_element,
+        to_mont: fiat_p384_to_montgomery,
+        msat: fiat_p384_msat
+    );
 }

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -156,6 +156,11 @@ impl<'de> Deserialize<'de> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U384};
+    #[cfg(not(p384_backend = "bignum"))]
+    use super::{
+        ScalarParams, fiat_p384_scalar_montgomery_domain_field_element, fiat_p384_scalar_msat,
+        fiat_p384_scalar_non_montgomery_domain_field_element, fiat_p384_scalar_to_montgomery,
+    };
     use crate::{FieldBytes, NistP384, NonZeroScalar};
     use elliptic_curve::{
         Curve,
@@ -166,6 +171,17 @@ mod tests {
     use proptest::{prelude::any, prop_compose, proptest};
 
     primefield::test_primefield!(Scalar, U384);
+
+    #[cfg(not(p384_backend = "bignum"))]
+    primefield::test_fiat_monty_field_arithmetic!(
+        name: Scalar,
+        params: ScalarParams,
+        uint: U384,
+        non_mont: fiat_p384_scalar_non_montgomery_domain_field_element,
+        mont: fiat_p384_scalar_montgomery_domain_field_element,
+        to_mont: fiat_p384_scalar_to_montgomery,
+        msat: fiat_p384_scalar_msat
+    );
 
     #[test]
     fn from_to_bytes_roundtrip() {


### PR DESCRIPTION
Adds a macro which tests that `crypto-bigint` and `fiat-crypto` use equivalent Montgomery form representations.

There seem to be some odd edge cases, particularly curves where the number of 32-bit limbs * 2 != the number of 64-bit limbs (e.g. P-224, P-521) where these are differing, though we aren't actually using `fiat-crypto` in these cases (mit-plv/fiat-crypto#2166).

If they do differ, it means the representation used by `MontyFieldElement`, which is currently always the internal representation of our field newtypes, is incompatible with the representation used by `fiat-crypto`.

Currently this is wired up in the `p384` crate, but we should do it for all crates eventually. This is just an initial implementation.