### PR TITLE
primefield: deduplicate MontyFieldElement::is_zero in ff::Field impl

### DIFF
--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -425,7 +425,7 @@ where
     }
 
     fn is_zero(&self) -> Choice {
-        Self::ZERO.ct_eq(self)
+        MontyFieldElement::<MOD, LIMBS>::is_zero(self)
     }
 
     fn square(&self) -> Self {


### PR DESCRIPTION
Deduplicate zero-check logic**: `ff::Field::is_zero` now delegates to the existing `MontyFieldElement::is_zero` implementation (`primefield/src/monty.rs`).

