### PR TITLE
Bump (transitive) `pkcs8` dependency to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "ed448"
-version = "0.5.0-rc.5"
+version = "0.5.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6517ef61d12c57c218393995d2ee5ab2dac4c27501d24f7595590e097985c9"
+checksum = "6d25a15e5c469a3655c10bfeb6fc8cc8a00cf38909c794e66a253ccc5f5ac9e0"
 dependencies = [
  "pkcs8",
  "serde",
@@ -501,8 +501,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.31"
-source = "git+https://github.com/RustCrypto/traits#30a48abdd75d1420e816bbc00f3c419409eac03d"
+version = "0.14.0-rc.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda94f31325c4275e9706adecbb6f0650dee2f904c915a98e3d81adaaaa757aa"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -934,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.11"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "spki",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,3 @@ ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
-
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.31", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.32", features = ["sec1"] }
 
 # optional dependencies
 belt-block = { version = "0.2", optional = true }
@@ -30,7 +30,7 @@ hex-literal = { version = "1", optional = true }
 hkdf = { version = "0.13", optional = true }
 hmac = { version = "0.13", optional = true }
 rand_core = "0.10"
-pkcs8 = { version = "0.11.0-rc.11", optional = true }
+pkcs8 = { version = "0.11", optional = true }
 primefield = { version = "0.14.0-rc.9", optional = true }
 primeorder = { version = "0.14.0-rc.9", optional = true }
 sec1 = { version = "0.8.1", optional = true }
@@ -38,7 +38,7 @@ signature = { version = "3.0.0-rc.10", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.9", features = ["dev"] }
 proptest = "1"

--- a/bignp256/src/secret_key.rs
+++ b/bignp256/src/secret_key.rs
@@ -142,8 +142,9 @@ impl TryFrom<pkcs8::PrivateKeyInfoRef<'_>> for SecretKey {
         private_key_info
             .algorithm
             .assert_oids(ALGORITHM_OID, BignP256::OID)?;
+
         Self::from_slice(private_key_info.private_key.as_bytes())
-            .map_err(|_| pkcs8::Error::KeyMalformed)
+            .map_err(|_| pkcs8::KeyError::Invalid.into())
     }
 }
 

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.17", optional = true, default-features = false, features = ["der"] }
@@ -24,7 +24,7 @@ sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.17", optional = true, default-features = false, features = ["der"] }
@@ -24,7 +24,7 @@ sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -16,14 +16,14 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.31", features = ["arithmetic", "pkcs8"] }
+elliptic-curve = { version = "0.14.0-rc.32", features = ["arithmetic", "pkcs8"] }
 hash2curve = "0.14.0-rc.12"
 rand_core = { version = "0.10", default-features = false }
 sha3 = { version = "0.11", default-features = false }
 subtle = { version = "2.6", default-features = false }
 
 # optional dependencies
-ed448 = { version = "0.5.0-rc.3", optional = true, default-features = false }
+ed448 = { version = "0.5.0-rc.6", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true }
 signature = { version = "3.0.0-rc.10", optional = true, default-features = false, features = ["digest", "rand_core"] }
 
@@ -44,7 +44,7 @@ std = ["alloc", "getrandom"]
 
 bits = ["elliptic-curve/bits"]
 getrandom = ["elliptic-curve/getrandom"]
-pkcs8 = ["ed448?/pkcs8", "elliptic-curve/pkcs8"]
+pkcs8 = ["ed448/pkcs8", "elliptic-curve/pkcs8"]
 signing = ["dep:ed448", "dep:signature"]
 serde = ["dep:serdect", "ed448?/serde_bytes"]
 

--- a/ed448-goldilocks/src/sign/signing_key.rs
+++ b/ed448-goldilocks/src/sign/signing_key.rs
@@ -16,7 +16,7 @@ use signature::Error;
 use subtle::{Choice, ConstantTimeEq};
 
 #[cfg(feature = "pkcs8")]
-use crate::{PUBLIC_KEY_LENGTH, edwards::affine::PointBytes};
+use ::ed448::pkcs8::{KeypairBytes, PublicKeyBytes};
 
 /// Ed448 secret key as defined in [RFC8032 § 5.2.5]
 ///
@@ -330,70 +330,6 @@ impl pkcs8::spki::DynSignatureAlgorithmIdentifier for SigningKey {
 }
 
 #[cfg(feature = "pkcs8")]
