### PR TITLE
Bump dependency requirements in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,7 +90,7 @@ dependencies = [
  "primefield",
  "primeorder",
  "proptest",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "rfc6979",
  "sec1",
  "signature",
@@ -182,14 +188,14 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.8"
+version = "0.10.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31cd65b2ca03198c223cd9a8fa1152c4ec251cd79049f6dc584152ad3fb5ba9d"
+checksum = "c81d916c6ae06736ec667b51f95ee5ff660a75f4ea6ce1bd932c942365c0ea43"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
 ]
 
 [[package]]
@@ -357,28 +363,28 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.21"
+version = "0.7.0-rc.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f9a78b88bb8255ec59a81423aa92ada22f96883f9ae59dcb68613907636ae5"
+checksum = "053c3561863ce55e3226ecc48b08679f4b66cb1b92b9afb42c2c402dfe8b9b51"
 dependencies = [
  "ctutils",
- "getrandom 0.4.0-rc.0",
+ "getrandom 0.4.0-rc.1",
  "hybrid-array",
  "num-traits",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.11"
+version = "0.2.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2bcc93d5cde6659e8649fc412894417ebc14dee54cfc6ee439c683a4a58342"
+checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
 dependencies = [
- "getrandom 0.4.0-rc.0",
+ "getrandom 0.4.0-rc.1",
  "hybrid-array",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
 ]
 
 [[package]]
@@ -404,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.7"
+version = "0.11.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca14c221bd9052fd2da7c34a2eeb5ae54732db28be47c35937be71793d675422"
+checksum = "2fc1408b7a9f59a7b933faff3e9e7fc15a05a524effd3b3d1601156944c8077f"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -417,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.13"
+version = "0.17.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b41c78c24288ec2644aeb00ebc58bf8cd5ff7e9a6e2a2081ed80fa7e1262dc7"
+checksum = "1e5676a9322ce14a73b65930ef95139fb8c41df02dfa610a3a5928a52f9ae4ee"
 dependencies = [
  "der",
  "digest",
@@ -451,12 +457,12 @@ dependencies = [
  "criterion",
  "ed448",
  "elliptic-curve",
- "getrandom 0.4.0-rc.0",
+ "getrandom 0.4.0-rc.1",
  "hash2curve",
  "hex",
  "hex-literal",
  "proptest",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "serde_bare",
  "serde_json",
  "serdect",
@@ -473,22 +479,22 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.23"
+version = "0.14.0-rc.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660a2eb4d46d49d4c0b122a8cad1fa7926b0e3e99913796243a7dc280021eadc"
+checksum = "5b0f6cc67cc39a00bce2c6f8f8aced0e8c0a06eb1a30f9dd2a9c9f4618bdf3b4"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "crypto-common",
  "digest",
- "getrandom 0.4.0-rc.0",
+ "getrandom 0.4.0-rc.1",
  "hex-literal",
  "hkdf",
  "hybrid-array",
  "once_cell",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "rustcrypto-ff",
  "rustcrypto-group",
  "sec1",
@@ -496,6 +502,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -526,6 +538,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,15 +563,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.0-rc.0"
+version = "0.4.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b99f0d993a2b9b97b9a201193aa8ad21305cde06a3be9a7e1f8f4201e5cc27e"
+checksum = "74f70a332ddf75e5e5e43284304179ba02f391f82f692f030b08a8378adf3c99"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -577,6 +596,27 @@ dependencies = [
  "sha2",
  "sha3",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -617,6 +657,24 @@ dependencies = [
  "subtle",
  "typenum",
  "zeroize",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -676,12 +734,18 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d546793a04a1d3049bd192856f804cfe96356e2cf36b54b4e575155babe9f41"
+checksum = "5a412fe37705d515cba9dbf1448291a717e187e2351df908cfc0137cbec3d480"
 dependencies = [
  "cpufeatures",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -694,6 +758,12 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -827,7 +897,7 @@ dependencies = [
  "primefield",
  "primeorder",
  "proptest",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "serdect",
  "sha2",
 ]
@@ -895,12 +965,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "primefield"
 version = "0.14.0-rc.5"
 dependencies = [
  "crypto-bigint",
  "crypto-common",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "rustcrypto-ff",
  "subtle",
  "zeroize",
@@ -1013,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-5"
+version = "0.10.0-rc-6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a06e03bd1f2ae861ab9e7498b6c64ed3dadb9ce175c0464a2522a5f23c0045"
+checksum = "70765ff7112b0fb2d272d24d9a2f907fc206211304328fe58b2db15a5649ef28"
 
 [[package]]
 name = "rand_xorshift"
@@ -1087,12 +1167,12 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-ff"
-version = "0.14.0-pre.0"
+version = "0.14.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9cd37111549306f79b09aa2618e15b1e8241b7178c286821e3dd71579db4db"
+checksum = "36fdf8f956089df8343b9479045c026932f9eb004d0f32d8497b4d133b316a66"
 dependencies = [
  "bitvec",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "rustcrypto-ff_derive",
  "subtle",
 ]
@@ -1114,11 +1194,11 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-group"
-version = "0.14.0-pre.0"
+version = "0.14.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e394cd734b5f97dfc3484fa42aad7acd912961c2bcd96c99aa05b3d6cab7cafd"
+checksum = "df76d08c12814c794ffe95ac788b48081cccb607fade4ed746825d29791ce538"
 dependencies = [
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "rustcrypto-ff",
  "subtle",
 ]
@@ -1177,6 +1257,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1252,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
+checksum = "7535f94fa3339fe9e5e9be6260a909e62af97f6e14b32345ccf79b92b8b81233"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1263,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2103ca0e6f4e9505eae906de5e5883e06fc3b2232fb5d6914890c7bbcb62f478"
+checksum = "1deee7fbcdd62fbcffc9dc2f5f17f96adac881ec7e1506e1eedee1644d0cc535"
 dependencies = [
  "digest",
  "keccak",
@@ -1273,12 +1359,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c04b70a14ee5f15e2e0c785a5fdb2e9a51138dfe13ba3cf8eab037a9e60b1879"
+checksum = "0ad0ce3b3f8efd7406f22e2ca5d02be21cdf3b3d1d53ab141f784de8965c7c7e"
 dependencies = [
  "digest",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
 ]
 
 [[package]]
@@ -1293,7 +1379,7 @@ dependencies = [
  "primefield",
  "primeorder",
  "proptest",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "rfc6979",
  "serdect",
  "signature",
@@ -1401,6 +1487,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,7 +1517,16 @@ version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.3.1+wasi-0.3.0-rc-2025-09-16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba4be47b1d11244670d11857eee0758a8f2c39aea64d80b78c1ce29b4642cd"
+dependencies = [
+ "wit-bindgen 0.48.1",
 ]
 
 [[package]]
@@ -1474,6 +1575,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01164c9dda68301e34fdae536c23ed6fe90ce6d97213ccc171eebbd3d02d6b8"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876fe286f2fa416386deedebe8407e6f19e0b5aeaef3d03161e77a15fa80f167"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d90019b1afd4b808c263e428de644f3003691f243387d30d673211ee0cb8e8"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1509,9 +1644,97 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8c2adb5f74ac9395bc3121c99a1254bf9310482c27b13f97167aedb5887138"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b881a098cae03686d7a0587f8f306f8a58102ad8da8b5599100fbe0e7f5800b"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69667efa439a453e1d50dac939c6cab6d2c3ac724a9d232b6631dad2472a5b70"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.114",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae2e22cceb5d105d52326c07e3e67603a861cc7add70fc467f7cc7ec5265017"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0c57df25e7ee612d946d3b7646c1ddb2310f8280aa2c17e543b66e0812241"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ef1c6ad67f35c831abd4039c02894de97034100899614d1c44e2268ad01c91"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "wyz"

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.23", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.24", features = ["sec1"] }
 
 # optional dependencies
 belt-hash = { version = "0.2.0-rc.0", optional = true, default-features = false }
@@ -27,17 +27,17 @@ digest = { version = "0.11.0-rc.7", optional = true }
 hex-literal = { version = "1", optional = true }
 hkdf = { version = "0.13.0-rc.3", optional = true }
 hmac = { version = "0.13.0-rc.3", optional = true }
-rand_core = "0.10.0-rc-5"
+rand_core = "0.10.0-rc-6"
 rfc6979 = { version = "0.5.0-rc.3", optional = true }
 pkcs8 = { version = "0.11.0-rc.9", optional = true }
 primefield = { version = "0.14.0-rc.5", optional = true }
 primeorder = { version = "0.14.0-rc.5", optional = true }
 sec1 = { version = "0.8.0-rc.13", optional = true }
-signature = { version = "3.0.0-rc.8", optional = true }
+signature = { version = "3.0.0-rc.9", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.5", features = ["dev"] }
 proptest = "1"

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,17 +14,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.13", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.14", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14.0-rc.5", optional = true }
 primeorder = { version = "0.14.0-rc.5", optional = true }
-sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,17 +14,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.13", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.14", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14.0-rc.5", optional = true }
 primeorder = { version = "0.14.0-rc.5", optional = true }
-sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -16,24 +16,24 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.23", features = ["arithmetic", "pkcs8"] }
+elliptic-curve = { version = "0.14.0-rc.24", features = ["arithmetic", "pkcs8"] }
 hash2curve = "0.14.0-rc.8"
-rand_core = { version = "0.10.0-rc-5", default-features = false }
-sha3 = { version = "0.11.0-rc.3", default-features = false }
+rand_core = { version = "0.10.0-rc-6", default-features = false }
+sha3 = { version = "0.11.0-rc.4", default-features = false }
 subtle = { version = "2.6", default-features = false }
 
 # optional dependencies
 ed448 = { version = "0.5.0-rc.2", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true }
-signature = { version = "3.0.0-rc.8", optional = true, default-features = false, features = ["digest", "rand_core"] }
+signature = { version = "3.0.0-rc.9", optional = true, default-features = false, features = ["digest", "rand_core"] }
 
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false, features = ["cargo_bench_support"] }
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
+getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
 hex-literal = "1"
 hex = "0.4"
 proptest = { version = "1", features = ["attr-macro"] }
-chacha20 = { version = "0.10.0-rc.8", features = ["rng"] }
+chacha20 = { version = "0.10.0-rc.9", features = ["rng"] }
 serde_bare = "0.5"
 serde_json = "1.0"
 

--- a/ed448-goldilocks/benches/bench.rs
+++ b/ed448-goldilocks/benches/bench.rs
@@ -3,7 +3,7 @@ use ed448_goldilocks::{
     Decaf448, DecafPoint, DecafScalar, Ed448, EdwardsPoint, EdwardsScalar, MontgomeryPoint,
     elliptic_curve::{Generate, group::GroupEncoding},
 };
-use getrandom::{SysRng, rand_core::TryRngCore};
+use getrandom::{SysRng, rand_core::TryRng};
 use hash2curve::GroupDigest;
 
 pub fn ed448(c: &mut Criterion) {

--- a/ed448-goldilocks/src/decaf/points.rs
+++ b/ed448-goldilocks/src/decaf/points.rs
@@ -12,7 +12,7 @@ use elliptic_curve::{
     ops::LinearCombination,
     point::NonIdentity,
 };
-use rand_core::{CryptoRng, TryCryptoRng, TryRngCore};
+use rand_core::{CryptoRng, TryCryptoRng, TryRng};
 use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 /// The bytes representation of a compressed point
@@ -268,7 +268,7 @@ impl Group for DecafPoint {
 
     fn try_from_rng<R>(rng: &mut R) -> Result<Self, R::Error>
     where
-        R: TryRngCore + ?Sized,
+        R: TryRng + ?Sized,
     {
         let mut bytes = DecafPointRepr::default();
 

--- a/ed448-goldilocks/src/edwards/affine.rs
+++ b/ed448-goldilocks/src/edwards/affine.rs
@@ -3,7 +3,7 @@ use crate::*;
 use core::fmt::{Display, Formatter, LowerHex, Result as FmtResult, UpperHex};
 use core::ops::Mul;
 use elliptic_curve::{Error, Generate, ctutils, point::NonIdentity, zeroize::DefaultIsZeroes};
-use rand_core::{TryCryptoRng, TryRngCore};
+use rand_core::{TryCryptoRng, TryRng};
 use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 /// Affine point on untwisted curve
@@ -100,11 +100,11 @@ impl AffinePoint {
 
     /// Generate a random [`AffinePoint`].
     ///
-    /// Helper method that has `TryRngCore` bounds so `ProjectivePoint` can call it for its `group`
+    /// Helper method that has `TryRng` bounds so `ProjectivePoint` can call it for its `group`
     /// impls, otherwise end users should use the `Generate` trait.
     pub(crate) fn try_from_rng<R>(rng: &mut R) -> Result<Self, R::Error>
     where
-        R: TryRngCore + ?Sized,
+        R: TryRng + ?Sized,
     {
         let mut bytes = CompressedEdwardsY::default();
 

--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -26,7 +26,7 @@ use elliptic_curve::{
     ops::{BatchInvert, LinearCombination},
     point::NonIdentity,
 };
-use rand_core::{TryCryptoRng, TryRngCore};
+use rand_core::{TryCryptoRng, TryRng};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "alloc")]
@@ -134,7 +134,7 @@ impl Group for EdwardsPoint {
 
     fn try_from_rng<R>(rng: &mut R) -> Result<Self, R::Error>
     where
-        R: TryRngCore + ?Sized,
+        R: TryRng + ?Sized,
     {
         loop {
             let point = AffinePoint::try_from_rng(rng)?;

--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -19,7 +19,7 @@ use elliptic_curve::{
     zeroize::DefaultIsZeroes,
 };
 use hash2curve::MapToCurve;
-use rand_core::TryRngCore;
+use rand_core::TryRng;
 use subtle::{
     Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess,
     CtOption,
@@ -238,7 +238,7 @@ impl Field for FieldElement {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut bytes = [0; 56];
 
         loop {

--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -20,7 +20,7 @@ use elliptic_curve::{
     ops::{Invert, Reduce, ReduceNonZero},
     scalar::{FromUintUnchecked, IsHigh},
 };
-use rand_core::{CryptoRng, RngCore, TryCryptoRng, TryRngCore};
+use rand_core::{CryptoRng, Rng, TryCryptoRng, TryRng};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, CtOption};
 
 #[cfg(feature = "bits")]
@@ -316,7 +316,7 @@ impl<C: CurveWithScalar> Field for Scalar<C> {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut seed = WideScalarBytes::<C>::default();
         rng.try_fill_bytes(&mut seed)?;
         Ok(C::from_bytes_mod_order_wide(&seed))
@@ -827,12 +827,12 @@ impl<C: CurveWithScalar> Scalar<C> {
     ///
     /// # Inputs
     ///
-    /// * `rng`: any RNG which implements the `RngCore + CryptoRng` interface.
+    /// * `rng`: any RNG which implements the `Rng + CryptoRng` interface.
     ///
     /// # Returns
     ///
     /// A random scalar within ℤ/lℤ.
-    pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    pub fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self {
         let mut scalar_bytes = WideScalarBytes::<C>::default();
         rng.fill_bytes(&mut scalar_bytes);
         C::from_bytes_mod_order_wide(&scalar_bytes)

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -15,9 +15,9 @@ rust-version = "1.85"
 
 [dependencies]
 digest = { version = "0.11.0-rc.7" }
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["arithmetic"] }
 
 [dev-dependencies]
 hex-literal = "1"
-sha2 = { version = "0.11.0-rc.3", default-features = false }
-sha3 = { version = "0.11.0-rc.3", default-features = false }
+sha2 = { version = "0.11.0-rc.4", default-features = false }
+sha3 = { version = "0.11.0-rc.4", default-features = false }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,26 +20,26 @@ rust-version = "1.85"
 
 [dependencies]
 cfg-if = "1.0"
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
 hash2curve = { version = "0.14.0-rc.8", optional = true }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primeorder = { version = "0.14.0-rc.5", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
-signature = { version = "3.0.0-rc.8", optional = true }
+sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
+signature = { version = "3.0.0-rc.9", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4.3"
 hex-literal = "1"
 num-bigint = "0.4"
 num-traits = "0.2"
 proptest = "1.9"
-sha3 = { version = "0.11.0-rc.3", default-features = false }
+sha3 = { version = "0.11.0-rc.6", default-features = false }
 
 [features]
 default = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "schnorr", "std"]

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -10,7 +10,7 @@ use elliptic_curve::{
     ff::PrimeField,
     group::{GroupEncoding, prime::PrimeCurveAffine},
     point::{AffineCoordinates, DecompactPoint, DecompressPoint, NonIdentity},
-    rand_core::{TryCryptoRng, TryRngCore},
+    rand_core::{TryCryptoRng, TryRng},
     sec1::{self, FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
@@ -80,7 +80,7 @@ impl AffinePoint {
     ///
     /// This internal method avoids the `TryCryptoRng` bounds so it can be used in `group` impls for
     /// `ProjectivePoint`.
-    pub(crate) fn try_from_rng<R: TryRngCore + ?Sized>(
+    pub(crate) fn try_from_rng<R: TryRng + ?Sized>(
         rng: &mut R,
     ) -> core::result::Result<Self, R::Error> {
         let mut bytes = FieldBytes::default();

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -41,7 +41,7 @@ use elliptic_curve::{
     bigint::{Odd, U256, modular::Retrieve},
     ff::{self, Field, PrimeField},
     ops::Invert,
-    rand_core::{TryCryptoRng, TryRngCore},
+    rand_core::{TryCryptoRng, TryRng},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
 };
@@ -257,7 +257,7 @@ impl Field for FieldElement {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut bytes = FieldBytes::default();
 
         loop {

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -17,7 +17,7 @@ use elliptic_curve::{
     },
     ops::BatchInvert,
     point::NonIdentity,
-    rand_core::{TryCryptoRng, TryRngCore},
+    rand_core::{TryCryptoRng, TryRng},
     sec1::{FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
@@ -476,7 +476,7 @@ impl CurveGroup for ProjectivePoint {
 impl Group for ProjectivePoint {
     type Scalar = Scalar;
 
-    fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
+    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
         AffinePoint::try_from_rng(rng).map(Self::from)
     }
 

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -20,7 +20,7 @@ use elliptic_curve::{
     ctutils,
     ff::{self, Field, FromUniformBytes, PrimeField},
     ops::{Invert, Reduce, ReduceNonZero},
-    rand_core::{CryptoRng, TryCryptoRng, TryRngCore},
+    rand_core::{CryptoRng, TryCryptoRng, TryRng},
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{
         Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
@@ -181,7 +181,7 @@ impl Field for Scalar {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         // Uses rejection sampling as the default random generation method,
         // which produces a uniformly random distribution of scalars.
         //

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.5", optional = true }
 primeorder = { version = "0.14.0-rc.5", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.5", features = ["dev"] }
 

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,18 +17,18 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.5", optional = true }
 primeorder = { version = "0.14.0-rc.5", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.5", features = ["dev"] }
 

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,20 +18,20 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.8", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.5", optional = true }
 primeorder = { version = "0.14.0-rc.5", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primefield = { version = "0.14.0-rc.5" }
 primeorder = { version = "0.14.0-rc.5", features = ["dev"] }

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -17,7 +17,7 @@ use elliptic_curve::{
     ctutils,
     group::ff::{self, Field, FromUniformBytes, PrimeField},
     ops::{Invert, Reduce, ReduceNonZero},
-    rand_core::TryRngCore,
+    rand_core::TryRng,
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{
         Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
@@ -184,7 +184,7 @@ impl Field for Scalar {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut bytes = FieldBytes::default();
 
         // Generate a uniformly random scalar using rejection sampling,
@@ -262,7 +262,7 @@ impl Field for Scalar {
 }
 
 impl Generate for Scalar {
-    fn try_generate_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_generate_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         Self::try_from_rng(rng)
     }
 }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,23 +18,23 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.8", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.5", optional = true }
 primeorder = { version = "0.14.0-rc.5", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
 
 [target.'cfg(not(p384_backend = "bignum"))'.dependencies]
 fiat-crypto = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.5", features = ["dev"] }
 proptest = "1.9"

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -18,21 +18,21 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "1"
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.8", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.5", optional = true }
 primeorder = { version = "0.14.0-rc.5", optional = true }
-rand_core = { version = "0.10.0-rc-5", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-6", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.13", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.5", features = ["dev"] }
 proptest = "1.9"

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -34,7 +34,7 @@ use elliptic_curve::{
     bigint::{Word, modular::Retrieve},
     ff::{self, Field, PrimeField},
     ops::Invert,
-    rand_core::TryRngCore,
+    rand_core::TryRng,
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, CtOption},
     zeroize::DefaultIsZeroes,
 };
@@ -474,7 +474,7 @@ impl Field for FieldElement {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         // NOTE: can't use ScalarValue::random due to CryptoRng bound
         let mut bytes = <FieldBytes>::default();
 
@@ -512,7 +512,7 @@ impl Field for FieldElement {
 }
 
 impl Generate for FieldElement {
-    fn try_generate_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_generate_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         Self::try_from_rng(rng)
     }
 }

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -17,9 +17,9 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-bigint = { package = "crypto-bigint", version = "0.7.0-rc.21", default-features = false, features = ["rand_core", "hybrid-array", "subtle"] }
-common = { package = "crypto-common", version = "0.2.0-rc.11", features = ["rand_core"] }
-ff = { version = "=0.14.0-pre.0", package = "rustcrypto-ff", default-features = false }
+bigint = { package = "crypto-bigint", version = "0.7.0-rc.22", default-features = false, features = ["rand_core", "hybrid-array", "subtle"] }
+common = { package = "crypto-common", version = "0.2.0-rc.13", features = ["rand_core"] }
+ff = { version = "=0.14.0-pre.1", package = "rustcrypto-ff", default-features = false }
 subtle = { version = "2.6", default-features = false, features = ["const-generics"] }
-rand_core = { version = "0.10.0-rc-5", default-features = false }
+rand_core = { version = "0.10.0-rc-6", default-features = false }
 zeroize = { version = "1.7", default-features = false }

--- a/primefield/src/macros.rs
+++ b/primefield/src/macros.rs
@@ -261,7 +261,7 @@ macro_rules! monty_field_element {
 
         impl $crate::bigint::modular::ConstMontyParams<{ <$params>::LIMBS }> for $fe {
             const LIMBS: usize = <$params>::LIMBS;
-            const PARAMS: $crate::bigint::modular::MontyParams<{ <$uint>::LIMBS }> =
+            const PARAMS: $crate::bigint::modular::FixedMontyParams<{ <$uint>::LIMBS }> =
                 <$params>::PARAMS;
         }
 
@@ -277,7 +277,7 @@ macro_rules! monty_field_element {
             const ZERO: Self = Self::ZERO;
             const ONE: Self = Self::ONE;
 
-            fn try_from_rng<R: $crate::rand_core::TryRngCore + ?Sized>(
+            fn try_from_rng<R: $crate::rand_core::TryRng + ?Sized>(
                 rng: &mut R,
             ) -> ::core::result::Result<Self, R::Error> {
                 $crate::MontyFieldElement::<$params, { <$params>::LIMBS }>::try_from_rng(rng)

--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -7,7 +7,7 @@ use crate::ByteOrder;
 use bigint::{
     ArrayEncoding, ByteArray, Invert, Limb, Reduce, Uint, Word, ctutils,
     hybrid_array::{Array, ArraySize, typenum::Unsigned},
-    modular::{ConstMontyForm as MontyForm, ConstMontyParams, MontyParams, Retrieve},
+    modular::{ConstMontyForm as MontyForm, ConstMontyParams, FixedMontyParams, Retrieve},
 };
 use common::Generate;
 use core::{
@@ -413,7 +413,7 @@ where
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: rand_core::TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_from_rng<R: rand_core::TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut bytes = MontyFieldBytes::<MOD, LIMBS>::default();
 
         loop {
@@ -840,7 +840,7 @@ where
     MOD: MontyFieldParams<LIMBS>,
 {
     const LIMBS: usize = LIMBS;
-    const PARAMS: MontyParams<LIMBS> = MOD::PARAMS;
+    const PARAMS: FixedMontyParams<LIMBS> = MOD::PARAMS;
 }
 
 impl<MOD, const LIMBS: usize> Default for MontyFieldElement<MOD, LIMBS>

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true, default-features = false }

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -14,7 +14,7 @@ use elliptic_curve::{
     ff::{Field, PrimeField},
     group::{GroupEncoding, prime::PrimeCurveAffine},
     point::{AffineCoordinates, DecompactPoint, DecompressPoint, Double, NonIdentity},
-    rand_core::{TryCryptoRng, TryRngCore},
+    rand_core::{TryCryptoRng, TryRng},
     sec1::{
         self, CompressedPoint, EncodedPoint, FromEncodedPoint, ModulusSize, ToCompactEncodedPoint,
         ToEncodedPoint, UncompressedPointSize,
@@ -81,7 +81,7 @@ where
     /// Internal RNG that avoids a `TryCryptoRng` bound so we can use it with `group`.
     ///
     /// TODO(tarcieri): find some way to avoid this?
-    pub(crate) fn try_from_rng<R: TryRngCore + ?Sized>(
+    pub(crate) fn try_from_rng<R: TryRng + ?Sized>(
         rng: &mut R,
     ) -> core::result::Result<Self, R::Error>
     where

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -22,7 +22,7 @@ use elliptic_curve::{
     },
     ops::{BatchInvert, LinearCombination},
     point::{Double, NonIdentity},
-    rand_core::{TryCryptoRng, TryRngCore},
+    rand_core::{TryCryptoRng, TryRng},
     sec1::{
         CompressedPoint, EncodedPoint, FromEncodedPoint, ModulusSize, ToEncodedPoint,
         UncompressedPointSize,
@@ -309,7 +309,7 @@ where
 {
     type Scalar = Scalar<C>;
 
-    fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
+    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
         AffinePoint::try_from_rng(rng).map(Self::from)
     }
 

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -18,22 +18,22 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
-rand_core = { version = "0.10.0-rc-5", default-features = false }
+rand_core = { version = "0.10.0-rc-6", default-features = false }
 
 # optional dependencies
 primefield = { version = "0.14.0-rc.5", optional = true }
 primeorder = { version = "0.14.0-rc.5", optional = true }
 rfc6979 = { version = "0.5.0-rc.3", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-signature = { version = "3.0.0-rc.8", optional = true, features = ["rand_core"] }
+signature = { version = "3.0.0-rc.9", optional = true, features = ["rand_core"] }
 sm3 = { version = "0.5.0-rc.3", optional = true, default-features = false }
 der = { version = "0.8.0-rc.10", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.23", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["dev"] }
 hex-literal = "1"
 proptest = "1"
 


### PR DESCRIPTION
Upgrades the following dependencies:
- `crypto-bigint` v0.7.0-rc.22
- `digest` v0.11.0-rc.8
- `ecdsa` v0.17.0-rc.14
- `elliptic-curve` v0.14.0-rc.24
- `getrandom` v0.4.0-rc.1
- `rand_core` v0.10.0-rc-6
- `sha2` v0.11.0-rc.4
- `sha3` v0.11.0-rc.6
- `signature` v3.0.0-rc.9

The `rand_core` update includes changes that rename `(Try)RngCore` => `(Try)Rng`.