### PR TITLE
ed448-goldilocks,hash2curve: replace sha3 with shake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
  "serde_bare",
  "serde_json",
  "serdect",
- "sha3",
+ "shake",
  "signature",
  "subtle",
 ]
@@ -614,7 +614,7 @@ dependencies = [
  "elliptic-curve",
  "hex-literal",
  "sha2",
- "sha3",
+ "shake",
 ]
 
 [[package]]
@@ -1384,6 +1384,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1441,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "subtle"

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -19,7 +19,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 elliptic-curve = { version = "0.14.0-rc.32", features = ["arithmetic", "pkcs8"] }
 hash2curve = "0.14.0-rc.12"
 rand_core = { version = "0.10", default-features = false }
-sha3 = { version = "0.11", default-features = false }
+shake = { version = "0.1", default-features = false }
 subtle = { version = "2.6", default-features = false }
 
 # optional dependencies

--- a/ed448-goldilocks/README.md
+++ b/ed448-goldilocks/README.md
@@ -20,7 +20,7 @@ It is intended to be portable, fast, and safe.
 use ed448_goldilocks::{
     Ed448, EdwardsPoint, CompressedEdwardsY, EdwardsScalar,
     elliptic_curve::Generate,
-    sha3::Shake256
+    shake::Shake256
 };
 use elliptic_curve::{consts::U84, Field, group::GroupEncoding};
 use hash2curve::{ExpandMsgXof, GroupDigest};

