### PR TITLE
ed448-goldilocks: impl `MulByGeneratorVartime` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.30"
-source = "git+https://github.com/RustCrypto/traits#403d4d134df62322beaff2612818ed47d1a8946a"
+source = "git+https://github.com/RustCrypto/traits#4aa20faef303aa04f61892d33c229314bdcea43f"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1473,7 +1473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/ed448-goldilocks/src/decaf/ops.rs
+++ b/ed448-goldilocks/src/decaf/ops.rs
@@ -2,7 +2,7 @@ use crate::{DecafAffinePoint, DecafScalar, curve::scalar_mul::double_and_add};
 use core::{borrow::Borrow, iter::Sum};
 use elliptic_curve::{
     CurveGroup,
-    ops::{Add, AddAssign, Mul, MulAssign, MulVartime, Neg, Sub, SubAssign},
+    ops::{Add, AddAssign, Mul, MulAssign, MulByGeneratorVartime, MulVartime, Neg, Sub, SubAssign},
 };
 
 use super::DecafPoint;
@@ -35,6 +35,8 @@ impl MulVartime<&DecafScalar> for &DecafPoint {
         self * scalar
     }
 }
+
+impl MulByGeneratorVartime for DecafPoint {}
 
 define_mul_variants!(LHS = DecafPoint, RHS = DecafScalar, Output = DecafPoint);
 

--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -3,7 +3,9 @@ use core::{
     fmt::{Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
     iter::Sum,
 };
-use elliptic_curve::ops::{Add, AddAssign, Mul, MulAssign, MulVartime, Neg, Sub, SubAssign};
+use elliptic_curve::ops::{
+    Add, AddAssign, Mul, MulAssign, MulByGeneratorVartime, MulVartime, Neg, Sub, SubAssign,
+};
 
 use crate::{
     GOLDILOCKS_BASE_POINT, MontgomeryPoint, U57, U448,
@@ -741,6 +743,8 @@ impl MulVartime<&EdwardsScalar> for &EdwardsPoint {
         self.scalar_mul(scalar)
     }
 }
+
+impl MulByGeneratorVartime for EdwardsPoint {}
 
 #[cfg(feature = "serde")]
 impl serdect::serde::Serialize for EdwardsPoint {

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -419,7 +419,7 @@ impl MulByGeneratorVartime for ProjectivePoint {
     // When we're guaranteed *not* to have basepoint tables available (because they need `alloc`)
     // use linear combinations for this computation, but they're slower when they are available
     #[cfg(not(feature = "alloc"))]
-    fn mul_by_generator_and_mul_add_point_vartime(
+    fn mul_by_generator_and_mul_add_vartime(
         a: &Self::Scalar,
         b_scalar: &Self::Scalar,
         b_point: &Self,

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -926,7 +926,7 @@ where
     // When we're guaranteed *not* to have basepoint tables available (because they need `alloc`)
     // use linear combinations for this computation, but they're slower when they are available
     #[cfg(not(feature = "alloc"))]
-    fn mul_by_generator_and_mul_add_point_vartime(
+    fn mul_by_generator_and_mul_add_vartime(
         a: &Self::Scalar,
         b_scalar: &Self::Scalar,
         b_point: &Self,


### PR DESCRIPTION
Like #1726 did for `primeorder` and #1728 did for `k256`, this impls this new trait which was introduced in RustCrypto/traits#2381.

We don't actually have vartime support in this crate, so this just falls back to the constant-time implementation.