### PR TITLE
Bump dependency requirements in `Cargo.toml`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d0d625c21e8e5ca317b31568d257c4af4e93fd5a756d0301f5d517951ea6fd"
+checksum = "c56883a45783acff1ccdf0903f38b8688363e633d3c9a199c2063f0cc946832b"
 dependencies = [
  "belt-block",
  "digest",
@@ -369,9 +369,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.24"
+version = "0.7.0-rc.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51312f2b7fae18a144261dcc5c32b0de4bc7e50225d1c0b5a30e0312831da20d"
+checksum = "cba9eeeb213f7fd29353032f71f7c173e5f6d95d85151cb3a47197b0ea7e8be7"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.14"
+version = "0.2.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5569e5de27d32e673283717728eb5b0e4f30898b523f151a19c51e6188006599"
+checksum = "6f8441110cea75afde0b89a8d796e2bc67b23432f5a9566cb15d9d365d91a2b0"
 dependencies = [
  "getrandom 0.4.0",
  "hybrid-array",
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.10"
+version = "0.11.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa94b64bfc6549e6e4b5a3216f22593224174083da7a90db47e951c4fb31725"
+checksum = "02b42f1d9edf5207c137646b568a0168ca0ec25b7f9eaf7f9961da51a3d91cea"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.15"
+version = "0.17.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8f0121ea408940811dbc86785c20ebaf18bf9906565e66f2310943f3b3e35a"
+checksum = "91bbdd377139884fafcad8dc43a760a3e1e681aa26db910257fa6535b70e1829"
 dependencies = [
  "der",
  "digest",
@@ -486,9 +486,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.27"
+version = "0.14.0-rc.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df662176e1c736be2dfeb34f52874644bd563c11a992aeaa5121b104909a810e"
+checksum = "bde7860544606d222fd6bd6d9f9a0773321bf78072a637e1d560a058c0031978"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -638,18 +638,18 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hkdf"
-version = "0.13.0-rc.4"
+version = "0.13.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1493605868fc7d216afa78a26956d56f5c0a12dbdb8ee4fe9e0b70a28ec7d57"
+checksum = "cbb55385998ae66b8d2d5143c05c94b9025ab863966f0c94ce7a5fde30105092"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.4"
+version = "0.13.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9956e202a691c5c86c60303a421f66f93f44b29433407b7c43cf2bebadc750e"
+checksum = "ef451d73f36d8a3f93ad32c332ea01146c9650e1ec821a9b0e46c01277d544f8"
 dependencies = [
  "digest",
 ]
@@ -1163,9 +1163,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-rc.4"
+version = "0.5.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a478f26ee9327bce006ff44c03e9a80dba5cedfba171d37c03ca3669e70d461"
+checksum = "23a3127ee32baec36af75b4107082d9bd823501ec14a4e016be4b6b37faa74ae"
 dependencies = [
  "hmac",
  "subtle",
@@ -1173,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-ff"
-version = "0.14.0-pre.1"
+version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36fdf8f956089df8343b9479045c026932f9eb004d0f32d8497b4d133b316a66"
+checksum = "c5db129183b2c139d7d87d08be57cba626c715789db17aec65c8866bfd767d1f"
 dependencies = [
  "bitvec",
  "rand_core 0.10.0",
@@ -1185,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-ff_derive"
-version = "0.14.0-pre.0"
+version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2aef88cb4ddb3b1c83beff963f9197607dac780cc39a09f19c041dacbb0b6a5"
+checksum = "4cda22ea03582974ab5687fc131eba2dc78e258e7eef4d7e01bcd0522ed79f66"
 dependencies = [
  "addchain",
  "num-bigint 0.3.3",
@@ -1200,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-group"
-version = "0.14.0-pre.1"
+version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df76d08c12814c794ffe95ac788b48081cccb607fade4ed746825d29791ce538"
+checksum = "57c4b1463f274a3ff6fb2f44da43e576cb9424367bd96f185ead87b52fe00523"
 dependencies = [
  "rand_core 0.10.0",
  "rustcrypto-ff",
@@ -1344,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7535f94fa3339fe9e5e9be6260a909e62af97f6e14b32345ccf79b92b8b81233"
+checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1355,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.6"
+version = "0.11.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1deee7fbcdd62fbcffc9dc2f5f17f96adac881ec7e1506e1eedee1644d0cc535"
+checksum = "c5bfe7820113e633d8886e839aae78c1184b8d7011000db6bc7eb61e34f28350"
 dependencies = [
  "digest",
  "keccak",
@@ -1394,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "sm3"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ff18c123c240b3941d71fdddab04932ac4ba772e60d38a9c8e4522c6296b32"
+checksum = "c44880f8d51209218c4902dd6781b26f398acb6732363427293e459715386126"
 dependencies = [
  "digest",
 ]

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -18,17 +18,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.27", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.28", features = ["sec1"] }
 
 # optional dependencies
-belt-hash = { version = "0.2.0-rc.0", optional = true, default-features = false }
+belt-hash = { version = "0.2.0-rc.5", optional = true, default-features = false }
 der = { version = "0.8.0-rc.10" }
-digest = { version = "0.11.0-rc.10", optional = true }
+digest = { version = "0.11.0-rc.11", optional = true }
 hex-literal = { version = "1", optional = true }
-hkdf = { version = "0.13.0-rc.4", optional = true }
-hmac = { version = "0.13.0-rc.4", optional = true }
+hkdf = { version = "0.13.0-rc.5", optional = true }
+hmac = { version = "0.13.0-rc.5", optional = true }
 rand_core = "0.10"
-rfc6979 = { version = "0.5.0-rc.4", optional = true }
+rfc6979 = { version = "0.5.0-rc.5", optional = true }
 pkcs8 = { version = "0.11.0-rc.10", optional = true }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
@@ -37,7 +37,7 @@ signature = { version = "3.0.0-rc.10", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
 proptest = "1"

--- a/bignp256/src/ecdh.rs
+++ b/bignp256/src/ecdh.rs
@@ -14,25 +14,25 @@
 //! // NOTE: requires 'getrandom' feature is enabled
 //!
 //! use bignp256::{
-//!     EncodedPoint, PublicKey,
+//!     Sec1Point, PublicKey,
 //!     ecdh::EphemeralSecret,
 //!     elliptic_curve::Generate
 //! };
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::generate();
-//! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
+//! let alice_pk_bytes = Sec1Point::from(alice_secret.public_key());
 //!
 //! // Bob
 //! let bob_secret = EphemeralSecret::generate();
-//! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
+//! let bob_pk_bytes = Sec1Point::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it
-//! let bob_public = PublicKey::from_encoded_point(bob_pk_bytes)?;
+//! let bob_public = PublicKey::from_sec1_point(bob_pk_bytes)?;
 //! let alice_shared = alice_secret.diffie_hellman(&bob_public.into());
 //!
 //! // Bob decodes Alice's serialized public key and computes the same shared secret
-//! let alice_public = PublicKey::from_encoded_point(alice_pk_bytes)?;
+//! let alice_public = PublicKey::from_sec1_point(alice_pk_bytes)?;
 //! let bob_shared = bob_secret.diffie_hellman(&alice_public.into());
 //!
 //! // Both participants arrive on the same shared secret

--- a/bignp256/src/ecdsa.rs
+++ b/bignp256/src/ecdsa.rs
@@ -8,7 +8,7 @@
 //! // NOTE: requires the `ecdsa` and `getrandom` crate features are enabled
 //! use bignp256::{
 //!     ecdsa::{SigningKey, Signature, signature::Signer},
-//!     elliptic_curve::{Generate, sec1::ToEncodedPoint},
+//!     elliptic_curve::{Generate, sec1::ToSec1Point},
 //!     SecretKey,
 //! };
 //!
@@ -20,7 +20,7 @@
 //! let signature: Signature = signing_key.sign(message);
 //!
 //! // Verification
-//! use bignp256::{EncodedPoint, ecdsa::{VerifyingKey, signature::Verifier}};
+//! use bignp256::{Sec1Point, ecdsa::{VerifyingKey, signature::Verifier}};
 //!
 //! let verifying_key = VerifyingKey::from_bytes(&verifying_key_bytes)?;
 //! verifying_key.verify(message, &signature)?;

--- a/bignp256/src/ecdsa/verifying.rs
+++ b/bignp256/src/ecdsa/verifying.rs
@@ -19,7 +19,7 @@ use alloc::boxed::Box;
 
 use super::{BELT_OID, Signature};
 use crate::{
-    AffinePoint, BignP256, EncodedPoint, FieldBytes, Hash, ProjectivePoint, PublicKey, Scalar,
+    AffinePoint, BignP256, FieldBytes, Hash, ProjectivePoint, PublicKey, Scalar, Sec1Point,
 };
 use belt_hash::{
     BeltHash,
@@ -33,7 +33,7 @@ use elliptic_curve::{
 };
 use signature::{Error, MultipartVerifier, Result, Verifier, hazmat::PrehashVerifier};
 
-use elliptic_curve::sec1::ToEncodedPoint;
+use elliptic_curve::sec1::ToSec1Point;
 
 /// Bign256 public key used for verifying signatures are valid for a given
 /// message.
@@ -205,8 +205,8 @@ impl From<&VerifyingKey> for PublicKey {
     }
 }
 
-impl ToEncodedPoint<BignP256> for VerifyingKey {
-    fn to_encoded_point(&self, compress: bool) -> EncodedPoint {
-        self.as_affine().to_encoded_point(compress)
+impl ToSec1Point<BignP256> for VerifyingKey {
+    fn to_sec1_point(&self, compress: bool) -> Sec1Point {
+        self.as_affine().to_sec1_point(compress)
     }
 }

--- a/bignp256/src/lib.rs
+++ b/bignp256/src/lib.rs
@@ -124,7 +124,7 @@ impl pkcs8::AssociatedOid for BignP256 {
 pub type FieldBytes = elliptic_curve::FieldBytes<BignP256>;
 
 /// SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<BignP256>;
+pub type Sec1Point = elliptic_curve::sec1::Sec1Point<BignP256>;
 
 impl FieldBytesEncoding<BignP256> for U256 {
     fn decode_field_bytes(field_bytes: &FieldBytes) -> Self {

--- a/bignp256/src/public_key.rs
+++ b/bignp256/src/public_key.rs
@@ -1,13 +1,13 @@
 //! Public key types and traits
 // TODO(tarcieri): replace with `elliptic_curve::PublicKey`
 
-use crate::{ALGORITHM_OID, AffinePoint, BignP256, EncodedPoint, NonZeroScalar, ProjectivePoint};
+use crate::{ALGORITHM_OID, AffinePoint, BignP256, NonZeroScalar, ProjectivePoint, Sec1Point};
 use core::{fmt::Display, str::FromStr};
 use elliptic_curve::{
     CurveArithmetic, Error, Group,
     array::Array,
     point::NonIdentity,
-    sec1::{FromEncodedPoint, ToEncodedPoint},
+    sec1::{FromSec1Point, ToSec1Point},
 };
 use pkcs8::{
     AssociatedOid, DecodePublicKey, EncodePublicKey, ObjectIdentifier,
@@ -70,8 +70,8 @@ impl PublicKey {
         bytes[..32].reverse();
         bytes[32..].reverse();
 
-        let point = EncodedPoint::from_untagged_bytes(&bytes);
-        let affine = AffinePoint::from_encoded_point(&point);
+        let point = Sec1Point::from_untagged_bytes(&bytes);
+        let affine = AffinePoint::from_sec1_point(&point);
         if affine.is_none().into() {
             Err(Error)
         } else {
@@ -82,8 +82,8 @@ impl PublicKey {
     }
 
     /// Get [`PublicKey`] from encoded point
-    pub fn from_encoded_point(point: EncodedPoint) -> Result<Self, Error> {
-        let affine = AffinePoint::from_encoded_point(&point);
+    pub fn from_sec1_point(point: Sec1Point) -> Result<Self, Error> {
+        let affine = AffinePoint::from_sec1_point(&point);
         if affine.is_none().into() {
             Err(Error)
         } else {
@@ -96,7 +96,7 @@ impl PublicKey {
     #[cfg(feature = "alloc")]
     /// Get bytes from [`PublicKey`]
     pub fn to_bytes(&self) -> Box<[u8]> {
-        let mut bytes = self.point.to_encoded_point(false).to_bytes();
+        let mut bytes = self.point.to_sec1_point(false).to_bytes();
         bytes[1..32 + 1].reverse();
         bytes[33..].reverse();
         bytes[1..].to_vec().into_boxed_slice()
@@ -104,8 +104,8 @@ impl PublicKey {
 
     #[cfg(feature = "alloc")]
     /// Get encoded point from [`PublicKey`]
-    pub fn to_encoded_point(&self) -> EncodedPoint {
-        self.point.to_encoded_point(false)
+    pub fn to_sec1_point(&self) -> Sec1Point {
+        self.point.to_sec1_point(false)
     }
 }
 
@@ -197,9 +197,9 @@ impl EncodePublicKey for PublicKey {
     }
 }
 
-impl From<PublicKey> for EncodedPoint {
+impl From<PublicKey> for Sec1Point {
     fn from(value: PublicKey) -> Self {
-        value.point.to_encoded_point(false)
+        value.point.to_sec1_point(false)
     }
 }
 

--- a/bignp256/tests/projective.rs
+++ b/bignp256/tests/projective.rs
@@ -8,7 +8,7 @@ use bignp256::{
 };
 use elliptic_curve::{
     group::{GroupEncoding, ff::PrimeField},
-    sec1::{self, ToEncodedPoint},
+    sec1::{self, ToSec1Point},
 };
 use primeorder::{Double, test_projective_arithmetic};
 

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,17 +14,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.15", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.16", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
-sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp256/src/r1.rs
+++ b/bp256/src/r1.rs
@@ -50,7 +50,7 @@ impl pkcs8::AssociatedOid for BrainpoolP256r1 {
 }
 
 /// brainpoolP256r1 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<BrainpoolP256r1>;
+pub type Sec1Point = elliptic_curve::sec1::Sec1Point<BrainpoolP256r1>;
 
 /// brainpoolP256r1 field element serialized as bytes.
 ///

--- a/bp256/src/t1.rs
+++ b/bp256/src/t1.rs
@@ -50,7 +50,7 @@ impl pkcs8::AssociatedOid for BrainpoolP256t1 {
 }
 
 /// brainpoolP256t1 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<BrainpoolP256t1>;
+pub type Sec1Point = elliptic_curve::sec1::Sec1Point<BrainpoolP256t1>;
 
 /// brainpoolP256t1 field element serialized as bytes.
 ///

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,17 +14,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.15", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.16", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
-sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp384/src/r1.rs
+++ b/bp384/src/r1.rs
@@ -50,7 +50,7 @@ impl pkcs8::AssociatedOid for BrainpoolP384r1 {
 }
 
 /// brainpoolP384r1 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<BrainpoolP384r1>;
+pub type Sec1Point = elliptic_curve::sec1::Sec1Point<BrainpoolP384r1>;
 
 /// brainpoolP384r1 field element serialized as bytes.
 ///

--- a/bp384/src/t1.rs
+++ b/bp384/src/t1.rs
@@ -50,7 +50,7 @@ impl pkcs8::AssociatedOid for BrainpoolP384t1 {
 }
 
 /// brainpoolP384t1 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<BrainpoolP384t1>;
+pub type Sec1Point = elliptic_curve::sec1::Sec1Point<BrainpoolP384t1>;
 
 /// brainpoolP384t1 field element serialized as bytes.
 ///

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -16,10 +16,10 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.27", features = ["arithmetic", "pkcs8"] }
+elliptic-curve = { version = "0.14.0-rc.28", features = ["arithmetic", "pkcs8"] }
 hash2curve = "0.14.0-rc.9"
 rand_core = { version = "0.10", default-features = false }
-sha3 = { version = "0.11.0-rc.4", default-features = false }
+sha3 = { version = "0.11.0-rc.5", default-features = false }
 subtle = { version = "2.6", default-features = false }
 
 # optional dependencies

--- a/ed448-goldilocks/src/sign/signing_key.rs
+++ b/ed448-goldilocks/src/sign/signing_key.rs
@@ -10,7 +10,7 @@ use elliptic_curve::{
 };
 use sha3::digest::{
     Digest, ExtendableOutput, FixedOutput, FixedOutputReset, HashMarker, Update, XofReader,
-    consts::U64, crypto_common::BlockSizeUser, typenum::IsEqual,
+    common::BlockSizeUser, consts::U64, typenum::IsEqual,
 };
 use signature::Error;
 use subtle::{Choice, ConstantTimeEq};

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -14,10 +14,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-digest = { version = "0.11.0-rc.10" }
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["arithmetic"] }
+digest = { version = "0.11.0-rc.11" }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["arithmetic"] }
 
 [dev-dependencies]
 hex-literal = "1"
-sha2 = { version = "0.11.0-rc.4", default-features = false }
-sha3 = { version = "0.11.0-rc.4", default-features = false }
+sha2 = { version = "0.11.0-rc.5", default-features = false }
+sha3 = { version = "0.11.0-rc.5", default-features = false }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,26 +20,26 @@ rust-version = "1.85"
 
 [dependencies]
 cpubits = "0.1.0-rc.3"
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["sec1"] }
 hash2curve = { version = "0.14.0-rc.9", optional = true }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 signature = { version = "3.0.0-rc.10", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4.3"
 hex-literal = "1"
 num-bigint = "0.4"
 num-traits = "0.2"
 proptest = "1.9"
-sha3 = { version = "0.11.0-rc.6", default-features = false }
+sha3 = { version = "0.11.0-rc.7", default-features = false }
 
 [features]
 default = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "schnorr", "std"]

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::op_ref)]
 
 use super::{AffinePoint, CURVE_EQUATION_B_SINGLE, FieldElement, Scalar};
-use crate::{CompressedPoint, EncodedPoint, PublicKey, Secp256k1};
+use crate::{CompressedPoint, PublicKey, Sec1Point, Secp256k1};
 use core::{
     iter::Sum,
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
@@ -18,7 +18,7 @@ use elliptic_curve::{
     ops::BatchInvert,
     point::NonIdentity,
     rand_core::{TryCryptoRng, TryRng},
-    sec1::{FromEncodedPoint, ToEncodedPoint},
+    sec1::{FromSec1Point, ToSec1Point},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
 };
@@ -347,15 +347,15 @@ impl From<&ProjectivePoint> for AffinePoint {
     }
 }
 
-impl FromEncodedPoint<Secp256k1> for ProjectivePoint {
-    fn from_encoded_point(p: &EncodedPoint) -> ctutils::CtOption<Self> {
-        AffinePoint::from_encoded_point(p).map(ProjectivePoint::from)
+impl FromSec1Point<Secp256k1> for ProjectivePoint {
+    fn from_sec1_point(p: &Sec1Point) -> ctutils::CtOption<Self> {
+        AffinePoint::from_sec1_point(p).map(ProjectivePoint::from)
     }
 }
 
-impl ToEncodedPoint<Secp256k1> for ProjectivePoint {
-    fn to_encoded_point(&self, compress: bool) -> EncodedPoint {
-        self.to_affine().to_encoded_point(compress)
+impl ToSec1Point<Secp256k1> for ProjectivePoint {
+    fn to_sec1_point(&self, compress: bool) -> Sec1Point {
+        self.to_affine().to_sec1_point(compress)
     }
 }
 

--- a/k256/src/ecdh.rs
+++ b/k256/src/ecdh.rs
@@ -13,18 +13,18 @@
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! // NOTE: requires the `ecdh` and `getrandom` crate features are enabled
 //! use k256::{
-//!     EncodedPoint, PublicKey,
+//!     Sec1Point, PublicKey,
 //!     elliptic_curve::Generate,
 //!     ecdh::EphemeralSecret
 //! };
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::generate();
-//! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
+//! let alice_pk_bytes = Sec1Point::from(alice_secret.public_key());
 //!
 //! // Bob
 //! let bob_secret = EphemeralSecret::generate();
-//! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
+//! let bob_pk_bytes = Sec1Point::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it
 //! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())?;

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -28,13 +28,13 @@
 //!
 //! // Signing
 //! let signing_key = SigningKey::generate(); // Serialize with `::to_bytes()`
-//! let verifying_key_bytes = signing_key.verifying_key().to_encoded_point(true); // 33-bytes
+//! let verifying_key_bytes = signing_key.verifying_key().to_sec1_point(true); // 33-bytes
 //!
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature: Signature = signing_key.sign(message);
 //!
 //! // Verification
-//! use k256::{EncodedPoint, ecdsa::{VerifyingKey, signature::Verifier}};
+//! use k256::{Sec1Point, ecdsa::{VerifyingKey, signature::Verifier}};
 //!
 //! let verifying_key = VerifyingKey::from_sec1_bytes(verifying_key_bytes.as_ref())?;
 //! verifying_key.verify(message, &signature)?;
@@ -60,7 +60,7 @@
 //! use hex_literal::hex;
 //! use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
 //! use sha3::{Keccak256, Digest};
-//! use elliptic_curve::sec1::ToEncodedPoint;
+//! use elliptic_curve::sec1::ToSec1Point;
 //!
 //! let msg = b"example message";
 //!
@@ -171,7 +171,7 @@ mod tests {
     #[cfg(feature = "sha256")]
     mod recovery {
         use crate::{
-            EncodedPoint,
+            Sec1Point,
             ecdsa::{
                 RecoveryId, Signature, SigningKey, VerifyingKey, signature::hazmat::PrehashVerifier,
             },
@@ -218,7 +218,7 @@ mod tests {
                 let sig = Signature::try_from(vector.sig.as_slice()).unwrap();
                 let recid = vector.recid;
                 let pk = VerifyingKey::recover_from_digest(digest, &sig, recid).unwrap();
-                assert_eq!(&vector.pk[..], EncodedPoint::from(&pk).as_bytes());
+                assert_eq!(&vector.pk[..], Sec1Point::from(&pk).as_bytes());
             }
         }
 
@@ -262,7 +262,7 @@ mod tests {
     }
 
     mod wycheproof {
-        use crate::{EncodedPoint, Secp256k1};
+        use crate::{Sec1Point, Secp256k1};
         use ecdsa_core::{Signature, signature::Verifier};
         use elliptic_curve::array::typenum::Unsigned;
 
@@ -300,9 +300,8 @@ mod tests {
                 let x = element_from_padded_slice::<Secp256k1>(wx);
                 let y = element_from_padded_slice::<Secp256k1>(wy);
                 let q_encoded =
-                    EncodedPoint::from_affine_coordinates(&x, &y, /* compress= */ false);
-                let verifying_key =
-                    ecdsa_core::VerifyingKey::from_encoded_point(&q_encoded).unwrap();
+                    Sec1Point::from_affine_coordinates(&x, &y, /* compress= */ false);
+                let verifying_key = ecdsa_core::VerifyingKey::from_sec1_point(&q_encoded).unwrap();
 
                 let sig = if p1363_sig {
                     match Signature::<Secp256k1>::from_slice(sig) {

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -118,7 +118,7 @@ impl pkcs8::AssociatedOid for Secp256k1 {
 pub type CompressedPoint = Array<u8, U33>;
 
 /// SEC1-encoded secp256k1 (K-256) curve point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<Secp256k1>;
+pub type Sec1Point = elliptic_curve::sec1::Sec1Point<Secp256k1>;
 
 /// secp256k1 (K-256) field element serialized as bytes.
 ///

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
 

--- a/p192/src/lib.rs
+++ b/p192/src/lib.rs
@@ -72,7 +72,7 @@ impl pkcs8::AssociatedOid for NistP192 {
 pub type CompressedPoint = Array<u8, U25>;
 
 /// NIST P-192 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP192>;
+pub type Sec1Point = elliptic_curve::sec1::Sec1Point<NistP192>;
 
 /// NIST P-192 field element serialized as bytes.
 ///

--- a/p192/tests/projective.rs
+++ b/p192/tests/projective.rs
@@ -4,7 +4,7 @@
 
 use elliptic_curve::{
     group::ff::PrimeField,
-    sec1::{self, ToEncodedPoint},
+    sec1::{self, ToSec1Point},
 };
 use p192::{
     AffinePoint, ProjectivePoint, Scalar,

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,18 +17,18 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
 

--- a/p224/src/ecdh.rs
+++ b/p224/src/ecdh.rs
@@ -13,18 +13,18 @@
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! // NOTE: requires the `ecdh` and `getrandom` crate features are enabled
 //! use p224::{
-//!     EncodedPoint, PublicKey,
+//!     Sec1Point, PublicKey,
 //!     elliptic_curve::Generate,
 //!     ecdh::EphemeralSecret
 //! };
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::generate();
-//! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
+//! let alice_pk_bytes = Sec1Point::from(alice_secret.public_key());
 //!
 //! // Bob
 //! let bob_secret = EphemeralSecret::generate();
-//! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
+//! let bob_pk_bytes = Sec1Point::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it
 //! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())?;

--- a/p224/src/ecdsa.rs
+++ b/p224/src/ecdsa.rs
@@ -28,13 +28,13 @@
 //!
 //! // Signing
 //! let signing_key = SigningKey::generate(); // Serialize with `::to_bytes()`
-//! let verifying_key_bytes = signing_key.verifying_key().to_encoded_point(false); // 57-bytes
+//! let verifying_key_bytes = signing_key.verifying_key().to_sec1_point(false); // 57-bytes
 //!
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature: Signature = signing_key.sign(message);
 //!
 //! // Verification
-//! use p224::{EncodedPoint, ecdsa::{VerifyingKey, signature::Verifier}};
+//! use p224::{Sec1Point, ecdsa::{VerifyingKey, signature::Verifier}};
 //!
 //! let verifying_key = VerifyingKey::from_sec1_bytes(verifying_key_bytes.as_ref())?;
 //! verifying_key.verify(message, &signature)?;

--- a/p224/src/lib.rs
+++ b/p224/src/lib.rs
@@ -90,7 +90,7 @@ pub type BlindedScalar = elliptic_curve::scalar::BlindedScalar<NistP224>;
 pub type CompressedPoint = Array<u8, U29>;
 
 /// NIST P-224 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP224>;
+pub type Sec1Point = elliptic_curve::sec1::Sec1Point<NistP224>;
 
 /// NIST P-224 field element serialized as bytes.
 ///

--- a/p224/tests/projective.rs
+++ b/p224/tests/projective.rs
@@ -4,7 +4,7 @@
 
 use elliptic_curve::{
     group::ff::PrimeField,
-    sec1::{self, ToEncodedPoint},
+    sec1::{self, ToSec1Point},
 };
 use p224::{
     AffinePoint, ProjectivePoint, Scalar,

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,20 +18,20 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.9", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primefield = { version = "0.14.0-rc.6" }
 primeorder = { version = "0.14.0-rc.6", features = ["dev"] }

--- a/p256/src/arithmetic/hash2curve.rs
+++ b/p256/src/arithmetic/hash2curve.rs
@@ -98,7 +98,7 @@ mod tests {
         array::Array,
         bigint::{ArrayEncoding, CheckedSub, NonZero, U384, modular::ConstMontyParams},
         consts::U48,
-        sec1::{self, ToEncodedPoint},
+        sec1::{self, ToSec1Point},
     };
     use hash2curve::{self, ExpandMsgXmd, MapToCurve};
     use hex_literal::hex;
@@ -216,7 +216,7 @@ mod tests {
             // TODO(tarcieri): use coordinate APIs. See zkcrypto/group#30
             macro_rules! assert_point_eq {
                 ($actual:expr, $expected_x:expr, $expected_y:expr) => {
-                    let point = $actual.to_affine().to_encoded_point(false);
+                    let point = $actual.to_affine().to_sec1_point(false);
                     let (actual_x, actual_y) = match point.coordinates() {
                         sec1::Coordinates::Uncompressed { x, y } => (x, y),
                         _ => unreachable!(),

--- a/p256/src/ecdh.rs
+++ b/p256/src/ecdh.rs
@@ -13,18 +13,18 @@
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! // NOTE: requires the `ecdh` and `getrandom` crate features are enabled
 //! use p256::{
-//!     EncodedPoint, PublicKey,
+//!     Sec1Point, PublicKey,
 //!     elliptic_curve::Generate,
 //!     ecdh::EphemeralSecret
 //! };
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::generate();
-//! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
+//! let alice_pk_bytes = Sec1Point::from(alice_secret.public_key());
 //!
 //! // Bob
 //! let bob_secret = EphemeralSecret::generate();
-//! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
+//! let bob_pk_bytes = Sec1Point::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it
 //! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())?;

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -28,13 +28,13 @@
 //!
 //! // Signing
 //! let signing_key = SigningKey::generate(); // Serialize with `::to_bytes()`
-//! let verifying_key_bytes = signing_key.verifying_key().to_encoded_point(false); // 65-bytes
+//! let verifying_key_bytes = signing_key.verifying_key().to_sec1_point(false); // 65-bytes
 //!
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature: Signature = signing_key.sign(message);
 //!
 //! // Verification
-//! use p256::{EncodedPoint, ecdsa::{VerifyingKey, signature::Verifier}};
+//! use p256::{Sec1Point, ecdsa::{VerifyingKey, signature::Verifier}};
 //!
 //! let verifying_key = VerifyingKey::from_sec1_bytes(verifying_key_bytes.as_ref())?;
 //! verifying_key.verify(message, &signature)?;
@@ -75,14 +75,14 @@ impl ecdsa_core::hazmat::DigestAlgorithm for NistP256 {
 #[cfg(all(test, feature = "ecdsa"))]
 mod tests {
     use crate::{
-        AffinePoint, EncodedPoint,
+        AffinePoint, Sec1Point,
         ecdsa::{
             Signature, SigningKey, VerifyingKey,
             signature::Signer,
             signature::hazmat::{PrehashSigner, PrehashVerifier},
         },
     };
-    use elliptic_curve::sec1::FromEncodedPoint;
+    use elliptic_curve::sec1::FromSec1Point;
     use hex_literal::hex;
     use sha2::Digest;
 
@@ -133,7 +133,7 @@ mod tests {
         // (P-256, SHA-384, from `SigGen.txt` in `186-4ecdsatestvectors.zip`)
         // <https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/digital-signatures>
         let verifier = VerifyingKey::from_affine(
-            AffinePoint::from_encoded_point(&EncodedPoint::from_affine_coordinates(
+            AffinePoint::from_sec1_point(&Sec1Point::from_affine_coordinates(
                 &hex!("e0e7b99bc62d8dd67883e39ed9fa0657789c5ff556cc1fd8dd1e2a55e9e3f243").into(),
                 &hex!("63fbfd0232b95578075c903a4dbf85ad58f8350516e1ec89b0ee1f5e1362da69").into(),
                 false,

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -137,7 +137,7 @@ pub type BlindedScalar = elliptic_curve::scalar::BlindedScalar<NistP256>;
 pub type CompressedPoint = Array<u8, U33>;
 
 /// NIST P-256 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP256>;
+pub type Sec1Point = elliptic_curve::sec1::Sec1Point<NistP256>;
 
 /// NIST P-256 field element serialized as bytes.
 ///

--- a/p256/tests/affine.rs
+++ b/p256/tests/affine.rs
@@ -4,10 +4,10 @@
 
 use elliptic_curve::{
     group::{GroupEncoding, prime::PrimeCurveAffine},
-    sec1::{FromEncodedPoint, ToCompactEncodedPoint, ToEncodedPoint},
+    sec1::{FromSec1Point, ToCompactSec1Point, ToSec1Point},
 };
 use hex_literal::hex;
-use p256::{AffinePoint, EncodedPoint};
+use p256::{AffinePoint, Sec1Point};
 
 const UNCOMPRESSED_BASEPOINT: &[u8] = &hex!(
     "04 6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296
@@ -29,42 +29,42 @@ const UNCOMPACT_BASEPOINT: &[u8] = &hex!(
 
 #[test]
 fn uncompressed_round_trip() {
-    let pubkey = EncodedPoint::from_bytes(UNCOMPRESSED_BASEPOINT).unwrap();
-    let point = AffinePoint::from_encoded_point(&pubkey).unwrap();
+    let pubkey = Sec1Point::from_bytes(UNCOMPRESSED_BASEPOINT).unwrap();
+    let point = AffinePoint::from_sec1_point(&pubkey).unwrap();
     assert_eq!(point, AffinePoint::generator());
 
-    let res: EncodedPoint = point.into();
+    let res: Sec1Point = point.into();
     assert_eq!(res, pubkey);
 }
 
 #[test]
 fn compressed_round_trip() {
-    let pubkey = EncodedPoint::from_bytes(COMPRESSED_BASEPOINT).unwrap();
-    let point = AffinePoint::from_encoded_point(&pubkey).unwrap();
+    let pubkey = Sec1Point::from_bytes(COMPRESSED_BASEPOINT).unwrap();
+    let point = AffinePoint::from_sec1_point(&pubkey).unwrap();
     assert_eq!(point, AffinePoint::generator());
 
-    let res: EncodedPoint = point.to_encoded_point(true);
+    let res: Sec1Point = point.to_sec1_point(true);
     assert_eq!(res, pubkey);
 }
 
 #[test]
 fn uncompressed_to_compressed() {
-    let encoded = EncodedPoint::from_bytes(UNCOMPRESSED_BASEPOINT).unwrap();
+    let encoded = Sec1Point::from_bytes(UNCOMPRESSED_BASEPOINT).unwrap();
 
-    let res = AffinePoint::from_encoded_point(&encoded)
+    let res = AffinePoint::from_sec1_point(&encoded)
         .unwrap()
-        .to_encoded_point(true);
+        .to_sec1_point(true);
 
     assert_eq!(res.as_bytes(), COMPRESSED_BASEPOINT);
 }
 
 #[test]
 fn compressed_to_uncompressed() {
-    let encoded = EncodedPoint::from_bytes(COMPRESSED_BASEPOINT).unwrap();
+    let encoded = Sec1Point::from_bytes(COMPRESSED_BASEPOINT).unwrap();
 
-    let res = AffinePoint::from_encoded_point(&encoded)
+    let res = AffinePoint::from_sec1_point(&encoded)
         .unwrap()
-        .to_encoded_point(false);
+        .to_sec1_point(false);
 
     assert_eq!(res.as_bytes(), UNCOMPRESSED_BASEPOINT);
 }
@@ -77,32 +77,32 @@ fn affine_negation() {
 
 #[test]
 fn compact_round_trip() {
-    let pubkey = EncodedPoint::from_bytes(COMPACT_BASEPOINT).unwrap();
+    let pubkey = Sec1Point::from_bytes(COMPACT_BASEPOINT).unwrap();
     assert!(pubkey.is_compact());
 
-    let point = AffinePoint::from_encoded_point(&pubkey).unwrap();
+    let point = AffinePoint::from_sec1_point(&pubkey).unwrap();
     let res = point.to_compact_encoded_point().unwrap();
     assert_eq!(res, pubkey)
 }
 
 #[test]
 fn uncompact_to_compact() {
-    let pubkey = EncodedPoint::from_bytes(UNCOMPACT_BASEPOINT).unwrap();
+    let pubkey = Sec1Point::from_bytes(UNCOMPACT_BASEPOINT).unwrap();
     assert!(!pubkey.is_compact());
 
-    let point = AffinePoint::from_encoded_point(&pubkey).unwrap();
+    let point = AffinePoint::from_sec1_point(&pubkey).unwrap();
     let res = point.to_compact_encoded_point().unwrap();
     assert_eq!(res.as_bytes(), COMPACT_BASEPOINT)
 }
 
 #[test]
 fn compact_to_uncompact() {
-    let pubkey = EncodedPoint::from_bytes(COMPACT_BASEPOINT).unwrap();
+    let pubkey = Sec1Point::from_bytes(COMPACT_BASEPOINT).unwrap();
     assert!(pubkey.is_compact());
 
-    let point = AffinePoint::from_encoded_point(&pubkey).unwrap();
+    let point = AffinePoint::from_sec1_point(&pubkey).unwrap();
     // Do not do compact encoding as we want to keep uncompressed point
-    let res = point.to_encoded_point(false);
+    let res = point.to_sec1_point(false);
     assert_eq!(res.as_bytes(), UNCOMPACT_BASEPOINT);
 }
 

--- a/p256/tests/pkcs8.rs
+++ b/p256/tests/pkcs8.rs
@@ -4,7 +4,7 @@
 
 use hex_literal::hex;
 use p256::{
-    elliptic_curve::sec1::ToEncodedPoint,
+    elliptic_curve::sec1::ToSec1Point,
     pkcs8::{DecodePrivateKey, DecodePublicKey},
 };
 
@@ -39,7 +39,7 @@ fn decode_pkcs8_public_key_from_der() {
         "041CACFFB55F2F2CEFD89D89EB374B2681152452802DEEA09916068137D839CF7FC481A44492304D7EF66AC117BEFE83A8D08F155F2B52F9F618DD447029048E0F"
     );
     assert_eq!(
-        public_key.to_encoded_point(false).as_bytes(),
+        public_key.to_sec1_point(false).as_bytes(),
         &expected_sec1_point[..]
     );
 }

--- a/p256/tests/projective.rs
+++ b/p256/tests/projective.rs
@@ -9,7 +9,7 @@ use elliptic_curve::{
     group::{GroupEncoding, ff::PrimeField},
     ops::{LinearCombination, Reduce, ReduceNonZero},
     point::NonIdentity,
-    sec1::{self, ToEncodedPoint},
+    sec1::{self, ToSec1Point},
 };
 use p256::{
     AffinePoint, FieldBytes, NonZeroScalar, ProjectivePoint, Scalar,

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,23 +18,23 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.9", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 
 [target.'cfg(not(p384_backend = "bignum"))'.dependencies]
 fiat-crypto = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
 proptest = "1.9"

--- a/p384/src/arithmetic/hash2curve.rs
+++ b/p384/src/arithmetic/hash2curve.rs
@@ -102,7 +102,7 @@ mod tests {
         ff::Field,
         group::cofactor::CofactorGroup,
         ops::Reduce,
-        sec1::{self, ToEncodedPoint},
+        sec1::{self, ToSec1Point},
     };
     use hash2curve::{self, ExpandMsgXmd, MapToCurve};
     use hex_literal::hex;
@@ -217,7 +217,7 @@ mod tests {
             // TODO(tarcieri): use coordinate APIs. See zkcrypto/group#30
             macro_rules! assert_point_eq {
                 ($actual:expr, $expected_x:expr, $expected_y:expr) => {
-                    let point = $actual.to_affine().to_encoded_point(false);
+                    let point = $actual.to_affine().to_sec1_point(false);
                     let (actual_x, actual_y) = match point.coordinates() {
                         sec1::Coordinates::Uncompressed { x, y } => (x, y),
                         _ => unreachable!(),

--- a/p384/src/ecdh.rs
+++ b/p384/src/ecdh.rs
@@ -13,18 +13,18 @@
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! // NOTE: requires the `ecdh` and `getrandom` crate features are enabled
 //! use p384::{
-//!     EncodedPoint, PublicKey,
+//!     Sec1Point, PublicKey,
 //!     elliptic_curve::Generate,
 //!     ecdh::EphemeralSecret
 //! };
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::generate();
-//! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
+//! let alice_pk_bytes = Sec1Point::from(alice_secret.public_key());
 //!
 //! // Bob
 //! let bob_secret = EphemeralSecret::generate();
-//! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
+//! let bob_pk_bytes = Sec1Point::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it
 //! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())?;

--- a/p384/src/ecdsa.rs
+++ b/p384/src/ecdsa.rs
@@ -28,13 +28,13 @@
 //!
 //! // Signing
 //! let signing_key = SigningKey::generate(); // Serialize with `::to_bytes()`
-//! let verifying_key_bytes = signing_key.verifying_key().to_encoded_point(false); // 97-bytes
+//! let verifying_key_bytes = signing_key.verifying_key().to_sec1_point(false); // 97-bytes
 //!
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature: Signature = signing_key.sign(message);
 //!
 //! // Verification
-//! use p384::{EncodedPoint, ecdsa::{VerifyingKey, signature::Verifier}};
+//! use p384::{Sec1Point, ecdsa::{VerifyingKey, signature::Verifier}};
 //!
 //! let verifying_key = VerifyingKey::from_sec1_bytes(verifying_key_bytes.as_ref())?;
 //! verifying_key.verify(message, &signature)?;
@@ -73,7 +73,7 @@ impl ecdsa_core::hazmat::DigestAlgorithm for NistP384 {
 #[cfg(all(test, feature = "ecdsa"))]
 mod tests {
     use crate::{
-        AffinePoint, EncodedPoint, SecretKey,
+        AffinePoint, Sec1Point, SecretKey,
         ecdsa::{
             Signature, SigningKey, VerifyingKey,
             signature::Signer,
@@ -81,7 +81,7 @@ mod tests {
         },
     };
 
-    use elliptic_curve::sec1::FromEncodedPoint;
+    use elliptic_curve::sec1::FromSec1Point;
     use hex_literal::hex;
     use sha2::Digest;
 
@@ -137,8 +137,8 @@ mod tests {
         // (P-384, SHA-256, from `SigGen.txt` in `186-4ecdsatestvectors.zip`)
         // <https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/digital-signatures>
         let verifier = VerifyingKey::from_affine(
-            AffinePoint::from_encoded_point(
-                &EncodedPoint::from_affine_coordinates(
+            AffinePoint::from_sec1_point(
+                &Sec1Point::from_affine_coordinates(
                     &hex!("0400193b21f07cd059826e9453d3e96dd145041c97d49ff6b7047f86bb0b0439e909274cb9c282bfab88674c0765bc75").into(),
                     &hex! ("f70d89c52acbc70468d2c5ae75c76d7f69b76af62dcf95e99eba5dd11adf8f42ec9a425b0c5ec98e2f234a926b82a147").into(),
                     false,

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -114,7 +114,7 @@ impl pkcs8::AssociatedOid for NistP384 {
 pub type CompressedPoint = Array<u8, U49>;
 
 /// NIST P-384 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP384>;
+pub type Sec1Point = elliptic_curve::sec1::Sec1Point<NistP384>;
 
 /// NIST P-384 field element serialized as bytes.
 ///

--- a/p384/tests/affine.rs
+++ b/p384/tests/affine.rs
@@ -6,11 +6,11 @@
 
 use elliptic_curve::{
     group::{GroupEncoding, prime::PrimeCurveAffine},
-    sec1::{FromEncodedPoint, ToEncodedPoint},
+    sec1::{FromSec1Point, ToSec1Point},
 };
 use hex_literal::hex;
 
-use p384::{AffinePoint, EncodedPoint};
+use p384::{AffinePoint, Sec1Point};
 
 const UNCOMPRESSED_BASEPOINT: &[u8] = &hex!(
     "04 aa87ca22 be8b0537 8eb1c71e f320ad74 6e1d3b62 8ba79b98
@@ -26,42 +26,42 @@ const COMPRESSED_BASEPOINT: &[u8] = &hex!(
 
 #[test]
 fn uncompressed_round_trip() {
-    let pubkey = EncodedPoint::from_bytes(UNCOMPRESSED_BASEPOINT).unwrap();
-    let point = AffinePoint::from_encoded_point(&pubkey).unwrap();
+    let pubkey = Sec1Point::from_bytes(UNCOMPRESSED_BASEPOINT).unwrap();
+    let point = AffinePoint::from_sec1_point(&pubkey).unwrap();
     assert_eq!(point, AffinePoint::generator());
 
-    let res: EncodedPoint = point.into();
+    let res: Sec1Point = point.into();
     assert_eq!(res, pubkey);
 }
 
 #[test]
 fn compressed_round_trip() {
-    let pubkey = EncodedPoint::from_bytes(COMPRESSED_BASEPOINT).unwrap();
-    let point = AffinePoint::from_encoded_point(&pubkey).unwrap();
+    let pubkey = Sec1Point::from_bytes(COMPRESSED_BASEPOINT).unwrap();
+    let point = AffinePoint::from_sec1_point(&pubkey).unwrap();
     assert_eq!(point, AffinePoint::generator());
 
-    let res: EncodedPoint = point.to_encoded_point(true);
+    let res: Sec1Point = point.to_sec1_point(true);
     assert_eq!(res, pubkey);
 }
 
 #[test]
 fn uncompressed_to_compressed() {
-    let encoded = EncodedPoint::from_bytes(UNCOMPRESSED_BASEPOINT).unwrap();
+    let encoded = Sec1Point::from_bytes(UNCOMPRESSED_BASEPOINT).unwrap();
 
-    let res = AffinePoint::from_encoded_point(&encoded)
+    let res = AffinePoint::from_sec1_point(&encoded)
         .unwrap()
-        .to_encoded_point(true);
+        .to_sec1_point(true);
 
     assert_eq!(res.as_bytes(), COMPRESSED_BASEPOINT);
 }
 
 #[test]
 fn compressed_to_uncompressed() {
-    let encoded = EncodedPoint::from_bytes(COMPRESSED_BASEPOINT).unwrap();
+    let encoded = Sec1Point::from_bytes(COMPRESSED_BASEPOINT).unwrap();
 
-    let res = AffinePoint::from_encoded_point(&encoded)
+    let res = AffinePoint::from_sec1_point(&encoded)
         .unwrap()
-        .to_encoded_point(false);
+        .to_sec1_point(false);
 
     assert_eq!(res.as_bytes(), UNCOMPRESSED_BASEPOINT);
 }

--- a/p384/tests/projective.rs
+++ b/p384/tests/projective.rs
@@ -4,7 +4,7 @@
 
 use elliptic_curve::{
     PrimeField,
-    sec1::{self, ToEncodedPoint},
+    sec1::{self, ToSec1Point},
 };
 use p384::{
     AffinePoint, ProjectivePoint, Scalar,

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -18,21 +18,21 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "1"
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.9", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
 rand_core = { version = "0.10", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.15", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.16", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.6", features = ["dev"] }
 proptest = "1.9"

--- a/p521/src/arithmetic/hash2curve.rs
+++ b/p521/src/arithmetic/hash2curve.rs
@@ -106,7 +106,7 @@ mod tests {
         consts::U98,
         group::cofactor::CofactorGroup,
         ops::Reduce,
-        sec1::{self, ToEncodedPoint},
+        sec1::{self, ToSec1Point},
     };
     use hash2curve::{self, ExpandMsgXmd, MapToCurve};
     use hex_literal::hex;
@@ -225,7 +225,7 @@ mod tests {
             // TODO(tarcieri): use coordinate APIs. See zkcrypto/group#30
             macro_rules! assert_point_eq {
                 ($actual:expr, $expected_x:expr, $expected_y:expr) => {
-                    let point = $actual.to_affine().to_encoded_point(false);
+                    let point = $actual.to_affine().to_sec1_point(false);
                     let (actual_x, actual_y) = match point.coordinates() {
                         sec1::Coordinates::Uncompressed { x, y } => (x, y),
                         _ => unreachable!(),

--- a/p521/src/ecdh.rs
+++ b/p521/src/ecdh.rs
@@ -13,18 +13,18 @@
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! // NOTE: requires the `ecdh` and `getrandom` crate features are enabled
 //! use p521::{
-//!     EncodedPoint, PublicKey,
+//!     Sec1Point, PublicKey,
 //!     elliptic_curve::Generate,
 //!     ecdh::EphemeralSecret
 //! };
 //!
 //! // Alice
 //! let alice_secret = EphemeralSecret::generate();
-//! let alice_pk_bytes = EncodedPoint::from(alice_secret.public_key());
+//! let alice_pk_bytes = Sec1Point::from(alice_secret.public_key());
 //!
 //! // Bob
 //! let bob_secret = EphemeralSecret::generate();
-//! let bob_pk_bytes = EncodedPoint::from(bob_secret.public_key());
+//! let bob_pk_bytes = Sec1Point::from(bob_secret.public_key());
 //!
 //! // Alice decodes Bob's serialized public key and computes a shared secret from it
 //! let bob_public = PublicKey::from_sec1_bytes(bob_pk_bytes.as_ref())?;

--- a/p521/src/ecdsa.rs
+++ b/p521/src/ecdsa.rs
@@ -28,13 +28,13 @@
 //!
 //! // Signing
 //! let signing_key = SigningKey::generate(); // Serialize with `::to_bytes()`
-//! let verifying_key_bytes = signing_key.verifying_key().to_encoded_point(false); // 133-bytes
+//! let verifying_key_bytes = signing_key.verifying_key().to_sec1_point(false); // 133-bytes
 //!
 //! let message = b"ECDSA proves knowledge of a secret number in the context of a single message";
 //! let signature: Signature = signing_key.sign(message);
 //!
 //! // Verification
-//! use p521::{EncodedPoint, ecdsa::{VerifyingKey, signature::Verifier}};
+//! use p521::{Sec1Point, ecdsa::{VerifyingKey, signature::Verifier}};
 //!
 //! let verifying_key = VerifyingKey::from_sec1_bytes(verifying_key_bytes.as_ref())?;
 //! verifying_key.verify(message, &signature)?;

--- a/p521/src/lib.rs
+++ b/p521/src/lib.rs
@@ -109,7 +109,7 @@ impl pkcs8::AssociatedOid for NistP521 {
 pub type CompressedPoint = Array<u8, U66>;
 
 /// NIST P-521 SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<NistP521>;
+pub type Sec1Point = elliptic_curve::sec1::Sec1Point<NistP521>;
 
 /// NIST P-521 field element serialized as bytes.
 ///

--- a/p521/tests/projective.rs
+++ b/p521/tests/projective.rs
@@ -4,7 +4,7 @@
 
 use elliptic_curve::{
     group::ff::PrimeField,
-    sec1::{self, ToEncodedPoint},
+    sec1::{self, ToSec1Point},
 };
 use p521::{
     AffinePoint, ProjectivePoint, Scalar,

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -17,9 +17,9 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-bigint = { package = "crypto-bigint", version = "0.7.0-rc.24", default-features = false, features = ["rand_core", "hybrid-array", "subtle"] }
-common = { package = "crypto-common", version = "0.2.0-rc.14", features = ["rand_core"] }
-ff = { version = "=0.14.0-pre.1", package = "rustcrypto-ff", default-features = false }
+bigint = { package = "crypto-bigint", version = "0.7.0-rc.25", default-features = false, features = ["rand_core", "hybrid-array", "subtle"] }
+common = { package = "crypto-common", version = "0.2.0-rc.15", features = ["rand_core"] }
+ff = { version = "0.14.0-rc.0", package = "rustcrypto-ff", default-features = false }
 subtle = { version = "2.6", default-features = false, features = ["const-generics"] }
 rand_core = { version = "0.10", default-features = false }
 zeroize = { version = "1.7", default-features = false }

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true, default-features = false }

--- a/primeorder/src/dev.rs
+++ b/primeorder/src/dev.rs
@@ -16,7 +16,7 @@ macro_rules! test_projective_arithmetic {
             ($actual:expr, $expected:expr) => {
                 let (expected_x, expected_y) = $expected;
 
-                let point = $actual.to_affine().to_encoded_point(false);
+                let point = $actual.to_affine().to_sec1_point(false);
                 let (actual_x, actual_y) = match point.coordinates() {
                     sec1::Coordinates::Uncompressed { x, y } => (x, y),
                     _ => unreachable!(),

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -24,8 +24,7 @@ use elliptic_curve::{
     point::{Double, NonIdentity},
     rand_core::{TryCryptoRng, TryRng},
     sec1::{
-        CompressedPoint, EncodedPoint, FromEncodedPoint, ModulusSize, ToEncodedPoint,
-        UncompressedPointSize,
+        CompressedPoint, FromSec1Point, ModulusSize, Sec1Point, ToSec1Point, UncompressedPointSize,
     },
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
@@ -229,15 +228,15 @@ where
     }
 }
 
-impl<C> FromEncodedPoint<C> for ProjectivePoint<C>
+impl<C> FromSec1Point<C> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
     FieldBytes<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
     CompressedPoint<C>: Copy,
 {
-    fn from_encoded_point(p: &EncodedPoint<C>) -> ctutils::CtOption<Self> {
-        AffinePoint::<C>::from_encoded_point(p).map(Self::from)
+    fn from_sec1_point(p: &Sec1Point<C>) -> ctutils::CtOption<Self> {
+        AffinePoint::<C>::from_sec1_point(p).map(Self::from)
     }
 }
 
@@ -553,15 +552,15 @@ where
     }
 }
 
-impl<C> ToEncodedPoint<C> for ProjectivePoint<C>
+impl<C> ToSec1Point<C> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
     CompressedPoint<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
     <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
-    fn to_encoded_point(&self, compress: bool) -> EncodedPoint<C> {
-        self.to_affine().to_encoded_point(compress)
+    fn to_sec1_point(&self, compress: bool) -> Sec1Point<C> {
+        self.to_affine().to_sec1_point(compress)
     }
 }
 

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -18,22 +18,22 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
 rand_core = { version = "0.10", default-features = false }
 
 # optional dependencies
+der = { version = "0.8.0-rc.10", optional = true }
 primefield = { version = "0.14.0-rc.6", optional = true }
 primeorder = { version = "0.14.0-rc.6", optional = true }
-rfc6979 = { version = "0.5.0-rc.4", optional = true }
+rfc6979 = { version = "0.5.0-rc.5", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 signature = { version = "3.0.0-rc.10", optional = true, features = ["rand_core"] }
-sm3 = { version = "0.5.0-rc.3", optional = true, default-features = false }
-der = { version = "0.8.0-rc.10", optional = true }
+sm3 = { version = "0.5.0-rc.5", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.27", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["dev"] }
 hex-literal = "1"
 proptest = "1"
 

--- a/sm2/src/distid.rs
+++ b/sm2/src/distid.rs
@@ -3,7 +3,7 @@
 use crate::{AffinePoint, Hash, Sm2};
 use elliptic_curve::{
     Error, Result,
-    sec1::{self, ToEncodedPoint},
+    sec1::{self, ToSec1Point},
 };
 use primeorder::PrimeCurveParams;
 use sm3::{Digest, Sm3};
@@ -33,7 +33,7 @@ pub(crate) fn hash_z(distid: &DistId, public_key: &impl AsRef<AffinePoint>) -> R
     sm3.update(Sm2::GENERATOR.0.to_bytes());
     sm3.update(Sm2::GENERATOR.1.to_bytes());
 
-    match public_key.as_ref().to_encoded_point(false).coordinates() {
+    match public_key.as_ref().to_sec1_point(false).coordinates() {
         sec1::Coordinates::Uncompressed { x, y } => {
             sm3.update(x);
             sm3.update(y);

--- a/sm2/src/dsa/verifying.rs
+++ b/sm2/src/dsa/verifying.rs
@@ -14,7 +14,7 @@
 
 use super::Signature;
 use crate::{
-    AffinePoint, DistId, EncodedPoint, FieldBytes, Hash, ProjectivePoint, PublicKey, Scalar, Sm2,
+    AffinePoint, DistId, FieldBytes, Hash, ProjectivePoint, PublicKey, Scalar, Sec1Point, Sm2,
     distid::hash_z,
 };
 use elliptic_curve::{
@@ -22,7 +22,7 @@ use elliptic_curve::{
     array::typenum::Unsigned,
     ops::{LinearCombination, Reduce},
     point::AffineCoordinates,
-    sec1::ToEncodedPoint,
+    sec1::ToSec1Point,
 };
 use signature::{Error, MultipartVerifier, Result, Verifier, hazmat::PrehashVerifier};
 use sm3::{Sm3, digest::Digest};
@@ -210,9 +210,9 @@ impl From<&VerifyingKey> for PublicKey {
     }
 }
 
-impl ToEncodedPoint<Sm2> for VerifyingKey {
-    fn to_encoded_point(&self, compress: bool) -> EncodedPoint {
-        self.as_affine().to_encoded_point(compress)
+impl ToSec1Point<Sm2> for VerifyingKey {
+    fn to_sec1_point(&self, compress: bool) -> Sec1Point {
+        self.as_affine().to_sec1_point(compress)
     }
 }
 

--- a/sm2/src/lib.rs
+++ b/sm2/src/lib.rs
@@ -125,7 +125,7 @@ pub type CompressedPoint = Array<u8, U33>;
 pub type UncompressedPoint = Array<u8, U65>;
 
 /// SEC1 encoded point.
-pub type EncodedPoint = elliptic_curve::sec1::EncodedPoint<Sm2>;
+pub type Sec1Point = elliptic_curve::sec1::Sec1Point<Sm2>;
 
 /// SM2 field element serialized as bytes.
 ///

--- a/sm2/src/pke.rs
+++ b/sm2/src/pke.rs
@@ -55,7 +55,7 @@ use elliptic_curve::{
         Decode, DecodeValue, Encode, EncodeValue, Length, Reader, Sequence, Tag, Writer,
         asn1::OctetStringRef, asn1::UintRef,
     },
-    sec1::ToEncodedPoint,
+    sec1::ToSec1Point,
 };
 use sm3::digest::DynDigest;
 
@@ -134,7 +134,7 @@ fn kdf(hasher: &mut dyn DynDigest, kpb: AffinePoint, c2: &mut [u8]) -> Result<()
     let mut offset = 0;
     let digest_size = hasher.output_size();
     let mut ha = vec![0u8; digest_size];
-    let encode_point = kpb.to_encoded_point(false);
+    let encode_point = kpb.to_sec1_point(false);
 
     while offset < klen {
         hasher.update(encode_point.x().ok_or(elliptic_curve::Error)?);

--- a/sm2/src/pke/decrypting.rs
+++ b/sm2/src/pke/decrypting.rs
@@ -1,7 +1,7 @@
 use core::fmt::{self, Debug};
 
 use crate::{
-    AffinePoint, EncodedPoint, FieldBytes, NonZeroScalar, PublicKey, Scalar, SecretKey,
+    AffinePoint, FieldBytes, NonZeroScalar, PublicKey, Scalar, Sec1Point, SecretKey,
     UncompressedPoint, arithmetic::field::FieldElement,
 };
 
@@ -11,7 +11,7 @@ use elliptic_curve::{
     bigint::{ArrayEncoding, U256},
     ops::Reduce,
     pkcs8::der::Decode,
-    sec1::{FromEncodedPoint, ToEncodedPoint},
+    sec1::{FromSec1Point, ToSec1Point},
     subtle::{Choice, ConstantTimeEq},
 };
 use primeorder::PrimeField;
@@ -164,10 +164,10 @@ fn decrypt(
         .split_at_checked(size_of::<UncompressedPoint>())
         .ok_or(Error)?;
 
-    let encoded_c1 = EncodedPoint::from_bytes(c1).map_err(Error::from)?;
+    let encoded_c1 = Sec1Point::from_bytes(c1).map_err(Error::from)?;
 
     // verify that point c1 satisfies the elliptic curve
-    let mut c1_point = AffinePoint::from_encoded_point(&encoded_c1)
+    let mut c1_point = AffinePoint::from_sec1_point(&encoded_c1)
         .into_option()
         .ok_or(Error)?;
 
@@ -195,7 +195,7 @@ fn decrypt(
 
     // compute 𝑢 = 𝐻𝑎𝑠ℎ(𝑥2 ∥ 𝑀′∥ 𝑦2).
     let mut u = vec![0u8; digest_size];
-    let encode_point = c1_point.to_encoded_point(false);
+    let encode_point = c1_point.to_sec1_point(false);
     hasher.update(encode_point.x().ok_or(Error)?);
     hasher.update(&c2);
     hasher.update(encode_point.y().ok_or(Error)?);

--- a/sm2/src/pke/encrypting.rs
+++ b/sm2/src/pke/encrypting.rs
@@ -13,7 +13,7 @@ use elliptic_curve::{
     ops::Reduce,
     pkcs8::der::Encode,
     rand_core::TryCryptoRng,
-    sec1::ToEncodedPoint,
+    sec1::ToSec1Point,
 };
 
 use primeorder::PrimeField;
@@ -177,12 +177,12 @@ fn encrypt<R: TryCryptoRng + ?Sized>(
         // // If 𝑡 is an all-zero bit string, go to A1.
         // if all of t are 0, xor(c2) == c2
         if c2.iter().zip(msg).any(|(pre, cur)| pre != cur) {
-            let uncompress_kg = kg.to_encoded_point(false);
+            let uncompress_kg = kg.to_sec1_point(false);
             c1.copy_from_slice(uncompress_kg.as_bytes());
             break;
         }
     }
-    let encode_point = hpb.to_encoded_point(false);
+    let encode_point = hpb.to_sec1_point(false);
 
     // A7: compute 𝐶3 = 𝐻𝑎𝑠ℎ(𝑥2||𝑀||𝑦2)
     let mut c3 = vec![0; digest.output_size()];

--- a/sm2/tests/pkcs8.rs
+++ b/sm2/tests/pkcs8.rs
@@ -10,7 +10,7 @@ use sm2::pkcs8::DecodePublicKey;
 
 #[cfg(all(feature = "arithmetic", feature = "pem"))]
 use {
-    elliptic_curve::sec1::ToEncodedPoint,
+    elliptic_curve::sec1::ToSec1Point,
     sm2::elliptic_curve::pkcs8::{EncodePrivateKey, EncodePublicKey},
 };
 
@@ -61,7 +61,7 @@ fn decode_pkcs8_private_key_from_der() {
 
     #[cfg(feature = "arithmetic")]
     assert_eq!(
-        secret_key.public_key().to_encoded_point(false).as_bytes(),
+        secret_key.public_key().to_sec1_point(false).as_bytes(),
         &SEC1_PUBLIC_KEY[..]
     );
 }
@@ -72,7 +72,7 @@ fn decode_pkcs8_public_key_from_der() {
     let public_key = sm2::PublicKey::from_public_key_der(&PKCS8_PUBLIC_KEY_DER[..]).unwrap();
 
     assert_eq!(
-        public_key.to_encoded_point(false).as_bytes(),
+        public_key.to_sec1_point(false).as_bytes(),
         &SEC1_PUBLIC_KEY[..]
     );
 }


### PR DESCRIPTION
Upgrades the following dependencies:
- `belt-hash` v0.2.0-rc.5
- `crypto-bigint` v0.7.0-rc.25
- `crypto-common` v0.2.0-rc.15
- `digest` v0.11.0-rc.11
- `ecdsa` v0.17.0-rc.16
- `elliptic-curve` v0.14.0-rc.28
- `hkdf` v0.13.0-rc.5
- `hmac` v0.13.0-rc.5
- `rfc6979` v0.5.0-rc.5
- `(rustcrypto-)ff` v0.14.0-rc.0
- `sha2` v0.11.0-rc.5
- `sha3` v0.11.0-rc.7
- `sm3` v0.5.0-rc.5

This also includes the needed `*EncodedPoint` => `*Sec1Point` changes for compatibility with RustCrypto/traits#2264.