### PR TITLE
Bump `rand_core` to v0.10.0

### DIFF
--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -32,33 +32,30 @@ jobs:
         rust:
           - 1.85.0 # MSRV
           - stable
-        target:
-          - thumbv7em-none-eabi
-          - wasm32-unknown-unknown
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          targets: ${{ matrix.target }}
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features critical-section
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdh
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa-core
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features hash2curve
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features group-digest
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features schnorr
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha256
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa,sha256
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits,critical-section,ecdh,ecdsa,group-digest,pem,pkcs8,schnorr,serde,sha256
+          targets: thumbv7em-none-eabi
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features alloc
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features arithmetic
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features bits
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features critical-section
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdh
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdsa-core
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdsa
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features hash2curve
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features group-digest
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features pem
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features pkcs8
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features schnorr
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features serde
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features sha256
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdsa
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdsa,sha256
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features bits,critical-section,ecdh,ecdsa,group-digest,pem,pkcs8,schnorr,serde,sha256
 
   benches:
     runs-on: ubuntu-latest

--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -32,30 +32,27 @@ jobs:
         rust:
           - 1.85.0 # MSRV
           - stable
-        target:
-          - thumbv7em-none-eabi
-          - wasm32-unknown-unknown
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          targets: ${{ matrix.target }}
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdh
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa-core
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdsa
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features hash2curve
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features group-digest
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features oprf
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sha256
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,bits,ecdh,ecdsa,group-digest,oprf,pem,pkcs8,serde,sha256
+          targets: thumbv7em-none-eabi
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features alloc
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features arithmetic
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features bits
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdh
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdsa-core
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdsa
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features hash2curve
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features group-digest
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features oprf
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features pem
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features pkcs8
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features serde
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features sha256
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features arithmetic,bits,ecdh,ecdsa,group-digest,oprf,pem,pkcs8,serde,sha256
 
   benches:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
  "primefield",
  "primeorder",
  "proptest",
- "rand_core 0.10.0-rc-6",
+ "rand_core 0.10.0",
  "rfc6979",
  "sec1",
  "signature",
@@ -188,14 +188,14 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.9"
+version = "0.10.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c81d916c6ae06736ec667b51f95ee5ff660a75f4ea6ce1bd932c942365c0ea43"
+checksum = "c536927023d1c432e6e23a25ef45f6756094eac2ab460db5fb17a772acdfd312"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "rand_core 0.10.0-rc-6",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.5"
+version = "0.5.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557bad79bc426785757001b5d732f323ae965363983d758295c1a1935496880"
+checksum = "cf7e48717e58fd82d6470086ab1c0e12f56426b4ef96c84bb84b9c3fefc6d9c7"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -281,6 +281,12 @@ checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a8c0210fa48ba3ea04ac1e9c6e72ae66009db3b1f1745635d4ff2e58eaadd0"
 
 [[package]]
 name = "cpufeatures"
