### PR TITLE
fix: remove redundant code duplication in scalar multiplication

### DIFF
--- a/ed448-goldilocks/src/curve/scalar_mul/variable_base.rs
+++ b/ed448-goldilocks/src/curve/scalar_mul/variable_base.rs
@@ -14,10 +14,7 @@ pub fn variable_base(point: &ExtendedPoint, s: &EdwardsScalar) -> ExtensiblePoin
     let lookup = LookupTable::from(point);
 
     for i in (0..113).rev() {
-        result = result.double();
-        result = result.double();
-        result = result.double();
-        result = result.double();
+        result = result.double().double().double().double();
 
         // The mask is the top bit, will be 1 for negative numbers, 0 for positive numbers
         let mask = scalar[i] >> 7;


### PR DESCRIPTION


Refactor `variable_base` to eliminate code duplication by chaining four `double()` calls instead of repeating the same operation four times.

