### PR TITLE
p521: fix `multiplicative_generator` for `Scalar`

### DIFF
--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -26,7 +26,7 @@ primefield::monty_field_params! {
     modulus: ORDER_HEX,
     uint: Uint,
     byte_order: primefield::ByteOrder::BigEndian,
-    multiplicative_generator: 2,
+    multiplicative_generator: 3,
     doc: "Montgomery parameters for the NIST P-521 scalar modulus `n`."
 }
 
@@ -105,8 +105,5 @@ impl<'de> Deserialize<'de> for Scalar {
 mod tests {
     use super::{Scalar, Uint};
     use elliptic_curve::ff::PrimeField;
-    primefield::test_primefield_constants!(Scalar, Uint);
-    primefield::test_field_identity!(Scalar);
-    primefield::test_field_invert!(Scalar);
-    //primefield::test_field_sqrt!(Scalar); TODO(tarcieri): working sqrt impl
+    primefield::test_primefield!(Scalar, Uint);
 }


### PR DESCRIPTION
This was originally correctly computed as `3` in #760.

Somewhere along the way it got changed to `2`. This is why the `sqrt` impl wasn't working: it was correctly selecting Tonelli-Shanks, but if multiplicative generator is incorrect it will miscompute `ROOT_OF_UNITY`, which will result in invalid outputs for `sqrt`.

Unfortunately though we test the constants, this doesn't seem to have been caught by our existing tests, aside from it indirectly causing the `sqrt` test to fail.