### PR TITLE
k256: use `Generate::generate()` for tests

### DIFF
--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -524,7 +524,6 @@ mod tests {
     use elliptic_curve::Generate;
     use elliptic_curve::ff::{Field, PrimeField};
     use elliptic_curve::ops::BatchInvert;
-    use getrandom::SysRng;
     use num_bigint::{BigUint, ToBigUint};
     use proptest::prelude::*;
 
@@ -709,9 +708,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "getrandom")]
     fn batch_invert_array() {
-        let k: FieldElement = FieldElement::try_generate_from_rng(&mut SysRng).unwrap();
-        let l: FieldElement = FieldElement::try_generate_from_rng(&mut SysRng).unwrap();
+        let k: FieldElement = FieldElement::generate();
+        let l: FieldElement = FieldElement::generate();
 
         let expected = [k.invert().unwrap(), l.invert().unwrap()];
         let actual = <FieldElement as BatchInvert<_>>::batch_invert([k, l]).unwrap();
@@ -721,10 +721,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "getrandom"))]
     fn batch_invert() {
-        let k: FieldElement = FieldElement::try_generate_from_rng(&mut SysRng).unwrap();
-        let l: FieldElement = FieldElement::try_generate_from_rng(&mut SysRng).unwrap();
+        let k: FieldElement = FieldElement::generate();
+        let l: FieldElement = FieldElement::generate();
 
         let expected = vec![k.invert().unwrap(), l.invert().unwrap()];
         let field_elements = vec![k, l]; // to test impl of `BatchInvert` for `Vec`

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -392,14 +392,14 @@ mod tests {
     use super::*;
     use crate::arithmetic::{ProjectivePoint, Scalar};
     use elliptic_curve::Generate;
-    use getrandom::SysRng;
 
     #[test]
+    #[cfg(feature = "getrandom")]
     fn test_lincomb() {
-        let x = ProjectivePoint::try_generate_from_rng(&mut SysRng).unwrap();
-        let y = ProjectivePoint::try_generate_from_rng(&mut SysRng).unwrap();
-        let k = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
-        let l = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
+        let x = ProjectivePoint::generate();
+        let y = ProjectivePoint::generate();
+        let k = Scalar::generate();
+        let l = Scalar::generate();
 
         let reference = x * k + y * l;
         let test = ProjectivePoint::lincomb(&[(x, k), (y, l)]);
@@ -407,20 +407,21 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "getrandom")]
     fn test_mul_by_generator() {
-        let k = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
+        let k = Scalar::generate();
         let reference = ProjectivePoint::GENERATOR * k;
         let test = ProjectivePoint::mul_by_generator(&k);
         assert_eq!(reference, test);
     }
 
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "getrandom"))]
     #[test]
     fn test_lincomb_slice() {
-        let x = ProjectivePoint::try_generate_from_rng(&mut SysRng).unwrap();
-        let y = ProjectivePoint::try_generate_from_rng(&mut SysRng).unwrap();
-        let k = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
-        let l = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
+        let x = ProjectivePoint::generate();
+        let y = ProjectivePoint::generate();
+        let k = Scalar::generate();
+        let l = Scalar::generate();
 
         let reference = x * k + y * l;
         let points_and_scalars = vec![(x, k), (y, l)];

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -747,7 +747,6 @@ mod tests {
     use elliptic_curve::BatchNormalize;
     use elliptic_curve::group::{ff::PrimeField, prime::PrimeCurveAffine};
     use elliptic_curve::{CurveGroup, Generate};
-    use getrandom::SysRng;
 
     #[cfg(feature = "alloc")]
     use alloc::vec::Vec;
@@ -770,9 +769,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "getrandom")]
     fn batch_normalize_array() {
-        let k: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
-        let l: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
+        let k: Scalar = Scalar::generate();
+        let l: Scalar = Scalar::generate();
         let g = ProjectivePoint::mul_by_generator(&k);
         let h = ProjectivePoint::mul_by_generator(&l);
 
@@ -787,8 +787,7 @@ mod tests {
         assert_eq!(res, expected);
 
         let mut res = [AffinePoint::IDENTITY; 3];
-        let non_normalized_identity =
-            ProjectivePoint::IDENTITY * Scalar::try_generate_from_rng(&mut SysRng).unwrap();
+        let non_normalized_identity = ProjectivePoint::IDENTITY * Scalar::generate();
         let expected = [g.to_affine(), AffinePoint::IDENTITY, AffinePoint::IDENTITY];
         assert_eq!(
             <ProjectivePoint as BatchNormalize<_>>::batch_normalize(&[
@@ -807,10 +806,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "getrandom"))]
     fn batch_normalize_slice() {
-        let k: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
-        let l: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
+        let k: Scalar = Scalar::generate();
+        let l: Scalar = Scalar::generate();
         let g = ProjectivePoint::mul_by_generator(&k);
         let h = ProjectivePoint::mul_by_generator(&l);
 

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -990,9 +990,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "getrandom")]
     fn batch_invert_array() {
-        let k: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
-        let l: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
+        let k: Scalar = Scalar::generate();
+        let l: Scalar = Scalar::generate();
 
         let expected = [k.invert().unwrap(), l.invert().unwrap()];
         assert_eq!(
@@ -1002,10 +1003,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "getrandom"))]
     fn batch_invert() {
-        let k: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
-        let l: Scalar = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
+        let k: Scalar = Scalar::generate();
+        let l: Scalar = Scalar::generate();
 
         let expected = vec![k.invert().unwrap(), l.invert().unwrap()];
         let scalars = vec![k, l];
@@ -1059,10 +1060,9 @@ mod tests {
         assert_eq!((a - &a).is_zero().unwrap_u8(), 1);
     }
 
-    #[cfg(feature = "getrandom")]
     #[test]
     fn try_generate_from_rng() {
-        let a = Scalar::generate();
+        let a = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
         // just to make sure `a` is not optimized out by the compiler
         assert_eq!((a - &a).is_zero().unwrap_u8(), 1);
     }


### PR DESCRIPTION
This is a followup to https://github.com/RustCrypto/elliptic-curves/pull/1620