@@ -363,28 +369,29 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.22"
+version = "0.7.0-rc.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c3561863ce55e3226ecc48b08679f4b66cb1b92b9afb42c2c402dfe8b9b51"
+checksum = "51312f2b7fae18a144261dcc5c32b0de4bc7e50225d1c0b5a30e0312831da20d"
 dependencies = [
+ "cpubits",
  "ctutils",
  "getrandom 0.4.0-rc.1",
  "hybrid-array",
  "num-traits",
- "rand_core 0.10.0-rc-6",
+ "rand_core 0.10.0",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
+checksum = "5569e5de27d32e673283717728eb5b0e4f30898b523f151a19c51e6188006599"
 dependencies = [
  "getrandom 0.4.0-rc.1",
  "hybrid-array",
- "rand_core 0.10.0-rc-6",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -410,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.9"
+version = "0.11.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff8de092798697546237a3a701e4174fe021579faec9b854379af9bf1e31962"
+checksum = "afa94b64bfc6549e6e4b5a3216f22593224174083da7a90db47e951c4fb31725"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -423,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.14"
+version = "0.17.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5676a9322ce14a73b65930ef95139fb8c41df02dfa610a3a5928a52f9ae4ee"
+checksum = "0d8f0121ea408940811dbc86785c20ebaf18bf9906565e66f2310943f3b3e35a"
 dependencies = [
  "der",
  "digest",
@@ -462,7 +469,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "proptest",
- "rand_core 0.10.0-rc-6",
+ "rand_core 0.10.0",
  "serde_bare",
  "serde_json",
  "serdect",
@@ -479,22 +486,21 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.24"
+version = "0.14.0-rc.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0f6cc67cc39a00bce2c6f8f8aced0e8c0a06eb1a30f9dd2a9c9f4618bdf3b4"
+checksum = "df662176e1c736be2dfeb34f52874644bd563c11a992aeaa5121b104909a810e"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "crypto-common",
  "digest",
- "getrandom 0.4.0-rc.1",
  "hex-literal",
  "hkdf",
  "hybrid-array",
  "once_cell",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.10.0-rc-6",
+ "rand_core 0.10.0",
  "rustcrypto-ff",
  "rustcrypto-group",
  "sec1",
@@ -570,7 +576,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core 0.10.0-rc-6",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -715,7 +721,7 @@ dependencies = [
 name = "k256"
 version = "0.14.0-rc.6"
 dependencies = [
- "cfg-if",
+ "cpubits",
  "criterion",
  "ecdsa",
  "elliptic-curve",
@@ -897,7 +903,7 @@ dependencies = [
  "primefield",
  "primeorder",
  "proptest",
- "rand_core 0.10.0-rc-6",
+ "rand_core 0.10.0",
  "serdect",
  "sha2",
 ]
@@ -980,7 +986,7 @@ version = "0.14.0-rc.6"
 dependencies = [
  "crypto-bigint",
  "crypto-common",
- "rand_core 0.10.0-rc-6",
+ "rand_core 0.10.0",
  "rustcrypto-ff",
  "subtle",
  "zeroize",
@@ -1093,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70765ff7112b0fb2d272d24d9a2f907fc206211304328fe58b2db15a5649ef28"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_xorshift"
@@ -1172,7 +1178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36fdf8f956089df8343b9479045c026932f9eb004d0f32d8497b4d133b316a66"
 dependencies = [
  "bitvec",
- "rand_core 0.10.0-rc-6",
+ "rand_core 0.10.0",
  "rustcrypto-ff_derive",
  "subtle",
 ]
@@ -1198,7 +1204,7 @@ version = "0.14.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df76d08c12814c794ffe95ac788b48081cccb607fade4ed746825d29791ce538"
 dependencies = [
- "rand_core 0.10.0-rc-6",
+ "rand_core 0.10.0",
  "rustcrypto-ff",
  "subtle",
 ]
@@ -1359,12 +1365,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.9"
+version = "3.0.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad0ce3b3f8efd7406f22e2ca5d02be21cdf3b3d1d53ab141f784de8965c7c7e"
+checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
 dependencies = [
  "digest",
- "rand_core 0.10.0-rc-6",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1379,7 +1385,7 @@ dependencies = [
  "primefield",
  "primeorder",
  "proptest",
- "rand_core 0.10.0-rc-6",
+ "rand_core 0.10.0",
  "rfc6979",
  "serdect",
  "signature",

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -18,26 +18,26 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.24", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.27", features = ["sec1"] }
 
 # optional dependencies
 belt-hash = { version = "0.2.0-rc.0", optional = true, default-features = false }
 der = { version = "0.8.0-rc.10" }
-digest = { version = "0.11.0-rc.7", optional = true }
+digest = { version = "0.11.0-rc.10", optional = true }
 hex-literal = { version = "1", optional = true }
 hkdf = { version = "0.13.0-rc.4", optional = true }
 hmac = { version = "0.13.0-rc.4", optional = true }
-rand_core = "0.10.0-rc-6"
+rand_core = "0.10"
 rfc6979 = { version = "0.5.0-rc.4", optional = true }
 pkcs8 = { version = "0.11.0-rc.10", optional = true }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
 sec1 = { version = "0.8.0-rc.13", optional = true }
-signature = { version = "3.0.0-rc.9", optional = true }
+signature = { version = "3.0.0-rc.10", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
 proptest = "1"
@@ -56,6 +56,10 @@ pkcs8 = ["dep:pkcs8"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh", "dep:digest", "dep:hkdf", "dep:hmac", "dep:belt-hash", "alloc"]
 serde = ["elliptic-curve/serde", "primeorder?/serde"]
 test-vectors = ["dep:hex-literal"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(cpubits, values("16", "32", "64"))']
 
 [[bench]]
 name = "field"

--- a/bignp256/src/arithmetic/field.rs
+++ b/bignp256/src/arithmetic/field.rs
@@ -13,26 +13,46 @@
 
 #![allow(clippy::arithmetic_side_effects)]
 
-#[cfg_attr(target_pointer_width = "32", path = "field/bignp256_32.rs")]
-#[cfg_attr(target_pointer_width = "64", path = "field/bignp256_64.rs")]
-#[allow(
-    clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
-    clippy::cast_sign_loss,
-    clippy::identity_op,
-    clippy::needless_lifetimes,
-    clippy::unnecessary_cast,
-    clippy::too_many_arguments
-)]
-#[allow(dead_code)] // TODO(tarcieri): remove this when we can use `const _` to silence warnings
-mod field_impl;
-
-use self::field_impl::*;
 use crate::U256;
 use elliptic_curve::{
+    bigint::cpubits,
     ff::PrimeField,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
+
+// TODO(tarcieri): remove this when we can use `const _` to silence warnings
+cpubits! {
+    32 => {
+        #[path = "field/bignp256_32.rs"]
+        #[allow(
+            dead_code,
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap,
+            clippy::cast_sign_loss,
+            clippy::identity_op,
+            clippy::needless_lifetimes,
+            clippy::too_many_arguments,
+            clippy::unnecessary_cast
+        )]
+        mod field_impl;
+    }
+    64 => {
+        #[path = "field/bignp256_64.rs"]
+        #[allow(
+            dead_code,
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap,
+            clippy::cast_sign_loss,
+            clippy::identity_op,
+            clippy::needless_lifetimes,
+            clippy::too_many_arguments,
+            clippy::unnecessary_cast
+        )]
+        mod field_impl;
+    }
+}
+
+use self::field_impl::*;
 
 /// Constant representing the modulus: p = 2^{256} − 189
 const MODULUS_HEX: &str = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff43";

--- a/bignp256/src/arithmetic/scalar.rs
+++ b/bignp256/src/arithmetic/scalar.rs
@@ -2,28 +2,48 @@
 
 #![allow(clippy::arithmetic_side_effects)]
 
-#[cfg_attr(target_pointer_width = "32", path = "scalar/bignp256_scalar_32.rs")]
-#[cfg_attr(target_pointer_width = "64", path = "scalar/bignp256_scalar_64.rs")]
-#[allow(
-    clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
-    clippy::cast_sign_loss,
-    clippy::identity_op,
-    clippy::needless_lifetimes,
-    clippy::unnecessary_cast,
-    clippy::too_many_arguments
-)]
-#[allow(dead_code)] // TODO(tarcieri): remove this when we can use `const _` to silence warnings
-mod scalar_impl;
-
-use self::scalar_impl::*;
 use crate::{BignP256, ORDER_HEX, U256};
 use elliptic_curve::{
     Curve as _,
+    bigint::cpubits,
     ff::PrimeField,
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
+
+// TODO(tarcieri): remove this when we can use `const _` to silence warnings
+cpubits! {
+    32 => {
+        #[path = "scalar/bignp256_scalar_32.rs"]
+        #[allow(
+            dead_code,
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap,
+            clippy::cast_sign_loss,
+            clippy::identity_op,
+            clippy::needless_lifetimes,
+            clippy::too_many_arguments,
+            clippy::unnecessary_cast
+        )]
+        mod scalar_impl;
+    }
+    64 => {
+        #[path = "scalar/bignp256_scalar_64.rs"]
+        #[allow(
+            dead_code,
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap,
+            clippy::cast_sign_loss,
+            clippy::identity_op,
+            clippy::needless_lifetimes,
+            clippy::too_many_arguments,
+            clippy::unnecessary_cast
+        )]
+        mod scalar_impl;
+    }
+}
+
+use self::scalar_impl::*;
 
 #[cfg(doc)]
 use core::ops::{Add, Mul, Neg, Sub};

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,17 +14,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.14", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.15", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
 sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]
