### PR TITLE
k256: impl `MulByGeneratorVartime` for `ProjectivePoint`

### DIFF
--- a/k256/benches/scalar.rs
+++ b/k256/benches/scalar.rs
@@ -9,7 +9,7 @@ use k256::{
     elliptic_curve::{
         Group,
         group::ff::PrimeField,
-        ops::{LinearCombination, MulVartime},
+        ops::{LinearCombination, MulByGeneratorVartime, MulVartime},
     },
 };
 use std::hint::black_box;
@@ -75,6 +75,10 @@ fn bench_point_mul_by_generator<M: Measurement>(group: &mut BenchmarkGroup<'_, M
 
     group.bench_function("mul_by_generator precomputed", |b| {
         b.iter(|| ProjectivePoint::mul_by_generator(&black_box(x)))
+    });
+
+    group.bench_function("mul_by_generator_vartime", |b| {
+        b.iter(|| ProjectivePoint::mul_by_generator_vartime(&black_box(x)))
     });
 }
 

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -39,7 +39,7 @@ use crate::arithmetic::{
     scalar::{Scalar, WideScalar},
 };
 use elliptic_curve::{
-    ops::{LinearCombination, Mul, MulAssign, MulVartime},
+    ops::{LinearCombination, Mul, MulAssign, MulByGeneratorVartime, MulVartime},
     scalar::IsHigh,
     subtle::ConditionallySelectable,
 };
@@ -407,6 +407,24 @@ impl MulVartime<&Scalar> for ProjectivePoint {
     // TODO(tarcieri): actual vartime implementation (i.e. wNAF)
     fn mul_vartime(self, other: &Scalar) -> ProjectivePoint {
         mul(&self, other)
+    }
+}
+
+impl MulByGeneratorVartime for ProjectivePoint {
+    // TODO(tarcieri): actual vartime implementation (i.e. wNAF)
+    fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
+        Self::mul_by_generator(k)
+    }
+
+    // When we're guaranteed *not* to have basepoint tables available (because they need `alloc`)
+    // use linear combinations for this computation, but they're slower when they are available
+    #[cfg(not(feature = "alloc"))]
+    fn mul_by_generator_and_mul_add_point_vartime(
+        a: &Self::Scalar,
+        b_scalar: &Self::Scalar,
+        b_point: &Self,
+    ) -> Self {
+        Self::lincomb(&[(Self::GENERATOR, *a), (*b_point, *b_scalar)])
     }
 }
 

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -923,10 +923,6 @@ impl<C> MulByGeneratorVartime for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
 {
-    fn mul_by_generator_vartime(scalar: &Scalar<C>) -> Self {
-        Self::GENERATOR.mul_vartime(scalar)
-    }
-
     // When we're guaranteed *not* to have basepoint tables available (because they need `alloc`)
     // use linear combinations for this computation, but they're slower when they are available
     #[cfg(not(feature = "alloc"))]


### PR DESCRIPTION
Like #1726 did for `primeorder`, this impls this new trait which was introduced in RustCrypto/traits#2381.

Since `group::Wnaf` winds up being slower since it doesn't support the endomorphism optimization, this just calls into the constant-time operation.