### PR TITLE
bp256: add `cfg(bp256_backend = "bignum")`

### DIFF
--- a/.github/workflows/bp256.yml
+++ b/.github/workflows/bp256.yml
@@ -68,3 +68,7 @@ jobs:
       - run: cargo test --no-default-features
       - run: cargo test
       - run: cargo test --all-features
+      - env:
+          RUSTFLAGS: '--cfg bp256_backend="bignum"'
+          RUSTDOCFLAGS: '--cfg bp256_backend="bignum"'
+        run: cargo test --release --all-features

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -37,3 +37,7 @@ sha256 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(bp256_backend, values("bignum", "fiat"))'] # default: "fiat"

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -10,6 +10,7 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
+#[cfg(not(bp256_backend = "bignum"))]
 #[cfg_attr(target_pointer_width = "32", path = "field/bp256_32.rs")]
 #[cfg_attr(target_pointer_width = "64", path = "field/bp256_64.rs")]
 #[allow(
@@ -21,12 +22,14 @@
 #[allow(dead_code)] // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 mod field_impl;
 
-use self::field_impl::*;
 use crate::U256;
 use elliptic_curve::{
     ff::PrimeField,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
+
+#[cfg(not(bp256_backend = "bignum"))]
+use self::field_impl::*;
 
 /// Constant representing the modulus serialized as hex.
 const MODULUS_HEX: &str = "a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5377";
@@ -47,6 +50,14 @@ primefield::monty_field_element! {
     doc: "Element in the brainpoolP256 finite field modulo p"
 }
 
+#[cfg(bp256_backend = "bignum")]
+primefield::monty_field_arithmetic! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U256
+}
+
+#[cfg(not(bp256_backend = "bignum"))]
 primefield::fiat_monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
@@ -69,12 +80,15 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U256};
+    #[cfg(not(bp256_backend = "bignum"))]
     use super::{
         FieldParams, fiat_bp256_montgomery_domain_field_element, fiat_bp256_msat,
         fiat_bp256_non_montgomery_domain_field_element, fiat_bp256_to_montgomery,
     };
 
     primefield::test_primefield!(FieldElement, U256);
+
+    #[cfg(not(bp256_backend = "bignum"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: FieldElement,
         params: FieldParams,

--- a/bp256/src/lib.rs
+++ b/bp256/src/lib.rs
@@ -15,6 +15,32 @@
     unused_qualifications
 )]
 
+//! ## Backends
+//!
+//! This crate has support for two different field arithmetic backends which can be selected using
+//! `cfg(bp256_backend)`, e.g. to select the `bignum` backend:
+//!
+//! ```console
+//! $ RUSTFLAGS='--cfg bp256_backend="bignum"' cargo test
+//! ```
+//!
+//! Or it can be set through [`.cargo/config`][buildrustflags]:
+//!
+//! ```toml
+//! [build]
+//! rustflags = ['--cfg', 'bp256_backend="bignum"']
+//! ```
+//!
+//! The available backends are:
+//! - `bignum`: experimental backend provided by [crypto-bigint]. May offer better performance in
+//!   some cases along with smaller code size, but might also have bugs.
+//! - `fiat` (default): formally verified implementation synthesized by [fiat-crypto] which should
+//!   be correct for all inputs (though there's a possibility of bugs in the code which glues to it)
+//!
+//! [buildrustflags]: https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags
+//! [crypto-bigint]: https://github.com/RustCrypto/crypto-bigint
+//! [fiat-crypto]: https://github.com/mit-plv/fiat-crypto
+
 pub mod r1;
 pub mod t1;
 


### PR DESCRIPTION
Adds support for an experimental backend which uses `crypto-bigint` as the field element representation, as an off-by-default alternative to `fiat-crypto`, similar to what was introduced in `p384` in #1548.

This uses the `monty_field_arithmetic!` macro introduced in #1547.