@@ -38,6 +38,13 @@ pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa/serde", "elliptic-curve/serde"]
 sha256 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(bp256_backend, values("bignum", "fiat"))', # default: "fiat"
+    'cfg(cpubits, values("16", "32", "64"))'
+]
 
 [[bench]]
 name = "field"
@@ -56,7 +63,3 @@ required-features = ["arithmetic"]
 
 [package.metadata.docs.rs]
 all-features = true
-
-[lints.rust.unexpected_cfgs]
-level = "warn"
-check-cfg = ['cfg(bp256_backend, values("bignum", "fiat"))'] # default: "fiat"

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -10,23 +10,40 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
-#[cfg(not(bp256_backend = "bignum"))]
-#[cfg_attr(target_pointer_width = "32", path = "field/bp256_32.rs")]
-#[cfg_attr(target_pointer_width = "64", path = "field/bp256_64.rs")]
-#[allow(
-    clippy::identity_op,
-    clippy::needless_lifetimes,
-    clippy::unnecessary_cast,
-    clippy::too_many_arguments
-)]
-#[allow(dead_code)] // TODO(tarcieri): remove this when we can use `const _` to silence warnings
-mod field_impl;
-
 use crate::U256;
 use elliptic_curve::{
+    bigint::cpubits,
     ff::PrimeField,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
+
+// TODO(tarcieri): remove this when we can use `const _` to silence warnings
+cpubits! {
+    32 => {
+        #[cfg(not(bp256_backend = "bignum"))]
+        #[allow(
+            dead_code,
+            clippy::identity_op,
+            clippy::needless_lifetimes,
+            clippy::unnecessary_cast,
+            clippy::too_many_arguments
+        )]
+        #[path = "field/bp256_32.rs"]
+        mod field_impl;
+    }
+    64 => {
+        #[cfg(not(bp256_backend = "bignum"))]
+        #[allow(
+            dead_code,
+            clippy::identity_op,
+            clippy::needless_lifetimes,
+            clippy::unnecessary_cast,
+            clippy::too_many_arguments
+        )]
+        #[path = "field/bp256_64.rs"]
+        mod field_impl;
+    }
+}
 
 #[cfg(not(bp256_backend = "bignum"))]
 use self::field_impl::*;

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -10,24 +10,41 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
-#[cfg(not(bp256_backend = "bignum"))]
-#[cfg_attr(target_pointer_width = "32", path = "scalar/bp256_scalar_32.rs")]
-#[cfg_attr(target_pointer_width = "64", path = "scalar/bp256_scalar_64.rs")]
-#[allow(
-    clippy::identity_op,
-    clippy::needless_lifetimes,
-    clippy::unnecessary_cast,
-    clippy::too_many_arguments
-)]
-#[allow(dead_code)] // TODO(tarcieri): remove this when we can use `const _` to silence warnings
-mod scalar_impl;
-
 use crate::{BrainpoolP256r1, BrainpoolP256t1, ORDER, ORDER_HEX, U256};
 use elliptic_curve::{
+    bigint::cpubits,
     ff::PrimeField,
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
+
+// TODO(tarcieri): remove this when we can use `const _` to silence warnings
+cpubits! {
+    32 => {
+        #[cfg(not(bp256_backend = "bignum"))]
+        #[path = "scalar/bp256_scalar_32.rs"]
+        #[allow(
+            dead_code,
+            clippy::identity_op,
+            clippy::needless_lifetimes,
+            clippy::unnecessary_cast,
+            clippy::too_many_arguments
+        )]
+        mod scalar_impl;
+    }
+    64 => {
+        #[cfg(not(bp256_backend = "bignum"))]
+        #[path = "scalar/bp256_scalar_64.rs"]
+        #[allow(
+            dead_code,
+            clippy::identity_op,
+            clippy::needless_lifetimes,
+            clippy::unnecessary_cast,
+            clippy::too_many_arguments
+        )]
+        mod scalar_impl;
+    }
+}
 
 #[cfg(not(bp256_backend = "bignum"))]
 use self::scalar_impl::*;

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,17 +14,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.14", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.15", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
 sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]
