### PR TITLE
RNG cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,6 @@ dependencies = [
  "der",
  "digest",
  "elliptic-curve",
- "getrandom 0.4.0-rc.0",
  "hex-literal",
  "hkdf",
  "hmac",
@@ -264,9 +263,9 @@ checksum = "df1888fb431ee159b513b5c2f249e03f1c9d788f7bd842927619dbeb88764039"
 
 [[package]]
 name = "const-oid"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
@@ -662,7 +661,6 @@ dependencies = [
  "criterion",
  "ecdsa",
  "elliptic-curve",
- "getrandom 0.4.0-rc.0",
  "hash2curve",
  "hex",
  "hex-literal",
@@ -776,7 +774,6 @@ version = "0.14.0-rc.4"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "getrandom 0.4.0-rc.0",
  "hex-literal",
  "primefield",
  "primeorder",
@@ -791,7 +788,6 @@ dependencies = [
  "criterion",
  "ecdsa",
  "elliptic-curve",
- "getrandom 0.4.0-rc.0",
  "hash2curve",
  "hex-literal",
  "primefield",
@@ -809,7 +805,6 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "fiat-crypto",
- "getrandom 0.4.0-rc.0",
  "hash2curve",
  "hex-literal",
  "primefield",
@@ -827,7 +822,6 @@ dependencies = [
  "criterion",
  "ecdsa",
  "elliptic-curve",
- "getrandom 0.4.0-rc.0",
  "hash2curve",
  "hex-literal",
  "primefield",
@@ -1301,7 +1295,6 @@ dependencies = [
  "der",
  "elliptic-curve",
  "fiat-crypto",
- "getrandom 0.4.0-rc.0",
  "hex-literal",
  "primefield",
  "primeorder",
@@ -1540,8 +1533,6 @@ name = "x448"
 version = "0.14.0-pre.4"
 dependencies = [
  "ed448-goldilocks",
- "getrandom 0.4.0-rc.0",
- "rand_core 0.10.0-rc-5",
  "serdect",
  "zeroize",
 ]

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -38,7 +38,6 @@ signature = { version = "3.0.0-rc.8", optional = true }
 [dev-dependencies]
 criterion = "0.7"
 elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["dev"] }
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.4", features = ["dev"] }
 proptest = "1"

--- a/ed448-goldilocks/README.md
+++ b/ed448-goldilocks/README.md
@@ -17,9 +17,12 @@ It is intended to be portable, fast, and safe.
 ## Usage
 
 ```rust
-use ed448_goldilocks::{Ed448, EdwardsPoint, CompressedEdwardsY, EdwardsScalar, sha3::Shake256};
+use ed448_goldilocks::{
+    Ed448, EdwardsPoint, CompressedEdwardsY, EdwardsScalar,
+    elliptic_curve::Generate,
+    sha3::Shake256
+};
 use elliptic_curve::{consts::U84, Field, group::GroupEncoding};
-use getrandom::SysRng;
 use hash2curve::{ExpandMsgXof, GroupDigest};
 
 let secret_key = EdwardsScalar::TWO;
@@ -27,7 +30,7 @@ let public_key = EdwardsPoint::GENERATOR * &secret_key;
 
 assert_eq!(public_key, EdwardsPoint::GENERATOR + EdwardsPoint::GENERATOR);
 
-let secret_key = EdwardsScalar::try_from_rng(&mut SysRng).unwrap();
+let secret_key = EdwardsScalar::generate();
 let public_key = EdwardsPoint::GENERATOR * &secret_key;
 let compressed_public_key = public_key.to_bytes();
 

--- a/ed448-goldilocks/benches/bench.rs
+++ b/ed448-goldilocks/benches/bench.rs
@@ -1,8 +1,8 @@
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use ed448_goldilocks::{
     Decaf448, DecafPoint, DecafScalar, Ed448, EdwardsPoint, EdwardsScalar, MontgomeryPoint,
+    elliptic_curve::{Generate, group::GroupEncoding},
 };
-use elliptic_curve::{Field, Group, group::GroupEncoding};
 use getrandom::{SysRng, rand_core::TryRngCore};
 use hash2curve::GroupDigest;
 
@@ -12,8 +12,8 @@ pub fn ed448(c: &mut Criterion) {
     group.bench_function("scalar multiplication", |b| {
         b.iter_batched(
             || {
-                let point = EdwardsPoint::try_from_rng(&mut SysRng).unwrap();
-                let scalar = EdwardsScalar::try_from_rng(&mut SysRng).unwrap();
+                let point = EdwardsPoint::generate();
+                let scalar = EdwardsScalar::generate();
                 (point, scalar)
             },
             |(point, scalar)| point * scalar,
@@ -24,8 +24,8 @@ pub fn ed448(c: &mut Criterion) {
     group.bench_function("point addition", |b| {
         b.iter_batched(
             || {
-                let p1 = EdwardsPoint::try_from_rng(&mut SysRng).unwrap();
-                let p2 = EdwardsPoint::try_from_rng(&mut SysRng).unwrap();
+                let p1 = EdwardsPoint::generate();
+                let p2 = EdwardsPoint::generate();
                 (p1, p2)
             },
             |(p1, p2)| p1 + p2,
@@ -47,7 +47,7 @@ pub fn ed448(c: &mut Criterion) {
 
     group.bench_function("compress", |b| {
         b.iter_batched(
-            || EdwardsPoint::try_from_rng(&mut SysRng).unwrap(),
+            || EdwardsPoint::generate(),
             |point| point.to_bytes(),
             BatchSize::SmallInput,
         )
@@ -55,7 +55,7 @@ pub fn ed448(c: &mut Criterion) {
 
     group.bench_function("decompress", |b| {
         b.iter_batched(
-            || EdwardsPoint::try_from_rng(&mut SysRng).unwrap().to_bytes(),
+            || EdwardsPoint::generate().to_bytes(),
             |bytes| EdwardsPoint::from_bytes(&bytes).unwrap(),
             BatchSize::SmallInput,
         )
@@ -70,8 +70,8 @@ pub fn decaf448(c: &mut Criterion) {
     group.bench_function("scalar multiplication", |b| {
         b.iter_batched(
             || {
-                let point = DecafPoint::try_from_rng(&mut SysRng).unwrap();
-                let scalar = DecafScalar::try_from_rng(&mut SysRng).unwrap();
+                let point = DecafPoint::generate();
+                let scalar = DecafScalar::generate();
                 (point, scalar)
             },
             |(point, scalar)| point * scalar,
@@ -82,8 +82,8 @@ pub fn decaf448(c: &mut Criterion) {
     group.bench_function("point addition", |b| {
         b.iter_batched(
             || {
-                let p1 = DecafPoint::try_from_rng(&mut SysRng).unwrap();
-                let p2 = DecafPoint::try_from_rng(&mut SysRng).unwrap();
+                let p1 = DecafPoint::generate();
+                let p2 = DecafPoint::generate();
                 (p1, p2)
             },
             |(p1, p2)| p1 + p2,
@@ -105,7 +105,7 @@ pub fn decaf448(c: &mut Criterion) {
 
     group.bench_function("encode", |b| {
         b.iter_batched(
-            || DecafPoint::try_from_rng(&mut SysRng).unwrap(),
+            || DecafPoint::generate(),
             |point| point.to_bytes(),
             BatchSize::SmallInput,
         )
@@ -113,7 +113,7 @@ pub fn decaf448(c: &mut Criterion) {
 
     group.bench_function("decode", |b| {
         b.iter_batched(
-            || DecafPoint::try_from_rng(&mut SysRng).unwrap().to_bytes(),
+            || DecafPoint::generate().to_bytes(),
             |bytes| DecafPoint::from_bytes(&bytes).unwrap(),
             BatchSize::SmallInput,
         )
@@ -130,7 +130,7 @@ pub fn x448(c: &mut Criterion) {
             || {
                 let mut point = MontgomeryPoint::default();
                 SysRng.try_fill_bytes(&mut point.0).unwrap();
-                let scalar = EdwardsScalar::try_from_rng(&mut SysRng).unwrap();
+                let scalar = EdwardsScalar::generate();
                 (point, scalar)
             },
             |(point, scalar)| &point * &scalar,

--- a/ed448-goldilocks/src/lib.rs
+++ b/ed448-goldilocks/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc = include_str!("../README.md")]
+#![cfg_attr(
+    feature = "getrandom",
+    doc = include_str!("../README.md")
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
@@ -21,6 +24,20 @@
     unused_mut,
     unused_must_use
 )]
+
+//! ## `serde` support
+//!
+//! When the `serde` feature of this crate is enabled, `Serialize` and
+//! `Deserialize` are impl'd for the following types:
+//!
+//! - [`CompressedDecaf`]
+//! - [`CompressedEdwardsY`]
+//! - [`EdwardsPoint`]
+//! - [`Scalar`]
+//! - [`SigningKey`]
+//! - [`VerifyingKey`]
+//!
+//! Please see type-specific documentation for more information.
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/ed448-goldilocks/src/sign.rs
+++ b/ed448-goldilocks/src/sign.rs
@@ -8,11 +8,11 @@
 //! to produce a [`Signature`]. Then verify the signature using the corresponding
 //! [`VerifyingKey`].
 //!
-//! ```
-//! use ed448_goldilocks::*;
-//! use getrandom::{SysRng, rand_core::TryRngCore};
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
+//! use ed448_goldilocks::{SigningKey, elliptic_curve::Generate};
 //!
-//! let signing_key = SigningKey::generate(&mut SysRng.unwrap_err());
+//! let signing_key = SigningKey::generate();
 //! let signature = signing_key.sign_raw(b"Hello, world!");
 //! let verifying_key = signing_key.verifying_key();
 //!
@@ -53,14 +53,15 @@
 //! # Example
 //! This is an example of using the SHAKE-256 algorithm to sign and verify a message
 //! which is the normal default anyway but performed explicitly.
-//! ```
-//! use ed448_goldilocks::*;
+//!
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
+//! use ed448_goldilocks::{SigningKey, PreHasherXof, elliptic_curve::Generate};
 //! use sha3::{Shake256, digest::Update};
-//! use getrandom::{SysRng, rand_core::TryRngCore};
 //!
 //! let msg = b"Hello World";
 //!
-//! let signing_key = SigningKey::generate(&mut SysRng.unwrap_err());
+//! let signing_key = SigningKey::generate();
 //! let signature = signing_key.sign_prehashed::<PreHasherXof<Shake256>>(
 //!     None,
 //!     Shake256::default().chain(msg).into(),
@@ -89,8 +90,7 @@ pub use signing_key::*;
 pub use verifying_key::*;
 
 use crate::{CompressedEdwardsY, EdwardsPoint, EdwardsScalar};
-use elliptic_curve::array::Array;
-use elliptic_curve::group::GroupEncoding;
+use elliptic_curve::{array::Array, group::GroupEncoding};
 
 /// Length of a secret key in bytes
 pub const SECRET_KEY_LENGTH: usize = 57;

--- a/ed448-goldilocks/src/sign/verifying_key.rs
+++ b/ed448-goldilocks/src/sign/verifying_key.rs
@@ -434,14 +434,11 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "getrandom", feature = "serde"))]
     #[test]
     fn serialization() {
-        use chacha20::ChaCha8Rng;
-        use rand_core::SeedableRng;
-
-        let mut rng = ChaCha8Rng::from_seed([0u8; 32]);
-        let signing_key = SigningKey::generate(&mut rng);
+        use elliptic_curve::Generate;
+        let signing_key = SigningKey::generate();
         let verifying_key = signing_key.verifying_key();
 
         let bytes = serde_bare::to_vec(&verifying_key).unwrap();

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -39,7 +39,6 @@ hex-literal = "1"
 num-bigint = "0.4"
 num-traits = "0.2"
 proptest = "1.9"
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 sha3 = { version = "0.11.0-rc.3", default-features = false }
 
 [features]

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -744,9 +744,10 @@ mod tests {
         Scalar,
         test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
     };
-    use elliptic_curve::BatchNormalize;
-    use elliptic_curve::group::{ff::PrimeField, prime::PrimeCurveAffine};
-    use elliptic_curve::{CurveGroup, Generate};
+    use elliptic_curve::{
+        BatchNormalize, CurveGroup, Generate,
+        group::{ff::PrimeField, prime::PrimeCurveAffine},
+    };
 
     #[cfg(feature = "alloc")]
     use alloc::vec::Vec;

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -835,13 +835,12 @@ mod tests {
         ops::{BatchInvert, Reduce},
         scalar::IsHigh,
     };
-    use getrandom::SysRng;
     use num_bigint::{BigUint, ToBigUint};
     use num_traits::Zero;
     use proptest::prelude::*;
 
     #[cfg(feature = "getrandom")]
-    use elliptic_curve::Generate;
+    use elliptic_curve::{Generate, common::getrandom::SysRng};
 
     impl From<&BigUint> for Scalar {
         fn from(x: &BigUint) -> Self {

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -31,7 +31,6 @@ sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.4", features = ["dev"] }
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -36,7 +36,6 @@ hex-literal = "1"
 primefield = { version = "0.14.0-rc.4" }
 primeorder = { version = "0.14.0-rc.4", features = ["dev"] }
 proptest = "1"
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -38,7 +38,6 @@ ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", default-features = f
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.4", features = ["dev"] }
 proptest = "1.9"
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -36,7 +36,6 @@ ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", default-features = f
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.4", features = ["dev"] }
 proptest = "1.9"
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -34,7 +34,6 @@ der = { version = "0.8.0-rc.10", optional = true }
 [dev-dependencies]
 criterion = "0.7"
 elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["dev"] }
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 hex-literal = "1"
 proptest = "1"
 

--- a/sm2/tests/sm2pke.rs
+++ b/sm2/tests/sm2pke.rs
@@ -1,7 +1,6 @@
-#![cfg(feature = "pke")]
+#![cfg(all(feature = "getrandom", feature = "pke"))]
 
-use elliptic_curve::{NonZeroScalar, ops::Reduce};
-use getrandom::SysRng;
+use elliptic_curve::{NonZeroScalar, common::getrandom::SysRng, ops::Reduce};
 use hex_literal::hex;
 use proptest::prelude::*;
 

--- a/x448/Cargo.toml
+++ b/x448/Cargo.toml
@@ -15,7 +15,6 @@ description = "Pure Rust implementation of X448, an elliptic curve Diffie-Hellma
 
 [dependencies]
 ed448-goldilocks = { version = "0.14.0-pre.7", default-features = false }
-rand_core = { version = "0.10.0-rc-5", default-features = false }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true }
@@ -24,9 +23,6 @@ serdect = { version = "0.4", optional = true }
 version = "1"
 default-features = false
 features = ["zeroize_derive"]
-
-[dev-dependencies]
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 
 [features]
 default = ["getrandom"]

--- a/x448/README.md
+++ b/x448/README.md
@@ -34,12 +34,12 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/ed448-goldilocks?logo=rust
-[crate-link]: https://crates.io/crates/ed448-goldilocks
-[docs-image]: https://docs.rs/ed448-goldilocks/badge.svg
-[docs-link]: https://docs.rs/ed448-goldilocks/
-[build-image]: https://github.com/RustCrypto/elliptic-curves/actions/workflows/ed448-goldilocks.yml/badge.svg
-[build-link]: https://github.com/RustCrypto/elliptic-curves/actions/workflows/ed448-goldilocks.yml
+[crate-image]: https://img.shields.io/crates/v/x448?logo=rust
+[crate-link]: https://crates.io/crates/x448
+[docs-image]: https://docs.rs/x448/badge.svg
+[docs-link]: https://docs.rs/x448/
+[build-image]: https://github.com/RustCrypto/elliptic-curves/actions/workflows/x448.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/elliptic-curves/actions/workflows/x448.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
@@ -48,4 +48,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (links)
 
 [RustCrypto]: https://github.com/RustCrypto
-[`ed448-goldilocks`]: https://docs.rs/ed448-goldilocks/
+[`ed448-goldilocks`]: https://docs.rs/ed448-goldilocks


### PR DESCRIPTION
- Migrate more tests to the `Generate` trait
- Remove `getrandom` dev-dependency
- Cleanups for `x448` API