### PR TITLE
primefield: add `bench_field!` macro; use in `bp256`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
 name = "bp256"
 version = "0.14.0-rc.3"
 dependencies = [
+ "criterion",
  "ecdsa",
  "elliptic-curve",
  "primefield",

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -22,6 +22,9 @@ primefield = { version = "0.14.0-rc.3", optional = true }
 primeorder = { version = "0.14.0-rc.3", optional = true }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
+[dev-dependencies]
+criterion = "0.7"
+
 [features]
 default = ["pkcs8", "std"]
 alloc = ["ecdsa?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
@@ -34,6 +37,16 @@ pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa/serde", "elliptic-curve/serde"]
 sha256 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
+
+[[bench]]
+name = "field"
+harness = false
+required-features = ["arithmetic"]
+
+[[bench]]
+name = "scalar"
+harness = false
+required-features = ["arithmetic"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/bp256/benches/field.rs
+++ b/bp256/benches/field.rs
@@ -1,0 +1,18 @@
+//! bp256 `FieldElement` benchmarks
+
+use bp256::BrainpoolP256r1;
+use criterion::{Criterion, criterion_group, criterion_main};
+use primeorder::PrimeCurveParams;
+
+type FieldElement = <BrainpoolP256r1 as PrimeCurveParams>::FieldElement;
+
+const FE_A: FieldElement = FieldElement::from_hex_vartime(
+    "8bd2aeb9cb7e57cb2c4b482ffc81b7afb9de27e1e3bd23c23a4453bd9ace3262",
+);
+const FE_B: FieldElement = FieldElement::from_hex_vartime(
+    "547ef835c3dac4fd97f8461a14611dc9c27745132ded8e545c1d54c72f046997",
+);
+
+primefield::bench_field!(bench_field_element, "FieldElement", FE_A, FE_B);
+criterion_group!(benches, bench_field_element);
+criterion_main!(benches);

--- a/bp256/benches/scalar.rs
+++ b/bp256/benches/scalar.rs
@@ -1,0 +1,13 @@
+//! bp256 `Scalar` benchmarks
+
+use bp256::Scalar;
+use criterion::{Criterion, criterion_group, criterion_main};
+
+const SCALAR_A: Scalar =
+    Scalar::from_hex_vartime("9bb0d8b72602b70dd5cfed99607a2e2c021dd0fe3b3af842df02c06f8c1a0f4e");
+const SCALAR_B: Scalar =
+    Scalar::from_hex_vartime("6494152e2b6c34768296d2ea0e984f89a77f0d7399b70f2e29789128423a9bea");
+
+primefield::bench_field!(bench_scalar, "Scalar", SCALAR_A, SCALAR_B);
+criterion_group!(benches, bench_scalar);
+criterion_main!(benches);

--- a/primefield/src/dev.rs
+++ b/primefield/src/dev.rs
@@ -1,3 +1,74 @@
+/// Write a series of `criterion`-based benchmarks for a field implementation.
+#[macro_export]
+macro_rules! bench_field {
+    { $name:ident, $desc:expr, $fe_a:expr, $fe_b:expr } => {
+        fn bench_add<M: ::criterion::measurement::Measurement>(
+            group: &mut ::criterion::BenchmarkGroup<'_, M>,
+        ) {
+            let x = core::hint::black_box($fe_a);
+            let y = core::hint::black_box($fe_b);
+            group.bench_function("add", |b| b.iter(|| x + y));
+        }
+
+        fn bench_sub<M: ::criterion::measurement::Measurement>(
+            group: &mut ::criterion::BenchmarkGroup<'_, M>,
+        ) {
+            let x = core::hint::black_box($fe_a);
+            let y = core::hint::black_box($fe_b);
+            group.bench_function("sub", |b| b.iter(|| x - y));
+        }
+
+        fn bench_mul<M: ::criterion::measurement::Measurement>(
+            group: &mut ::criterion::BenchmarkGroup<'_, M>,
+        ) {
+            let x = core::hint::black_box($fe_a);
+            let y = core::hint::black_box($fe_b);
+            group.bench_function("mul", |b| b.iter(|| x * y));
+        }
+
+        fn bench_neg<M: ::criterion::measurement::Measurement>(
+            group: &mut ::criterion::BenchmarkGroup<'_, M>,
+        ) {
+            let x = core::hint::black_box($fe_a);
+            group.bench_function("neg", |b| b.iter(|| -x));
+        }
+
+        fn bench_invert<M: ::criterion::measurement::Measurement>(
+            group: &mut ::criterion::BenchmarkGroup<'_, M>,
+        ) {
+            let x = core::hint::black_box($fe_a);
+            group.bench_function("invert", |b| b.iter(|| x.invert()));
+        }
+
+        fn bench_square<'a, M: ::criterion::measurement::Measurement>(
+            group: &mut ::criterion::BenchmarkGroup<'a, M>,
+        ) {
+            let x = core::hint::black_box($fe_a);
+            group.bench_function("square", |b| b.iter(|| x.square()));
+        }
+
+        fn bench_sqrt<'a, M: ::criterion::measurement::Measurement>(
+            group: &mut ::criterion::BenchmarkGroup<'a, M>,
+        ) {
+            use ::primefield::ff::Field;
+            let x = core::hint::black_box($fe_a);
+            group.bench_function("sqrt", |b| b.iter(|| x.sqrt()));
+        }
+
+        fn $name(c: &mut Criterion) {
+            let mut group = c.benchmark_group($desc);
+            bench_add(&mut group);
+            bench_sub(&mut group);
+            bench_mul(&mut group);
+            bench_neg(&mut group);
+            bench_invert(&mut group);
+            bench_square(&mut group);
+            bench_sqrt(&mut group);
+            group.finish();
+        }
+    };
+}
+
 /// Implement all tests for a type which impls the `PrimeField` trait.
 #[macro_export]
 macro_rules! test_primefield {


### PR DESCRIPTION
This adds a macro to the `primefield::dev` macro for writing field benchmarks, and uses them to write a basic set of benchmarks for the `FieldElement` and `Scalar` types in `bp256`.

We should roll these out to the other crates that currently lack benchmarks, but first it would be nice to augment them with ones for point operations, namely scalar multiplication.