### PR TITLE
fix(k256): avoid redundant `Scalar::retrieve` byte roundtrip

### DIFF
--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -755,7 +755,7 @@ impl Retrieve for Scalar {
     type Output = U256;
 
     fn retrieve(&self) -> U256 {
-        U256::from_be_byte_array(self.to_bytes())
+        self.0
     }
 }
 


### PR DESCRIPTION
`Scalar::retrieve()` converted the inner `U256` to bytes and back (t`o_bytes() + from_be_byte_array()`), which is redundant because Scalar already stores a canonical `U256`. This added unnecessary work on hot paths like inversion without changing semantics.

`Scalar::retrieve()` now directly returns the inner `U256` (self.0), removing the extra encode/decode roundtrip while keeping behavior identical.