### PR TITLE
Impl `crypto_common::Generate` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,9 +357,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.14"
+version = "0.7.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c6daa2049db6a5fad90a981b8c63f023dbaf75a0fae73db4dcf234556fc957"
+checksum = "1a9e36ac79ac44866b74e08a0b4925f97b984e3fff17680d2c6fbce8317ab0f6"
 dependencies = [
  "ctutils",
  "getrandom 0.4.0-rc.0",
@@ -372,11 +372,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6165b8029cdc3e765b74d3548f85999ee799d5124877ce45c2c85ca78e4d4aa"
+version = "0.2.0-rc.9"
+source = "git+https://github.com/RustCrypto/traits#ded0d2297fba206939bfb5f47b4fd823c4bccae8"
 dependencies = [
+ "getrandom 0.4.0-rc.0",
  "hybrid-array",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -416,8 +417,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.17.0-rc.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "569a1f3377df19ab839b2811061095ff7d9fb7ea3c0e500b7a4724343cf6ee3d"
+source = "git+https://github.com/RustCrypto/signatures#d669c66b4ab443c0b7b82b2ab449ee7b15704a66"
 dependencies = [
  "der",
  "digest",
@@ -472,11 +472,11 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4874d0de0bf58704a6917f26154afcdd49ebc11cae10b6d53950217aee9408"
+source = "git+https://github.com/RustCrypto/traits#ded0d2297fba206939bfb5f47b4fd823c4bccae8"
 dependencies = [
  "base16ct",
  "crypto-bigint",
+ "crypto-common",
  "digest",
  "getrandom 0.4.0-rc.0",
  "hex-literal",
@@ -901,6 +901,7 @@ name = "primefield"
 version = "0.14.0-rc.3"
 dependencies = [
  "crypto-bigint",
+ "crypto-common",
  "rand_core 0.10.0-rc-3",
  "rustcrypto-ff",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,7 @@ ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
+
+crypto-common = { git = "https://github.com/RustCrypto/traits" }
+ecdsa = { git = "https://github.com/RustCrypto/signatures" }
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/bignp256/src/ecdh.rs
+++ b/bignp256/src/ecdh.rs
@@ -10,9 +10,14 @@
 //!
 #![cfg_attr(feature = "getrandom", doc = "```")]
 #![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! // NOTE: requires 'getrandom' feature is enabled
 //!
-//! use bignp256::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
+//! use bignp256::{
+//!     EncodedPoint, PublicKey,
+//!     ecdh::EphemeralSecret,
+//!     elliptic_curve::Generate
+//! };
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::generate();
@@ -23,15 +28,11 @@
 //! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it
-//! let bob_public =
-//!     PublicKey::from_encoded_point(bob_pk_bytes).expect("bob's public key is invalid!"); // In real usage, don't panic, handle this!
-//!
+//! let bob_public = PublicKey::from_encoded_point(bob_pk_bytes)?;
 //! let alice_shared = alice_secret.diffie_hellman(&bob_public.into());
 //!
 //! // Bob decodes Alice's serialized public key and computes the same shared secret
-//! let alice_public =
-//!     PublicKey::from_encoded_point(alice_pk_bytes).expect("alice's public key is invalid!"); // In real usage, don't panic, handle this!
-//!
+//! let alice_public = PublicKey::from_encoded_point(alice_pk_bytes)?;
 //! let bob_shared = bob_secret.diffie_hellman(&alice_public.into());
 //!
 //! // Both participants arrive on the same shared secret
@@ -39,6 +40,8 @@
 //!     alice_shared.raw_secret_bytes(),
 //!     bob_shared.raw_secret_bytes()
 //! );
+//! # Ok(())
+//! # }
 //! ```
 
 pub use elliptic_curve::ecdh::diffie_hellman;

--- a/bignp256/src/ecdsa.rs
+++ b/bignp256/src/ecdsa.rs
@@ -2,26 +2,25 @@
 //!
 //! ## Usage
 //!
-//! NOTE: requires the `dsa` crate feature enabled, and `rand_core` dependency
-//! with `getrandom` feature enabled.
-#![cfg_attr(feature = "std", doc = "```")]
-#![cfg_attr(not(feature = "std"), doc = "```ignore")]
-//! # fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! use getrandom::{SysRng, rand_core::TryRngCore};
+#![cfg_attr(all(feature = "ecdsa", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "ecdsa", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `ecdsa` and `getrandom` crate features are enabled
 //! use bignp256::{
-//!     ecdsa::{Signature, SigningKey, signature::Signer},
-//!     SecretKey
+//!     ecdsa::{SigningKey, Signature, signature::Signer},
+//!     elliptic_curve::{Generate, sec1::ToEncodedPoint},
+//!     SecretKey,
 //! };
 //!
 //! // Signing
-//! let secret_key = SecretKey::try_from_rng(&mut SysRng).unwrap(); // serialize with `::to_bytes()`
-//! let signing_key = SigningKey::new(&secret_key)?;
+//! let signing_key = SigningKey::generate(); // Serialize with `::to_bytes()`
 //! let verifying_key_bytes = signing_key.verifying_key().to_bytes();
+//!
 //! let message = b"test message";
 //! let signature: Signature = signing_key.sign(message);
 //!
-//! // Verifying
-//! use bignp256::ecdsa::{VerifyingKey, signature::Verifier};
+//! // Verification
+//! use bignp256::{EncodedPoint, ecdsa::{VerifyingKey, signature::Verifier}};
 //!
 //! let verifying_key = VerifyingKey::from_bytes(&verifying_key_bytes)?;
 //! verifying_key.verify(message, &signature)?;

--- a/bignp256/tests/ecdsa.rs
+++ b/bignp256/tests/ecdsa.rs
@@ -37,7 +37,7 @@ prop_compose! {
         loop {
             let scalar = <Scalar as Reduce<FieldBytes>>::reduce(&bytes.into());
             if let Some(scalar) = Option::from(NonZeroScalar::new(scalar)) {
-                return SigningKey::from_nonzero_scalar(scalar).unwrap();
+                return SigningKey::from_nonzero_scalar(scalar);
             }
         }
     }

--- a/ed448-goldilocks/src/edwards/scalar.rs
+++ b/ed448-goldilocks/src/edwards/scalar.rs
@@ -1,11 +1,13 @@
 use crate::Ed448;
 use crate::field::{CurveWithScalar, ORDER, Scalar, ScalarBytes, WideScalarBytes};
 
-use elliptic_curve::array::Array;
-use elliptic_curve::bigint::{Limb, NonZero, U448, U704};
-use elliptic_curve::consts::{U57, U84, U88};
-use elliptic_curve::ops::Reduce;
-use elliptic_curve::scalar::FromUintUnchecked;
+use elliptic_curve::{
+    array::Array,
+    bigint::{Limb, NonZero, U448, U704},
+    consts::{U57, U84, U88},
+    ops::Reduce,
+    scalar::FromUintUnchecked,
+};
 use subtle::{Choice, ConstantTimeEq, CtOption};
 
 impl CurveWithScalar for Ed448 {

--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -8,7 +8,7 @@ use core::ops::{
     Add, AddAssign, Index, IndexMut, Mul, MulAssign, Neg, Shr, ShrAssign, Sub, SubAssign,
 };
 use elliptic_curve::{
-    CurveArithmetic, PrimeField,
+    CurveArithmetic, Generate, PrimeField,
     array::{
         Array, ArraySize,
         typenum::{Prod, Unsigned},
@@ -20,7 +20,7 @@ use elliptic_curve::{
     ops::{Invert, Reduce, ReduceNonZero},
     scalar::{FromUintUnchecked, IsHigh},
 };
-use rand_core::{CryptoRng, RngCore, TryRngCore};
+use rand_core::{CryptoRng, RngCore, TryCryptoRng, TryRngCore};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, CtOption};
 
 #[cfg(feature = "bits")]
@@ -369,6 +369,12 @@ impl<C: CurveWithScalar> PrimeField for Scalar<C> {
     ));
 
     const DELTA: Self = Self::new(U448::from_u8(49));
+}
+
+impl<C: CurveWithScalar> Generate for Scalar<C> {
+    fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        Self::try_from_rng(rng)
+    }
 }
 
 #[cfg(feature = "alloc")]

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -45,14 +45,4 @@ mod tests {
     fn verify_constants() {
         assert_eq!(CURVE_EQUATION_B.to_bytes(), CURVE_EQUATION_B_BYTES);
     }
-
-    #[test]
-    fn try_from_rng() {
-        use crate::SecretKey;
-        use getrandom::SysRng;
-        let key = SecretKey::try_from_rng(&mut SysRng).unwrap();
-
-        // Sanity check
-        assert!(!key.to_bytes().iter().all(|b| *b == 0))
-    }
 }

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -9,7 +9,7 @@ use core::{
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
 };
 use elliptic_curve::{
-    BatchNormalize, CurveGroup, Error, Result, ctutils,
+    BatchNormalize, CurveGroup, Error, Generate, Result, ctutils,
     group::{
         Group, GroupEncoding,
         cofactor::CofactorGroup,
@@ -17,7 +17,7 @@ use elliptic_curve::{
     },
     ops::BatchInvert,
     point::NonIdentity,
-    rand_core::TryRngCore,
+    rand_core::{TryCryptoRng, TryRngCore},
     sec1::{FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
@@ -254,6 +254,14 @@ impl From<AffinePoint> for ProjectivePoint {
             z: FieldElement::ONE,
         };
         Self::conditional_select(&projective, &Self::IDENTITY, p.is_identity())
+    }
+}
+
+impl Generate for ProjectivePoint {
+    fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(
+        rng: &mut R,
+    ) -> core::result::Result<Self, R::Error> {
+        AffinePoint::try_generate_from_rng(rng).map(Into::into)
     }
 }
 

--- a/k256/src/ecdh.rs
+++ b/k256/src/ecdh.rs
@@ -8,21 +8,26 @@
 //! This usage example is from the perspective of two participants in the
 //! exchange, nicknamed "Alice" and "Bob".
 //!
-//! ```
-//! use k256::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use getrandom::{SysRng, rand_core::TryRngCore};
+#![cfg_attr(all(feature = "ecdh", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "ecdh", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `ecdh` and `getrandom` crate features are enabled
+//! use k256::{
+//!     EncodedPoint, PublicKey,
+//!     elliptic_curve::Generate,
+//!     ecdh::EphemeralSecret
+//! };
 //!
 //! // Alice
-//! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
+//! let alice_secret = EphemeralSecret::generate();
 //! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
 //!
 //! // Bob
-//! let bob_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
+//! let bob_secret = EphemeralSecret::generate();
 //! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it
-//! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())
-//!     .expect("bob's public key is invalid!"); // In real usage, don't panic, handle this!
+//! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())?;
 //!
 //! let alice_shared = alice_secret.diffie_hellman(&bob_public);
 //!
@@ -34,6 +39,8 @@
 //!
 //! // Both participants arrive on the same shared secret
 //! assert_eq!(alice_shared.raw_secret_bytes(), bob_shared.raw_secret_bytes());
+//! # Ok(())
+//! # }
 //! ```
 
 pub use elliptic_curve::ecdh::diffie_hellman;

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -14,36 +14,31 @@
 //!   [`VerifyingKey`] types which natively implement ECDSA/secp256k1 signing and
 //!   verification.
 //!
-//! Most users of this library who want to sign/verify signatures will want to
-//! enable the `ecdsa` and `sha256` Cargo features.
+//! ## Signing/Verification Example
 //!
-//! ## Signing and Verifying Signatures
-//!
-//! This example requires the `ecdsa` and `sha256` Cargo features are enabled:
-//!
-//! ```
-//! # #[cfg(all(feature = "ecdsa", feature = "sha256"))]
-//! # {
+#![cfg_attr(all(feature = "ecdsa", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "ecdsa", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `ecdsa` and `getrandom` crate features are enabled
 //! use k256::{
 //!     ecdsa::{SigningKey, Signature, signature::Signer},
+//!     elliptic_curve::Generate,
 //!     SecretKey,
 //! };
-//! use getrandom::SysRng;
 //!
 //! // Signing
-//! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`
-//! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
+//! let signing_key = SigningKey::generate(); // Serialize with `::to_bytes()`
+//! let verifying_key_bytes = signing_key.verifying_key().to_encoded_point(true); // 33-bytes
 //!
-//! // Note: The signature type must be annotated or otherwise inferable as
-//! // `Signer` has many impls of the `Signer` trait (for both regular and
-//! // recoverable signature types).
+//! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature: Signature = signing_key.sign(message);
 //!
 //! // Verification
 //! use k256::{EncodedPoint, ecdsa::{VerifyingKey, signature::Verifier}};
 //!
-//! let verifying_key = VerifyingKey::from(&signing_key); // Serialize with `::to_encoded_point()`
-//! assert!(verifying_key.verify(message, &signature).is_ok());
+//! let verifying_key = VerifyingKey::from_sec1_bytes(verifying_key_bytes.as_ref())?;
+//! verifying_key.verify(message, &signature)?;
+//! # Ok(())
 //! # }
 //! ```
 //!
@@ -60,9 +55,8 @@
 //!
 //! ### Recovering a [`VerifyingKey`] from a signature
 //!
-#![cfg_attr(feature = "std", doc = "```")]
-#![cfg_attr(not(feature = "std"), doc = "```ignore")]
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! ```
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use hex_literal::hex;
 //! use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
 //! use sha3::{Keccak256, Digest};

--- a/k256/src/schnorr.rs
+++ b/k256/src/schnorr.rs
@@ -28,19 +28,25 @@
 //!
 //! # Usage
 //!
-#![cfg_attr(feature = "std", doc = "```")]
-#![cfg_attr(not(feature = "std"), doc = "```ignore")]
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! use k256::schnorr::{
-//!     signature::{Signer, Verifier},
-//!     SigningKey, VerifyingKey
+#![cfg_attr(all(feature = "getrandom", feature = "schnorr"), doc = "```")]
+#![cfg_attr(
+    not(all(feature = "getrandom", feature = "schnorr")),
+    doc = "```ignore"
+)]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `getrandom` and `schnorr` crate features are enabled
+//! use k256::{
+//!     elliptic_curve::Generate,
+//!     schnorr::{
+//!         signature::{Signer, Verifier},
+//!         SigningKey, VerifyingKey
+//!     }
 //! };
-//! use getrandom::SysRng;
 //!
 //! //
 //! // Signing
 //! //
-//! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // serialize with `.to_bytes()`
+//! let signing_key = SigningKey::generate(); // serialize with `.to_bytes()`
 //! let verifying_key_bytes = signing_key.verifying_key().to_bytes(); // 32-bytes
 //!
 //! let message = b"Schnorr signatures prove knowledge of a secret in the random oracle model";

--- a/p224/src/ecdh.rs
+++ b/p224/src/ecdh.rs
@@ -8,21 +8,26 @@
 //! This usage example is from the perspective of two participants in the
 //! exchange, nicknamed "Alice" and "Bob".
 //!
-//! ```
-//! use p224::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use getrandom::SysRng;
+#![cfg_attr(all(feature = "ecdh", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "ecdh", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `ecdh` and `getrandom` crate features are enabled
+//! use p224::{
+//!     EncodedPoint, PublicKey,
+//!     elliptic_curve::Generate,
+//!     ecdh::EphemeralSecret
+//! };
 //!
 //! // Alice
-//! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
+//! let alice_secret = EphemeralSecret::generate();
 //! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
 //!
 //! // Bob
-//! let bob_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
+//! let bob_secret = EphemeralSecret::generate();
 //! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it
-//! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())
-//!     .expect("bob's public key is invalid!"); // In real usage, don't panic, handle this!
+//! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())?;
 //!
 //! let alice_shared = alice_secret.diffie_hellman(&bob_public);
 //!
@@ -34,6 +39,8 @@
 //!
 //! // Both participants arrive on the same shared secret
 //! assert_eq!(alice_shared.raw_secret_bytes(), bob_shared.raw_secret_bytes());
+//! # Ok(())
+//! # }
 //! ```
 
 pub use elliptic_curve::ecdh::diffie_hellman;

--- a/p224/src/ecdsa.rs
+++ b/p224/src/ecdsa.rs
@@ -16,24 +16,29 @@
 //!
 //! ## Signing/Verification Example
 //!
-//! This example requires the `ecdsa` Cargo feature is enabled:
-//!
-//! ```
-//! # #[cfg(feature = "ecdsa")]
-//! # {
-//! use p224::ecdsa::{signature::Signer, Signature, SigningKey};
-//! use getrandom::{SysRng, rand_core::TryRngCore};
+#![cfg_attr(all(feature = "ecdsa", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "ecdsa", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `ecdsa` and `getrandom` crate features are enabled
+//! use p224::{
+//!     ecdsa::{SigningKey, Signature, signature::Signer},
+//!     elliptic_curve::Generate,
+//!     SecretKey,
+//! };
 //!
 //! // Signing
-//! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`
+//! let signing_key = SigningKey::generate(); // Serialize with `::to_bytes()`
+//! let verifying_key_bytes = signing_key.verifying_key().to_encoded_point(false); // 57-bytes
+//!
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature: Signature = signing_key.sign(message);
 //!
 //! // Verification
-//! use p224::ecdsa::{signature::Verifier, VerifyingKey};
+//! use p224::{EncodedPoint, ecdsa::{VerifyingKey, signature::Verifier}};
 //!
-//! let verifying_key = VerifyingKey::from(&signing_key); // Serialize with `::to_encoded_point()`
-//! assert!(verifying_key.verify(message, &signature).is_ok());
+//! let verifying_key = VerifyingKey::from_sec1_bytes(verifying_key_bytes.as_ref())?;
+//! verifying_key.verify(message, &signature)?;
+//! # Ok(())
 //! # }
 //! ```
 

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -12,7 +12,7 @@ use core::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, ShrAssign, Sub, SubAssign},
 };
 use elliptic_curve::{
-    Curve,
+    Curve, Generate,
     bigint::{ArrayEncoding, Integer, Limb, Odd, U256, Uint, modular::Retrieve},
     ctutils,
     group::ff::{self, Field, FromUniformBytes, PrimeField},
@@ -258,6 +258,12 @@ impl Field for Scalar {
 
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
         ff::helpers::sqrt_ratio_generic(num, div)
+    }
+}
+
+impl Generate for Scalar {
+    fn try_generate_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        Self::try_from_rng(rng)
     }
 }
 

--- a/p256/src/ecdh.rs
+++ b/p256/src/ecdh.rs
@@ -8,21 +8,26 @@
 //! This usage example is from the perspective of two participants in the
 //! exchange, nicknamed "Alice" and "Bob".
 //!
-//! ```
-//! use p256::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use getrandom::SysRng;
+#![cfg_attr(all(feature = "ecdh", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "ecdh", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `ecdh` and `getrandom` crate features are enabled
+//! use p256::{
+//!     EncodedPoint, PublicKey,
+//!     elliptic_curve::Generate,
+//!     ecdh::EphemeralSecret
+//! };
 //!
 //! // Alice
-//! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
+//! let alice_secret = EphemeralSecret::generate();
 //! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
 //!
 //! // Bob
-//! let bob_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
+//! let bob_secret = EphemeralSecret::generate();
 //! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it
-//! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())
-//!     .expect("bob's public key is invalid!"); // In real usage, don't panic, handle this!
+//! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())?;
 //!
 //! let alice_shared = alice_secret.diffie_hellman(&bob_public);
 //!
@@ -34,6 +39,8 @@
 //!
 //! // Both participants arrive on the same shared secret
 //! assert_eq!(alice_shared.raw_secret_bytes(), bob_shared.raw_secret_bytes());
+//! # Ok(())
+//! # }
 //! ```
 
 pub use elliptic_curve::ecdh::diffie_hellman;

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -16,26 +16,29 @@
 //!
 //! ## Signing/Verification Example
 //!
-//! This example requires the `ecdsa` Cargo feature is enabled:
-//!
-//! ```
-//! # #[cfg(feature = "ecdsa")]
-//! # {
+#![cfg_attr(all(feature = "ecdsa", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "ecdsa", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `ecdsa` and `getrandom` crate features are enabled
 //! use p256::{
 //!     ecdsa::{SigningKey, Signature, signature::Signer},
+//!     elliptic_curve::Generate,
+//!     SecretKey,
 //! };
-//! use getrandom::SysRng;
 //!
 //! // Signing
-//! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`
+//! let signing_key = SigningKey::generate(); // Serialize with `::to_bytes()`
+//! let verifying_key_bytes = signing_key.verifying_key().to_encoded_point(false); // 65-bytes
+//!
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature: Signature = signing_key.sign(message);
 //!
 //! // Verification
-//! use p256::ecdsa::{VerifyingKey, signature::Verifier};
+//! use p256::{EncodedPoint, ecdsa::{VerifyingKey, signature::Verifier}};
 //!
-//! let verifying_key = VerifyingKey::from(&signing_key); // Serialize with `::to_encoded_point()`
-//! assert!(verifying_key.verify(message, &signature).is_ok());
+//! let verifying_key = VerifyingKey::from_sec1_bytes(verifying_key_bytes.as_ref())?;
+//! verifying_key.verify(message, &signature)?;
+//! # Ok(())
 //! # }
 //! ```
 

--- a/p384/src/ecdh.rs
+++ b/p384/src/ecdh.rs
@@ -8,21 +8,26 @@
 //! This usage example is from the perspective of two participants in the
 //! exchange, nicknamed "Alice" and "Bob".
 //!
-//! ```
-//! use p384::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use getrandom::SysRng;
+#![cfg_attr(all(feature = "ecdh", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "ecdh", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `ecdh` and `getrandom` crate features are enabled
+//! use p384::{
+//!     EncodedPoint, PublicKey,
+//!     elliptic_curve::Generate,
+//!     ecdh::EphemeralSecret
+//! };
 //!
 //! // Alice
-//! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
+//! let alice_secret = EphemeralSecret::generate();
 //! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
 //!
 //! // Bob
-//! let bob_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
+//! let bob_secret = EphemeralSecret::generate();
 //! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it
-//! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())
-//!     .expect("bob's public key is invalid!"); // In real usage, don't panic, handle this!
+//! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())?;
 //!
 //! let alice_shared = alice_secret.diffie_hellman(&bob_public);
 //!
@@ -34,6 +39,8 @@
 //!
 //! // Both participants arrive on the same shared secret
 //! assert_eq!(alice_shared.raw_secret_bytes(), bob_shared.raw_secret_bytes());
+//! # Ok(())
+//! # }
 //! ```
 
 pub use elliptic_curve::ecdh::diffie_hellman;

--- a/p384/src/ecdsa.rs
+++ b/p384/src/ecdsa.rs
@@ -16,24 +16,29 @@
 //!
 //! ## Signing/Verification Example
 //!
-//! This example requires the `ecdsa` Cargo feature is enabled:
-//!
-//! ```
-//! # #[cfg(feature = "ecdsa")]
-//! # {
-//! use p384::ecdsa::{signature::Signer, Signature, SigningKey};
-//! use getrandom::{SysRng, rand_core::TryRngCore};
+#![cfg_attr(all(feature = "ecdsa", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "ecdsa", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `ecdsa` and `getrandom` crate features are enabled
+//! use p384::{
+//!     ecdsa::{SigningKey, Signature, signature::Signer},
+//!     elliptic_curve::Generate,
+//!     SecretKey,
+//! };
 //!
 //! // Signing
-//! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`
+//! let signing_key = SigningKey::generate(); // Serialize with `::to_bytes()`
+//! let verifying_key_bytes = signing_key.verifying_key().to_encoded_point(false); // 97-bytes
+//!
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature: Signature = signing_key.sign(message);
 //!
 //! // Verification
-//! use p384::ecdsa::{signature::Verifier, VerifyingKey};
+//! use p384::{EncodedPoint, ecdsa::{VerifyingKey, signature::Verifier}};
 //!
-//! let verifying_key = VerifyingKey::from(&signing_key); // Serialize with `::to_encoded_point()`
-//! assert!(verifying_key.verify(message, &signature).is_ok());
+//! let verifying_key = VerifyingKey::from_sec1_bytes(verifying_key_bytes.as_ref())?;
+//! verifying_key.verify(message, &signature)?;
+//! # Ok(())
 //! # }
 //! ```
 

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -29,7 +29,7 @@ use core::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 use elliptic_curve::{
-    Error, FieldBytesEncoding,
+    Error, FieldBytesEncoding, Generate,
     array::Array,
     bigint::{Word, modular::Retrieve},
     ff::{self, Field, PrimeField},
@@ -508,6 +508,12 @@ impl Field for FieldElement {
 
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
         ff::helpers::sqrt_ratio_generic(num, div)
+    }
+}
+
+impl Generate for FieldElement {
+    fn try_generate_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        Self::try_from_rng(rng)
     }
 }
 

