### PR TITLE
sm2: add `cfg(sm2_backend = "bignum")`

### DIFF
--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -27,6 +27,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  benches:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.85.0 # MSRV
+      - run: cargo build --all-features --benches
+
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -55,20 +64,6 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha384
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa-core,group-digest,oprf,pem,pkcs8,serde,sha384
-
-  benches:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.85.0 # MSRV
-          - stable
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-      - run: cargo build --all-features --benches
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/sm2.yml
+++ b/.github/workflows/sm2.yml
@@ -87,3 +87,7 @@ jobs:
       - run: cargo test --release --target ${{ matrix.target }} --no-default-features
       - run: cargo test --release --target ${{ matrix.target }}
       - run: cargo test --release --target ${{ matrix.target }} --all-features
+      - env:
+          RUSTFLAGS: '--cfg sm2_backend="bignum"'
+          RUSTDOCFLAGS: '--cfg sm2_backend="bignum"'
+        run: cargo test --release --target ${{ matrix.target }} --all-features

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -74,3 +74,7 @@ required-features = ["arithmetic"]
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(sm2_backend, values("bignum", "fiat"))'] # default: "fiat"

--- a/sm2/src/arithmetic/field.rs
+++ b/sm2/src/arithmetic/field.rs
@@ -10,9 +10,10 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
-#[cfg(target_pointer_width = "32")]
+// Default backend: fiat-crypto
+#[cfg(all(not(sm2_backend = "bignum"), target_pointer_width = "32"))]
 use fiat_crypto::sm2_32::*;
-#[cfg(target_pointer_width = "64")]
+#[cfg(all(not(sm2_backend = "bignum"), target_pointer_width = "64"))]
 use fiat_crypto::sm2_64::*;
 
 use crate::U256;
@@ -40,6 +41,14 @@ primefield::monty_field_element! {
     doc: "Element in the SM2 finite field modulo `p = 0xfffffffeffffffffffffffffffffffffffffffff00000000ffffffffffffffff`"
 }
 
+#[cfg(sm2_backend = "bignum")]
+primefield::monty_field_arithmetic! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U256
+}
+
+#[cfg(not(sm2_backend = "bignum"))]
 primefield::fiat_monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
@@ -62,12 +71,15 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U256};
+    #[cfg(not(sm2_backend = "bignum"))]
     use super::{
         FieldParams, fiat_sm2_montgomery_domain_field_element, fiat_sm2_msat,
         fiat_sm2_non_montgomery_domain_field_element, fiat_sm2_to_montgomery,
     };
 
     primefield::test_primefield!(FieldElement, U256);
+
+    #[cfg(not(sm2_backend = "bignum"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: FieldElement,
         params: FieldParams,

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -10,9 +10,10 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
-#[cfg(target_pointer_width = "32")]
+// Default backend: fiat-crypto
+#[cfg(all(not(sm2_backend = "bignum"), target_pointer_width = "32"))]
 use fiat_crypto::sm2_scalar_32::*;
-#[cfg(target_pointer_width = "64")]
+#[cfg(all(not(sm2_backend = "bignum"), target_pointer_width = "64"))]
 use fiat_crypto::sm2_scalar_64::*;
 
 use crate::{ORDER_HEX, Sm2, U256};
@@ -48,6 +49,14 @@ primefield::monty_field_element! {
     doc: "Element in the SM2 scalar field modulo `n`."
 }
 
+#[cfg(sm2_backend = "bignum")]
+primefield::monty_field_arithmetic! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U256
+}
+
+#[cfg(not(sm2_backend = "bignum"))]
 primefield::fiat_monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
@@ -119,12 +128,14 @@ impl<'de> Deserialize<'de> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U256};
+    #[cfg(not(sm2_backend = "bignum"))]
     use super::{
         ScalarParams, fiat_sm2_scalar_montgomery_domain_field_element, fiat_sm2_scalar_msat,
         fiat_sm2_scalar_non_montgomery_domain_field_element, fiat_sm2_scalar_to_montgomery,
     };
 
     primefield::test_primefield!(Scalar, U256);
+    #[cfg(not(sm2_backend = "bignum"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: Scalar,
         params: ScalarParams,

--- a/sm2/src/lib.rs
+++ b/sm2/src/lib.rs
@@ -24,6 +24,32 @@
     unused_qualifications
 )]
 
+//! ## Backends
+//!
+//! This crate has support for two different field arithmetic backends which can be selected using
+//! `cfg(sm2_backend)`, e.g. to select the `bignum` backend:
+//!
+//! ```console
+//! $ RUSTFLAGS='--cfg sm2_backend="bignum"' cargo test
+//! ```
+//!
+//! Or it can be set through [`.cargo/config`][buildrustflags]:
+//!
+//! ```toml
+//! [build]
+//! rustflags = ['--cfg', 'sm2_backend="bignum"']
+//! ```
+//!
+//! The available backends are:
+//! - `bignum`: experimental backend provided by [crypto-bigint]. May offer better performance in
+//!   some cases along with smaller code size, but might also have bugs.
+//! - `fiat` (default): formally verified implementation synthesized by [fiat-crypto] which should
+//!   be correct for all inputs (though there's a possibility of bugs in the code which glues to it)
+//!
+//! [buildrustflags]: https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags
+//! [crypto-bigint]: https://github.com/RustCrypto/crypto-bigint
+//! [fiat-crypto]: https://github.com/mit-plv/fiat-crypto
+
 #[cfg(feature = "alloc")]
 #[allow(unused_extern_crates)]
 extern crate alloc;


### PR DESCRIPTION
Adds support for an experimental backend which uses `crypto-bigint` as the field element representation, as an off-by-default alternative to `fiat-crypto`, similar to what was introduced in `p384` in #1548 and `bp256` in #1583.

Some benchmarks:

    SM2DSA/sign         time:   [121.52 µs 121.69 µs 121.87 µs]
                        change: [−17.168% −16.819% −16.453%] (p = 0.00 < 0.05)
                        Performance has improved.

    SM2DSA/verify       time:   [148.22 µs 148.52 µs 148.87 µs]
                        change: [−8.2571% −7.4902% −6.5855%] (p = 0.00 < 0.05)
                        Performance has improved.

    ProjectivePoint/scalar mul
                        time:   [121.54 µs 121.79 µs 122.09 µs]
                        change: [−24.162% −23.868% −23.576%] (p = 0.00 < 0.05)
                        Performance has improved.