### PR TITLE
k256: use ORDER constant instead of reconstructing from ORDER_HEX

### DIFF
--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -135,18 +135,14 @@ impl Scalar {
 
     /// Returns the multiplicative inverse of self, if self is non-zero.
     pub fn invert(&self) -> CtOption<Self> {
-        let inv = self
-            .retrieve()
-            .invert_odd_mod(&ORDER);
+        let inv = self.retrieve().invert_odd_mod(&ORDER);
 
         CtOption::from(inv).map(Self::from_uint_unchecked)
     }
 
     /// Returns the multiplicative inverse of self in variable-time, if self is non-zero.
     pub fn invert_vartime(&self) -> CtOption<Self> {
-        let inv = self
-            .retrieve()
-            .invert_odd_mod_vartime(&ORDER);
+        let inv = self.retrieve().invert_odd_mod_vartime(&ORDER);
 
         CtOption::from(inv).map(Self::from_uint_unchecked)
     }


### PR DESCRIPTION


Remove redundant modulus reconstruction in `Scalar::invert()` and `Scalar::invert_vartime()` by using the existing `ORDER` constant instead of rebuilding it from `ORDER_HEX`.