@@ -38,6 +38,13 @@ pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa/serde", "elliptic-curve/serde"]
 sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(bp384_backend, values("bignum", "fiat"))', # default: "fiat"
+    'cfg(cpubits, values("16", "32", "64"))'
+]
 
 [[bench]]
 name = "field"
@@ -56,7 +63,3 @@ required-features = ["arithmetic"]
 
 [package.metadata.docs.rs]
 all-features = true
-
-[lints.rust.unexpected_cfgs]
-level = "warn"
-check-cfg = ['cfg(bp384_backend, values("bignum", "fiat"))'] # default: "fiat"

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -10,23 +10,40 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
-#[cfg(not(bp384_backend = "bignum"))]
-#[cfg_attr(target_pointer_width = "32", path = "field/bp384_32.rs")]
-#[cfg_attr(target_pointer_width = "64", path = "field/bp384_64.rs")]
-#[allow(
-    clippy::identity_op,
-    clippy::needless_lifetimes,
-    clippy::unnecessary_cast,
-    clippy::too_many_arguments
-)]
-#[allow(dead_code)] // TODO(tarcieri): remove this when we can use `const _` to silence warnings
-mod field_impl;
-
 use crate::U384;
 use elliptic_curve::{
+    bigint::cpubits,
     ff::PrimeField,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
+
+// TODO(tarcieri): remove this when we can use `const _` to silence warnings
+cpubits! {
+    32 => {
+        #[cfg(not(bp384_backend = "bignum"))]
+        #[path = "field/bp384_32.rs"]
+        #[allow(
+            dead_code,
+            clippy::identity_op,
+            clippy::needless_lifetimes,
+            clippy::unnecessary_cast,
+            clippy::too_many_arguments
+        )]
+        mod field_impl;
+    }
+    64 => {
+        #[cfg(not(bp384_backend = "bignum"))]
+        #[path = "field/bp384_64.rs"]
+        #[allow(
+            dead_code,
+            clippy::identity_op,
+            clippy::needless_lifetimes,
+            clippy::unnecessary_cast,
+            clippy::too_many_arguments
+        )]
+        mod field_impl;
+    }
+}
 
 #[cfg(not(bp384_backend = "bignum"))]
 use self::field_impl::*;

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -10,24 +10,41 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
-#[cfg(not(bp384_backend = "bignum"))]
-#[cfg_attr(target_pointer_width = "32", path = "scalar/bp384_scalar_32.rs")]
-#[cfg_attr(target_pointer_width = "64", path = "scalar/bp384_scalar_64.rs")]
-#[allow(
-    clippy::identity_op,
-    clippy::needless_lifetimes,
-    clippy::unnecessary_cast,
-    clippy::too_many_arguments
-)]
-#[allow(dead_code)] // TODO(tarcieri): remove this when we can use `const _` to silence warnings
-mod scalar_impl;
-
 use crate::{BrainpoolP384r1, BrainpoolP384t1, ORDER, ORDER_HEX, U384};
 use elliptic_curve::{
+    bigint::cpubits,
     ff::PrimeField,
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
+
+// TODO(tarcieri): remove this when we can use `const _` to silence warnings
+cpubits! {
+    32 => {
+        #[cfg(not(bp384_backend = "bignum"))]
+        #[path = "scalar/bp384_scalar_32.rs"]
+        #[allow(
+            dead_code,
+            clippy::identity_op,
+            clippy::needless_lifetimes,
+            clippy::unnecessary_cast,
+            clippy::too_many_arguments
+        )]
+        mod scalar_impl;
+    }
+    64 => {
+        #[cfg(not(bp384_backend = "bignum"))]
+        #[path = "scalar/bp384_scalar_64.rs"]
+        #[allow(
+            dead_code,
+            clippy::identity_op,
+            clippy::needless_lifetimes,
+            clippy::unnecessary_cast,
+            clippy::too_many_arguments
+        )]
+        mod scalar_impl;
+    }
+}
 
 #[cfg(not(bp384_backend = "bignum"))]
 use self::scalar_impl::*;

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -16,16 +16,16 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.24", features = ["arithmetic", "pkcs8"] }
+elliptic-curve = { version = "0.14.0-rc.27", features = ["arithmetic", "pkcs8"] }
 hash2curve = "0.14.0-rc.9"