-/// Keypair bytes for Ed448
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct KeypairBytes {
-    /// The secret key bytes
-    pub secret_key: PointBytes,
-    /// The public key bytes if included
-    pub verifying_key: Option<PointBytes>,
-}
-
-#[cfg(all(feature = "alloc", feature = "pkcs8"))]
-impl pkcs8::EncodePrivateKey for KeypairBytes {
-    fn to_pkcs8_der(&self) -> pkcs8::Result<pkcs8::SecretDocument> {
-        let verifying_key = self.verifying_key.as_ref();
-        let public_key = verifying_key
-            .map(|k| pkcs8::der::asn1::BitStringRef::from_bytes(k))
-            .transpose()?;
-        let private_key = pkcs8::der::asn1::OctetStringRef::new(self.secret_key.as_ref())?;
-
-        let private_key_info = pkcs8::PrivateKeyInfoRef {
-            algorithm: super::ALGORITHM_ID,
-            private_key,
-            public_key,
-        };
-        let result = pkcs8::SecretDocument::encode_msg(&private_key_info)?;
-
-        Ok(result)
-    }
-}
-
-#[cfg(feature = "pkcs8")]
-impl TryFrom<pkcs8::PrivateKeyInfoRef<'_>> for KeypairBytes {
-    type Error = pkcs8::Error;
-
-    fn try_from(value: pkcs8::PrivateKeyInfoRef<'_>) -> Result<Self, Self::Error> {
-        if value.algorithm.oid != super::ALGORITHM_OID {
-            return Err(pkcs8::Error::KeyMalformed);
-        }
-        if value.private_key.as_bytes().len() != SECRET_KEY_LENGTH {
-            return Err(pkcs8::Error::KeyMalformed);
-        }
-        let mut secret_key = [0u8; SECRET_KEY_LENGTH];
-        secret_key.copy_from_slice(value.private_key.as_bytes());
-        let verifying_key = if let Some(public_key) = value.public_key {
-            if public_key.has_unused_bits() {
-                return Err(pkcs8::Error::KeyMalformed);
-            }
-            let public_key = public_key.raw_bytes();
-            if public_key.len() != PUBLIC_KEY_LENGTH {
-                return Err(pkcs8::Error::KeyMalformed);
-            }
-            let mut bytes = [0u8; PUBLIC_KEY_LENGTH];
-            bytes.copy_from_slice(public_key);
-            Some(bytes)
-        } else {
-            None
-        };
-        Ok(KeypairBytes {
-            secret_key,
-            verifying_key,
-        })
-    }
-}
-
-#[cfg(feature = "pkcs8")]
 impl TryFrom<KeypairBytes> for SigningKey {
     type Error = pkcs8::Error;
 
@@ -410,11 +346,11 @@ impl TryFrom<&KeypairBytes> for SigningKey {
         let signing_key =
             SigningKey::from(SecretKey::try_from(&value.secret_key[..]).expect("invalid length"));
 
-        if let Some(public_bytes) = value.verifying_key {
-            let verifying_key =
-                VerifyingKey::from_bytes(&public_bytes).map_err(|_| pkcs8::Error::KeyMalformed)?;
+        if let Some(public_bytes) = &value.public_key {
+            let verifying_key = VerifyingKey::from_bytes(public_bytes.as_ref())
+                .map_err(|_| pkcs8::KeyError::Invalid)?;
             if signing_key.verifying_key() != verifying_key {
-                return Err(pkcs8::Error::KeyMalformed);
+                return Err(pkcs8::KeyError::Invalid.into());
             }
         }
         Ok(signing_key)
@@ -425,8 +361,8 @@ impl TryFrom<&KeypairBytes> for SigningKey {
 impl From<&SigningKey> for KeypairBytes {
     fn from(signing_key: &SigningKey) -> Self {
         KeypairBytes {
-            secret_key: PointBytes::from(signing_key.to_bytes()),
-            verifying_key: Some(PointBytes::from(signing_key.verifying_key().to_bytes())),
+            secret_key: signing_key.to_bytes().into(),
+            public_key: Some(PublicKeyBytes(signing_key.verifying_key().to_bytes())),
         }
     }
 }

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = { version = "0.11" }
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["arithmetic"] }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85"
 
 [dependencies]
 cpubits = "0.1"
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
 hash2curve = { version = "0.14.0-rc.12", optional = true }
 
 # optional dependencies

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "1"
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true, default-features = false }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
 rand_core = { version = "0.10", default-features = false }
 
@@ -33,7 +33,7 @@ sm3 = { version = "0.5", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["dev"] }
 hex-literal = "1"
 proptest = "1"
 


### PR DESCRIPTION
Updates the `elliptic-curve` dependency to v0.14.0-rc.32 which transitively pulls in `pkcs8` v0.11, and also updates some specific requirements for other crates like `pkcs8` itself and `ed448`.

This also migrates `ed448-goldilocks` to using `ed448::pkcs8::KeypairBytes` rather than specifying its own similar-shaped structure, so we don't have to duplicate the `pkcs8` API changes and can instead handle them in one place.