### PR TITLE
Initial `MulVartime` impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,8 +508,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7a0bfd012613a7bcfe02cbfccf2b846e9ef9e1bccb641c48d461253cfb034d"
+source = "git+https://github.com/RustCrypto/traits#b48dd1eb7647bb96ba213cc339bc985577e66c7e"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,5 @@ ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
+
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/ed448-goldilocks/src/decaf/affine.rs
+++ b/ed448-goldilocks/src/decaf/affine.rs
@@ -2,9 +2,9 @@ use crate::{
     Decaf448FieldBytes, DecafPoint, DecafScalar, ORDER,
     curve::twedwards::affine::AffinePoint as InnerAffinePoint, field::FieldElement,
 };
-use core::ops::Mul;
 use elliptic_curve::{
     Error, Generate, ctutils,
+    ops::{Mul, MulVartime},
     point::{AffineCoordinates, NonIdentity},
     zeroize::DefaultIsZeroes,
 };
@@ -131,6 +131,28 @@ impl Mul<&DecafScalar> for &AffinePoint {
     #[inline]
     fn mul(self, scalar: &DecafScalar) -> DecafPoint {
         self.to_decaf() * scalar
+    }
+}
+
+impl MulVartime<DecafScalar> for AffinePoint {
+    #[inline]
+    fn mul_vartime(self, scalar: DecafScalar) -> DecafPoint {
+        self.mul_vartime(&scalar)
+    }
+}
+
+impl MulVartime<&DecafScalar> for AffinePoint {
+    #[inline]
+    fn mul_vartime(self, scalar: &DecafScalar) -> DecafPoint {
+        // TODO(tarcieri): optimized vartime implementation
+        self.to_decaf() * scalar
+    }
+}
+
+impl MulVartime<&DecafScalar> for &AffinePoint {
+    #[inline]
+    fn mul_vartime(self, scalar: &DecafScalar) -> DecafPoint {
+        (*self).mul_vartime(scalar)
     }
 }
 

--- a/ed448-goldilocks/src/decaf/ops.rs
+++ b/ed448-goldilocks/src/decaf/ops.rs
@@ -1,10 +1,9 @@
 use crate::{DecafAffinePoint, DecafScalar, curve::scalar_mul::double_and_add};
-use core::{
-    borrow::Borrow,
-    iter::Sum,
-    ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+use core::{borrow::Borrow, iter::Sum};
+use elliptic_curve::{
+    CurveGroup,
+    ops::{Add, AddAssign, Mul, MulAssign, MulVartime, Neg, Sub, SubAssign},
 };
-use elliptic_curve::CurveGroup;
 
 use super::DecafPoint;
 
@@ -15,6 +14,25 @@ impl Mul<&DecafScalar> for &DecafPoint {
     fn mul(self, scalar: &DecafScalar) -> DecafPoint {
         // XXX: We can do better than double and add
         DecafPoint(double_and_add(&self.0, scalar.bits()).to_extended())
+    }
+}
+
+impl MulVartime<DecafScalar> for DecafPoint {
+    fn mul_vartime(self, scalar: DecafScalar) -> DecafPoint {
+        MulVartime::mul_vartime(&self, &scalar)
+    }
+}
+
+impl MulVartime<&DecafScalar> for DecafPoint {
+    fn mul_vartime(self, scalar: &DecafScalar) -> DecafPoint {
+        MulVartime::mul_vartime(&self, scalar)
+    }
+}
+
+impl MulVartime<&DecafScalar> for &DecafPoint {
+    fn mul_vartime(self, scalar: &DecafScalar) -> DecafPoint {
+        // TODO(tarcieri): optimized vartime implementation
+        self * scalar
     }
 }
 

--- a/ed448-goldilocks/src/edwards/affine.rs
+++ b/ed448-goldilocks/src/edwards/affine.rs
@@ -1,8 +1,11 @@
-use crate::field::FieldElement;
-use crate::*;
+use crate::{field::FieldElement, *};
 use core::fmt::{Display, Formatter, LowerHex, Result as FmtResult, UpperHex};
-use core::ops::Mul;
-use elliptic_curve::{Error, Generate, ctutils, point::NonIdentity, zeroize::DefaultIsZeroes};
+use elliptic_curve::{
+    Error, Generate, ctutils,
+    ops::{Mul, MulVartime},
+    point::NonIdentity,
+    zeroize::DefaultIsZeroes,
+};
 use rand_core::{TryCryptoRng, TryRng};
 use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq, CtOption};
 
