### PR TITLE
hash2curve: rename misleading variable in encode_from_bytes

### DIFF
--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -111,8 +111,8 @@ where
     X: ExpandMsg<C::SecurityLevel>,
 {
     let [u] = hash_to_field::<1, X, _, C::FieldElement, C::Length>(msg, dst)?;
-    let q0 = C::map_to_curve(u);
-    Ok(q0.clear_cofactor())
+    let q = C::map_to_curve(u);
+    Ok(q.clear_cofactor())
 }
 
 /// Computes the hash to field routine according to


### PR DESCRIPTION
Rename `q0` to `q` in `encode_from_bytes()` to avoid confusion with the `hash_from_bytes()` implementation.

