### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "bignp256"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 dependencies = [
  "belt-hash",
  "criterion",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "bp256"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "bp384"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "ed448"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca586ed223f9d5ecdfe636576d2d284fd26ddfbfb8b5289b527c736293c7926"
+checksum = "8a6517ef61d12c57c218393995d2ee5ab2dac4c27501d24f7595590e097985c9"
 dependencies = [
  "pkcs8",
  "serde",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "ed448-goldilocks"
-version = "0.14.0-pre.9"
+version = "0.14.0-pre.10"
 dependencies = [
  "chacha20",
  "criterion",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "hash2curve"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.10"
 dependencies = [
  "digest",
  "elliptic-curve",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 dependencies = [
  "cpubits",
  "criterion",
@@ -834,7 +834,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p192"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "p224"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 dependencies = [
  "base16ct",
  "criterion",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 dependencies = [
  "crypto-bigint",
  "crypto-common",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 dependencies = [
  "elliptic-curve",
  "serdect",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "sm2"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 dependencies = [
  "criterion",
  "der",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "x448"
-version = "0.14.0-pre.6"
+version = "0.14.0-pre.7"
 dependencies = [
  "ed448-goldilocks",
  "serdect",

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bignp256"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 description = """
 Pure Rust implementation of the Bign P-256 (a.k.a. bign-curve256v1)
 elliptic curve as defined in STB 34.101.45-2013, with
@@ -30,8 +30,8 @@ hmac = { version = "0.13.0-rc.5", optional = true }
 rand_core = "0.10"
 rfc6979 = { version = "0.5.0-rc.5", optional = true }
 pkcs8 = { version = "0.11.0-rc.10", optional = true }
-primefield = { version = "0.14.0-rc.6", optional = true }
-primeorder = { version = "0.14.0-rc.6", optional = true }
+primefield = { version = "0.14.0-rc.7", optional = true }
+primeorder = { version = "0.14.0-rc.7", optional = true }
 sec1 = { version = "0.8.0-rc.13", optional = true }
 signature = { version = "3.0.0-rc.10", optional = true }
 
@@ -39,7 +39,7 @@ signature = { version = "3.0.0-rc.10", optional = true }
 criterion = "0.7"
 elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.7", features = ["dev"] }
 proptest = "1"
 
 [features]

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp256"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 description = "Brainpool P-256 (brainpoolP256r1 and brainpoolP256t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -18,8 +18,8 @@ elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features 
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.16", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "0.14.0-rc.6", optional = true }
-primeorder = { version = "0.14.0-rc.6", optional = true }
+primefield = { version = "0.14.0-rc.7", optional = true }
+primeorder = { version = "0.14.0-rc.7", optional = true }
 sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp384"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -18,8 +18,8 @@ elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features 
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.16", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "0.14.0-rc.6", optional = true }
-primeorder = { version = "0.14.0-rc.6", optional = true }
+primefield = { version = "0.14.0-rc.7", optional = true }
+primeorder = { version = "0.14.0-rc.7", optional = true }
 sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed448-goldilocks"
-version = "0.14.0-pre.9"
+version = "0.14.0-pre.10"
 authors = ["RustCrypto Developers"]
 categories = ["cryptography"]
 keywords = ["cryptography", "decaf", "ed448", "ed448-goldilocks"]
@@ -17,13 +17,13 @@ This crate also includes signing and verifying of Ed448 signatures.
 
 [dependencies]
 elliptic-curve = { version = "0.14.0-rc.28", features = ["arithmetic", "pkcs8"] }
-hash2curve = "0.14.0-rc.9"
+hash2curve = "0.14.0-rc.10"
 rand_core = { version = "0.10", default-features = false }
-sha3 = { version = "0.11.0-rc.5", default-features = false }
+sha3 = { version = "0.11.0-rc.7", default-features = false }
 subtle = { version = "2.6", default-features = false }
 
 # optional dependencies
-ed448 = { version = "0.5.0-rc.2", optional = true, default-features = false }
+ed448 = { version = "0.5.0-rc.3", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true }
 signature = { version = "3.0.0-rc.10", optional = true, default-features = false, features = ["digest", "rand_core"] }
 

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash2curve"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.10"
 description = "hash2curve algorithm implementation"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -20,4 +20,4 @@ elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features 
 [dev-dependencies]
 hex-literal = "1"
 sha2 = { version = "0.11.0-rc.5", default-features = false }
-sha3 = { version = "0.11.0-rc.5", default-features = false }
+sha3 = { version = "0.11.0-rc.7", default-features = false }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification/public-key recovery, Taproot Schnorr signatures (BIP340),
@@ -21,12 +21,12 @@ rust-version = "1.85"
 [dependencies]
 cpubits = "0.1.0-rc.3"
 elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["sec1"] }
-hash2curve = { version = "0.14.0-rc.9", optional = true }
+hash2curve = { version = "0.14.0-rc.10", optional = true }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primeorder = { version = "0.14.0-rc.6", optional = true }
+primeorder = { version = "0.14.0-rc.7", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 signature = { version = "3.0.0-rc.10", optional = true }

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p192"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 description = """
 Pure Rust implementation of the NIST P-192 (a.k.a. secp192r1) elliptic curve
 as defined in SP 800-186
@@ -22,14 +22,14 @@ elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.6", optional = true }
-primeorder = { version = "0.14.0-rc.6", optional = true }
+primefield = { version = "0.14.0-rc.7", optional = true }
+primeorder = { version = "0.14.0-rc.7", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
 ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.7", features = ["dev"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p224"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 description = """
 Pure Rust implementation of the NIST P-224 (a.k.a. secp224r1) elliptic curve
 as defined in SP 800-186
@@ -22,15 +22,15 @@ elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.6", optional = true }
-primeorder = { version = "0.14.0-rc.6", optional = true }
+primefield = { version = "0.14.0-rc.7", optional = true }
+primeorder = { version = "0.14.0-rc.7", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 
 [dev-dependencies]
 ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.7", features = ["dev"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve as defined in SP 800-186, with support for ECDH, ECDSA
@@ -22,10 +22,10 @@ elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features 
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.9", optional = true }
+hash2curve = { version = "0.14.0-rc.10", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.6", optional = true }
-primeorder = { version = "0.14.0-rc.6", optional = true }
+primefield = { version = "0.14.0-rc.7", optional = true }
+primeorder = { version = "0.14.0-rc.7", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 
@@ -33,8 +33,8 @@ sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 criterion = "0.7"
 ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primefield = { version = "0.14.0-rc.6" }
-primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
+primefield = { version = "0.14.0-rc.7" }
+primeorder = { version = "0.14.0-rc.7", features = ["dev"] }
 proptest = "1"
 
 [features]

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p384"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 description = """
 Pure Rust implementation of the NIST P-384 (a.k.a. secp384r1) elliptic curve
 as defined in SP 800-186 with support for ECDH, ECDSA signing/verification,
@@ -22,10 +22,10 @@ elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features 
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.9", optional = true }
+hash2curve = { version = "0.14.0-rc.10", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.6", optional = true }
-primeorder = { version = "0.14.0-rc.6", optional = true }
+primefield = { version = "0.14.0-rc.7", optional = true }
+primeorder = { version = "0.14.0-rc.7", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 
@@ -36,7 +36,7 @@ fiat-crypto = { version = "0.3", default-features = false }
 criterion = "0.7"
 ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.7", features = ["dev"] }
 proptest = "1.9"
 
 [features]

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p521"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 description = """
 Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve
 as defined in SP 800-186
@@ -22,10 +22,10 @@ elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features 
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.9", optional = true }
+hash2curve = { version = "0.14.0-rc.10", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.6", optional = true }
-primeorder = { version = "0.14.0-rc.6", optional = true }
+primefield = { version = "0.14.0-rc.7", optional = true }
+primeorder = { version = "0.14.0-rc.7", optional = true }
 rand_core = { version = "0.10", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
@@ -34,7 +34,7 @@ sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 criterion = "0.7"
 ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.7", features = ["dev"] }
 proptest = "1.9"
 
 [features]

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primefield"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 description = """
 Generic implementation of prime fields built on `crypto-bigint`, along with macros for writing
 field element newtypes including ones with formally verified arithmetic using `fiat-crypto`

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm2"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 description = """
 Pure Rust implementation of the SM2 elliptic curve as defined in the Chinese
 national standard GM/T 0003-2012 as well as ISO/IEC 14888. Includes support for
@@ -24,8 +24,8 @@ rand_core = { version = "0.10", default-features = false }
 
 # optional dependencies
 der = { version = "0.8.0-rc.10", optional = true }
-primefield = { version = "0.14.0-rc.6", optional = true }
-primeorder = { version = "0.14.0-rc.6", optional = true }
+primefield = { version = "0.14.0-rc.7", optional = true }
+primeorder = { version = "0.14.0-rc.7", optional = true }
 rfc6979 = { version = "0.5.0-rc.5", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 signature = { version = "3.0.0-rc.10", optional = true, features = ["rand_core"] }

--- a/x448/Cargo.toml
+++ b/x448/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x448"
-version = "0.14.0-pre.6"
+version = "0.14.0-pre.7"
 authors = ["RustCrypto Developers"]
 categories = ["cryptography"]
 keywords = ["cryptography", "crypto", "x448", "diffie-hellman", "curve448", ]
@@ -14,7 +14,7 @@ readme = "README.md"
 description = "Pure Rust implementation of X448, an elliptic curve Diffie-Hellman function"
 
 [dependencies]
-ed448-goldilocks = { version = "0.14.0-pre.9", default-features = false }
+ed448-goldilocks = { version = "0.14.0-pre.10", default-features = false }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true }


### PR DESCRIPTION
Includes `rand_core` v0.10 support.

Releases the following:

- `bignp256` v0.14.0-rc.7
- `bp256` v0.14.0-rc.7
- `bp384` v0.14.0-rc.7
- `ed448-goldilocks` v0.14.0-pre.10
- `hash2curve` v0.14.0-rc.10
- `k256` v0.14.0-rc.7
- `p192` v0.14.0-rc.7
- `p224` v0.14.0-rc.7
- `p256` v0.14.0-rc.7
- `p384` v0.14.0-rc.7
- `p521` v0.14.0-rc.7
- `primefield` v0.14.0-rc.7
- `primeorder` v0.14.0-rc.7
- `sm2` v0.14.0-rc.7
- `x448` v0.14.0-pre.7