### PR TITLE
k256: use `mul_by_generator_and_mul_add_vartime` for Schnorr verify

### DIFF
--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -416,9 +416,8 @@ impl MulByGeneratorVartime for ProjectivePoint {
         Self::mul_by_generator(k)
     }
 
-    // When we're guaranteed *not* to have basepoint tables available (because they need `alloc`)
-    // use linear combinations for this computation, but they're slower when they are available
-    #[cfg(not(feature = "alloc"))]
+    // When the basepoint tables aren't available, use linear combinations for this computation.
+    #[cfg(not(feature = "precomputed-tables"))]
     fn mul_by_generator_and_mul_add_vartime(
         a: &Self::Scalar,
         b_scalar: &Self::Scalar,

--- a/k256/src/schnorr/verifying.rs
+++ b/k256/src/schnorr/verifying.rs
@@ -4,7 +4,7 @@ use super::{CHALLENGE_TAG, Signature, tagged_hash};
 use crate::{AffinePoint, FieldBytes, ProjectivePoint, PublicKey, Scalar};
 use elliptic_curve::{
     group::prime::PrimeCurveAffine,
-    ops::{LinearCombination, Reduce},
+    ops::{MulByGeneratorVartime, Reduce},
     point::DecompactPoint,
 };
 use sha2::{
@@ -71,10 +71,11 @@ impl VerifyingKey {
                 .finalize(),
         );
 
-        let R = ProjectivePoint::lincomb(&[
-            (ProjectivePoint::GENERATOR, **s),
-            (self.inner.to_projective(), -e),
-        ])
+        let R = ProjectivePoint::mul_by_generator_and_mul_add_vartime(
+            s,
+            &(-e),
+            &self.inner.to_projective(),
+        )
         .to_affine();
 
         if R.is_identity().into() || R.y.normalize().is_odd().into() || R.x.normalize() != *r {


### PR DESCRIPTION
When the basepoint tables are available, this uses them to multiply by the generator instead of using linear combinations, which results in about a ~10% performance improvement:

    schnorr/verify
        time:   [56.213 µs 56.441 µs 56.741 µs]
        change: [−10.486% −9.5370% −8.5718%] (p = 0.00 < 0.05)