### PR TITLE
primeorder: impl `MulByGeneratorVartime` for `ProjectivePoint`

### DIFF
--- a/p256/benches/scalar.rs
+++ b/p256/benches/scalar.rs
@@ -6,7 +6,11 @@ use criterion::{
 use hex_literal::hex;
 use p256::{
     ProjectivePoint, Scalar,
-    elliptic_curve::{group::ff::PrimeField, ops::MulVartime},
+    elliptic_curve::{
+        Group,
+        group::ff::PrimeField,
+        ops::{MulByGeneratorVartime, MulVartime},
+    },
 };
 use std::hint::black_box;
 
@@ -28,9 +32,22 @@ fn bench_point_mul<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let p = ProjectivePoint::GENERATOR;
     let m = test_scalar_x();
     let s = Scalar::from_repr(m.into()).unwrap();
-    group.bench_function("point-scalar mul", |b| b.iter(|| p * s));
+    group.bench_function("point-scalar mul", |b| {
+        b.iter(|| black_box(p) * black_box(s))
+    });
     group.bench_function("point-scalar mul (variable-time)", |b| {
         b.iter(|| black_box(p).mul_vartime(&black_box(s)))
+    });
+}
+
+fn bench_point_mul_by_generator<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
+    let m = test_scalar_x();
+    let s = Scalar::from_repr(m.into()).unwrap();
+    group.bench_function("generator-scalar mul", |b| {
+        b.iter(|| ProjectivePoint::mul_by_generator(&black_box(s)))
+    });
+    group.bench_function("generator-scalar mul (variable-time)", |b| {
+        b.iter(|| ProjectivePoint::mul_by_generator_vartime(&black_box(s)))
     });
 }
 
@@ -73,6 +90,7 @@ fn bench_scalar(c: &mut Criterion) {
     bench_scalar_sub(&mut group);
     bench_scalar_add(&mut group);
     bench_scalar_mul(&mut group);
+    bench_point_mul_by_generator(&mut group);
     bench_scalar_negate(&mut group);
     bench_scalar_invert(&mut group);
     group.finish();

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -16,8 +16,8 @@ use elliptic_curve::{
         prime::{PrimeCurve, PrimeGroup},
     },
     ops::{
-        Add, AddAssign, BatchInvert, LinearCombination, Mul, MulAssign, MulVartime, Neg, Sub,
-        SubAssign,
+        Add, AddAssign, BatchInvert, LinearCombination, Mul, MulAssign, MulByGeneratorVartime,
+        MulVartime, Neg, Sub, SubAssign,
     },
     point::{Double, NonIdentity},
     rand_core::{TryCryptoRng, TryRng},
@@ -916,6 +916,26 @@ where
 {
     fn mul_vartime(self, scalar: &Scalar<C>) -> ProjectivePoint<C> {
         ProjectivePoint::mul_vartime(self, scalar)
+    }
+}
+
+impl<C> MulByGeneratorVartime for ProjectivePoint<C>
+where
+    C: PrimeCurveParams,
+{
+    fn mul_by_generator_vartime(scalar: &Scalar<C>) -> Self {
+        Self::GENERATOR.mul_vartime(scalar)
+    }
+
+    // When we're guaranteed *not* to have basepoint tables available (because they need `alloc`)
+    // use linear combinations for this computation, but they're slower when they are available
+    #[cfg(not(feature = "alloc"))]
+    fn mul_by_generator_and_mul_add_point_vartime(
+        a: &Self::Scalar,
+        b_scalar: &Self::Scalar,
+        b_point: &Self,
+    ) -> Self {
+        Self::lincomb(&[(Self::GENERATOR, *a), (*b_point, *b_scalar)])
     }
 }
 


### PR DESCRIPTION
Implements the trait introduced in RustCrypto/traits#2381 which makes it possible to provide optimized implementations of multiplication by the generator. Currently this just naively calls `mul_vartime` on `ProjectivePoint::GENERATOR`, which still provides some optimization when the `alloc` feature is enabled:

    scalar operations/generator-scalar mul
        time:   [122.08 µs 122.48 µs 122.97 µs]

    scalar operations/generator-scalar mul (variable-time)
        time:   [105.83 µs 107.98 µs 111.45 µs]

When `alloc` isn't available, it uses linear combinations to implement computing `aG * bB`, which should still provide a speedup in that case.