### PR TITLE
bp256: add `ProjectivePoint` benchmarks

### DIFF
--- a/.github/workflows/bp256.yml
+++ b/.github/workflows/bp256.yml
@@ -26,6 +26,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  benches:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.85.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo build --all-features --benches
+
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ dependencies = [
 [[package]]
 name = "crypto-common"
 version = "0.2.0-rc.9"
-source = "git+https://github.com/RustCrypto/traits#ded0d2297fba206939bfb5f47b4fd823c4bccae8"
+source = "git+https://github.com/RustCrypto/traits#f3f7feb394e9ced9e77ec7cd9ff5e4c832efbeb0"
 dependencies = [
  "getrandom 0.4.0-rc.0",
  "hybrid-array",
@@ -473,7 +473,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.20"
-source = "git+https://github.com/RustCrypto/traits#ded0d2297fba206939bfb5f47b4fd823c4bccae8"
+source = "git+https://github.com/RustCrypto/traits#f3f7feb394e9ced9e77ec7cd9ff5e4c832efbeb0"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -24,6 +24,7 @@ sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
+elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]
@@ -40,6 +41,11 @@ sha256 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
 
 [[bench]]
 name = "field"
+harness = false
+required-features = ["arithmetic"]
+
+[[bench]]
+name = "point"
 harness = false
 required-features = ["arithmetic"]
 

--- a/bp256/benches/field.rs
+++ b/bp256/benches/field.rs
@@ -1,7 +1,7 @@
 //! bp256 `FieldElement` benchmarks
 
 use bp256::BrainpoolP256r1;
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main};
 use primeorder::PrimeCurveParams;
 
 type FieldElement = <BrainpoolP256r1 as PrimeCurveParams>::FieldElement;

--- a/bp256/benches/point.rs
+++ b/bp256/benches/point.rs
@@ -1,0 +1,21 @@
+//! bp256r1 `ProjectivePoint` benchmarks
+
+use bp256::r1::{ProjectivePoint, Scalar};
+use criterion::{criterion_group, criterion_main};
+
+const POINT_A: ProjectivePoint = ProjectivePoint::GENERATOR;
+const POINT_B: ProjectivePoint = ProjectivePoint::GENERATOR;
+
+const SCALAR: Scalar =
+    Scalar::from_hex_vartime("9bb0d8b72602b70dd5cfed99607a2e2c021dd0fe3b3af842df02c06f8c1a0f4e");
+
+elliptic_curve::bench_projective!(
+    bench_projective,
+    "ProjectivePoint",
+    POINT_A,
+    POINT_B,
+    SCALAR
+);
+
+criterion_group!(benches, bench_projective);
+criterion_main!(benches);

--- a/bp256/benches/scalar.rs
+++ b/bp256/benches/scalar.rs
@@ -1,7 +1,7 @@
 //! bp256 `Scalar` benchmarks
 
 use bp256::Scalar;
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main};
 
 const SCALAR_A: Scalar =
     Scalar::from_hex_vartime("9bb0d8b72602b70dd5cfed99607a2e2c021dd0fe3b3af842df02c06f8c1a0f4e");

--- a/primefield/src/dev.rs
+++ b/primefield/src/dev.rs
@@ -55,7 +55,7 @@ macro_rules! bench_field {
             group.bench_function("sqrt", |b| b.iter(|| x.sqrt()));
         }
 
-        fn $name(c: &mut Criterion) {
+        fn $name(c: &mut ::criterion::Criterion) {
             let mut group = c.benchmark_group($desc);
             bench_add(&mut group);
             bench_sub(&mut group);


### PR DESCRIPTION
Uses the `elliptic_curve::bench_projective!` macro introduced in RustCrypto/traits#2177 to run a set of benchmarks against `ProjectivePoint`, including point addition, negation, and scalar multiplication.

After this we can roll out all of the benchmark macros added to `bp256` to the curves which currently don't have any, and use the macros to replace some of the existing tests in the ones that do.