### PR TITLE
ed448-goldilocks: bump `ed448` dependency to v0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,13 +461,13 @@ dependencies = [
 
 [[package]]
 name = "ed448"
-version = "0.5.0-rc.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d25a15e5c469a3655c10bfeb6fc8cc8a00cf38909c794e66a253ccc5f5ac9e0"
+checksum = "ae112a25f86ae3598d4e8533ed1e65149cec6eb21918e7a6f4c06dddec370263"
 dependencies = [
  "pkcs8",
- "serde",
  "serde_bytes",
+ "serdect",
  "signature",
 ]
 

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -23,7 +23,7 @@ sha3 = { version = "0.11", default-features = false }
 subtle = { version = "2.6", default-features = false }
 
 # optional dependencies
-ed448 = { version = "0.5.0-rc.6", optional = true, default-features = false }
+ed448 = { version = "0.5", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true }
 signature = { version = "3", optional = true, default-features = false, features = ["digest", "rand_core"] }
 


### PR DESCRIPTION
The `ed448` crate provides an `ed448::Signature` type along with generic PKCS#8 support.

Release PR: RustCrypto/signatures#1335