--- a/p521/src/ecdh.rs
+++ b/p521/src/ecdh.rs
@@ -8,21 +8,26 @@
 //! This usage example is from the perspective of two participants in the
 //! exchange, nicknamed "Alice" and "Bob".
 //!
-//! ```
-//! use p521::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
-//! use getrandom::{SysRng, rand_core::TryRngCore};
+#![cfg_attr(all(feature = "ecdh", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "ecdh", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `ecdh` and `getrandom` crate features are enabled
+//! use p521::{
+//!     EncodedPoint, PublicKey,
+//!     elliptic_curve::Generate,
+//!     ecdh::EphemeralSecret
+//! };
 //!
 //! // Alice
-//! let alice_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
+//! let alice_secret = EphemeralSecret::generate();
 //! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
 //!
 //! // Bob
-//! let bob_secret = EphemeralSecret::try_from_rng(&mut SysRng).unwrap();
+//! let bob_secret = EphemeralSecret::generate();
 //! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it
-//! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())
-//!     .expect("bob's public key is invalid!"); // In real usage, don't panic, handle this!
+//! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())?;
 //!
 //! let alice_shared = alice_secret.diffie_hellman(&bob_public);
 //!
@@ -34,6 +39,8 @@
 //!
 //! // Both participants arrive on the same shared secret
 //! assert_eq!(alice_shared.raw_secret_bytes(), bob_shared.raw_secret_bytes());
