### PR TITLE
Impl `primefield::test_fiat_monty_field_arithmetic!`

### DIFF
--- a/bignp256/src/arithmetic/field.rs
+++ b/bignp256/src/arithmetic/field.rs
@@ -75,5 +75,19 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U256};
+    use super::{
+        FieldParams, fiat_bignp256_montgomery_domain_field_element, fiat_bignp256_msat,
+        fiat_bignp256_non_montgomery_domain_field_element, fiat_bignp256_to_montgomery,
+    };
+
     primefield::test_primefield!(FieldElement, U256);
+    primefield::test_fiat_monty_field_arithmetic!(
+        name: FieldElement,
+        params: FieldParams,
+        uint: U256,
+        non_mont: fiat_bignp256_non_montgomery_domain_field_element,
+        mont: fiat_bignp256_montgomery_domain_field_element,
+        to_mont: fiat_bignp256_to_montgomery,
+        msat: fiat_bignp256_msat
+    );
 }

--- a/bignp256/src/arithmetic/scalar.rs
+++ b/bignp256/src/arithmetic/scalar.rs
@@ -107,5 +107,20 @@ impl Reduce<FieldBytes> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U256};
+    use super::{
+        ScalarParams, fiat_bignp256_scalar_montgomery_domain_field_element,
+        fiat_bignp256_scalar_msat, fiat_bignp256_scalar_non_montgomery_domain_field_element,
+        fiat_bignp256_scalar_to_montgomery,
+    };
+
     primefield::test_primefield!(Scalar, U256);
+    primefield::test_fiat_monty_field_arithmetic!(
+        name: Scalar,
+        params: ScalarParams,
+        uint: U256,
+        non_mont: fiat_bignp256_scalar_non_montgomery_domain_field_element,
+        mont: fiat_bignp256_scalar_montgomery_domain_field_element,
+        to_mont: fiat_bignp256_scalar_to_montgomery,
+        msat: fiat_bignp256_scalar_msat
+    );
 }

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -69,5 +69,19 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U256};
+    use super::{
+        FieldParams, fiat_bp256_montgomery_domain_field_element, fiat_bp256_msat,
+        fiat_bp256_non_montgomery_domain_field_element, fiat_bp256_to_montgomery,
+    };
+
     primefield::test_primefield!(FieldElement, U256);
+    primefield::test_fiat_monty_field_arithmetic!(
+        name: FieldElement,
+        params: FieldParams,
+        uint: U256,
+        non_mont: fiat_bp256_non_montgomery_domain_field_element,
+        mont: fiat_bp256_montgomery_domain_field_element,
+        to_mont: fiat_bp256_to_montgomery,
+        msat: fiat_bp256_msat
+    );
 }

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -111,5 +111,19 @@ impl Reduce<FieldBytes> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U256};
+    use super::{
+        ScalarParams, fiat_bp256_scalar_montgomery_domain_field_element, fiat_bp256_scalar_msat,
+        fiat_bp256_scalar_non_montgomery_domain_field_element, fiat_bp256_scalar_to_montgomery,
+    };
+
     primefield::test_primefield!(Scalar, U256);
+    primefield::test_fiat_monty_field_arithmetic!(
+        name: Scalar,
+        params: ScalarParams,
+        uint: U256,
+        non_mont: fiat_bp256_scalar_non_montgomery_domain_field_element,
+        mont: fiat_bp256_scalar_montgomery_domain_field_element,
+        to_mont: fiat_bp256_scalar_to_montgomery,
+        msat: fiat_bp256_scalar_msat
+    );
 }

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -69,5 +69,19 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U384};
+    use super::{
+        FieldParams, fiat_bp384_montgomery_domain_field_element, fiat_bp384_msat,
+        fiat_bp384_non_montgomery_domain_field_element, fiat_bp384_to_montgomery,
+    };
+
     primefield::test_primefield!(FieldElement, U384);
+    primefield::test_fiat_monty_field_arithmetic!(
+        name: FieldElement,
+        params: FieldParams,
+        uint: U384,
+        non_mont: fiat_bp384_non_montgomery_domain_field_element,
+        mont: fiat_bp384_montgomery_domain_field_element,
+        to_mont: fiat_bp384_to_montgomery,
+        msat: fiat_bp384_msat
+    );
 }

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -111,5 +111,19 @@ impl Reduce<FieldBytes> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U384};
+    use super::{
+        ScalarParams, fiat_bp384_scalar_montgomery_domain_field_element, fiat_bp384_scalar_msat,
+        fiat_bp384_scalar_non_montgomery_domain_field_element, fiat_bp384_scalar_to_montgomery,
+    };
+
     primefield::test_primefield!(Scalar, U384);
+    primefield::test_fiat_monty_field_arithmetic!(
+        name: Scalar,
+        params: ScalarParams,
+        uint: U384,
+        non_mont: fiat_bp384_scalar_non_montgomery_domain_field_element,
+        mont: fiat_bp384_scalar_montgomery_domain_field_element,
+        to_mont: fiat_bp384_scalar_to_montgomery,
+        msat: fiat_bp384_scalar_msat
+    );
 }

--- a/p192/src/arithmetic/field.rs
+++ b/p192/src/arithmetic/field.rs
@@ -70,5 +70,19 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U192};
+    use super::{
+        FieldParams, fiat_p192_montgomery_domain_field_element, fiat_p192_msat,
+        fiat_p192_non_montgomery_domain_field_element, fiat_p192_to_montgomery,
+    };
+
     primefield::test_primefield!(FieldElement, U192);
