### PR TITLE
p521: add `precomputed-tables` feature

### DIFF
--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -38,7 +38,7 @@ primeorder = { version = "0.14.0-rc.8", features = ["dev"] }
 proptest = "1.11"
 
 [features]
-default = ["arithmetic", "ecdsa", "pem", "std"]
+default = ["arithmetic", "ecdsa", "pem", "precomputed-tables", "std"]
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std", "getrandom"]
 
@@ -54,6 +54,7 @@ group-digest = ["hash2curve", "dep:sha2"]
 oprf = ["group-digest"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa-core?/pkcs8", "elliptic-curve/pkcs8"]
+precomputed-tables = ["arithmetic", "primeorder/basepoint-table"]
 serde = ["ecdsa-core?/serde", "elliptic-curve/serde", "primeorder?/serde", "serdect"]
 sha512 = ["digest", "dep:sha2"]
 test-vectors = ["dep:hex-literal"]

--- a/p521/benches/scalar.rs
+++ b/p521/benches/scalar.rs
@@ -4,7 +4,13 @@ use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
 use hex_literal::hex;
-use p521::{ProjectivePoint, Scalar, elliptic_curve::group::ff::PrimeField};
+use p521::{
+    ProjectivePoint, Scalar,
+    elliptic_curve::{
+        group::{Group, ff::PrimeField},
+        ops::MulByGeneratorVartime,
+    },
+};
 use std::hint::black_box;
 
 fn test_scalar_x() -> Scalar {
@@ -24,6 +30,17 @@ fn bench_point_mul<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let m = test_scalar_x();
     let s = Scalar::from_repr(m.into()).unwrap();
     group.bench_function("point-scalar mul", |b| b.iter(|| p * s));
+}
+
+fn bench_point_mul_by_generator<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
+    let m = test_scalar_x();
+    let s = Scalar::from_repr(m.into()).unwrap();
+    group.bench_function("generator-scalar mul", |b| {
+        b.iter(|| ProjectivePoint::mul_by_generator(&black_box(s)))
+    });
+    group.bench_function("generator-scalar mul (variable-time)", |b| {
+        b.iter(|| ProjectivePoint::mul_by_generator_vartime(&black_box(s)))
+    });
 }
 
 fn bench_scalar_sub<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
@@ -57,6 +74,7 @@ fn bench_scalar_invert<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 fn bench_point(c: &mut Criterion) {
     let mut group = c.benchmark_group("point operations");
     bench_point_mul(&mut group);
+    bench_point_mul_by_generator(&mut group);
     group.finish();
 }
 

--- a/p521/src/arithmetic.rs
+++ b/p521/src/arithmetic.rs
@@ -9,6 +9,8 @@ pub(crate) mod scalar;
 
 #[cfg(feature = "hash2curve")]
 mod hash2curve;
+#[cfg(feature = "precomputed-tables")]
+mod tables;
 
 pub use self::scalar::Scalar;
 
@@ -70,4 +72,9 @@ impl PrimeCurveParams for NistP521 {
             "011839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650",
         ),
     );
+
+    #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
+    fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
+        tables::BASEPOINT_TABLE_VARTIME.mul(k)
+    }
 }

--- a/p521/src/arithmetic/tables.rs
+++ b/p521/src/arithmetic/tables.rs
@@ -1,0 +1,24 @@
+//! Precomputed tables (optional).
+
+#[cfg(feature = "alloc")]
+pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
+
+#[cfg(feature = "alloc")]
+mod vartime {
+    use crate::{NistP521, ProjectivePoint};
+    use primeorder::PrimeCurveWithBasepointTableVartime;
+
+    /// Window size for the variable-time basepoint table.
+    const WINDOW_SIZE_VARTIME: usize = 8;
+
+    /// Variable-time basepoint table for NIST P-521's generator.
+    type BasepointTableVartime =
+        elliptic_curve::point::BasepointTableVartime<ProjectivePoint, WINDOW_SIZE_VARTIME>;
+
+    /// Lazily computed basepoint table.
+    pub(crate) static BASEPOINT_TABLE_VARTIME: BasepointTableVartime = BasepointTableVartime::new();
+
+    impl PrimeCurveWithBasepointTableVartime<WINDOW_SIZE_VARTIME> for NistP521 {
+        const BASEPOINT_TABLE_VARTIME: &'static BasepointTableVartime = &BASEPOINT_TABLE_VARTIME;
+    }
+}


### PR DESCRIPTION
Adds a feature similar to the ones in `k256`, `p256`, and `p384` which uses `BasepointTableVartime` and wNAF for `mul_by_generator_vartime`.

Includes new benchmarks. The performance improvement is ~14%, which is better than the 9% we saw in `p256` and `p384`:

    point operations/generator-scalar mul (variable-time)
	time:   [363.32 µs 363.95 µs 364.58 µs]
	change: [−14.188% −13.693% −13.167%] (p = 0.00 < 0.05)
	Performance has improved.