+//! # Ok(())
+//! # }
 //! ```
 
 pub use elliptic_curve::ecdh::diffie_hellman;

--- a/p521/src/ecdsa.rs
+++ b/p521/src/ecdsa.rs
@@ -16,24 +16,29 @@
 //!
 //! ## Signing/Verification Example
 //!
-//! This example requires the `ecdsa` Cargo feature is enabled:
-//!
-//! ```
-//! # #[cfg(feature = "ecdsa")]
-//! # {
-//! use p521::ecdsa::{signature::Signer, Signature, SigningKey};
-//! use getrandom::SysRng;
+#![cfg_attr(all(feature = "ecdsa", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "ecdsa", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `ecdsa` and `getrandom` crate features are enabled
+//! use p521::{
+//!     ecdsa::{SigningKey, Signature, signature::Signer},
+//!     elliptic_curve::Generate,
+//!     SecretKey,
+//! };
 //!
 //! // Signing
-//! let signing_key = SigningKey::try_from_rng(&mut SysRng).unwrap(); // Serialize with `::to_bytes()`
+//! let signing_key = SigningKey::generate(); // Serialize with `::to_bytes()`
+//! let verifying_key_bytes = signing_key.verifying_key().to_encoded_point(false); // 133-bytes
+//!
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature: Signature = signing_key.sign(message);
 //!
 //! // Verification
