### PR TITLE
k256+p256: add initial `mul_vartime` benchmarks

### DIFF
--- a/k256/benches/scalar.rs
+++ b/k256/benches/scalar.rs
@@ -6,7 +6,11 @@ use criterion::{
 use hex_literal::hex;
 use k256::{
     ProjectivePoint, Scalar,
-    elliptic_curve::{Group, group::ff::PrimeField, ops::LinearCombination},
+    elliptic_curve::{
+        Group,
+        group::ff::PrimeField,
+        ops::{LinearCombination, MulVartime},
+    },
 };
 use std::hint::black_box;
 
@@ -40,6 +44,10 @@ fn bench_point_mul<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let s = Scalar::from_repr(m.into()).unwrap();
     group.bench_function("point-scalar mul", |b| {
         b.iter(|| black_box(p) * black_box(s))
+    });
+
+    group.bench_function("point-scalar mul (variable-time)", |b| {
+        b.iter(|| black_box(p).mul_vartime(black_box(s)))
     });
 }
 

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -24,7 +24,10 @@ use elliptic_curve::{
 };
 
 #[cfg(feature = "alloc")]
-use {alloc::vec::Vec, elliptic_curve::group::WnafGroup};
+use {
+    alloc::vec::Vec,
+    elliptic_curve::group::{Wnaf, WnafGroup},
+};
 
 #[rustfmt::skip]
 const ENDOMORPHISM_BETA: FieldElement = FieldElement::from_bytes_unchecked(&[
@@ -243,6 +246,12 @@ impl ProjectivePoint {
         let y_eq = rhs_y.negate(1).add(&self.y).normalizes_to_zero();
 
         both_identity | (!rhs_identity & x_eq & y_eq)
+    }
+
+    /// Obtain a wNAF context for this group.
+    #[cfg(feature = "alloc")]
+    pub fn wnaf() -> Wnaf<(), Vec<Self>, Vec<i64>> {
+        Wnaf::new()
     }
 }
 

--- a/p256/benches/scalar.rs
+++ b/p256/benches/scalar.rs
@@ -4,7 +4,11 @@ use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
 use hex_literal::hex;
-use p256::{ProjectivePoint, Scalar, elliptic_curve::group::ff::PrimeField};
+use p256::{
+    ProjectivePoint, Scalar,
+    elliptic_curve::{group::ff::PrimeField, ops::MulVartime},
+};
+use std::hint::black_box;
 
 fn test_scalar_x() -> Scalar {
     Scalar::from_repr(
@@ -25,6 +29,9 @@ fn bench_point_mul<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let m = test_scalar_x();
     let s = Scalar::from_repr(m.into()).unwrap();
     group.bench_function("point-scalar mul", |b| b.iter(|| p * s));
+    group.bench_function("point-scalar mul (variable-time)", |b| {
+        b.iter(|| black_box(p).mul_vartime(&black_box(s)))
+    });
 }
 
 fn bench_scalar_sub<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
@@ -42,7 +49,7 @@ fn bench_scalar_add<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 fn bench_scalar_mul<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let x = test_scalar_x();
     let y = test_scalar_y();
-    group.bench_function("mul", |b| b.iter(|| x * y));
+    group.bench_function("mul", |b| b.iter(|| black_box(x) * black_box(y)));
 }
 
 fn bench_scalar_negate<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {


### PR DESCRIPTION
Right now it's still using the constant-time implementation, but this lets us see if wNAF is an improvement.

After trying it on `k256` with a transient context for a single point/scalar multiplication, it was not, but more investigation is needed.