### PR TITLE
sm2: add `precomputed-tables` feature

### DIFF
--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -38,8 +38,8 @@ hex-literal = "1"
 proptest = "1"
 
 [features]
-default = ["arithmetic", "dsa", "getrandom", "pke", "pem", "std"]
-alloc = ["elliptic-curve/alloc"]
+default = ["arithmetic", "dsa", "getrandom", "pke", "pem", "precomputed-tables", "std"]
+alloc = ["elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "elliptic-curve/std"]
 
 arithmetic = ["dep:primefield", "dep:primeorder", "elliptic-curve/arithmetic"]
@@ -49,6 +49,7 @@ getrandom = ["elliptic-curve/getrandom"]
 pke = ["arithmetic", "dep:sm3"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["elliptic-curve/pkcs8", "der"]
+precomputed-tables = ["arithmetic", "primeorder/basepoint-table"]
 serde = ["elliptic-curve/serde", "primeorder?/serde", "serdect"]
 
 [[bench]]

--- a/sm2/src/arithmetic.rs
+++ b/sm2/src/arithmetic.rs
@@ -8,6 +8,9 @@
 pub(crate) mod field;
 pub(crate) mod scalar;
 
+#[cfg(feature = "precomputed-tables")]
+mod tables;
+
 pub use self::scalar::Scalar;
 
 use self::field::FieldElement;
@@ -60,4 +63,9 @@ impl PrimeCurveParams for Sm2 {
             "BC3736A2F4F6779C59BDCEE36B692153D0A9877CC62A474002DF32E52139F0A0",
         ),
     );
+
+    #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
+    fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
+        tables::BASEPOINT_TABLE_VARTIME.mul(k)
+    }
 }

--- a/sm2/src/arithmetic/tables.rs
+++ b/sm2/src/arithmetic/tables.rs
@@ -1,0 +1,24 @@
+//! Precomputed tables (optional).
+
+#[cfg(feature = "alloc")]
+pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
+
+#[cfg(feature = "alloc")]
+mod vartime {
+    use crate::{ProjectivePoint, Sm2};
+    use primeorder::PrimeCurveWithBasepointTableVartime;
+
+    /// Window size for the variable-time basepoint table.
+    const WINDOW_SIZE_VARTIME: usize = 8;
+
+    /// Variable-time basepoint table for NIST P-384's generator.
+    type BasepointTableVartime =
+        elliptic_curve::point::BasepointTableVartime<ProjectivePoint, WINDOW_SIZE_VARTIME>;
+
+    /// Lazily computed basepoint table.
+    pub(crate) static BASEPOINT_TABLE_VARTIME: BasepointTableVartime = BasepointTableVartime::new();
+
+    impl PrimeCurveWithBasepointTableVartime<WINDOW_SIZE_VARTIME> for Sm2 {
+        const BASEPOINT_TABLE_VARTIME: &'static BasepointTableVartime = &BASEPOINT_TABLE_VARTIME;
+    }
+}


### PR DESCRIPTION
Adds a feature similar to the ones in `k256`, `p256`, `p384` etc which uses `BasepointTableVartime` and wNAF for `mul_by_generator_vartime`.

Includes new benchmarks. The performance improvement is ~28%, which is the best we've seen yet:

    ProjectivePoint/generator-scalar mul (variable-time)
        time:   [123.66 µs 124.56 µs 125.53 µs]
        change: [−28.549% −27.668% −26.903%] (p = 0.00 < 0.05)
        Performance has improved.