-rand_core = { version = "0.10.0-rc-6", default-features = false }
+rand_core = { version = "0.10", default-features = false }
 sha3 = { version = "0.11.0-rc.4", default-features = false }
 subtle = { version = "2.6", default-features = false }
 
 # optional dependencies
 ed448 = { version = "0.5.0-rc.2", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true }
-signature = { version = "3.0.0-rc.9", optional = true, default-features = false, features = ["digest", "rand_core"] }
+signature = { version = "3.0.0-rc.10", optional = true, default-features = false, features = ["digest", "rand_core"] }
 
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false, features = ["cargo_bench_support"] }
@@ -33,7 +33,7 @@ getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
 hex-literal = "1"
 hex = "0.4"
 proptest = { version = "1", features = ["attr-macro"] }
-chacha20 = { version = "0.10.0-rc.9", features = ["rng"] }
+chacha20 = { version = "0.10.0-rc.10", features = ["rng"] }
 serde_bare = "0.5"
 serde_json = "1.0"
 

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-digest = { version = "0.11.0-rc.7" }
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["arithmetic"] }
+digest = { version = "0.11.0-rc.10" }
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["arithmetic"] }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -19,21 +19,21 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-cfg-if = "1.0"
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
+cpubits = "0.1.0-rc.3"
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
 hash2curve = { version = "0.14.0-rc.9", optional = true }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
-signature = { version = "3.0.0-rc.9", optional = true }
+signature = { version = "3.0.0-rc.10", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4.3"
 hex-literal = "1"
 num-bigint = "0.4"
@@ -64,8 +64,9 @@ serde = ["ecdsa-core/serde", "elliptic-curve/serde", "pkcs8", "serdect"]
 sha256 = ["digest", "sha2"]
 test-vectors = ["hex-literal"]
 
-[package.metadata.docs.rs]
-features = ["ecdh", "ecdsa", "schnorr"]
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(cpubits, values("16", "32", "64"))']
 
 [[bench]]
 name = "ecdsa"
@@ -80,3 +81,6 @@ required-features = ["expose-field"]
 [[bench]]
 name = "scalar"
 harness = false
+
+[package.metadata.docs.rs]
+features = ["ecdh", "ecdsa", "schnorr"]

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -2,16 +2,11 @@
 
 #![allow(clippy::assign_op_pattern, clippy::op_ref)]
 
-use cfg_if::cfg_if;
+use cpubits::{cfg_if, cpubits};
 
-cfg_if! {
-    if #[cfg(target_pointer_width = "32")] {
-        mod field_10x26;
-    } else if #[cfg(target_pointer_width = "64")] {
-        mod field_5x52;
-    } else {
-        compile_error!("unsupported target word size (i.e. target_pointer_width)");
-    }
+cpubits! {
+    32 => { mod field_10x26; }
+    64 => { mod field_5x52; }
 }
 
 cfg_if! {
@@ -19,14 +14,9 @@ cfg_if! {
         mod field_impl;
         use field_impl::FieldElementImpl;
     } else {
-        cfg_if! {
-            if #[cfg(target_pointer_width = "32")] {
-                use field_10x26::FieldElement10x26 as FieldElementImpl;
-            } else if #[cfg(target_pointer_width = "64")] {
-                use field_5x52::FieldElement5x52 as FieldElementImpl;
-            } else {
-                compile_error!("unsupported target word size (i.e. target_pointer_width)");
-            }
+        cpubits! {
+            32 => { use field_10x26::FieldElement10x26 as FieldElementImpl; }
+            64 => { use field_5x52::FieldElement5x52 as FieldElementImpl; }
         }
     }
 }

--- a/k256/src/arithmetic/field/field_impl.rs
+++ b/k256/src/arithmetic/field/field_impl.rs
@@ -9,11 +9,10 @@ use elliptic_curve::{
     zeroize::Zeroize,
 };
 
-#[cfg(target_pointer_width = "32")]
-use super::field_10x26::FieldElement10x26 as FieldElementUnsafeImpl;
-
-#[cfg(target_pointer_width = "64")]
-use super::field_5x52::FieldElement5x52 as FieldElementUnsafeImpl;
+cpubits::cpubits! {
+    32 => { use super::field_10x26::FieldElement10x26 as FieldElementUnsafeImpl; }
+    64 => { use super::field_5x52::FieldElement5x52 as FieldElementUnsafeImpl; }
+}
 
 #[derive(Clone, Copy, Debug)]
 pub struct FieldElementImpl {

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
 
@@ -45,6 +45,13 @@ pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8"]
 serde = ["elliptic-curve/serde", "primeorder?/serde", "serdect"]
 test-vectors = ["hex-literal"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(p192_backend, values("bignum", "fiat"))', # default: "fiat"
+    'cfg(cpubits, values("16", "32", "64"))'
+]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/p192/src/arithmetic/field.rs
+++ b/p192/src/arithmetic/field.rs
@@ -10,23 +10,43 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
-#[cfg_attr(target_pointer_width = "32", path = "field/p192_32.rs")]
-#[cfg_attr(target_pointer_width = "64", path = "field/p192_64.rs")]
-#[allow(
-    clippy::identity_op,
-    clippy::needless_lifetimes,
-    clippy::unnecessary_cast,
-    clippy::too_many_arguments
-)]
-#[allow(dead_code)] // TODO(tarcieri): remove this when we can use `const _` to silence warnings
-mod field_impl;
-
-use self::field_impl::*;
 use crate::U192;
 use elliptic_curve::{
+    bigint::cpubits,
     ff::PrimeField,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
+
+// TODO(tarcieri): remove this when we can use `const _` to silence warnings
+cpubits! {
+    32 => {
+        #[cfg(not(p192_backend = "bignum"))]
+        #[path = "field/p192_32.rs"]
+        #[allow(
+            dead_code,
+            clippy::identity_op,
+            clippy::needless_lifetimes,
+            clippy::unnecessary_cast,
+            clippy::too_many_arguments
+        )]
+        mod field_impl;
+    }
+    64 => {
+        #[cfg(not(p192_backend = "bignum"))]
+        #[path = "field/p192_64.rs"]
+        #[allow(
+            dead_code,
+            clippy::identity_op,
+            clippy::needless_lifetimes,
+            clippy::unnecessary_cast,
+            clippy::too_many_arguments
+        )]
+        mod field_impl;
+    }
+}
+
+#[cfg(not(p192_backend = "bignum"))]
+use self::field_impl::*;
 
 /// Constant representing the modulus serialized as hex.
 /// p = 2^{192} − 2^{64} - 1
