### PR TITLE
sm2: add `UncompressedPoint` type alias

### DIFF
--- a/sm2/src/lib.rs
+++ b/sm2/src/lib.rs
@@ -75,9 +75,9 @@ pub use elliptic_curve::pkcs8;
 
 use elliptic_curve::{
     FieldBytesEncoding,
-    array::{Array, typenum::U33},
+    array::Array,
     bigint::{ArrayEncoding, Odd},
-    consts::U32,
+    consts::{U32, U33, U65},
 };
 
 #[cfg(feature = "dsa")]
@@ -120,6 +120,9 @@ impl pkcs8::AssociatedOid for Sm2 {
 
 /// Compressed SEC1-encoded curve point.
 pub type CompressedPoint = Array<u8, U33>;
+
+/// Uncompressed SEC1-encoded curve point.
+pub type UncompressedPoint = Array<u8, U65>;
 
 /// SEC1 encoded point.
 pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<Sm2>;

--- a/sm2/src/pke/decrypting.rs
+++ b/sm2/src/pke/decrypting.rs
@@ -2,7 +2,7 @@ use core::fmt::{self, Debug};
 
 use crate::{
     AffinePoint, EncodedPoint, FieldBytes, NonZeroScalar, PublicKey, Scalar, SecretKey,
-    arithmetic::field::FieldElement,
+    UncompressedPoint, arithmetic::field::FieldElement,
 };
 
 use alloc::{borrow::ToOwned, vec::Vec};
@@ -159,11 +159,11 @@ fn decrypt(
     hasher: &mut dyn DynDigest,
     ciphertext: &[u8],
 ) -> Result<Vec<u8>> {
-    let q = U256::from_be_hex(FieldElement::MODULUS);
-    let c1_len = q.bits().div_ceil(8) * 2 + 1;
-
     // B1: get 𝐶1 from 𝐶
-    let (c1, c) = ciphertext.split_at_checked(c1_len as usize).ok_or(Error)?;
+    let (c1, c) = ciphertext
+        .split_at_checked(size_of::<UncompressedPoint>())
+        .ok_or(Error)?;
+
     let encoded_c1 = EncodedPoint::from_bytes(c1).map_err(Error::from)?;
 
     // verify that point c1 satisfies the elliptic curve

--- a/sm2/src/pke/encrypting.rs
+++ b/sm2/src/pke/encrypting.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 
 use crate::{
-    AffinePoint, FieldBytesSize, NonZeroScalar, ProjectivePoint, PublicKey, Scalar,
+    AffinePoint, NonZeroScalar, ProjectivePoint, PublicKey, Scalar, UncompressedPoint,
     arithmetic::field::FieldElement,
     pke::{kdf, vec},
 };
@@ -10,7 +10,6 @@ use crate::{
 use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
 use elliptic_curve::{
     Error, Generate, Group, Result,
-    array::typenum::Unsigned,
     bigint::{U256, Uint},
     ops::Reduce,
     pkcs8::der::Encode,
@@ -153,7 +152,7 @@ fn encrypt<R: TryCryptoRng + ?Sized>(
     digest: &mut dyn DynDigest,
     msg: &[u8],
 ) -> Result<Vec<u8>> {
-    let mut c1 = [0; FieldBytesSize::USIZE * 2 + 1];
+    let mut c1 = [0; size_of::<UncompressedPoint>()];
     let mut c2 = msg.to_owned();
     let mut hpb: AffinePoint;
     loop {


### PR DESCRIPTION
Adds a type alias for a byte `Array` the size of an uncompressed curve point, and uses that to simplify the SM2PKE implementation