### PR TITLE
Refactor `from_okm_fuzz` test to use `chunks_exact_mut()` instead of repetitive byte ranges

### DIFF
--- a/p521/src/arithmetic/hash2curve.rs
+++ b/p521/src/arithmetic/hash2curve.rs
@@ -370,7 +370,9 @@ mod tests {
                 for (chunk, block) in chunks.by_ref().zip(blocks.iter()) {
                     chunk.copy_from_slice(&block.to_be_bytes());
                 }
-                chunks.remainder().copy_from_slice(&b12.to_be_bytes());
+                chunks
+                    .into_remainder()
+                    .copy_from_slice(&b12.to_be_bytes());
 
                 let from_okm = Scalar::reduce(&data);
                 let simple_from_okm = simple_from_okm(data);


### PR DESCRIPTION


Replaces 13 repetitive `copy_from_slice` calls with manual byte ranges with a loop-based approach using `chunks_exact_mut()`, eliminating error-prone manual calculations and reducing code duplication.

