### PR TITLE
x448: Cargo.toml fixup

### DIFF
--- a/x448/Cargo.toml
+++ b/x448/Cargo.toml
@@ -15,14 +15,10 @@ description = "Pure Rust implementation of X448, an elliptic curve Diffie-Hellma
 
 [dependencies]
 ed448-goldilocks = { version = "0.14.0-pre.12", default-features = false }
+zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true }
-
-[dependencies.zeroize]
-version = "1"
-default-features = false
-features = ["zeroize_derive"]
 
 [features]
 default = ["getrandom"]


### PR DESCRIPTION
Having the dependency broken apart onto multiple lines like this was breaking the regex that looks for the version in Cargo.toml for Trusted Publishing