### PR TITLE
primeorder: use wNAF for `mul_vartime` when `alloc` is enabled

### DIFF
--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -123,8 +123,15 @@ where
     where
         Self: Double,
     {
-        // TODO(tarcieri): use wNAF for variable-time scalar multiplication when available
-        self.mul(k)
+        #[cfg(feature = "alloc")]
+        {
+            Self::wnaf().scalar(k).base(*self)
+        }
+
+        #[cfg(not(feature = "alloc"))]
+        {
+            self.mul(k)
+        }
     }
 
     /// Obtain a wNAF context for this group.


### PR DESCRIPTION
Wires up wNAF for the single-scalar/single-point use case.

This results in a ~14% speedup on `p256` benchmarks:

    point operations/point-scalar mul (variable-time)
        time:   [104.03 µs 104.22 µs 104.43 µs]
        change: [−14.852% −14.298% −13.788%] (p = 0.00 < 0.05)
        Performance has improved.