### PR TITLE
Bump `elliptic-curve` to v0.14.0-rc.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,9 +363,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.13"
+version = "0.7.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bb4138de6db76c8155b4423e967049fbef2cf84ad6af7f552f73a161941b72"
+checksum = "c9c6daa2049db6a5fad90a981b8c63f023dbaf75a0fae73db4dcf234556fc957"
 dependencies = [
  "ctutils",
  "getrandom 0.4.0-rc.0",
@@ -477,9 +477,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.19"
+version = "0.14.0-rc.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bfae4ab886ff791e2119cc79402281e35408f22b6b7322acef371d01061054b"
+checksum = "1f4874d0de0bf58704a6917f26154afcdd49ebc11cae10b6d53950217aee9408"
 dependencies = [
  "base16ct 1.0.0",
  "crypto-bigint",

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.19", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.20", features = ["sec1"] }
 
 # optional dependencies
 belt-hash = { version = "0.2.0-rc.0", optional = true, default-features = false }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.11", optional = true, default-features = false, features = ["der"] }

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.11", optional = true, default-features = false, features = ["der"] }

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -16,7 +16,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.19", features = ["arithmetic", "pkcs8"] }
+elliptic-curve = { version = "0.14.0-rc.20", features = ["arithmetic", "pkcs8"] }
 hash2curve = "0.14.0-rc.6"
 rand_core = { version = "0.10.0-rc-3", default-features = false }
 sha3 = { version = "0.11.0-rc.3", default-features = false }

--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -13,7 +13,7 @@ use elliptic_curve::{
         Array, ArraySize,
         typenum::{Prod, Unsigned},
     },
-    bigint::{Integer, Limb, U448, U896, Word},
+    bigint::{Integer, Limb, U448, U896, Word, modular::Retrieve},
     consts::U2,
     ctutils::{self, CtSelect},
     ff::{Field, helpers},
@@ -530,6 +530,14 @@ impl<C: CurveWithScalar> ReduceNonZero<U896> for Scalar<C> {
                 .1
                 .wrapping_add(&U448::ONE),
         )
+    }
+}
+
+impl<C: CurveWithScalar> Retrieve for Scalar<C> {
+    type Output = U448;
+
+    fn retrieve(&self) -> U448 {
+        U448::from_le_byte_array(self.to_bytes().into())
     }
 }
 

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = { version = "0.11.0-rc.5" }
-elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["arithmetic"] }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
 hash2curve = { version = "0.14.0-rc.6", optional = true }
 
 # optional dependencies

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -16,7 +16,7 @@ use core::{
 };
 use elliptic_curve::{
     Curve, Error, ScalarValue,
-    bigint::{ArrayEncoding, Integer, Limb, U256, U512, Word},
+    bigint::{ArrayEncoding, Integer, Limb, U256, U512, Word, modular::Retrieve},
     ctutils,
     ff::{self, Field, FromUniformBytes, PrimeField},
     ops::{Invert, Reduce, ReduceNonZero},
@@ -827,6 +827,14 @@ impl ReduceNonZero<WideBytes> for Scalar {
     #[inline]
     fn reduce_nonzero(bytes: &WideBytes) -> Self {
         Self::reduce_nonzero(&U512::from_be_byte_array(*bytes))
+    }
+}
+
+impl Retrieve for Scalar {
+    type Output = U256;
+
+    fn retrieve(&self) -> U256 {
+        U256::from_be_byte_array(self.to_bytes())
     }
 }
 

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "1"
-elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true, default-features = false }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.19", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
 rand_core = { version = "0.10.0-rc-3", default-features = false }
 


### PR DESCRIPTION
Adds `Retrieve` bounds to `Scalar` types