-//! use p521::ecdsa::{signature::Verifier, VerifyingKey};
+//! use p521::{EncodedPoint, ecdsa::{VerifyingKey, signature::Verifier}};
 //!
-//! let verifying_key = VerifyingKey::from(&signing_key); // Serialize with `::to_encoded_point()`
-//! assert!(verifying_key.verify(message, &signature).is_ok());
+//! let verifying_key = VerifyingKey::from_sec1_bytes(verifying_key_bytes.as_ref())?;
+//! verifying_key.verify(message, &signature)?;
+//! # Ok(())
 //! # }
 //! ```
 

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -17,7 +17,8 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-bigint = { package = "crypto-bigint", version = "0.7.0-rc.13", default-features = false, features = ["hybrid-array", "subtle"] }
+bigint = { package = "crypto-bigint", version = "0.7.0-rc.13", default-features = false, features = ["rand_core", "hybrid-array", "subtle"] }
+common = { package = "crypto-common", version = "0.2.0-rc.9", features = ["rand_core"] }
 ff = { version = "=0.14.0-pre.0", package = "rustcrypto-ff", default-features = false }
 subtle = { version = "2.6", default-features = false, features = ["const-generics"] }
 rand_core = { version = "0.10.0-rc-3", default-features = false }

--- a/primefield/src/lib.rs
+++ b/primefield/src/lib.rs
@@ -20,6 +20,7 @@ pub use crate::{
 pub use array::typenum::consts;
 pub use bigint;
 pub use bigint::hybrid_array as array;
+pub use common;
 pub use ff;
 pub use rand_core;
 pub use subtle;

--- a/primefield/src/macros.rs
+++ b/primefield/src/macros.rs
@@ -267,6 +267,14 @@ macro_rules! monty_field_element {
                 <$params>::PARAMS;
         }
 
+        impl $crate::common::Generate for $fe {
+            fn try_generate_from_rng<R: $crate::rand_core::TryCryptoRng + ?Sized>(
+                rng: &mut R,
+            ) -> ::core::result::Result<Self, R::Error> {
+                <Self as $crate::ff::Field>::try_from_rng(rng)
+            }
+        }
+
         impl $crate::ff::Field for $fe {
             const ZERO: Self = Self::ZERO;
             const ONE: Self = Self::ONE;

--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -9,6 +9,7 @@ use bigint::{
     hybrid_array::{Array, ArraySize, typenum::Unsigned},
     modular::{ConstMontyForm as MontyForm, ConstMontyParams, MontyParams, Retrieve},
 };
+use common::Generate;
 use core::{
     cmp::Ordering,
     fmt,
@@ -16,6 +17,7 @@ use core::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 use ff::{Field, PrimeField};
+use rand_core::TryCryptoRng;
 use subtle::{
     Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
     CtOption,
@@ -924,20 +926,38 @@ where
     }
 }
 
-impl<MOD: MontyFieldParams<LIMBS>, const LIMBS: usize> Ord for MontyFieldElement<MOD, LIMBS> {
+impl<MOD, const LIMBS: usize> Generate for MontyFieldElement<MOD, LIMBS>
+where
+    MOD: MontyFieldParams<LIMBS>,
+    MontyFieldBytes<MOD, LIMBS>: Copy,
+    Uint<LIMBS>: ArrayEncoding,
+{
+    fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        Self::try_from_rng(rng)
+    }
+}
+
+impl<MOD, const LIMBS: usize> Ord for MontyFieldElement<MOD, LIMBS>
+where
+    MOD: MontyFieldParams<LIMBS>,
+{
     fn cmp(&self, other: &Self) -> Ordering {
         self.to_canonical().cmp(&other.to_canonical())
     }
 }
-impl<MOD: MontyFieldParams<LIMBS>, const LIMBS: usize> PartialOrd
-    for MontyFieldElement<MOD, LIMBS>
+impl<MOD, const LIMBS: usize> PartialOrd for MontyFieldElement<MOD, LIMBS>
+where
+    MOD: MontyFieldParams<LIMBS>,
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<MOD: MontyFieldParams<LIMBS>, const LIMBS: usize> Retrieve for MontyFieldElement<MOD, LIMBS> {
+impl<MOD, const LIMBS: usize> Retrieve for MontyFieldElement<MOD, LIMBS>
+where
+    MOD: MontyFieldParams<LIMBS>,
+{
     type Output = Uint<LIMBS>;
 
     fn retrieve(&self) -> Uint<LIMBS> {

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -27,7 +27,7 @@ pub use elliptic_curve::{
     point::Double,
 };
 
-use elliptic_curve::{CurveArithmetic, ops::Invert, subtle::CtOption};
+use elliptic_curve::{CurveArithmetic, Generate, ops::Invert, subtle::CtOption};
 
 /// Parameters for elliptic curves of prime order which can be described by the
 /// short Weierstrass equation.
@@ -38,8 +38,9 @@ pub trait PrimeCurveParams:
     + CurveArithmetic<ProjectivePoint = ProjectivePoint<Self>>
 {
     /// Base field element type.
-    type FieldElement: PrimeField<Repr = FieldBytes<Self>>
+    type FieldElement: Generate
         + Invert<Output = CtOption<Self::FieldElement>>
+        + PrimeField<Repr = FieldBytes<Self>>
         + Retrieve<Output = Self::Uint>;
 
     /// [Point arithmetic](point_arithmetic) implementation, might be optimized for this specific curve

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -10,8 +10,8 @@ use core::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 use elliptic_curve::{
-    BatchNormalize, CurveGroup, Error, FieldBytes, FieldBytesSize, PrimeField, PublicKey, Result,
-    Scalar,
+    BatchNormalize, CurveGroup, Error, FieldBytes, FieldBytesSize, Generate, PrimeField, PublicKey,
+    Result, Scalar,
     array::ArraySize,
     bigint::{ArrayEncoding, ByteArray},
     ctutils,
@@ -22,7 +22,7 @@ use elliptic_curve::{
     },
     ops::{BatchInvert, LinearCombination},
     point::{Double, NonIdentity},
-    rand_core::TryRngCore,
+    rand_core::{TryCryptoRng, TryRngCore},
     sec1::{
         CompressedPoint, EncodedPoint, FromEncodedPoint, ModulusSize, ToEncodedPoint,
         UncompressedPointSize,
@@ -238,6 +238,18 @@ where
 {
     fn from_encoded_point(p: &EncodedPoint<C>) -> ctutils::CtOption<Self> {
         AffinePoint::<C>::from_encoded_point(p).map(Self::from)
+    }
+}
+
+impl<C> Generate for ProjectivePoint<C>
+where
+    C: PrimeCurveParams,
+    FieldBytes<C>: Copy,
+{
+    fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(
+        rng: &mut R,
+    ) -> core::result::Result<Self, R::Error> {
+        AffinePoint::try_generate_from_rng(rng).map(Self::from)
     }
 }
 

--- a/sm2/src/dsa.rs
+++ b/sm2/src/dsa.rs
@@ -2,20 +2,18 @@
 //!
 //! ## Usage
 //!
-//! NOTE: requires the `dsa` crate feature enabled, and `rand_core` dependency
-//! with `getrandom` feature enabled.
-//!
-#![cfg_attr(feature = "std", doc = "```")]
-#![cfg_attr(not(feature = "std"), doc = "```ignore")]
-//! # fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! use getrandom::{SysRng, rand_core::TryRngCore};
+#![cfg_attr(all(feature = "dsa", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "dsa", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `dsa` and `getrandom` crate features are enabled
 //! use sm2::{
 //!     dsa::{Signature, SigningKey, signature::Signer},
+//!     elliptic_curve::Generate,
 //!     SecretKey
 //! };
 //!
 //! // Signing
-//! let secret_key = SecretKey::try_from_rng(&mut SysRng).unwrap(); // serialize with `::to_bytes()`
+//! let secret_key = SecretKey::generate(); // serialize with `::to_bytes()`
 //! let distid = "example@rustcrypto.org"; // distinguishing identifier
 //! let signing_key = SigningKey::new(distid, &secret_key)?;
 //! let verifying_key_bytes = signing_key.verifying_key().to_sec1_bytes();

--- a/sm2/src/pke.rs
+++ b/sm2/src/pke.rs
@@ -2,21 +2,24 @@
 //!
 //! ## Usage
 //!
-//! NOTE: requires the `sm3` crate for digest functions and the `primeorder` crate for prime field operations.
+//! The `DecryptingKey` struct is used for decrypting messages that were encrypted using the SM2
+//! encryption algorithm.
 //!
-//! The `DecryptingKey` struct is used for decrypting messages that were encrypted using the SM2 encryption algorithm.
-//! It is initialized with a `SecretKey` or a non-zero scalar value and can decrypt ciphertexts using the specified decryption mode.
-#![cfg_attr(feature = "std", doc = "```")]
-#![cfg_attr(not(feature = "std"), doc = "```ignore")]
-//! # fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! use getrandom::SysRng;
+//! It is initialized with a `SecretKey` or a non-zero scalar value and can decrypt ciphertexts
+//! using the specified decryption mode.
+//!
+#![cfg_attr(all(feature = "pke", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "pke", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `pke` and `getrandom` crate features are enabled
 //! use sm2::{
+//!     elliptic_curve::{Generate, common::getrandom::SysRng},
 //!     pke::{EncryptingKey, Mode},
-//!     {SecretKey, PublicKey}
+//!     SecretKey, PublicKey
 //! };
 //!
 //! // Encrypting
-//! let secret_key = SecretKey::try_from_rng(&mut SysRng).unwrap(); // serialize with `::to_bytes()`
+//! let secret_key = SecretKey::generate(); // serialize with `::to_bytes()`
 //! let public_key = secret_key.public_key();
 //! let encrypting_key = EncryptingKey::new_with_mode(public_key, Mode::C1C2C3);
 //! let plaintext = b"plaintext";
@@ -36,9 +39,6 @@
 //! Ok(())
 //! # }
 //!  ```
-//!
-//!
-//!
 
 use core::cmp::min;
 


### PR DESCRIPTION
Replaces various bespoke RNG APIs with the new `Generate` trait from `crypto_common`, which was added to `elliptic-curve` in RustCrypto/traits#2173.

It's now a required bound for all affine/projective points and scalars, as well as the RNG API used by all generic types defined in the `elliptic-curve` crate itself.

This API avoids having to directly import `getrandom::SysRng`, making it possible to call `T::generate()` instead so long as the `getrandom` feature of `elliptic-curve` is enabled.