### PR TITLE
Expose hash2curve; Fix `GroupDigest` signature

### DIFF
--- a/ed448-goldilocks/README.md
+++ b/ed448-goldilocks/README.md
@@ -41,12 +41,12 @@ let input = hex_literal::hex!("8108d09ce4ea5707d44a6e52d75f290d0a0801cd5e366b9a0
 let expected_scalar = EdwardsScalar::from_canonical_bytes(&input.into()).unwrap();
 assert_eq!(hashed_scalar, expected_scalar);
 
-let hashed_point = Ed448::hash_from_bytes(b"test", b"test DST").unwrap();
+let hashed_point = Ed448::hash_from_bytes(&[b"test"], &[b"test", b" DST"]).unwrap();
 let expected = hex_literal::hex!("ff5af3430905789691f01a54feb6275dc6a28a4f7e99c1c6ef261fe665428f986723060f44d4410ed4dcf33255f53bed07e068084fdb68f980");
 let expected_point = CompressedEdwardsY(expected).decompress().unwrap().to_edwards();
 assert_eq!(hashed_point, expected_point);
 
-let hashed_point = Ed448::hash_from_bytes(b"test", b"test DST").unwrap();
+let hashed_point = Ed448::hash_from_bytes(&[b"test"], &[b"test DST"]).unwrap();
 assert_eq!(hashed_point, expected_point);
 ```
 

--- a/ed448-goldilocks/benches/bench.rs
+++ b/ed448-goldilocks/benches/bench.rs
@@ -40,7 +40,7 @@ pub fn ed448(c: &mut Criterion) {
                 SysRng.try_fill_bytes(&mut msg).unwrap();
                 msg
             },
-            |msg| Ed448::encode_from_bytes(&msg, b"test DST"),
+            |msg| Ed448::encode_from_bytes(&[&msg], &[b"test DST"]),
             BatchSize::SmallInput,
         )
     });
@@ -98,7 +98,7 @@ pub fn decaf448(c: &mut Criterion) {
                 SysRng.try_fill_bytes(&mut msg).unwrap();
                 msg
             },
-            |msg| Decaf448::encode_from_bytes(&msg, b"test DST"),
+            |msg| Decaf448::encode_from_bytes(&[&msg], &[b"test DST"]),
             BatchSize::SmallInput,
         )
     });

--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -1023,7 +1023,7 @@ mod tests {
         for _ in 0..25 {
             let mut msg = [0u8; 64];
             SysRng.try_fill_bytes(&mut msg).unwrap();
-            let p = Ed448::hash_from_bytes(&msg, b"test DST").unwrap();
+            let p = Ed448::hash_from_bytes(&[&msg], &[b"test DST"]).unwrap();
             assert_eq!(p.is_on_curve().unwrap_u8(), 1u8);
             assert_eq!(p.is_torsion_free().unwrap_u8(), 1u8);
         }
@@ -1118,7 +1118,7 @@ mod tests {
         let b = EdwardsScalar::random(&mut rng);
 
         let g1 = EdwardsPoint::GENERATOR;
-        let g2 = Ed448::hash_from_bytes(b"test_pow_add_mul", b"test DST").unwrap();
+        let g2 = Ed448::hash_from_bytes(&[b"test_pow_add_mul"], &[b"test DST"]).unwrap();
 
         let expected_commitment = g1 * x + g2 * b;
 

--- a/ed448-goldilocks/src/lib.rs
+++ b/ed448-goldilocks/src/lib.rs
@@ -52,6 +52,7 @@ use alloc::{boxed::Box, vec::Vec};
 pub(crate) mod macros;
 
 pub use elliptic_curve;
+pub use hash2curve;
 pub use rand_core;
 pub use sha3;
 pub use subtle;

--- a/hash2curve/src/group_digest.rs
+++ b/hash2curve/src/group_digest.rs
@@ -17,7 +17,8 @@ pub trait GroupDigest: MapToCurve {
     /// The `expand_message` function to use.
     type ExpandMsg: ExpandMsg<Self::SecurityLevel>;
 
-    /// Computes the hash to curve routine.
+    /// Computes the hash to curve routine, with message equal to the concatenation of the elements
+    /// in `msg`, and domain separator equal to the concatenation of the elements in `dst`.
     ///
     /// From <https://www.rfc-editor.org/rfc/rfc9380.html>:
     ///
@@ -36,14 +37,15 @@ pub trait GroupDigest: MapToCurve {
     /// [`ExpandMsgXmdError`]: crate::ExpandMsgXmdError
     /// [`ExpandMsgXofError`]: crate::ExpandMsgXofError
     fn hash_from_bytes(
-        msg: &[u8],
-        dst: &[u8],
+        msg: &[&[u8]],
+        dst: &[&[u8]],
     ) -> Result<ProjectivePoint<Self>, <Self::ExpandMsg as ExpandMsg<Self::SecurityLevel>>::Error>
     {
-        hash_from_bytes::<Self, Self::ExpandMsg>(&[msg], &[dst])
+        hash_from_bytes::<Self, Self::ExpandMsg>(msg, dst)
     }
 
-    /// Computes the encode to curve routine.
+    /// Computes the encode to curve routine, with message equal to the concatenation of the elements
+    /// in `msg`, and domain separator equal to the concatenation of the elements in `dst`.
     ///
     /// From <https://www.rfc-editor.org/rfc/rfc9380.html>:
     ///
@@ -61,11 +63,11 @@ pub trait GroupDigest: MapToCurve {
     /// [`ExpandMsgXmdError`]: crate::ExpandMsgXmdError
     /// [`ExpandMsgXofError`]: crate::ExpandMsgXofError
     fn encode_from_bytes(
-        msg: &[u8],
-        dst: &[u8],
+        msg: &[&[u8]],
+        dst: &[&[u8]],
     ) -> Result<ProjectivePoint<Self>, <Self::ExpandMsg as ExpandMsg<Self::SecurityLevel>>::Error>
     {
-        encode_from_bytes::<Self, Self::ExpandMsg>(&[msg], &[dst])
+        encode_from_bytes::<Self, Self::ExpandMsg>(msg, dst)
     }
 }
 

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -50,6 +50,9 @@ pub mod schnorr;
 #[cfg(any(feature = "test-vectors", test))]
 pub mod test_vectors;
 
+#[cfg(feature = "hash2curve")]
+pub use hash2curve;
+
 pub use elliptic_curve::{self, bigint::U256};
 
 #[cfg(feature = "arithmetic")]

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -39,6 +39,9 @@ pub mod ecdsa;
 #[cfg(any(feature = "test-vectors", test))]
 pub mod test_vectors;
 
+#[cfg(feature = "hash2curve")]
+pub use hash2curve;
+
 pub use elliptic_curve::{self, bigint::U256, consts::U32};
 
 #[cfg(feature = "arithmetic")]

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -70,6 +70,9 @@ pub use arithmetic::{AffinePoint, ProjectivePoint, scalar::Scalar};
 #[cfg(feature = "expose-field")]
 pub use arithmetic::field::FieldElement;
 
+#[cfg(feature = "hash2curve")]
+pub use hash2curve;
+
 #[cfg(feature = "pkcs8")]
 pub use elliptic_curve::pkcs8;
 

--- a/p521/src/lib.rs
+++ b/p521/src/lib.rs
@@ -44,6 +44,9 @@ pub use arithmetic::{AffinePoint, ProjectivePoint, scalar::Scalar};
 #[cfg(feature = "expose-field")]
 pub use arithmetic::field::FieldElement;
 
+#[cfg(feature = "hash2curve")]
+pub use hash2curve;
+
 pub use elliptic_curve;
 
 #[cfg(feature = "pkcs8")]


### PR DESCRIPTION
It looks like in the refactoring of `hash2curve` into its own crate, the re-exporting of the new crate was left out.

Also, I'm not sure how it happened, but for some reason in https://github.com/RustCrypto/elliptic-curves/pull/1389 the `msg: &[&[u8]]` syntax got changed to `msg: &[u8]` (ditto `dst`). The former was better because it lets you pass messages/domain separators from mixed sources without having to allocate.