### PR TITLE
ed448-goldilocks: deduplicate OKM→FieldElement test logic

### DIFF
--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -513,10 +513,7 @@ mod tests {
     use hex_literal::hex;
     use sha3::Shake256;
 
-    fn assert_from_okm(
-        dst: &[u8],
-        msgs: &[(&[u8], [u8; 56], [u8; 56])],
-    ) {
+    fn assert_from_okm(dst: &[u8], msgs: &[(&[u8], [u8; 56], [u8; 56])]) {
         for (msg, expected_u0, expected_u1) in msgs {
             let mut expander = <ExpandMsgXof<Shake256> as ExpandMsg<U32>>::expand_message(
                 &[*msg],


### PR DESCRIPTION


- Factor duplicated OKM→`FieldElement` test logic into a small helper.

The same OKM expansion + reduction + expected-bytes handling was duplicated across two tests, which increases maintenance cost and the chance of tests drifting over time.

- **`ed448-goldilocks/src/field/element.rs`**: add `assert_from_okm(...)` and reuse it in `from_okm_curve448` and `from_okm_edwards448`.

