### PR TITLE
chore(deps): bump `rand_core` to `0.10.0-rc-5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "primefield",
  "primeorder",
  "proptest",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "rfc6979",
  "sec1",
  "signature",
@@ -183,14 +183,14 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.6"
+version = "0.10.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f895fb33c1ad22da4bc79d37c0bddff8aee2ba4575705345eb73b8ffbc386074"
+checksum = "31cd65b2ca03198c223cd9a8fa1152c4ec251cd79049f6dc584152ad3fb5ba9d"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
 ]
 
 [[package]]
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155e4a260750fa4f7754649f049748aacc31db238a358d85fd721002f230f92f"
+checksum = "b557bad79bc426785757001b5d732f323ae965363983d758295c1a1935496880"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -258,9 +258,9 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cmov"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1339d398d44e506d9b72c1af2f6f51a41c9c64f9a0738eb9aedede47ed1f683"
+checksum = "df1888fb431ee159b513b5c2f249e03f1c9d788f7bd842927619dbeb88764039"
 
 [[package]]
 name = "const-oid"
@@ -358,35 +358,35 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.15"
+version = "0.7.0-rc.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9e36ac79ac44866b74e08a0b4925f97b984e3fff17680d2c6fbce8317ab0f6"
+checksum = "f9f9a78b88bb8255ec59a81423aa92ada22f96883f9ae59dcb68613907636ae5"
 dependencies = [
  "ctutils",
  "getrandom 0.4.0-rc.0",
  "hybrid-array",
  "num-traits",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.9"
+version = "0.2.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b8986f836d4aeb30ccf4c9d3bd562fd716074cfd7fc4a2948359fbd21ed809"
+checksum = "7d2bcc93d5cde6659e8649fc412894417ebc14dee54cfc6ee439c683a4a58342"
 dependencies = [
  "getrandom 0.4.0-rc.0",
  "hybrid-array",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
 ]
 
 [[package]]
 name = "ctutils"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130ffe18bdf7a4926e57ed19d404995244e6c8d6a97abf4eddde1f892bf1ce0c"
+checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
 dependencies = [
  "cmov",
  "subtle",
@@ -457,7 +457,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "proptest",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "serde_bare",
  "serde_json",
  "serdect",
@@ -489,7 +489,7 @@ dependencies = [
  "once_cell",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "rustcrypto-ff",
  "rustcrypto-group",
  "sec1",
@@ -553,7 +553,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "wasip2",
 ]
 
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7357b6e7aa75618c7864ebd0634b115a7218b0615f4cb1df33ac3eca23943d4"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "hybrid-array",
 ]
@@ -833,7 +833,7 @@ dependencies = [
  "primefield",
  "primeorder",
  "proptest",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "serdect",
  "sha2",
 ]
@@ -906,7 +906,7 @@ version = "0.14.0-rc.4"
 dependencies = [
  "crypto-bigint",
  "crypto-common",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "rustcrypto-ff",
  "subtle",
  "zeroize",
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-3"
+version = "0.10.0-rc-5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05"
+checksum = "05a06e03bd1f2ae861ab9e7498b6c64ed3dadb9ce175c0464a2522a5f23c0045"
 
 [[package]]
 name = "rand_xorshift"
@@ -1098,7 +1098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9cd37111549306f79b09aa2618e15b1e8241b7178c286821e3dd71579db4db"
 dependencies = [
  "bitvec",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "rustcrypto-ff_derive",
  "subtle",
 ]
@@ -1124,7 +1124,7 @@ version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e394cd734b5f97dfc3484fa42aad7acd912961c2bcd96c99aa05b3d6cab7cafd"
 dependencies = [
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "rustcrypto-ff",
  "subtle",
 ]
@@ -1177,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.11"
+version = "0.8.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2568531a8ace88b848310caa98fb2115b151ef924d54aa523e659c21b9d32d71"
+checksum = "5b54617aeb7e34ace1a4b72ba79bb6297e48285dc0cce064dc063ddcbf538996"
 dependencies = [
  "base16ct",
  "ctutils",
@@ -1290,7 +1290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a96996ccff7dfa16f052bd995b4cecc72af22c35138738dc029f0ead6608d"
 dependencies = [
  "digest",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
 ]
 
 [[package]]
@@ -1306,7 +1306,7 @@ dependencies = [
  "primefield",
  "primeorder",
  "proptest",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "rfc6979",
  "serdect",
  "signature",
@@ -1541,7 +1541,7 @@ version = "0.14.0-pre.4"
 dependencies = [
  "ed448-goldilocks",
  "getrandom 0.4.0-rc.0",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "serdect",
  "zeroize",
 ]

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -32,7 +32,7 @@ rfc6979 = { version = "0.5.0-rc.3", optional = true }
 pkcs8 = { version = "0.11.0-rc.8", optional = true }
 primefield = { version = "0.14.0-rc.4", optional = true }
 primeorder = { version = "0.14.0-rc.4", optional = true }
-sec1 = { version = "0.8.0-rc.10", optional = true }
+sec1 = { version = "0.8.0-rc.12", optional = true }
 signature = { version = "3.0.0-rc.6", optional = true }
 
 [dev-dependencies]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -33,7 +33,7 @@ getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 hex-literal = "1"
 hex = "0.4"
 proptest = { version = "1", features = ["attr-macro"] }
-chacha20 = { version = "0.10.0-rc.6", features = ["rng"] }
+chacha20 = { version = "0.10.0-rc.8", features = ["rng"] }
 serde_bare = "0.5"
 serde_json = "1.0"
 

--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -12,7 +12,7 @@ use elliptic_curve::{
     Field,
     array::Array,
     bigint::{
-        Integer, NonZero, U448, U704, Zero,
+        NonZero, U448, U704, Zero,
         consts::{U28, U56, U84, U88},
         modular::ConstMontyParams,
     },

--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -13,7 +13,7 @@ use elliptic_curve::{
         Array, ArraySize,
         typenum::{Prod, Unsigned},
     },
-    bigint::{Integer, Limb, U448, U896, Word, modular::Retrieve},
+    bigint::{Limb, U448, U896, Word, modular::Retrieve},
     consts::U2,
     ctutils::{self, CtSelect},
     ff::{Field, helpers},

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -391,15 +391,15 @@ impl MulAssign<&Scalar> for ProjectivePoint {
 mod tests {
     use super::*;
     use crate::arithmetic::{ProjectivePoint, Scalar};
-    use elliptic_curve::{Field, Group};
-    use getrandom::{SysRng, rand_core::TryRngCore};
+    use elliptic_curve::Generate;
+    use getrandom::SysRng;
 
     #[test]
     fn test_lincomb() {
-        let x = ProjectivePoint::random(&mut SysRng.unwrap_mut());
-        let y = ProjectivePoint::random(&mut SysRng.unwrap_mut());
-        let k = Scalar::random(&mut SysRng.unwrap_mut());
-        let l = Scalar::random(&mut SysRng.unwrap_mut());
+        let x = ProjectivePoint::try_generate_from_rng(&mut SysRng).unwrap();
+        let y = ProjectivePoint::try_generate_from_rng(&mut SysRng).unwrap();
+        let k = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
+        let l = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
 
         let reference = x * k + y * l;
         let test = ProjectivePoint::lincomb(&[(x, k), (y, l)]);
@@ -408,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_mul_by_generator() {
-        let k = Scalar::random(&mut SysRng.unwrap_mut());
+        let k = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
         let reference = ProjectivePoint::GENERATOR * k;
         let test = ProjectivePoint::mul_by_generator(&k);
         assert_eq!(reference, test);
@@ -417,10 +417,10 @@ mod tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn test_lincomb_slice() {
-        let x = ProjectivePoint::random(&mut SysRng.unwrap_mut());
-        let y = ProjectivePoint::random(&mut SysRng.unwrap_mut());
-        let k = Scalar::random(&mut SysRng.unwrap_mut());
-        let l = Scalar::random(&mut SysRng.unwrap_mut());
+        let x = ProjectivePoint::try_generate_from_rng(&mut SysRng).unwrap();
+        let y = ProjectivePoint::try_generate_from_rng(&mut SysRng).unwrap();
+        let k = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
+        let l = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
 
         let reference = x * k + y * l;
         let points_and_scalars = vec![(x, k), (y, l)];

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -746,8 +746,8 @@ mod tests {
     };
     use elliptic_curve::BatchNormalize;
     use elliptic_curve::group::{ff::PrimeField, prime::PrimeCurveAffine};
-    use elliptic_curve::{CurveGroup, Field};
-    use getrandom::{SysRng, rand_core::TryRngCore};
+    use elliptic_curve::{CurveGroup, Generate};
+    use getrandom::SysRng;
 
     #[cfg(feature = "alloc")]
     use alloc::vec::Vec;
@@ -771,8 +771,8 @@ mod tests {
 
     #[test]
     fn batch_normalize_array() {
-        let k: Scalar = Scalar::random(&mut SysRng.unwrap_mut());
-        let l: Scalar = Scalar::random(&mut SysRng.unwrap_mut());
+        let k: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
+        let l: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
         let g = ProjectivePoint::mul_by_generator(&k);
         let h = ProjectivePoint::mul_by_generator(&l);
 
@@ -788,7 +788,7 @@ mod tests {
 
         let mut res = [AffinePoint::IDENTITY; 3];
         let non_normalized_identity =
-            ProjectivePoint::IDENTITY * Scalar::random(&mut SysRng.unwrap_mut());
+            ProjectivePoint::IDENTITY * Scalar::try_generate_from_rng(&mut SysRng).unwrap();
         let expected = [g.to_affine(), AffinePoint::IDENTITY, AffinePoint::IDENTITY];
         assert_eq!(
             <ProjectivePoint as BatchNormalize<_>>::batch_normalize(&[
@@ -809,8 +809,8 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn batch_normalize_slice() {
-        let k: Scalar = Scalar::random(&mut SysRng.unwrap_mut());
-        let l: Scalar = Scalar::random(&mut SysRng.unwrap_mut());
+        let k: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
+        let l: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
         let g = ProjectivePoint::mul_by_generator(&k);
         let h = ProjectivePoint::mul_by_generator(&l);
 

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -16,7 +16,7 @@ use core::{
 };
 use elliptic_curve::{
     Curve, Error, Generate, ScalarValue,
-    bigint::{ArrayEncoding, Integer, Limb, U256, U512, Word, modular::Retrieve},
+    bigint::{ArrayEncoding, Limb, U256, U512, Word, modular::Retrieve},
     ctutils,
     ff::{self, Field, FromUniformBytes, PrimeField},
     ops::{Invert, Reduce, ReduceNonZero},
@@ -835,7 +835,7 @@ mod tests {
         ops::{BatchInvert, Reduce},
         scalar::IsHigh,
     };
-    use getrandom::{SysRng, rand_core::TryRngCore};
+    use getrandom::SysRng;
     use num_bigint::{BigUint, ToBigUint};
     use num_traits::Zero;
     use proptest::prelude::*;
@@ -991,8 +991,8 @@ mod tests {
 
     #[test]
     fn batch_invert_array() {
-        let k: Scalar = Scalar::random(&mut SysRng.unwrap_mut());
-        let l: Scalar = Scalar::random(&mut SysRng.unwrap_mut());
+        let k: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
+        let l: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
 
         let expected = [k.invert().unwrap(), l.invert().unwrap()];
         assert_eq!(
@@ -1004,8 +1004,8 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn batch_invert() {
-        let k: Scalar = Scalar::random(&mut SysRng.unwrap_mut());
-        let l: Scalar = Scalar::random(&mut SysRng.unwrap_mut());
+        let k: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
+        let l: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
 
         let expected = vec![k.invert().unwrap(), l.invert().unwrap()];
         let scalars = vec![k, l];

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -13,7 +13,7 @@ use core::{
 };
 use elliptic_curve::{
     Curve, Generate,
-    bigint::{ArrayEncoding, Integer, Limb, Odd, U256, Uint, modular::Retrieve},
+    bigint::{ArrayEncoding, Limb, Odd, U256, Uint, modular::Retrieve},
     ctutils,
     group::ff::{self, Field, FromUniformBytes, PrimeField},
     ops::{Invert, Reduce, ReduceNonZero},

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-bigint = { package = "crypto-bigint", version = "0.7.0-rc.13", default-features = false, features = ["rand_core", "hybrid-array", "subtle"] }
+bigint = { package = "crypto-bigint", version = "0.7.0-rc.21", default-features = false, features = ["rand_core", "hybrid-array", "subtle"] }
 common = { package = "crypto-common", version = "0.2.0-rc.9", features = ["rand_core"] }
 ff = { version = "=0.14.0-pre.0", package = "rustcrypto-ff", default-features = false }
 subtle = { version = "2.6", default-features = false, features = ["const-generics"] }

--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -5,7 +5,7 @@ mod sqrt;
 
 use crate::ByteOrder;
 use bigint::{
-    ArrayEncoding, ByteArray, Integer, Invert, Limb, Reduce, Uint, Word, ctutils,
+    ArrayEncoding, ByteArray, Invert, Limb, Reduce, Uint, Word, ctutils,
     hybrid_array::{Array, ArraySize, typenum::Unsigned},
     modular::{ConstMontyForm as MontyForm, ConstMontyParams, MontyParams, Retrieve},
 };


### PR DESCRIPTION
This also bumps `crypto-bigint` to `0.7.0-rc.21`.