### PR TITLE
primefield: add `invert_vartime` impls

### DIFF
--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -106,6 +106,11 @@ impl FieldElement {
         self.0.invert().map(Self)
     }
 
+    /// Returns the multiplicative inverse of self, if self is non-zero.
+    pub fn invert_vartime(&self) -> CtOption<Self> {
+        self.0.invert_vartime().map(Self)
+    }
+
     /// Returns the square root of self mod p, or `None` if no square root exists.
     pub fn sqrt(&self) -> CtOption<Self> {
         // We need to find alpha such that alpha^2 = beta mod p. For secp256r1,

--- a/primefield/src/macros.rs
+++ b/primefield/src/macros.rs
@@ -578,6 +578,10 @@ macro_rules! monty_field_element {
             fn invert(&self) -> CtOption<Self> {
                 self.invert()
             }
+
+            fn invert_vartime(&self) -> CtOption<Self> {
+                self.0.invert_vartime().map(Self)
+            }
         }
 
         impl $crate::bigint::modular::Retrieve for $fe {
@@ -729,7 +733,15 @@ macro_rules! monty_field_arithmetic {
             /// inversion: `1 / self`.
             #[inline]
             pub fn invert(&self) -> $crate::subtle::CtOption<Self> {
-                self.0.invert().map(|fe| Self(fe))
+                self.0.invert().map(Self)
+            }
+
+            /// Compute
+            #[doc = stringify!($fe)]
+            /// inversion: `1 / self` in variable-time.
+            #[inline]
+            pub fn invert_vartime(&self) -> $crate::subtle::CtOption<Self> {
+                self.0.invert_vartime().map(Self)
             }
 
             /// Compute field inversion as a `const fn`. Panics if `self` is zero.

--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -331,6 +331,12 @@ where
         CtOption::from(self.inner.invert()).map(|inner| Self { inner })
     }
 
+    /// Compute field inversion: `1 / self` in variable-time.
+    #[inline]
+    pub fn invert_vartime(&self) -> CtOption<Self> {
+        CtOption::from(self.inner.invert_vartime()).map(|inner| Self { inner })
+    }
+
     /// Compute field inversion as a `const fn`. Panics if `self` is zero.
     ///
     /// This is mainly intended for inverting constants at compile time.
@@ -655,6 +661,10 @@ where
 
     fn invert(&self) -> CtOption<Self> {
         Self::invert(self)
+    }
+
+    fn invert_vartime(&self) -> CtOption<Self> {
+        Self::invert_vartime(self)
     }
 }
 


### PR DESCRIPTION
Adds `MontyFieldElement::invert_vartime` which delegates to the ultimately variable-time implementation of safegcd-bounds, and has the macros write a wrapper for it and impl the `Invert::invert_vartime` method as well.