@@ -48,6 +68,14 @@ primefield::monty_field_element! {
     doc: "Element in the finite field modulo `p = 2^{192} − 2^{64} - 1`."
 }
 
+#[cfg(p192_backend = "bignum")]
+primefield::monty_field_arithmetic! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U192
+}
+
+#[cfg(not(p192_backend = "bignum"))]
 primefield::fiat_monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
@@ -70,12 +98,15 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U192};
+    #[cfg(not(p192_backend = "bignum"))]
     use super::{
         FieldParams, fiat_p192_montgomery_domain_field_element, fiat_p192_msat,
         fiat_p192_non_montgomery_domain_field_element, fiat_p192_to_montgomery,
     };
 
     primefield::test_primefield!(FieldElement, U192);
+
+    #[cfg(not(p192_backend = "bignum"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: FieldElement,
         params: FieldParams,

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,10 +17,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
@@ -28,7 +28,7 @@ serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
 
@@ -48,6 +48,13 @@ pkcs8 = ["ecdsa-core?/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa-core?/serde", "elliptic-curve/serde", "primeorder?/serde", "serdect"]
 sha224 = ["digest", "sha2"]
 test-vectors = ["dep:hex-literal"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(p224_backend, values("bignum", "fiat"))', # default: "fiat"
+    'cfg(cpubits, values("16", "32", "64"))'
+]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/p224/src/lib.rs
+++ b/p224/src/lib.rs
@@ -38,20 +38,22 @@ pub use elliptic_curve::pkcs8;
 use elliptic_curve::{
     FieldBytesEncoding,
     array::Array,
-    bigint::Odd,
+    bigint::{Odd, cpubits},
     consts::{U28, U29},
 };
 
-#[cfg(target_pointer_width = "32")]
-use elliptic_curve::bigint::U224 as Uint;
-#[cfg(target_pointer_width = "64")]
-use elliptic_curve::bigint::U256 as Uint;
+cpubits! {
+    32 => { use elliptic_curve::bigint::U224 as Uint; }
+    64 => { use elliptic_curve::bigint::U256 as Uint; }
+}
 
 /// Order of NIST P-224's elliptic curve group (i.e. scalar modulus) in hexadecimal.
-#[cfg(target_pointer_width = "32")]
-const ORDER_HEX: &str = "ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3d";
-#[cfg(target_pointer_width = "64")]
-const ORDER_HEX: &str = "00000000ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3d";
+const ORDER_HEX: &str = {
+    cpubits! {
+        32 => { "ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3d" }
+        64 => { "00000000ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3d" }
+    }
+};
 
 /// NIST P-224 elliptic curve.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,10 +18,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.9", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.6", optional = true }
@@ -31,7 +31,7 @@ sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primefield = { version = "0.14.0-rc.6" }
 primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
@@ -58,8 +58,9 @@ serde = ["ecdsa-core?/serde", "elliptic-curve/serde", "primeorder?/serde", "serd
 sha256 = ["digest", "sha2"]
 test-vectors = ["dep:hex-literal"]
 
-[package.metadata.docs.rs]
-all-features = true
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(cpubits, values("16", "32", "64"))']
 
 [[bench]]
 name = "ecdsa"
@@ -74,3 +75,6 @@ required-features = ["expose-field"]
 [[bench]]
 name = "scalar"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,10 +18,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.9", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.6", optional = true }
@@ -34,7 +34,7 @@ fiat-crypto = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
 proptest = "1.9"
@@ -65,8 +65,12 @@ serde = ["ecdsa-core?/serde", "elliptic-curve/serde", "primeorder?/serde", "serd
 sha384 = ["digest", "sha2"]
 test-vectors = ["hex-literal"]
 
-[package.metadata.docs.rs]
-all-features = true
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(p384_backend, values("bignum", "fiat"))', # default: "fiat"
+    'cfg(cpubits, values("16", "32", "64"))'
+]
 
 [[bench]]
 name = "field"
@@ -77,6 +81,5 @@ required-features = ["expose-field"]
 name = "scalar"
 harness = false
 
