### PR TITLE
p256: use `ecdsa::bench_ecdsa!` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.17.0-rc.11"
-source = "git+https://github.com/RustCrypto/signatures#d669c66b4ab443c0b7b82b2ab449ee7b15704a66"
+source = "git+https://github.com/RustCrypto/signatures#47379ade8c5954d0b786ed70286c6c180d47caf8"
 dependencies = [
  "der",
  "digest",

--- a/bp256/benches/field.rs
+++ b/bp256/benches/field.rs
@@ -13,6 +13,6 @@ const FE_B: FieldElement = FieldElement::from_hex_vartime(
     "547ef835c3dac4fd97f8461a14611dc9c27745132ded8e545c1d54c72f046997",
 );
 
-primefield::bench_field!(bench_field_element, "FieldElement", FE_A, FE_B);
-criterion_group!(benches, bench_field_element);
+primefield::bench_field!(bench_ecdsa, "FieldElement", FE_A, FE_B);
+criterion_group!(benches, bench_ecdsa);
 criterion_main!(benches);

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -63,6 +63,11 @@ test-vectors = ["dep:hex-literal"]
 all-features = true
 
 [[bench]]
+name = "ecdsa"
+harness = false
+required-features = ["ecdsa"]
+
+[[bench]]
 name = "field"
 harness = false
 required-features = ["expose-field"]

--- a/p256/benches/ecdsa.rs
+++ b/p256/benches/ecdsa.rs
@@ -1,0 +1,21 @@
+//! p256 ECDSA benchmarks
+
+use criterion::{criterion_group, criterion_main};
+use hex_literal::hex;
+use p256::ecdsa::{Signature, SigningKey};
+
+const SIGNING_KEY_BYTES: [u8; 32] =
+    hex!("1cf6bc6c7f642a84994119e206c9f0753ff100709f4fd12f2338c1be60bf4175");
+
+fn signing_key() -> SigningKey {
+    SigningKey::from_bytes(&SIGNING_KEY_BYTES.into()).unwrap()
+}
+
+ecdsa_core::bench_ecdsa!(
+    bench_ecdsa,
+    "ECDSA/P-256 (SHA-256)",
+    signing_key(),
+    Signature
+);
+criterion_group!(benches, bench_ecdsa);
+criterion_main!(benches);

--- a/primefield/src/dev.rs
+++ b/primefield/src/dev.rs
@@ -1,7 +1,7 @@
 /// Write a series of `criterion`-based benchmarks for a field implementation.
 #[macro_export]
 macro_rules! bench_field {
-    { $name:ident, $desc:expr, $fe_a:expr, $fe_b:expr } => {
+    ($name:ident, $desc:expr, $fe_a:expr, $fe_b:expr) => {
         fn bench_add<M: ::criterion::measurement::Measurement>(
             group: &mut ::criterion::BenchmarkGroup<'_, M>,
         ) {


### PR DESCRIPTION
Uses the macro introduced in RustCrypto/signtaures#1142 to write a basic ECDSA benchmark that tests both signing and verification