### PR TITLE
cleanup: reduce arithmetic module visibility

### DIFF
--- a/bignp256/src/lib.rs
+++ b/bignp256/src/lib.rs
@@ -47,7 +47,7 @@ pub use {
 pub type Result<T> = core::result::Result<T, Error>;
 
 #[cfg(feature = "arithmetic")]
-pub mod arithmetic;
+pub(crate) mod arithmetic;
 
 #[cfg(any(feature = "test-vectors", test))]
 pub mod test_vectors;


### PR DESCRIPTION
Reduce public surface by making the arithmetic module crate-visible only
This keeps existing reexports intact while avoiding exposing the internal arithmetic module as part of the public API