### PR TITLE
primeorder: get rid of `FieldBytes<C>: Copy` bounds

### DIFF
--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -81,10 +81,7 @@ where
     /// TODO(tarcieri): find some way to avoid this?
     pub(crate) fn try_from_rng<R: TryRng + ?Sized>(
         rng: &mut R,
-    ) -> core::result::Result<Self, R::Error>
-    where
-        FieldBytes<C>: Copy,
-    {
+    ) -> core::result::Result<Self, R::Error> {
         let mut bytes = FieldBytes::<C>::default();
         let mut sign = 0;
 
@@ -101,13 +98,12 @@ where
 impl<C> AffineCoordinates for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
 {
     type FieldRepr = FieldBytes<C>;
 
     fn from_coordinates(x: &Self::FieldRepr, y: &Self::FieldRepr) -> CtOption<Self> {
-        C::FieldElement::from_repr(*y).and_then(|y| {
-            C::FieldElement::from_repr(*x).and_then(|x| {
+        C::FieldElement::from_repr(y.clone()).and_then(|y| {
+            C::FieldElement::from_repr(x.clone()).and_then(|x| {
                 let lhs = y * &y;
                 let rhs = x * &x * &x + &(C::EQUATION_A * &x) + &C::EQUATION_B;
                 CtOption::new(Self { x, y, infinity: 0 }, lhs.ct_eq(&rhs))
@@ -187,10 +183,9 @@ impl<C> DefaultIsZeroes for AffinePoint<C> where C: PrimeCurveParams {}
 impl<C> DecompressPoint<C> for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
 {
     fn decompress(x_bytes: &FieldBytes<C>, y_is_odd: Choice) -> CtOption<Self> {
-        C::FieldElement::from_repr(*x_bytes).and_then(|x| {
+        C::FieldElement::from_repr(x_bytes.clone()).and_then(|x| {
             let alpha = x * &x * &x + &(C::EQUATION_A * &x) + &C::EQUATION_B;
             let beta = alpha.sqrt();
 
@@ -210,7 +205,6 @@ where
 impl<C> DecompactPoint<C> for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
 {
     fn decompact(x_bytes: &FieldBytes<C>) -> CtOption<Self> {
         Self::decompress(x_bytes, Choice::from(0)).map(|point| point.to_compact())
@@ -222,9 +216,7 @@ impl<C> Eq for AffinePoint<C> where C: PrimeCurveParams {}
 impl<C> FromSec1Point<C> for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
-    CompressedPoint<C>: Copy,
 {
     /// Attempts to parse the given [`Sec1Point`] as an SEC1-encoded
     /// [`AffinePoint`].
@@ -304,7 +296,6 @@ where
 impl<C> Generate for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
 {
     fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(
         rng: &mut R,
@@ -317,7 +308,6 @@ impl<C> GroupEncoding for AffinePoint<C>
 where
     C: PrimeCurveParams,
     CompressedPoint<C>: Copy + Send + Sync,
-    FieldBytes<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
     <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
@@ -363,11 +353,9 @@ where
 impl<C> PrimeCurveAffine for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Send + Sync,
-    FieldBytes<C>: Copy,
+    CompressedPoint<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
     ProjectivePoint<C>: Double,
-    CompressedPoint<C>: Copy,
     <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
     type Curve = ProjectivePoint<C>;
@@ -447,7 +435,6 @@ where
 impl<C> TryFrom<Sec1Point<C>> for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
     CompressedPoint<C>: Copy,
 {
@@ -461,7 +448,6 @@ where
 impl<C> TryFrom<&Sec1Point<C>> for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
     CompressedPoint<C>: Copy,
 {
@@ -602,7 +588,6 @@ where
 impl<'de, C> Deserialize<'de> for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
     CompressedPoint<C>: Copy,
 {

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -5,8 +5,8 @@
 use crate::{AffinePoint, Field, PrimeCurveParams, point_arithmetic::PointArithmetic};
 use core::{array, borrow::Borrow, iter::Sum};
 use elliptic_curve::{
-    BatchNormalize, CurveGroup, Error, FieldBytes, FieldBytesSize, Generate, PrimeField, PublicKey,
-    Result, Scalar,
+    BatchNormalize, CurveGroup, Error, FieldBytesSize, Generate, PrimeField, PublicKey, Result,
+    Scalar,
     array::ArraySize,
     bigint::{ArrayEncoding, ByteArray},
     ctutils,
@@ -129,10 +129,7 @@ where
 
     /// Obtain a wNAF context for this group.
     #[cfg(feature = "alloc")]
-    pub fn wnaf() -> Wnaf<(), Vec<Self>, Vec<i64>>
-    where
-        FieldBytes<C>: Copy,
-    {
+    pub fn wnaf() -> Wnaf<(), Vec<Self>, Vec<i64>> {
         Wnaf::new()
     }
 }
@@ -253,7 +250,6 @@ where
 impl<C> FromSec1Point<C> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
     CompressedPoint<C>: Copy,
 {
@@ -265,7 +261,6 @@ where
 impl<C> Generate for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
 {
     fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(
         rng: &mut R,
@@ -283,7 +278,6 @@ impl<C> CofactorGroup for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
     CompressedPoint<C>: Send + Sync,
-    FieldBytes<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
     CompressedPoint<C>: Copy,
     <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
@@ -306,7 +300,6 @@ where
 impl<C> CurveGroup for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
 {
     type AffineRepr = AffinePoint<C>;
 
@@ -326,7 +319,6 @@ where
 impl<C> Group for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
 {
     type Scalar = Scalar<C>;
 
@@ -354,10 +346,8 @@ where
 impl<C> GroupEncoding for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Send + Sync,
-    FieldBytes<C>: Copy,
+    CompressedPoint<C>: Copy + Send + Sync,
     FieldBytesSize<C>: ModulusSize,
-    CompressedPoint<C>: Copy,
     <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
     type Repr = CompressedPoint<C>;
@@ -381,7 +371,6 @@ where
     Self: Double,
     C: PrimeCurveParams,
     CompressedPoint<C>: Copy + Send + Sync,
-    FieldBytes<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
     <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
@@ -393,7 +382,6 @@ where
     Self: Double,
     C: PrimeCurveParams,
     CompressedPoint<C>: Copy + Send + Sync,
-    FieldBytes<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
     <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
@@ -406,7 +394,6 @@ where
 impl<const N: usize, C> BatchNormalize<[ProjectivePoint<C>; N]> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
 {
     type Output = [<Self as CurveGroup>::AffineRepr; N];
 
@@ -423,7 +410,6 @@ where
 impl<C> BatchNormalize<[ProjectivePoint<C>]> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
 {
     type Output = Vec<<Self as CurveGroup>::AffineRepr>;
 
@@ -475,7 +461,6 @@ where
 impl<C> LinearCombination<[(Self, Scalar<C>)]> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
 {
     #[cfg(feature = "alloc")]
     fn lincomb(points_and_scalars: &[(Self, Scalar<C>)]) -> Self {
@@ -496,7 +481,6 @@ where
 impl<C, const N: usize> LinearCombination<[(Self, Scalar<C>); N]> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
 {
     fn lincomb(points_and_scalars: &[(Self, Scalar<C>); N]) -> Self {
         let mut ks: [_; N] = array::from_fn(|index| {
@@ -624,7 +608,6 @@ where
 impl<C> WnafGroup for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
 {
     fn recommended_wnaf_for_num_scalars(_num_scalars: usize) -> usize {
         // TODO(tarcieri): provide a way for individual curves to configure this
@@ -986,7 +969,6 @@ where
 impl<'de, C> Deserialize<'de> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytes<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
     CompressedPoint<C>: Copy,
 {


### PR DESCRIPTION
This viral bound came because `PrimeField::from_repr` expects a value rather than a reference, and previously it was using `Copy` to do the conversion. However, `Clone` is available unconditionally avoiding the need for such bounds.

Ultimately `PrimeField::from_repr` should probably borrow its input. See: https://github.com/zkcrypto/ff#137

This came up implementing wNAF since `ProjectivePoint::wnaf` previously needed it, so if we use it for `mul_vartime` it ultimately adds viral bounds that it would be nice to avoid.