### PR TITLE
hash2curve: eliminate redundant DST length calculation in Domain methods

### DIFF
--- a/hash2curve/src/hash2field/expand_msg.rs
+++ b/hash2curve/src/hash2field/expand_msg.rs
@@ -72,9 +72,11 @@ impl<'a, L: ArraySize> Domain<'a, L> {
         X: Default + ExtendableOutput + Update,
     {
         // https://www.rfc-editor.org/rfc/rfc9380.html#section-3.1-4.2
-        if dst.iter().map(|slice| slice.len()).sum::<usize>() == 0 {
+        let dst_len = dst.iter().map(|slice| slice.len()).sum::<usize>();
+
+        if dst_len == 0 {
             Err(ExpandMsgXofError::EmptyDst)
-        } else if dst.iter().map(|slice| slice.len()).sum::<usize>() > MAX_DST_LEN {
+        } else if dst_len > MAX_DST_LEN {
             if L::USIZE > u8::MAX.into() {
                 return Err(ExpandMsgXofError::DstSecurityLevel);
             }
@@ -99,9 +101,11 @@ impl<'a, L: ArraySize> Domain<'a, L> {
         X: Digest<OutputSize = L>,
     {
         // https://www.rfc-editor.org/rfc/rfc9380.html#section-3.1-4.2
-        if dst.iter().map(|slice| slice.len()).sum::<usize>() == 0 {
+        let dst_len = dst.iter().map(|slice| slice.len()).sum::<usize>();
+
+        if dst_len == 0 {
             Err(ExpandMsgXmdError::EmptyDst)
-        } else if dst.iter().map(|slice| slice.len()).sum::<usize>() > MAX_DST_LEN {
+        } else if dst_len > MAX_DST_LEN {
             if L::USIZE > u8::MAX.into() {
                 return Err(ExpandMsgXmdError::DstHash);
             }


### PR DESCRIPTION


Previously, `dst.iter().map(|slice| slice.len()).sum::<usize>()` was computed twice in both `xof` and `xmd` methods (once for the empty check, once for the length check). This change computes the length once and reuses it, eliminating duplicate iteration over the DST slice.