+    primefield::test_fiat_monty_field_arithmetic!(
+        name: FieldElement,
+        params: FieldParams,
+        uint: U192,
+        non_mont: fiat_p192_non_montgomery_domain_field_element,
+        mont: fiat_p192_montgomery_domain_field_element,
+        to_mont: fiat_p192_to_montgomery,
+        msat: fiat_p192_msat
+    );
 }

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -138,5 +138,19 @@ impl<'de> Deserialize<'de> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U192};
+    use super::{
+        ScalarParams, fiat_p192_scalar_montgomery_domain_field_element, fiat_p192_scalar_msat,
+        fiat_p192_scalar_non_montgomery_domain_field_element, fiat_p192_scalar_to_montgomery,
+    };
+
     primefield::test_primefield!(Scalar, U192);
+    primefield::test_fiat_monty_field_arithmetic!(
+        name: Scalar,
+        params: ScalarParams,
+        uint: U192,
+        non_mont: fiat_p192_scalar_non_montgomery_domain_field_element,
+        mont: fiat_p192_scalar_montgomery_domain_field_element,
+        to_mont: fiat_p192_scalar_to_montgomery,
+        msat: fiat_p192_scalar_msat
+    );
 }

--- a/p224/src/arithmetic/field.rs
+++ b/p224/src/arithmetic/field.rs
@@ -73,5 +73,19 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, Uint};
+    use super::{
+        FieldParams, fiat_p224_montgomery_domain_field_element, fiat_p224_msat,
+        fiat_p224_non_montgomery_domain_field_element, fiat_p224_to_montgomery,
+    };
+
     primefield::test_primefield!(FieldElement, Uint);
+    primefield::test_fiat_monty_field_arithmetic!(
+        name: FieldElement,
+        params: FieldParams,
+        uint: Uint,
+        non_mont: fiat_p224_non_montgomery_domain_field_element,
+        mont: fiat_p224_montgomery_domain_field_element,
+        to_mont: fiat_p224_to_montgomery,
+        msat: fiat_p224_msat
+    );
 }

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -137,5 +137,19 @@ impl<'de> Deserialize<'de> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, Uint};
+    use super::{
+        ScalarParams, fiat_p224_scalar_montgomery_domain_field_element, fiat_p224_scalar_msat,
+        fiat_p224_scalar_non_montgomery_domain_field_element, fiat_p224_scalar_to_montgomery,
+    };
+
     primefield::test_primefield!(Scalar, Uint);
+    primefield::test_fiat_monty_field_arithmetic!(
+        name: Scalar,
+        params: ScalarParams,
+        uint: Uint,
+        non_mont: fiat_p224_scalar_non_montgomery_domain_field_element,
+        mont: fiat_p224_scalar_montgomery_domain_field_element,
+        to_mont: fiat_p224_scalar_to_montgomery,
+        msat: fiat_p224_scalar_msat
+    );
 }

--- a/primefield/src/macros/fiat.rs
+++ b/primefield/src/macros/fiat.rs
@@ -280,7 +280,7 @@ macro_rules! fiat_bernstein_yang_invert {
 /// If these tests do not pass, the fiat-crypto synthesized implementation is incompatible with
 /// `MontyField`.
 ///
-/// See also:
+/// See also: mit-plv/fiat-crypto#2166
 #[macro_export]
 macro_rules! test_fiat_monty_field_arithmetic {
     (

--- a/sm2/src/arithmetic/field.rs
+++ b/sm2/src/arithmetic/field.rs
@@ -62,5 +62,19 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U256};
+    use super::{
+        FieldParams, fiat_sm2_montgomery_domain_field_element, fiat_sm2_msat,
+        fiat_sm2_non_montgomery_domain_field_element, fiat_sm2_to_montgomery,
+    };
+
     primefield::test_primefield!(FieldElement, U256);
+    primefield::test_fiat_monty_field_arithmetic!(
+        name: FieldElement,
+        params: FieldParams,
+        uint: U256,
+        non_mont: fiat_sm2_non_montgomery_domain_field_element,
+        mont: fiat_sm2_montgomery_domain_field_element,
+        to_mont: fiat_sm2_to_montgomery,
+        msat: fiat_sm2_msat
+    );
 }

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -131,5 +131,19 @@ impl<'de> Deserialize<'de> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U256};
+    use super::{
+        ScalarParams, fiat_sm2_scalar_montgomery_domain_field_element, fiat_sm2_scalar_msat,
+        fiat_sm2_scalar_non_montgomery_domain_field_element, fiat_sm2_scalar_to_montgomery,
+    };
+
     primefield::test_primefield!(Scalar, U256);
+    primefield::test_fiat_monty_field_arithmetic!(
+        name: Scalar,
+        params: ScalarParams,
+        uint: U256,
+        non_mont: fiat_sm2_scalar_non_montgomery_domain_field_element,
+        mont: fiat_sm2_scalar_montgomery_domain_field_element,
+        to_mont: fiat_sm2_scalar_to_montgomery,
+        msat: fiat_sm2_scalar_msat
+    );
 }


### PR DESCRIPTION
For all crates that use `word-by-word-montgomery` field implementations synthesized by `fiat-crypto`, adds this test macro (from #1567) to ensure that the field representations used by `crypto_bigint::modular` and `fiat-crypto` match up in all cases, as we use `primefield::MontyFieldElement` as the storage type for all `fiat-crypto` computations.

This includes:
- `bignp256`
- `bp256`
- `bp384`
- `p192`
- `p224`
- `sm2`

(`p384` was already done in #1567, `p521` uses a special `unsaturated-solinas` representation)