-[lints.rust.unexpected_cfgs]
-level = "warn"
-check-cfg = ['cfg(p384_backend, values("bignum", "fiat"))'] # default: "fiat"
+[package.metadata.docs.rs]
+all-features = true

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -10,17 +10,23 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
-// Default backend: fiat-crypto
-#[cfg(all(not(p384_backend = "bignum"), target_pointer_width = "32"))]
-use fiat_crypto::p384_32::*;
-#[cfg(all(not(p384_backend = "bignum"), target_pointer_width = "64"))]
-use fiat_crypto::p384_64::*;
-
 use elliptic_curve::{
-    bigint::U384,
+    bigint::{U384, cpubits},
     ff::PrimeField,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
+
+// Default backend: fiat-crypto
+cpubits! {
+    32 => {
+        #[cfg(not(p384_backend = "bignum"))]
+        use fiat_crypto::p384_32::*;
+    }
+    64 => {
+        #[cfg(not(p384_backend = "bignum"))]
+        use fiat_crypto::p384_64::*;
+    }
+}
 
 /// Constant representing the modulus
 /// p = 2^{384} − 2^{128} − 2^{96} + 2^{32} − 1

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -10,20 +10,26 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
-#[cfg(all(not(p384_backend = "bignum"), target_pointer_width = "32"))]
-use fiat_crypto::p384_scalar_32::*;
-#[cfg(all(not(p384_backend = "bignum"), target_pointer_width = "64"))]
-use fiat_crypto::p384_scalar_64::*;
-
 use crate::{FieldBytes, NistP384, ORDER_HEX, U384};
 use elliptic_curve::{
     Curve as _,
-    bigint::{ArrayEncoding, Limb},
+    bigint::{ArrayEncoding, Limb, cpubits},
     ff::PrimeField,
     ops::{Reduce, ReduceNonZero},
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
+
+cpubits! {
+    32 => {
+        #[cfg(not(p384_backend = "bignum"))]
+        use fiat_crypto::p384_scalar_32::*;
+    }
+    64 => {
+        #[cfg(not(p384_backend = "bignum"))]
+        use fiat_crypto::p384_scalar_64::*;
+    }
+}
 
 #[cfg(feature = "serde")]
 use {

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -18,21 +18,21 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "1"
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.9", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
-rand_core = { version = "0.10.0-rc-6", optional = true, default-features = false }
+rand_core = { version = "0.10", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.14", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
 proptest = "1.9"
@@ -58,8 +58,9 @@ serde = ["ecdsa-core?/serde", "elliptic-curve/serde", "primeorder?/serde", "serd
 sha512 = ["digest", "dep:sha2"]
 test-vectors = ["dep:hex-literal"]
 
-[package.metadata.docs.rs]
-all-features = true
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(cpubits, values("16", "32", "64"))']
 
 [[bench]]
 name = "field"
@@ -69,3 +70,6 @@ required-features = ["expose-field"]
 [[bench]]
 name = "scalar"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true

--- a/p521/src/arithmetic/field/loose.rs
+++ b/p521/src/arithmetic/field/loose.rs
@@ -1,15 +1,16 @@
 use super::{FieldElement, field_impl::*};
 use core::ops::Mul;
+use elliptic_curve::bigint::cpubits;
 
 /// "Loose" field element: unreduced and intended to be followed by an
 /// additional operation which will perform a reduction.
 pub struct LooseFieldElement(pub(super) fiat_p521_loose_field_element);
 
 impl LooseFieldElement {
-    #[cfg(target_pointer_width = "32")]
-    const LIMBS: usize = 19;
-    #[cfg(target_pointer_width = "64")]
-    const LIMBS: usize = 9;
+    cpubits! {
+        32 => { const LIMBS: usize = 19; }
+        64 => { const LIMBS: usize = 9; }
+    }
 
     /// Reduce field element.
     #[inline]

--- a/p521/src/lib.rs
+++ b/p521/src/lib.rs
@@ -49,18 +49,29 @@ pub use elliptic_curve;
 #[cfg(feature = "pkcs8")]
 pub use elliptic_curve::pkcs8;
 
-use elliptic_curve::{FieldBytesEncoding, array::Array, bigint::Odd, consts::U66};
+use elliptic_curve::{
+    FieldBytesEncoding,
+    array::Array,
+    bigint::{Odd, cpubits},
+    consts::U66,
+};
 
-#[cfg(target_pointer_width = "32")]
-use elliptic_curve::bigint::U544 as Uint;
-#[cfg(target_pointer_width = "64")]
-use elliptic_curve::bigint::U576 as Uint;
+cpubits! {
+    32 => { use elliptic_curve::bigint::U544 as Uint; }
+    64 => { use elliptic_curve::bigint::U576 as Uint; }
+}
 
 /// Order of NIST P-521's elliptic curve group (i.e. scalar modulus) in hexadecimal.
-#[cfg(target_pointer_width = "32")]
-const ORDER_HEX: &str = "000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409";
-#[cfg(target_pointer_width = "64")]
-const ORDER_HEX: &str = "00000000000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409";
+const ORDER_HEX: &str = {
+    cpubits! {
+        32 => {
+            "000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409"
+        }
+        64 => {
+            "00000000000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409"
+        }
+    }
+};
 
 /// NIST P-521 elliptic curve.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -17,9 +17,9 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-bigint = { package = "crypto-bigint", version = "0.7.0-rc.22", default-features = false, features = ["rand_core", "hybrid-array", "subtle"] }
-common = { package = "crypto-common", version = "0.2.0-rc.13", features = ["rand_core"] }
+bigint = { package = "crypto-bigint", version = "0.7.0-rc.24", default-features = false, features = ["rand_core", "hybrid-array", "subtle"] }
+common = { package = "crypto-common", version = "0.2.0-rc.14", features = ["rand_core"] }
 ff = { version = "=0.14.0-pre.1", package = "rustcrypto-ff", default-features = false }
 subtle = { version = "2.6", default-features = false, features = ["const-generics"] }
-rand_core = { version = "0.10.0-rc-6", default-features = false }
+rand_core = { version = "0.10", default-features = false }
 zeroize = { version = "1.7", default-features = false }

--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -974,7 +974,7 @@ const fn compute_s<const LIMBS: usize>(modulus: &Uint<LIMBS>) -> u32 {
 pub const fn compute_t<const LIMBS: usize>(modulus: &Uint<LIMBS>) -> Uint<LIMBS> {
     modulus
         .wrapping_sub(&Uint::ONE)
-        .wrapping_shr(compute_s(modulus))
+        .unbounded_shr(compute_s(modulus))
 }
 
 #[cfg(test)]

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true, default-features = false }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -18,22 +18,22 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
-rand_core = { version = "0.10.0-rc-6", default-features = false }
+rand_core = { version = "0.10", default-features = false }
 
 # optional dependencies
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
 rfc6979 = { version = "0.5.0-rc.4", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-signature = { version = "3.0.0-rc.9", optional = true, features = ["rand_core"] }
+signature = { version = "3.0.0-rc.10", optional = true, features = ["rand_core"] }
 sm3 = { version = "0.5.0-rc.3", optional = true, default-features = false }
 der = { version = "0.8.0-rc.10", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.24", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["dev"] }
 hex-literal = "1"
 proptest = "1"
 
@@ -76,4 +76,7 @@ all-features = true
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
-check-cfg = ['cfg(sm2_backend, values("bignum", "fiat"))'] # default: "fiat"
+check-cfg = [
+    'cfg(cpubits, values("16", "32", "64"))',
+    'cfg(sm2_backend, values("bignum", "fiat"))' # default: "fiat"
+]

--- a/sm2/src/arithmetic/field.rs
+++ b/sm2/src/arithmetic/field.rs
@@ -10,17 +10,24 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
-// Default backend: fiat-crypto
-#[cfg(all(not(sm2_backend = "bignum"), target_pointer_width = "32"))]
-use fiat_crypto::sm2_32::*;
-#[cfg(all(not(sm2_backend = "bignum"), target_pointer_width = "64"))]
-use fiat_crypto::sm2_64::*;
-
 use crate::U256;
 use elliptic_curve::{
+    bigint::cpubits,
     ff::PrimeField,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
+
+// Default backend: fiat-crypto
+cpubits! {
+    32 => {
+        #[cfg(not(sm2_backend = "bignum"))]
+        use fiat_crypto::sm2_32::*;
+    }
+    64 => {
+        #[cfg(not(sm2_backend = "bignum"))]
+        use fiat_crypto::sm2_64::*;
+    }
+}
 
 /// Constant representing the modulus serialized as hex.
 const MODULUS_HEX: &str = "fffffffeffffffffffffffffffffffffffffffff00000000ffffffffffffffff";

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -10,19 +10,26 @@
 //! Apache License (Version 2.0), and the BSD 1-Clause License;
 //! users may pick which license to apply.
 
-// Default backend: fiat-crypto
-#[cfg(all(not(sm2_backend = "bignum"), target_pointer_width = "32"))]
-use fiat_crypto::sm2_scalar_32::*;
-#[cfg(all(not(sm2_backend = "bignum"), target_pointer_width = "64"))]
-use fiat_crypto::sm2_scalar_64::*;
-
 use crate::{ORDER_HEX, Sm2, U256};
 use elliptic_curve::{
     Curve as _,
+    bigint::cpubits,
     ff::PrimeField,
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
+
+// Default backend: fiat-crypto
+cpubits! {
+    32 => {
+        #[cfg(not(sm2_backend = "bignum"))]
+        use fiat_crypto::sm2_scalar_32::*;
+    }
+    64 => {
+        #[cfg(not(sm2_backend = "bignum"))]
+        use fiat_crypto::sm2_scalar_64::*;
+    }
+}
 
 #[cfg(feature = "serde")]
 use {


### PR DESCRIPTION
Release notes:

https://github.com/rust-random/rand_core/releases/tag/v0.10.0

Also bumps the following:
- `chacha20` v0.10.0-rc.10
- `crypto-bigint` v0.7.0-rc.24
- `crypto-common` v0.2.0-rc.14
- `digest` v0.11.0-rc.10
- `ecdsa` v0.17.0-rc.15
- `elliptic-curve` v0.14.0-rc.27
- `signature` v3.0.0-rc.10

This includes `wrapping_sh*` => `unbounded_sh*` changes that preserve the original behavior of our implementation after this change:

RustCrypto/crypto-bigint#1160

This also unfortunately includes the migration to `cpubits!` as it's part of this `crypto-bigint` release.