### PR TITLE
Refactor `TryFrom<ProjectivePoint>` for `PublicKey` to delegate to reference implementation

### DIFF
--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -584,7 +584,7 @@ where
     type Error = Error;
 
     fn try_from(point: ProjectivePoint<C>) -> Result<PublicKey<C>> {
-        AffinePoint::<C>::from(point).try_into()
+        PublicKey::try_from(&point)
     }
 }
 


### PR DESCRIPTION
Removed duplicated conversion logic by making `TryFrom<ProjectivePoint<C>> for PublicKey<C>` delegate to `TryFrom<&ProjectivePoint<C>> for PublicKey<C>`.
Keeps a single source of truth for converting `ProjectivePoint` to `PublicKey`, reducing the risk of future inconsistencies between value and reference conversions.
