### PR TITLE
primefield: add basic test for `MULTIPLICATIVE_GENERATOR`

### DIFF
--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -13,7 +13,7 @@ use core::{
 };
 use elliptic_curve::{
     Curve,
-    bigint::{ArrayEncoding, Integer, Limb, Odd, U256, Uint},
+    bigint::{ArrayEncoding, Integer, Limb, Odd, U256, Uint, modular::Retrieve},
     ctutils,
     group::ff::{self, Field, FromUniformBytes, PrimeField},
     ops::{Invert, Reduce, ReduceNonZero},
@@ -307,6 +307,14 @@ impl PrimeFieldBits for Scalar {
 
     fn char_le_bits() -> ScalarBits {
         NistP256::ORDER.to_words().into()
+    }
+}
+
+impl Retrieve for Scalar {
+    type Output = U256;
+
+    fn retrieve(&self) -> U256 {
+        self.0
     }
 }
 

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -30,7 +30,7 @@ use core::{
 };
 use elliptic_curve::{
     Error, FieldBytesEncoding,
-    bigint::Word,
+    bigint::{Word, modular::Retrieve},
     ff::{self, Field, PrimeField},
     ops::Invert,
     rand_core::TryRngCore,
@@ -686,11 +686,22 @@ impl<'a> Product<&'a FieldElement> for FieldElement {
     }
 }
 
+// `crypto-bigint` trait impls
+
 impl Invert for FieldElement {
     type Output = CtOption<Self>;
 
     fn invert(&self) -> CtOption<Self> {
         self.invert()
+    }
+}
+
+impl Retrieve for FieldElement {
+    type Output = Uint;
+
+    fn retrieve(&self) -> Uint {
+        // TODO(tarcieri): more optimized conversion
+        FieldBytesEncoding::<NistP521>::decode_field_bytes(&self.to_bytes())
     }
 }
 

--- a/primefield/src/macros.rs
+++ b/primefield/src/macros.rs
@@ -107,6 +107,7 @@ macro_rules! monty_field_params_with_root_of_unity {
 /// - `Eq`
 /// - `Field`
 /// - `PartialEq`
+/// - `Retrieve`
 ///
 /// ## Ops
 /// - `Add`
@@ -576,6 +577,14 @@ macro_rules! monty_field_element {
 
             fn invert(&self) -> CtOption<Self> {
                 self.invert()
+            }
+        }
+
+        impl $crate::bigint::modular::Retrieve for $fe {
+            type Output = $uint;
+
+            fn retrieve(&self) -> $uint {
+                $crate::bigint::modular::Retrieve::retrieve(&self.0)
             }
         }
 

--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -7,7 +7,7 @@ use crate::ByteOrder;
 use bigint::{
     ArrayEncoding, ByteArray, Integer, Invert, Limb, Reduce, Uint, Word, ctutils,
     hybrid_array::{Array, ArraySize, typenum::Unsigned},
-    modular::{ConstMontyForm as MontyForm, ConstMontyParams, MontyParams},
+    modular::{ConstMontyForm as MontyForm, ConstMontyParams, MontyParams, Retrieve},
 };
 use core::{
     cmp::Ordering,
@@ -930,6 +930,14 @@ impl<MOD: MontyFieldParams<LIMBS>, const LIMBS: usize> PartialOrd
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl<MOD: MontyFieldParams<LIMBS>, const LIMBS: usize> Retrieve for MontyFieldElement<MOD, LIMBS> {
+    type Output = Uint<LIMBS>;
+
+    fn retrieve(&self) -> Uint<LIMBS> {
+        self.to_canonical()
     }
 }
 


### PR DESCRIPTION
Uses `JacobiSymbol` to test that the specified `MULTIPLICATIVE_GENERATOR` constant is a quadratic non-residue of the `MODULUS`.

This isn't a fully comprehensive test but would've caught #1569.