### PR TITLE
bp384: add benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,7 @@ dependencies = [
 name = "bp384"
 version = "0.14.0-rc.3"
 dependencies = [
+ "criterion",
  "ecdsa",
  "elliptic-curve",
  "primefield",

--- a/bp256/benches/point.rs
+++ b/bp256/benches/point.rs
@@ -3,18 +3,19 @@
 use bp256::r1::{ProjectivePoint, Scalar};
 use criterion::{criterion_group, criterion_main};
 
-const POINT_A: ProjectivePoint = ProjectivePoint::GENERATOR;
-const POINT_B: ProjectivePoint = ProjectivePoint::GENERATOR;
-
-const SCALAR: Scalar =
+const SCALAR_A: Scalar =
     Scalar::from_hex_vartime("9bb0d8b72602b70dd5cfed99607a2e2c021dd0fe3b3af842df02c06f8c1a0f4e");
+const SCALAR_B: Scalar =
+    Scalar::from_hex_vartime("6494152e2b6c34768296d2ea0e984f89a77f0d7399b70f2e29789128423a9bea");
+const SCALAR_C: Scalar =
+    Scalar::from_hex_vartime("a316f6a92d2f8359218cf9f68900d9f791ad2ad77aee07686adeb5ec7c7b8cb3");
 
 elliptic_curve::bench_projective!(
     bench_projective,
     "ProjectivePoint",
-    POINT_A,
-    POINT_B,
-    SCALAR
+    ProjectivePoint::GENERATOR * SCALAR_A,
+    ProjectivePoint::GENERATOR * SCALAR_B,
+    SCALAR_C
 );
 
 criterion_group!(benches, bench_projective);

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -22,6 +22,10 @@ primefield = { version = "0.14.0-rc.3", optional = true }
 primeorder = { version = "0.14.0-rc.3", optional = true }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
+[dev-dependencies]
+criterion = "0.7"
+elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["dev"] }
+
 [features]
 default = ["pkcs8", "std"]
 alloc = ["ecdsa?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
@@ -34,6 +38,21 @@ pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa/serde", "elliptic-curve/serde"]
 sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
+
+[[bench]]
+name = "field"
+harness = false
+required-features = ["arithmetic"]
+
+[[bench]]
+name = "point"
+harness = false
+required-features = ["arithmetic"]
+
+[[bench]]
+name = "scalar"
+harness = false
+required-features = ["arithmetic"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/bp384/benches/field.rs
+++ b/bp384/benches/field.rs
@@ -1,0 +1,18 @@
+//! bp384 `FieldElement` benchmarks
+
+use bp384::BrainpoolP384r1;
+use criterion::{criterion_group, criterion_main};
+use primeorder::PrimeCurveParams;
+
+type FieldElement = <BrainpoolP384r1 as PrimeCurveParams>::FieldElement;
+
+const FE_A: FieldElement = FieldElement::from_hex_vartime(
+    "1d1c64f068cf45ffa2a63a81b7c13f6b8847a3e77ef14fe3db7fcafe0cbd10e8e826e03436d646aaef87b2e247d4af1e",
+);
+const FE_B: FieldElement = FieldElement::from_hex_vartime(
+    "8abe1d7520f9c2a45cb1eb8e95cfd55262b70b29feec5864e19c054ff99129280e4646217791811142820341263c5315",
+);
+
+primefield::bench_field!(bench_field_element, "FieldElement", FE_A, FE_B);
+criterion_group!(benches, bench_field_element);
+criterion_main!(benches);

--- a/bp384/benches/point.rs
+++ b/bp384/benches/point.rs
@@ -1,0 +1,25 @@
+//! bp384r1 `ProjectivePoint` benchmarks
+
+use bp384::r1::{ProjectivePoint, Scalar};
+use criterion::{criterion_group, criterion_main};
+
+const SCALAR_A: Scalar = Scalar::from_hex_vartime(
+    "15f50e6c168cec3af4a81b946b7d25e07253ac13eb22b3b0aa28bb4a4eb2996324f5d5579829a25a0a17108bb1f2cc05",
+);
+const SCALAR_B: Scalar = Scalar::from_hex_vartime(
+    "4b798823f02af50afddfdba4a0ac7b7eb70ad811ff6327f77d16f7d6069ea956bd68c7eabee8f7e959393630ae276fba",
+);
+const SCALAR_C: Scalar = Scalar::from_hex_vartime(
+    "8b5ede2fb64cacce9e951b66aab631c900328924a5cd73f69f0f5bbf9a4b2db560679cbe98ee4c6038c8cbdbe170cbe7",
+);
+
+elliptic_curve::bench_projective!(
+    bench_projective,
+    "ProjectivePoint",
+    ProjectivePoint::GENERATOR * SCALAR_A,
+    ProjectivePoint::GENERATOR * SCALAR_B,
+    SCALAR_C
+);
+
+criterion_group!(benches, bench_projective);
+criterion_main!(benches);

--- a/bp384/benches/scalar.rs
+++ b/bp384/benches/scalar.rs
@@ -1,0 +1,15 @@
+//! bp384 `Scalar` benchmarks
+
+use bp384::Scalar;
+use criterion::{criterion_group, criterion_main};
+
+const SCALAR_A: Scalar = Scalar::from_hex_vartime(
+    "15f50e6c168cec3af4a81b946b7d25e07253ac13eb22b3b0aa28bb4a4eb2996324f5d5579829a25a0a17108bb1f2cc05",
+);
+const SCALAR_B: Scalar = Scalar::from_hex_vartime(
+    "4b798823f02af50afddfdba4a0ac7b7eb70ad811ff6327f77d16f7d6069ea956bd68c7eabee8f7e959393630ae276fba",
+);
+
+primefield::bench_field!(bench_scalar, "Scalar", SCALAR_A, SCALAR_B);
+criterion_group!(benches, bench_scalar);
+criterion_main!(benches);


### PR DESCRIPTION
Adds benchmarks written with the `primefield::bench_field!` and `elliptic_curve::bench_projective!` macros, ala the ones introduced to `bp256` in #1587 and #1588