### PR TITLE
p384: add `precomputed-tables` feature

### DIFF
--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -40,7 +40,7 @@ primeorder = { version = "0.14.0-rc.8", features = ["dev"] }
 proptest = "1.11"
 
 [features]
-default = ["arithmetic", "ecdsa", "pem", "std"]
+default = ["arithmetic", "ecdsa", "pem", "precomputed-tables", "std"]
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std", "getrandom"]
 
@@ -61,6 +61,7 @@ group-digest = ["hash2curve", "sha2"]
 oprf = ["group-digest"]
 pem = ["elliptic-curve/pem", "ecdsa-core/pem", "pkcs8"]
 pkcs8 = ["ecdsa-core/pkcs8", "elliptic-curve/pkcs8"]
+precomputed-tables = ["arithmetic", "primeorder/basepoint-table"]
 serde = ["ecdsa-core?/serde", "elliptic-curve/serde", "primeorder?/serde", "serdect"]
 sha384 = ["digest", "sha2"]
 test-vectors = ["hex-literal"]

--- a/p384/benches/scalar.rs
+++ b/p384/benches/scalar.rs
@@ -4,7 +4,14 @@ use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
 use hex_literal::hex;
-use p384::{ProjectivePoint, Scalar, elliptic_curve::group::ff::PrimeField};
+use p384::{
+    ProjectivePoint, Scalar,
+    elliptic_curve::{
+        group::{Group, ff::PrimeField},
+        ops::MulByGeneratorVartime,
+    },
+};
+use std::hint::black_box;
 
 fn test_scalar_x() -> Scalar {
     Scalar::from_repr(
@@ -23,6 +30,17 @@ fn bench_point_mul<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let m = test_scalar_x();
     let s = Scalar::from_repr(m.into()).unwrap();
     group.bench_function("point-scalar mul", |b| b.iter(|| p * s));
+}
+
+fn bench_point_mul_by_generator<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
+    let m = test_scalar_x();
+    let s = Scalar::from_repr(m.into()).unwrap();
+    group.bench_function("generator-scalar mul", |b| {
+        b.iter(|| ProjectivePoint::mul_by_generator(&black_box(s)))
+    });
+    group.bench_function("generator-scalar mul (variable-time)", |b| {
+        b.iter(|| ProjectivePoint::mul_by_generator_vartime(&black_box(s)))
+    });
 }
 
 fn bench_scalar_sub<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
@@ -64,6 +82,7 @@ fn bench_scalar(c: &mut Criterion) {
     bench_scalar_sub(&mut group);
     bench_scalar_add(&mut group);
     bench_scalar_mul(&mut group);
+    bench_point_mul_by_generator(&mut group);
     bench_scalar_negate(&mut group);
     bench_scalar_invert(&mut group);
     group.finish();

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -5,9 +5,12 @@
 //! [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
 
 pub(crate) mod field;
+pub(crate) mod scalar;
+
 #[cfg(feature = "hash2curve")]
 mod hash2curve;
-pub(crate) mod scalar;
+#[cfg(feature = "precomputed-tables")]
+mod tables;
 
 use self::{field::FieldElement, scalar::Scalar};
 use crate::NistP384;
@@ -64,4 +67,9 @@ impl PrimeCurveParams for NistP384 {
             "3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f",
         ),
     );
+
+    #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
+    fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
+        tables::BASEPOINT_TABLE_VARTIME.mul(k)
+    }
 }

--- a/p384/src/arithmetic/tables.rs
+++ b/p384/src/arithmetic/tables.rs
@@ -1,0 +1,24 @@
+//! Precomputed tables (optional).
+
+#[cfg(feature = "alloc")]
+pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
+
+#[cfg(feature = "alloc")]
+mod vartime {
+    use crate::{NistP384, ProjectivePoint};
+    use primeorder::PrimeCurveWithBasepointTableVartime;
+
+    /// Window size for the variable-time basepoint table.
+    const WINDOW_SIZE_VARTIME: usize = 8;
+
+    /// Variable-time basepoint table for NIST P-384's generator.
+    type BasepointTableVartime =
+        elliptic_curve::point::BasepointTableVartime<ProjectivePoint, WINDOW_SIZE_VARTIME>;
+
+    /// Lazily computed basepoint table.
+    pub(crate) static BASEPOINT_TABLE_VARTIME: BasepointTableVartime = BasepointTableVartime::new();
+
+    impl PrimeCurveWithBasepointTableVartime<WINDOW_SIZE_VARTIME> for NistP384 {
+        const BASEPOINT_TABLE_VARTIME: &'static BasepointTableVartime = &BASEPOINT_TABLE_VARTIME;
+    }
+}


### PR DESCRIPTION
Adds a feature similar to the one in `k256` and `p256` which enables use of `BasepointTableVartime` and wNAF for `mul_by_generator_vartime`.

Includes new benchmarks. The performance improvement is ~9%, similar to the improvement in `p256`:

    scalar operations/generator-scalar mul (variable-time)
        time:   [338.77 µs 341.74 µs 345.03 µs]
        change: [−10.124% −9.4153% −8.6752%] (p = 0.00 < 0.05)