### PR TITLE
sm2: fix SM2PKE decryption DoS vulnerability [SECURITY]

### DIFF
--- a/sm2/src/pke/decrypting.rs
+++ b/sm2/src/pke/decrypting.rs
@@ -167,7 +167,9 @@ fn decrypt(
     let encoded_c1 = EncodedPoint::from_bytes(c1).map_err(Error::from)?;
 
     // verify that point c1 satisfies the elliptic curve
-    let mut c1_point = AffinePoint::from_encoded_point(&encoded_c1).unwrap();
+    let mut c1_point = AffinePoint::from_encoded_point(&encoded_c1)
+        .into_option()
+        .ok_or(Error)?;
 
     // B2: compute point 𝑆 = [ℎ]𝐶1
     let s = c1_point * Scalar::reduce(&U256::from_u32(FieldElement::S));


### PR DESCRIPTION
This fixes a potential denial-of-service attack in the SM2PKE decryption implementation originally reported as [GHSA-78p6-6878-8mj6](https://github.com/RustCrypto/elliptic-curves/security/advisories/GHSA-78p6-6878-8mj6) by @XlabAITeam

The implementation parses the ciphertext, extracting the bytes that represent the `C1` curve point, however previously after attempting to invoke `AffinePoint::from_encoded_point` the result was subsequently being `unwrap()`ed in the event the provided candidate encoded point is not actually a valid point on the SM2 elliptic curve, leading to a potential DoS in this case.

This is unfortunate because it was not caught by the `clippy::unwrap_used` lint, most likely because the actual method being invoked was `subtle::CtOption::unwrap` and it seems clippy does not check for every "unwrap" method invocation on every type, only `std::option::Option`/`Result`.

The problem was corrected by replacing the `unwrap` by converting to `Result` and then propagating the error.