@@ -217,6 +220,28 @@ impl Mul<&EdwardsScalar> for &AffinePoint {
     #[inline]
     fn mul(self, scalar: &EdwardsScalar) -> Self::Output {
         self.to_edwards() * scalar
+    }
+}
+
+impl MulVartime<EdwardsScalar> for AffinePoint {
+    #[inline]
+    fn mul_vartime(self, scalar: EdwardsScalar) -> Self::Output {
+        self.mul_vartime(&scalar)
+    }
+}
+
+impl MulVartime<&EdwardsScalar> for AffinePoint {
+    #[inline]
+    fn mul_vartime(self, scalar: &EdwardsScalar) -> Self::Output {
+        MulVartime::mul_vartime(&self, scalar)
+    }
+}
+
+impl MulVartime<&EdwardsScalar> for &AffinePoint {
+    #[inline]
+    fn mul_vartime(self, scalar: &EdwardsScalar) -> Self::Output {
+        // TODO(tarcieri): optimized vartime implementation
+        self * scalar
     }
 }
 

--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -1,7 +1,9 @@
-use core::borrow::Borrow;
-use core::fmt::{Display, Formatter, LowerHex, Result as FmtResult, UpperHex};
-use core::iter::Sum;
-use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use core::{
+    borrow::Borrow,
+    fmt::{Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
+    iter::Sum,
+};
+use elliptic_curve::ops::{Add, AddAssign, Mul, MulAssign, MulVartime, Neg, Sub, SubAssign};
 
 use crate::{
     GOLDILOCKS_BASE_POINT, MontgomeryPoint, U57, U448,
@@ -717,6 +719,25 @@ impl Mul<&EdwardsScalar> for &EdwardsPoint {
 
     /// Scalar multiplication: compute `scalar * self`.
     fn mul(self, scalar: &EdwardsScalar) -> EdwardsPoint {
+        self.scalar_mul(scalar)
+    }
+}
+
+impl MulVartime<EdwardsScalar> for EdwardsPoint {
+    fn mul_vartime(self, scalar: EdwardsScalar) -> EdwardsPoint {
+        self.mul_vartime(&scalar)
+    }
+}
+
+impl MulVartime<&EdwardsScalar> for EdwardsPoint {
+    fn mul_vartime(self, scalar: &EdwardsScalar) -> EdwardsPoint {
+        MulVartime::mul_vartime(&self, scalar)
+    }
+}
+
+impl MulVartime<&EdwardsScalar> for &EdwardsPoint {
+    fn mul_vartime(self, scalar: &EdwardsScalar) -> EdwardsPoint {
+        // TODO(tarcieri): optimized vartime implementation
         self.scalar_mul(scalar)
     }
 }

--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -1,11 +1,11 @@
 use crate::*;
 
-use core::cmp::Ordering;
-use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
-use core::iter::{Product, Sum};
-use core::marker::PhantomData;
-use core::ops::{
-    Add, AddAssign, Index, IndexMut, Mul, MulAssign, Neg, Shr, ShrAssign, Sub, SubAssign,
+use core::{
+    cmp::Ordering,
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    iter::{Product, Sum},
+    marker::PhantomData,
+    ops::{Index, IndexMut},
 };
 use elliptic_curve::{
     CurveArithmetic, Generate, PrimeField,
@@ -17,7 +17,10 @@ use elliptic_curve::{
     consts::U2,
     ctutils::{self, CtSelect},
     ff::{Field, helpers},
-    ops::{Invert, Reduce, ReduceNonZero},
+    ops::{
+        Add, AddAssign, Invert, Mul, MulAssign, Neg, Reduce, ReduceNonZero, Shr, ShrAssign, Sub,
+        SubAssign,
+    },
     scalar::{FromUintUnchecked, IsHigh},
 };
 use rand_core::{CryptoRng, Rng, TryCryptoRng, TryRng};

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -4,11 +4,11 @@
 
 use super::{CURVE_EQUATION_B, FieldElement, ProjectivePoint};
 use crate::{CompressedPoint, FieldBytes, PublicKey, Scalar, Sec1Point, Secp256k1};
-use core::ops::{Mul, Neg};
 use elliptic_curve::{
     Error, Generate, Result, ctutils,
     ff::PrimeField,
     group::{GroupEncoding, prime::PrimeCurveAffine},
+    ops::{Mul, MulVartime, Neg},
     point::{AffineCoordinates, DecompactPoint, DecompressPoint, NonIdentity},
     rand_core::{TryCryptoRng, TryRng},
     sec1::{self, FromSec1Point, ToSec1Point},
@@ -230,6 +230,18 @@ impl Mul<&Scalar> for AffinePoint {
 
     fn mul(self, scalar: &Scalar) -> ProjectivePoint {
         ProjectivePoint::from(self) * scalar
+    }
+}
+
+impl MulVartime<Scalar> for AffinePoint {
+    fn mul_vartime(self, scalar: Scalar) -> ProjectivePoint {
+        ProjectivePoint::from(self).mul_vartime(scalar)
+    }
+}
+
+impl MulVartime<&Scalar> for AffinePoint {
+    fn mul_vartime(self, scalar: &Scalar) -> ProjectivePoint {
+        ProjectivePoint::from(self).mul_vartime(scalar)
     }
 }
 

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -38,16 +38,25 @@ use crate::arithmetic::{
     ProjectivePoint,
     scalar::{Scalar, WideScalar},
 };
+use elliptic_curve::{
+    ops::{LinearCombination, Mul, MulAssign, MulVartime},
+    scalar::IsHigh,
+    subtle::ConditionallySelectable,
+};
 
-use core::ops::{Mul, MulAssign};
-use elliptic_curve::{ops::LinearCombination, scalar::IsHigh, subtle::ConditionallySelectable};
+#[cfg(feature = "precomputed-tables")]
+use elliptic_curve::point::PointWithBasepointTable;
 
-/// Lookup table for multiples of a given point.
-type LookupTable = elliptic_curve::point::LookupTable<ProjectivePoint>;
+/// Window size for the basepoint table.
+#[cfg(feature = "precomputed-tables")]
+const WINDOW_SIZE: usize = 33;
 
 /// Basepoint table for multiples of secp256k1's generator.
 #[cfg(feature = "precomputed-tables")]
-type BasepointTable = elliptic_curve::point::BasepointTable<ProjectivePoint, 33>;
+type BasepointTable = elliptic_curve::point::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
+
+/// Lookup table for multiples of a given point.
+type LookupTable = elliptic_curve::point::LookupTable<ProjectivePoint>;
 
 const MINUS_LAMBDA: Scalar = Scalar::from_bytes_unchecked(&[
     0xac, 0x9c, 0x52, 0xb3, 0x3f, 0xa3, 0xcf, 0x1f, 0x5a, 0xd9, 0xe3, 0xfd, 0x77, 0xed, 0x9b, 0xa4,
@@ -319,6 +328,11 @@ fn lincomb(
 #[cfg(feature = "precomputed-tables")]
 static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
 
+#[cfg(feature = "precomputed-tables")]
+impl PointWithBasepointTable<WINDOW_SIZE> for ProjectivePoint {
+    const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
+}
+
 impl ProjectivePoint {
     /// Calculates `k * G`, where `G` is the generator.
     #[cfg(not(feature = "precomputed-tables"))]
@@ -371,6 +385,27 @@ impl Mul<&Scalar> for ProjectivePoint {
     type Output = ProjectivePoint;
 
     fn mul(self, other: &Scalar) -> ProjectivePoint {
+        mul(&self, other)
+    }
+}
+
+impl MulVartime<Scalar> for ProjectivePoint {
+    fn mul_vartime(self, other: Scalar) -> ProjectivePoint {
+        // TODO(tarcieri): actual vartime implementation (i.e. wNAF)
+        mul(&self, &other)
+    }
+}
+
+impl MulVartime<&Scalar> for &ProjectivePoint {
+    fn mul_vartime(self, other: &Scalar) -> ProjectivePoint {
+        // TODO(tarcieri): actual vartime implementation (i.e. wNAF)
+        mul(self, other)
+    }
+}
+
+impl MulVartime<&Scalar> for ProjectivePoint {
+    // TODO(tarcieri): actual vartime implementation (i.e. wNAF)
+    fn mul_vartime(self, other: &Scalar) -> ProjectivePoint {
         mul(&self, other)
     }
 }

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -1,19 +1,16 @@
 //! Scalar field arithmetic.
 
-use crate::{
-    FieldBytes, NonZeroScalar, ORDER, ORDER_HEX, Secp256k1, WideBytes,
-    arithmetic::{AffinePoint, ProjectivePoint},
-};
-use core::{
-    iter::{Product, Sum},
-    ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, ShrAssign, Sub, SubAssign},
-};
+use crate::{FieldBytes, NonZeroScalar, ORDER, ORDER_HEX, Secp256k1, WideBytes};
+use core::iter::{Product, Sum};
 use elliptic_curve::{
     Curve, Error, Generate, ScalarValue,
     bigint::{ArrayEncoding, Limb, U256, U512, Word, cpubits, modular::Retrieve},
     ctutils,
     ff::{self, Field, FromUniformBytes, PrimeField},
-    ops::{Invert, Reduce, ReduceNonZero},
+    ops::{
+        Add, AddAssign, Invert, Mul, MulAssign, Neg, Reduce, ReduceNonZero, Shr, ShrAssign, Sub,
+        SubAssign,
+    },
     rand_core::{CryptoRng, TryCryptoRng, TryRng},
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{
@@ -615,77 +612,7 @@ impl Mul<&Scalar> for Scalar {
     }
 }
 
-impl Mul<AffinePoint> for Scalar {
-    type Output = ProjectivePoint;
-
-    #[inline]
-    fn mul(self, rhs: AffinePoint) -> ProjectivePoint {
-        rhs * self
-    }
-}
-
-impl Mul<&AffinePoint> for Scalar {
-    type Output = ProjectivePoint;
-
-    #[inline]
-    fn mul(self, rhs: &AffinePoint) -> ProjectivePoint {
-        *rhs * self
-    }
-}
-
-impl Mul<AffinePoint> for &Scalar {
-    type Output = ProjectivePoint;
-
-    #[inline]
-    fn mul(self, rhs: AffinePoint) -> ProjectivePoint {
-        rhs * self
-    }
-}
-
-impl Mul<&AffinePoint> for &Scalar {
-    type Output = ProjectivePoint;
-
-    #[inline]
-    fn mul(self, rhs: &AffinePoint) -> ProjectivePoint {
-        *rhs * self
-    }
-}
-
-impl Mul<ProjectivePoint> for Scalar {
-    type Output = ProjectivePoint;
-
-    #[inline]
-    fn mul(self, rhs: ProjectivePoint) -> ProjectivePoint {
-        rhs * self
-    }
-}
-
-impl Mul<&ProjectivePoint> for Scalar {
-    type Output = ProjectivePoint;
-
-    #[inline]
-    fn mul(self, rhs: &ProjectivePoint) -> ProjectivePoint {
-        rhs * &self
-    }
-}
-
-impl Mul<ProjectivePoint> for &Scalar {
-    type Output = ProjectivePoint;
-
-    #[inline]
-    fn mul(self, rhs: ProjectivePoint) -> ProjectivePoint {
-        rhs * self
-    }
-}
-
-impl Mul<&ProjectivePoint> for &Scalar {
-    type Output = ProjectivePoint;
-
-    #[inline]
-    fn mul(self, rhs: &ProjectivePoint) -> ProjectivePoint {
-        rhs * self
-    }
-}
+elliptic_curve::scalar_mul_impls!(Secp256k1, Scalar);
 
 impl MulAssign<Scalar> for Scalar {
     fn mul_assign(&mut self, rhs: Scalar) {

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -3,16 +3,14 @@
 #![allow(clippy::op_ref)]
 
 use crate::{PrimeCurveParams, ProjectivePoint};
-use core::{
-    borrow::Borrow,
-    ops::{Mul, Neg},
-};
+use core::borrow::Borrow;
 use elliptic_curve::{
     Error, FieldBytes, FieldBytesEncoding, FieldBytesSize, Generate, PublicKey, Result, Scalar,
     array::ArraySize,
     ctutils::{self, CtGt as _, CtSelect as _},
     ff::{Field, PrimeField},
     group::{GroupEncoding, prime::PrimeCurveAffine},
+    ops::{Mul, MulVartime, Neg},
     point::{AffineCoordinates, DecompactPoint, DecompressPoint, Double, NonIdentity},
     rand_core::{TryCryptoRng, TryRng},
     sec1::{
@@ -525,6 +523,30 @@ where
     #[inline]
     fn mul(self, scalar: S) -> ProjectivePoint<C> {
         ProjectivePoint::<C>::from(self) * scalar
+    }
+}
+
+impl<C, S> MulVartime<S> for AffinePoint<C>
+where
+    C: PrimeCurveParams,
+    S: Borrow<Scalar<C>>,
+    ProjectivePoint<C>: Double,
+{
+    #[inline]
+    fn mul_vartime(self, scalar: S) -> ProjectivePoint<C> {
+        ProjectivePoint::<C>::from(self).mul_vartime(scalar)
+    }
+}
+
+impl<C, S> MulVartime<S> for &AffinePoint<C>
+where
+    C: PrimeCurveParams,
+    S: Borrow<Scalar<C>>,
+    ProjectivePoint<C>: Double,
+{
+    #[inline]
+    fn mul_vartime(self, scalar: S) -> ProjectivePoint<C> {
+        ProjectivePoint::<C>::from(self).mul_vartime(scalar)
     }
 }
 

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -3,12 +3,7 @@
 #![allow(clippy::needless_range_loop, clippy::op_ref)]
 
 use crate::{AffinePoint, Field, PrimeCurveParams, point_arithmetic::PointArithmetic};
-use core::{
-    array,
-    borrow::Borrow,
-    iter::Sum,
-    ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
-};
+use core::{array, borrow::Borrow, iter::Sum};
 use elliptic_curve::{
     BatchNormalize, CurveGroup, Error, FieldBytes, FieldBytesSize, Generate, PrimeField, PublicKey,
     Result, Scalar,
@@ -20,7 +15,10 @@ use elliptic_curve::{
         cofactor::CofactorGroup,
         prime::{PrimeCurve, PrimeGroup},
     },
-    ops::{BatchInvert, LinearCombination},
+    ops::{
+        Add, AddAssign, BatchInvert, LinearCombination, Mul, MulAssign, MulVartime, Neg, Sub,
+        SubAssign,
+    },
     point::{Double, NonIdentity},
     rand_core::{TryCryptoRng, TryRng},
     sec1::{
@@ -118,6 +116,15 @@ where
         let mut pc = LookupTable::new(*self);
 
         lincomb(array::from_mut(&mut k), array::from_mut(&mut pc))
+    }
+
+    /// Returns `[k] self` computed in variable time.
+    fn mul_vartime(&self, k: &Scalar<C>) -> Self
+    where
+        Self: Double,
+    {
+        // TODO(tarcieri): use wNAF for variable-time scalar multiplication when available
+        self.mul(k)
     }
 
     /// Obtain a wNAF context for this group.
@@ -887,6 +894,38 @@ where
 
     fn mul(self, scalar: &Scalar<C>) -> ProjectivePoint<C> {
         ProjectivePoint::mul(self, scalar)
+    }
+}
+
+impl<C, S> MulVartime<S> for ProjectivePoint<C>
+where
+    Self: Double,
+    C: PrimeCurveParams,
+    S: Borrow<Scalar<C>>,
+{
+    fn mul_vartime(self, scalar: S) -> Self {
+        ProjectivePoint::mul_vartime(&self, scalar.borrow())
+    }
+}
+
+impl<C, S> MulVartime<S> for &ProjectivePoint<C>
+where
+    Self: Double,
+    C: PrimeCurveParams,
+    S: Borrow<Scalar<C>>,
+{
+    fn mul_vartime(self, scalar: S) -> ProjectivePoint<C> {
+        ProjectivePoint::mul_vartime(self, scalar.borrow())
+    }
+}
+
+impl<C> MulVartime<&Scalar<C>> for &ProjectivePoint<C>
+where
+    C: PrimeCurveParams,
+    ProjectivePoint<C>: Double,
+{
+    fn mul_vartime(self, scalar: &Scalar<C>) -> ProjectivePoint<C> {
+        ProjectivePoint::mul_vartime(self, scalar)
     }
 }
 


### PR DESCRIPTION
Companion PR to RustCrypto/traits#2379

This adds initial impls of the `MulVartime` trait which are required by the bounds added in the PR above.

These don't yet use variable-time implementations as noted in the TODOs, however the idea is we can opportunistically plug in wNAF when the `alloc` feature is enabled. However, actually implementing that has been saved for a follow-up.

This also adds an impl of the new `PointWithBasepointTable` to `k256`, which makes the table accessible in a generic context.