### PR TITLE
k256: use `crypto-bigint` to impl scalar inversions

### DIFF
--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -173,27 +173,25 @@ impl FieldElement {
     }
 
     /// Returns the multiplicative inverse of self, if self is non-zero.
+    ///
     /// The result has magnitude 1 and is normalized.
     pub fn invert(&self) -> CtOption<Self> {
-        CtOption::from(
-            self.0
-                .normalize()
-                .to_u256()
-                .invert_odd_mod(const { &Odd::from_be_hex(MODULUS_HEX) }),
-        )
-        .map(|uint| Self(FieldElementImpl::from_u256_unchecked(uint)))
+        let inv = self
+            .retrieve()
+            .invert_odd_mod(const { &Odd::from_be_hex(MODULUS_HEX) });
+
+        CtOption::from(inv).map(|uint| Self(FieldElementImpl::from_u256_unchecked(uint)))
     }
 
     /// Returns the multiplicative inverse of self in variable-time, if self is non-zero.
+    ///
     /// The result has magnitude 1 and is normalized.
     pub fn invert_vartime(&self) -> CtOption<Self> {
-        CtOption::from(
-            self.0
-                .normalize()
-                .to_u256()
-                .invert_odd_mod_vartime(const { &Odd::from_be_hex(MODULUS_HEX) }),
-        )
-        .map(|uint| Self(FieldElementImpl::from_u256_unchecked(uint)))
+        let inv = self
+            .retrieve()
+            .invert_odd_mod_vartime(const { &Odd::from_be_hex(MODULUS_HEX) });
+
+        CtOption::from(inv).map(|uint| Self(FieldElementImpl::from_u256_unchecked(uint)))
     }
 
     /// Returns the square root of self mod p, or `None` if no square root exists.


### PR DESCRIPTION
Uses the optimized safegcd-bounds algorithm in `crypto-bigint`.

Like other similar conversions, it's massively faster:

    scalar operations/invert
                        time:   [2.6595 µs 2.7676 µs 2.9068 µs]
                        change: [−80.024% −79.497% −78.858%] (p = 0.00 < 0.05)
                        Performance has improved.