### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "bignp256"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 dependencies = [
  "belt-hash",
  "criterion",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "bp256"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "bp384"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -374,7 +374,8 @@ dependencies = [
 [[package]]
 name = "crypto-common"
 version = "0.2.0-rc.9"
-source = "git+https://github.com/RustCrypto/traits#f3f7feb394e9ced9e77ec7cd9ff5e4c832efbeb0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b8986f836d4aeb30ccf4c9d3bd562fd716074cfd7fc4a2948359fbd21ed809"
 dependencies = [
  "getrandom 0.4.0-rc.0",
  "hybrid-array",
@@ -417,8 +418,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.11"
-source = "git+https://github.com/RustCrypto/signatures#47379ade8c5954d0b786ed70286c6c180d47caf8"
+version = "0.17.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18ccb2afbad0782e073b602a7d59dd08966d2b1173e08f96ebffb5446f8446d"
 dependencies = [
  "der",
  "digest",
@@ -444,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "ed448-goldilocks"
-version = "0.14.0-pre.6"
+version = "0.14.0-pre.7"
 dependencies = [
  "chacha20",
  "criterion",
@@ -472,8 +474,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.20"
-source = "git+https://github.com/RustCrypto/traits#f3f7feb394e9ced9e77ec7cd9ff5e4c832efbeb0"
+version = "0.14.0-rc.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ee4530cd12af66979d89bf0e555c66d04ed1dc58479d7a69d93c98a650fb738"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -567,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "hash2curve"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 dependencies = [
  "digest",
  "elliptic-curve",
@@ -653,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 dependencies = [
  "cfg-if",
  "criterion",
@@ -757,7 +760,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p192"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -769,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "p224"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -783,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -800,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -818,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 dependencies = [
  "base16ct",
  "criterion",
@@ -899,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 dependencies = [
  "crypto-bigint",
  "crypto-common",
@@ -911,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 dependencies = [
  "elliptic-curve",
  "serdect",
@@ -1292,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "sm2"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 dependencies = [
  "criterion",
  "der",
@@ -1534,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "x448"
-version = "0.14.0-pre.3"
+version = "0.14.0-pre.4"
 dependencies = [
  "ed448-goldilocks",
  "getrandom 0.4.0-rc.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,3 @@ ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
-
-crypto-common = { git = "https://github.com/RustCrypto/traits" }
-ecdsa = { git = "https://github.com/RustCrypto/signatures" }
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bignp256"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 description = """
 Pure Rust implementation of the Bign P-256 (a.k.a. bign-curve256v1)
 elliptic curve as defined in STB 34.101.45-2013, with
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.20", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.21", features = ["sec1"] }
 
 # optional dependencies
 belt-hash = { version = "0.2.0-rc.0", optional = true, default-features = false }
@@ -30,17 +30,17 @@ hmac = { version = "0.13.0-rc.3", optional = true }
 rand_core = "0.10.0-rc-3"
 rfc6979 = { version = "0.5.0-rc.3", optional = true }
 pkcs8 = { version = "0.11.0-rc.8", optional = true }
-primefield = { version = "0.14.0-rc.3", optional = true }
-primeorder = { version = "0.14.0-rc.3", optional = true }
+primefield = { version = "0.14.0-rc.4", optional = true }
+primeorder = { version = "0.14.0-rc.4", optional = true }
 sec1 = { version = "0.8.0-rc.10", optional = true }
 signature = { version = "3.0.0-rc.6", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["dev"] }
 getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.3", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.4", features = ["dev"] }
 proptest = "1"
 
 [features]

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp256"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 description = "Brainpool P-256 (brainpoolP256r1 and brainpoolP256t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -14,17 +14,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.11", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "0.14.0-rc.3", optional = true }
-primeorder = { version = "0.14.0-rc.3", optional = true }
+ecdsa = { version = "0.17.0-rc.12", optional = true, default-features = false, features = ["der"] }
+primefield = { version = "0.14.0-rc.4", optional = true }
+primeorder = { version = "0.14.0-rc.4", optional = true }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp384"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -14,17 +14,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.11", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "0.14.0-rc.3", optional = true }
-primeorder = { version = "0.14.0-rc.3", optional = true }
+ecdsa = { version = "0.17.0-rc.12", optional = true, default-features = false, features = ["der"] }
+primefield = { version = "0.14.0-rc.4", optional = true }
+primeorder = { version = "0.14.0-rc.4", optional = true }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed448-goldilocks"
-version = "0.14.0-pre.6"
+version = "0.14.0-pre.7"
 authors = ["RustCrypto Developers"]
 categories = ["cryptography"]
 keywords = ["cryptography", "decaf", "ed448", "ed448-goldilocks"]
@@ -16,8 +16,8 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.20", features = ["arithmetic", "pkcs8"] }
-hash2curve = "0.14.0-rc.6"
+elliptic-curve = { version = "0.14.0-rc.21", features = ["arithmetic", "pkcs8"] }
+hash2curve = "0.14.0-rc.7"
 rand_core = { version = "0.10.0-rc-3", default-features = false }
 sha3 = { version = "0.11.0-rc.3", default-features = false }
 subtle = { version = "2.6", default-features = false }

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash2curve"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 description = "hash2curve algorithm implementation"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = { version = "0.11.0-rc.5" }
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["arithmetic"] }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification/public-key recovery, Taproot Schnorr signatures (BIP340),
@@ -20,20 +20,20 @@ rust-version = "1.85"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
-hash2curve = { version = "0.14.0-rc.6", optional = true }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["sec1"] }
+hash2curve = { version = "0.14.0-rc.7", optional = true }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.12", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primeorder = { version = "0.14.0-rc.3", optional = true }
+primeorder = { version = "0.14.0-rc.4", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 signature = { version = "3.0.0-rc.6", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.12", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4.3"
 hex-literal = "1"
 num-bigint = "0.4"

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p192"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 description = """
 Pure Rust implementation of the NIST P-192 (a.k.a. secp192r1) elliptic curve
 as defined in SP 800-186
@@ -17,19 +17,19 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.12", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.3", optional = true }
-primeorder = { version = "0.14.0-rc.3", optional = true }
+primefield = { version = "0.14.0-rc.4", optional = true }
+primeorder = { version = "0.14.0-rc.4", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.12", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.3", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.4", features = ["dev"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p224"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 description = """
 Pure Rust implementation of the NIST P-224 (a.k.a. secp224r1) elliptic curve
 as defined in SP 800-186
@@ -17,20 +17,20 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.12", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.3", optional = true }
-primeorder = { version = "0.14.0-rc.3", optional = true }
+primefield = { version = "0.14.0-rc.4", optional = true }
+primeorder = { version = "0.14.0-rc.4", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.12", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.3", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.4", features = ["dev"] }
 getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 
 [features]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve as defined in SP 800-186, with support for ECDH, ECDSA
@@ -18,23 +18,23 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.6", optional = true }
+ecdsa-core = { version = "0.17.0-rc.12", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+hash2curve = { version = "0.14.0-rc.7", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.3", optional = true }
-primeorder = { version = "0.14.0-rc.3", optional = true }
+primefield = { version = "0.14.0-rc.4", optional = true }
+primeorder = { version = "0.14.0-rc.4", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.12", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primefield = { version = "0.14.0-rc.3" }
-primeorder = { version = "0.14.0-rc.3", features = ["dev"] }
+primefield = { version = "0.14.0-rc.4" }
+primeorder = { version = "0.14.0-rc.4", features = ["dev"] }
 proptest = "1"
 getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p384"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 description = """
 Pure Rust implementation of the NIST P-384 (a.k.a. secp384r1) elliptic curve
 as defined in SP 800-186 with support for ECDH, ECDSA signing/verification,
@@ -18,14 +18,14 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.6", optional = true }
+ecdsa-core = { version = "0.17.0-rc.12", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+hash2curve = { version = "0.14.0-rc.7", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.3", optional = true }
-primeorder = { version = "0.14.0-rc.3", optional = true }
+primefield = { version = "0.14.0-rc.4", optional = true }
+primeorder = { version = "0.14.0-rc.4", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
@@ -34,9 +34,9 @@ fiat-crypto = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.12", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.3", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.4", features = ["dev"] }
 proptest = "1.9"
 getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p521"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 description = """
 Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve
 as defined in SP 800-186
@@ -18,23 +18,23 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "1"
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.6", optional = true }
+ecdsa-core = { version = "0.17.0-rc.12", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+hash2curve = { version = "0.14.0-rc.7", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.3", optional = true }
-primeorder = { version = "0.14.0-rc.3", optional = true }
+primefield = { version = "0.14.0-rc.4", optional = true }
+primeorder = { version = "0.14.0-rc.4", optional = true }
 rand_core = { version = "0.10.0-rc-3", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.11", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.12", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.3", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.4", features = ["dev"] }
 proptest = "1.9"
 getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primefield"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 description = """
 Generic implementation of prime fields built on `crypto-bigint`, along with macros for writing
 field element newtypes including ones with formally verified arithmetic using `fiat-crypto`

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true, default-features = false }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm2"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 description = """
 Pure Rust implementation of the SM2 elliptic curve as defined in the Chinese
 national standard GM/T 0003-2012 as well as ISO/IEC 14888. Includes support for
@@ -18,13 +18,13 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
 rand_core = { version = "0.10.0-rc-3", default-features = false }
 
 # optional dependencies
-primefield = { version = "0.14.0-rc.3", optional = true }
-primeorder = { version = "0.14.0-rc.3", optional = true }
+primefield = { version = "0.14.0-rc.4", optional = true }
+primeorder = { version = "0.14.0-rc.4", optional = true }
 rfc6979 = { version = "0.5.0-rc.3", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 signature = { version = "3.0.0-rc.6", optional = true, features = ["rand_core"] }
@@ -33,7 +33,7 @@ der = { version = "0.8.0-rc.10", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.20", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.21", default-features = false, features = ["dev"] }
 getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 hex-literal = "1"
 proptest = "1"

--- a/x448/Cargo.toml
+++ b/x448/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x448"
-version = "0.14.0-pre.3"
+version = "0.14.0-pre.4"
 authors = ["RustCrypto Developers"]
 categories = ["cryptography"]
 keywords = ["cryptography", "crypto", "x448", "diffie-hellman", "curve448", ]
@@ -14,7 +14,7 @@ readme = "README.md"
 description = "Pure Rust implementation of X448, an elliptic curve Diffie-Hellman function"
 
 [dependencies]
-ed448-goldilocks = { version = "0.14.0-pre.6", default-features = false }
+ed448-goldilocks = { version = "0.14.0-pre.7", default-features = false }
 rand_core = { version = "0.10.0-rc-3", default-features = false }
 
 # optional dependencies


### PR DESCRIPTION
Releases the following:

- `bignp256` v0.14.0-rc.4
- `bp256` v0.14.0-rc.4
- `bp384` v0.14.0-rc.4
- `ed448-goldilocks` v0.14.0-pre.7
- `hash2curve` v0.14.0-rc.7
- `k256` v0.14.0-rc.4
- `p192` v0.14.0-rc.4
- `p224` v0.14.0-rc.4
- `p256` v0.14.0-rc.4
- `p384` v0.14.0-rc.4
- `p521` v0.14.0-rc.4
- `primefield` v0.14.0-rc.4
- `primeorder` v0.14.0-rc.4
- `sm2` v0.14.0-rc.4
- `x448` v0.14.0-pre.4