### PR TITLE
k256+p256: refactor basepoint tables

### DIFF
--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -2,14 +2,16 @@
 
 pub(crate) mod affine;
 mod field;
-#[cfg(feature = "hash2curve")]
-mod hash2curve;
 mod mul;
 pub(crate) mod projective;
 pub(crate) mod scalar;
 
 #[cfg(test)]
 mod dev;
+#[cfg(feature = "hash2curve")]
+mod hash2curve;
+#[cfg(feature = "precomputed-tables")]
+mod tables;
 
 pub use field::FieldElement;
 

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -34,7 +34,7 @@
 //! (Note that 'd' is also equal to the curve order here because `[a1,b1]` and `[a2,b2]` are found
 //! as outputs of the Extended Euclidean Algorithm on inputs 'order' and 'lambda').
 
-use crate::arithmetic::{
+use super::{
     ProjectivePoint,
     scalar::{Scalar, WideScalar},
 };
@@ -45,15 +45,7 @@ use elliptic_curve::{
 };
 
 #[cfg(feature = "precomputed-tables")]
-use elliptic_curve::point::PointWithBasepointTable;
-
-/// Window size for the basepoint table.
-#[cfg(feature = "precomputed-tables")]
-const WINDOW_SIZE: usize = 33;
-
-/// Basepoint table for multiples of secp256k1's generator.
-#[cfg(feature = "precomputed-tables")]
-type BasepointTable = elliptic_curve::point::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
+use super::tables::BASEPOINT_TABLE;
 
 /// Lookup table for multiples of a given point.
 type LookupTable = elliptic_curve::point::LookupTable<ProjectivePoint>;
@@ -322,15 +314,6 @@ fn lincomb(
         }
     }
     acc
-}
-
-/// Lazily computed basepoint table.
-#[cfg(feature = "precomputed-tables")]
-static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
-
-#[cfg(feature = "precomputed-tables")]
-impl PointWithBasepointTable<WINDOW_SIZE> for ProjectivePoint {
-    const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
 }
 
 impl ProjectivePoint {

--- a/k256/src/arithmetic/tables.rs
+++ b/k256/src/arithmetic/tables.rs
@@ -1,0 +1,21 @@
+//! Precomputed tables (optional).
+//!
+//! We only provide a constant-time basepoint table here as the generic wNAF implementation in the
+//! `group` crate doesn't support the secp256k1 endomorphism optimization and thus winds up being
+//! slower than the constant-time version (see RustCrypto/elliptic-curves
+
+use crate::ProjectivePoint;
+use elliptic_curve::point::PointWithBasepointTable;
+
+/// Window size for the basepoint table.
+const WINDOW_SIZE: usize = 33;
+
+/// Basepoint table for multiples of secp256k1's generator.
+type BasepointTable = elliptic_curve::point::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
+
+/// Lazily computed basepoint table.
+pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
+
+impl PointWithBasepointTable<WINDOW_SIZE> for ProjectivePoint {
+    const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
+}

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -38,7 +38,7 @@ primeorder = { version = "0.14.0-rc.8", features = ["dev"] }
 proptest = "1"
 
 [features]
-default = ["arithmetic", "ecdsa", "pem", "std"]
+default = ["arithmetic", "ecdsa", "pem", "precomputed-tables", "std"]
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std", "getrandom"]
 

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -9,33 +9,19 @@ pub(crate) mod scalar;
 
 #[cfg(feature = "hash2curve")]
 mod hash2curve;
+#[cfg(feature = "precomputed-tables")]
+mod tables;
 
 use self::{field::FieldElement, scalar::Scalar};
 use crate::NistP256;
 use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
 use primeorder::{PrimeCurveParams, point_arithmetic};
 
-#[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
-use primeorder::PrimeCurveWithBasepointTableVartime;
-
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<NistP256>;
 
 /// Elliptic curve point in projective coordinates.
 pub type ProjectivePoint = primeorder::ProjectivePoint<NistP256>;
-
-/// Window size for the variable-time basepoint table.
-#[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
-const WINDOW_SIZE_VARTIME: usize = 8;
-
-/// Variable-time basepoint table for NIST P-256's generator.
-#[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
-type BasepointTableVartime =
-    elliptic_curve::point::BasepointTableVartime<ProjectivePoint, WINDOW_SIZE_VARTIME>;
-
-/// Lazily computed basepoint table.
-#[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
-static BASEPOINT_TABLE_VARTIME: BasepointTableVartime = BasepointTableVartime::new();
 
 impl CurveArithmetic for NistP256 {
     type AffinePoint = AffinePoint;
@@ -80,11 +66,6 @@ impl PrimeCurveParams for NistP256 {
 
     #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
     fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
-        BASEPOINT_TABLE_VARTIME.mul(k)
+        tables::BASEPOINT_TABLE_VARTIME.mul(k)
     }
-}
-
-#[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
-impl PrimeCurveWithBasepointTableVartime<WINDOW_SIZE_VARTIME> for NistP256 {
-    const BASEPOINT_TABLE_VARTIME: &'static BasepointTableVartime = &BASEPOINT_TABLE_VARTIME;
 }

--- a/p256/src/arithmetic/tables.rs
+++ b/p256/src/arithmetic/tables.rs
@@ -1,0 +1,24 @@
+//! Precomputed tables (optional).
+
+#[cfg(feature = "alloc")]
+pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
+
+#[cfg(feature = "alloc")]
+mod vartime {
+    use crate::{NistP256, ProjectivePoint};
+    use primeorder::PrimeCurveWithBasepointTableVartime;
+
+    /// Window size for the variable-time basepoint table.
+    const WINDOW_SIZE_VARTIME: usize = 8;
+
+    /// Variable-time basepoint table for NIST P-256's generator.
+    type BasepointTableVartime =
+        elliptic_curve::point::BasepointTableVartime<ProjectivePoint, WINDOW_SIZE_VARTIME>;
+
+    /// Lazily computed basepoint table.
+    pub(crate) static BASEPOINT_TABLE_VARTIME: BasepointTableVartime = BasepointTableVartime::new();
+
+    impl PrimeCurveWithBasepointTableVartime<WINDOW_SIZE_VARTIME> for NistP256 {
+        const BASEPOINT_TABLE_VARTIME: &'static BasepointTableVartime = &BASEPOINT_TABLE_VARTIME;
+    }
+}


### PR DESCRIPTION
Replaces repetitive `cfg` gating by putting them in an `arithmetic::tables` module, a pattern we can repeat for the other crates.