### PR TITLE
bp384: add `cfg(bp384_backend = "bignum")`

### DIFF
--- a/.github/workflows/bp384.yml
+++ b/.github/workflows/bp384.yml
@@ -68,3 +68,7 @@ jobs:
       - run: cargo test --no-default-features
       - run: cargo test
       - run: cargo test --all-features
+      - env:
+          RUSTFLAGS: '--cfg bp384_backend="bignum"'
+          RUSTDOCFLAGS: '--cfg bp384_backend="bignum"'
+        run: cargo test --release --all-features

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -10,6 +10,7 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
+#[cfg(not(bp256_backend = "bignum"))]
 #[cfg_attr(target_pointer_width = "32", path = "scalar/bp256_scalar_32.rs")]
 #[cfg_attr(target_pointer_width = "64", path = "scalar/bp256_scalar_64.rs")]
 #[allow(
@@ -21,7 +22,6 @@
 #[allow(dead_code)] // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 mod scalar_impl;
 
-use self::scalar_impl::*;
 use crate::{BrainpoolP256r1, BrainpoolP256t1, FieldBytes, ORDER, ORDER_HEX, U256};
 use elliptic_curve::{
     bigint::{ArrayEncoding, Limb},
@@ -30,6 +30,9 @@ use elliptic_curve::{
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
+
+#[cfg(not(bp256_backend = "bignum"))]
+use self::scalar_impl::*;
 
 #[cfg(doc)]
 use core::ops::{Add, Mul, Sub};
@@ -50,6 +53,14 @@ primefield::monty_field_element! {
     doc: "Element in the brainpoolP256 scalar field modulo n"
 }
 
+#[cfg(bp256_backend = "bignum")]
+primefield::monty_field_arithmetic! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U256
+}
+
+#[cfg(not(bp256_backend = "bignum"))]
 primefield::fiat_monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
@@ -111,12 +122,15 @@ impl Reduce<FieldBytes> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U256};
+    #[cfg(not(bp256_backend = "bignum"))]
     use super::{
         ScalarParams, fiat_bp256_scalar_montgomery_domain_field_element, fiat_bp256_scalar_msat,
         fiat_bp256_scalar_non_montgomery_domain_field_element, fiat_bp256_scalar_to_montgomery,
     };
 
     primefield::test_primefield!(Scalar, U256);
+
+    #[cfg(not(bp256_backend = "bignum"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: Scalar,
         params: ScalarParams,

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -37,3 +37,7 @@ sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(bp384_backend, values("bignum", "fiat"))'] # default: "fiat"

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -10,6 +10,7 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
+#[cfg(not(bp384_backend = "bignum"))]
 #[cfg_attr(target_pointer_width = "32", path = "field/bp384_32.rs")]
 #[cfg_attr(target_pointer_width = "64", path = "field/bp384_64.rs")]
 #[allow(
@@ -21,12 +22,14 @@
 #[allow(dead_code)] // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 mod field_impl;
 
-use self::field_impl::*;
 use crate::U384;
 use elliptic_curve::{
     ff::PrimeField,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
+
+#[cfg(not(bp384_backend = "bignum"))]
+use self::field_impl::*;
 
 /// Constant representing the modulus serialized as hex.
 const MODULUS_HEX: &str = "8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec53";
@@ -44,9 +47,17 @@ primefield::monty_field_element! {
     name: FieldElement,
     params: FieldParams,
     uint: U384,
-    doc: "Element in the brainpoolP256 finite field modulo p"
+    doc: "Element in the brainpoolP384 finite field modulo p"
 }
 
+#[cfg(bp384_backend = "bignum")]
+primefield::monty_field_arithmetic! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U384
+}
+
+#[cfg(not(bp384_backend = "bignum"))]
 primefield::fiat_monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
@@ -69,12 +80,15 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U384};
+    #[cfg(not(bp384_backend = "bignum"))]
     use super::{
         FieldParams, fiat_bp384_montgomery_domain_field_element, fiat_bp384_msat,
         fiat_bp384_non_montgomery_domain_field_element, fiat_bp384_to_montgomery,
     };
 
     primefield::test_primefield!(FieldElement, U384);
+
+    #[cfg(not(bp384_backend = "bignum"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: FieldElement,
         params: FieldParams,

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -10,6 +10,7 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
+#[cfg(not(bp384_backend = "bignum"))]
 #[cfg_attr(target_pointer_width = "32", path = "scalar/bp384_scalar_32.rs")]
 #[cfg_attr(target_pointer_width = "64", path = "scalar/bp384_scalar_64.rs")]
 #[allow(
@@ -21,7 +22,6 @@
 #[allow(dead_code)] // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 mod scalar_impl;
 
-use self::scalar_impl::*;
 use crate::{BrainpoolP384r1, BrainpoolP384t1, FieldBytes, ORDER, ORDER_HEX, U384};
 use elliptic_curve::{
     bigint::{ArrayEncoding, Limb},
@@ -30,6 +30,9 @@ use elliptic_curve::{
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
+
+#[cfg(not(bp384_backend = "bignum"))]
+use self::scalar_impl::*;
 
 #[cfg(doc)]
 use core::ops::{Add, Mul, Sub};
@@ -50,6 +53,14 @@ primefield::monty_field_element! {
     doc: "Element in the brainpoolP256 scalar field modulo n"
 }
 
+#[cfg(bp384_backend = "bignum")]
+primefield::monty_field_arithmetic! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U384
+}
+
+#[cfg(not(bp384_backend = "bignum"))]
 primefield::fiat_monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
@@ -111,12 +122,15 @@ impl Reduce<FieldBytes> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U384};
+    #[cfg(not(bp384_backend = "bignum"))]
     use super::{
         ScalarParams, fiat_bp384_scalar_montgomery_domain_field_element, fiat_bp384_scalar_msat,
         fiat_bp384_scalar_non_montgomery_domain_field_element, fiat_bp384_scalar_to_montgomery,
     };
 
     primefield::test_primefield!(Scalar, U384);
+
+    #[cfg(not(bp384_backend = "bignum"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: Scalar,
         params: ScalarParams,

--- a/bp384/src/lib.rs
+++ b/bp384/src/lib.rs
@@ -15,6 +15,32 @@
     unused_qualifications
 )]
 
+//! ## Backends
+//!
+//! This crate has support for two different field arithmetic backends which can be selected using
+//! `cfg(bp384_backend)`, e.g. to select the `bignum` backend:
+//!
+//! ```console
+//! $ RUSTFLAGS='--cfg bp384_backend="bignum"' cargo test
+//! ```
+//!
+//! Or it can be set through [`.cargo/config`][buildrustflags]:
+//!
+//! ```toml
+//! [build]
+//! rustflags = ['--cfg', 'bp384_backend="bignum"']
+//! ```
+//!
+//! The available backends are:
+//! - `bignum`: experimental backend provided by [crypto-bigint]. May offer better performance in
+//!   some cases along with smaller code size, but might also have bugs.
+//! - `fiat` (default): formally verified implementation synthesized by [fiat-crypto] which should
+//!   be correct for all inputs (though there's a possibility of bugs in the code which glues to it)
+//!
+//! [buildrustflags]: https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags
+//! [crypto-bigint]: https://github.com/RustCrypto/crypto-bigint
+//! [fiat-crypto]: https://github.com/mit-plv/fiat-crypto
+
 pub mod r1;
 pub mod t1;
 


### PR DESCRIPTION
Adds support for an experimental backend which uses `crypto-bigint` as the field element representation, as an off-by-default alternative to `fiat-crypto`, similar to what was introduced in `p384` in #1548 and `bp256` in #1583.