--- a/ed448-goldilocks/src/decaf/points.rs
+++ b/ed448-goldilocks/src/decaf/points.rs
@@ -618,7 +618,7 @@ mod test {
     use super::*;
     use crate::TWISTED_EDWARDS_BASE_POINT;
     use hash2curve::ExpandMsgXof;
-    use sha3::Shake256;
+    use shake::Shake256;
 
     #[test]
     fn test_edwards_decaf_operations() {

--- a/ed448-goldilocks/src/decaf/scalar.rs
+++ b/ed448-goldilocks/src/decaf/scalar.rs
@@ -83,7 +83,7 @@ mod test {
     use hash2curve::ExpandMsgXof;
     use hex_literal::hex;
     use proptest::property_test;
-    use sha3::Shake256;
+    use shake::Shake256;
 
     #[test]
     fn test_basic_add() {

--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -1006,7 +1006,7 @@ mod tests {
 
         for (msg, x, y) in MSGS {
             let p =
-                hash2curve::hash_from_bytes::<Ed448, ExpandMsgXof<sha3::Shake256>>(&[msg], &[DST])
+                hash2curve::hash_from_bytes::<Ed448, ExpandMsgXof<shake::Shake256>>(&[msg], &[DST])
                     .unwrap();
             assert_eq!(p.is_on_curve().unwrap_u8(), 1u8);
             let p = p.to_affine();
@@ -1045,7 +1045,7 @@ mod tests {
         ];
 
         for (msg, x, y) in MSGS {
-            let p = hash2curve::encode_from_bytes::<Ed448, ExpandMsgXof<sha3::Shake256>>(
+            let p = hash2curve::encode_from_bytes::<Ed448, ExpandMsgXof<shake::Shake256>>(
                 &[msg],
                 &[DST],
             )

--- a/ed448-goldilocks/src/edwards/scalar.rs
+++ b/ed448-goldilocks/src/edwards/scalar.rs
@@ -102,7 +102,7 @@ mod test {
     use hash2curve::ExpandMsgXof;
     use hex_literal::hex;
     use proptest::property_test;
-    use sha3::Shake256;
+    use shake::Shake256;
 
     #[test]
     fn test_basic_add() {

--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -511,7 +511,7 @@ mod tests {
     use elliptic_curve::consts::U32;
     use hash2curve::{ExpandMsg, ExpandMsgXof, Expander};
     use hex_literal::hex;
-    use sha3::Shake256;
+    use shake::Shake256;
 
     fn assert_from_okm(dst: &[u8], msgs: &[(&[u8], [u8; 56], [u8; 56])]) {
         for (msg, expected_u0, expected_u1) in msgs {

--- a/ed448-goldilocks/src/lib.rs
+++ b/ed448-goldilocks/src/lib.rs
@@ -54,7 +54,7 @@ pub(crate) mod macros;
 pub use elliptic_curve;
 pub use hash2curve;
 pub use rand_core;
-pub use sha3;
+pub use shake;
 pub use subtle;
 
 pub(crate) mod curve;
@@ -87,7 +87,7 @@ use elliptic_curve::{
     point::PointCompression,
 };
 use hash2curve::{ExpandMsgXof, GroupDigest};
-use sha3::Shake256;
+use shake::Shake256;
 
 /// Edwards448 curve.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/ed448-goldilocks/src/sign.rs
+++ b/ed448-goldilocks/src/sign.rs
@@ -57,7 +57,7 @@
 #![cfg_attr(feature = "getrandom", doc = "```")]
 #![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! use ed448_goldilocks::{SigningKey, PreHasherXof, elliptic_curve::Generate};
-//! use sha3::{Shake256, digest::Update};
+//! use shake::{Shake256, digest::Update};
 //!
 //! let msg = b"Hello World";
 //!

--- a/ed448-goldilocks/src/sign/expanded.rs
+++ b/ed448-goldilocks/src/sign/expanded.rs
@@ -7,7 +7,7 @@ use elliptic_curve::{
     group::GroupEncoding,
     zeroize::{Zeroize, ZeroizeOnDrop},
 };
-use sha3::{
+use shake::{
     Shake256,
     digest::{ExtendableOutput, ExtendableOutputReset, Update, XofReader},
 };

--- a/ed448-goldilocks/src/sign/signing_key.rs
+++ b/ed448-goldilocks/src/sign/signing_key.rs
@@ -8,7 +8,7 @@ use elliptic_curve::{
     rand_core::TryCryptoRng,
     zeroize::{Zeroize, ZeroizeOnDrop},
 };
-use sha3::digest::{
+use shake::digest::{
     Digest, ExtendableOutput, FixedOutput, FixedOutputReset, HashMarker, Update, XofReader,
     common::BlockSizeUser, consts::U64, typenum::IsEqual,
 };

--- a/ed448-goldilocks/src/sign/verifying_key.rs
+++ b/ed448-goldilocks/src/sign/verifying_key.rs
@@ -19,7 +19,7 @@ use core::{
     hash::{Hash, Hasher},
 };
 use elliptic_curve::Group;
-use sha3::{
+use shake::{
     Shake256,
     digest::{Digest, ExtendableOutput, FixedOutput, HashMarker, Update, XofReader},
 };

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -20,4 +20,4 @@ elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features 
 [dev-dependencies]
 hex-literal = "1"
 sha2 = { version = "0.11", default-features = false }
-sha3 = { version = "0.11", default-features = false }
+shake = { version = "0.1", default-features = false }

--- a/hash2curve/src/hash2field/expand_msg/xof.rs
+++ b/hash2curve/src/hash2field/expand_msg/xof.rs
@@ -120,7 +120,7 @@ mod test {
         typenum::{IsLess, U16, U32, U128, U65536},
     };
     use hex_literal::hex;
-    use sha3::Shake128;
+    use shake::Shake128;
 
     #[test]
     fn edge_cases() {
@@ -347,7 +347,7 @@ mod test {
 
     #[test]
     fn expand_message_xof_shake_256() {
-        use sha3::Shake256;
+        use shake::Shake256;
 
         const DST: &[u8] = b"QUUX-V01-CS02-with-expander-SHAKE256";
         const DST_PRIME: &[u8] =


### PR DESCRIPTION
Shake has recently been split off from sha3 into a dedicated `shake` crate: https://github.com/RustCrypto/hashes/pull/869

This makes the adjustments in the downstream crates to reflect that change.