### PR TITLE
Remove `bits` features

### DIFF
--- a/.github/workflows/ed448-goldilocks.yml
+++ b/.github/workflows/ed448-goldilocks.yml
@@ -90,8 +90,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: ${{ matrix.deps }}
       - run: cargo test --target ${{ matrix.target }} --no-default-features
-      - run: cargo hack test --feature-powerset --target ${{ matrix.target }} --exclude-features bits,std
-      - run: cargo test --target ${{ matrix.target }} --features bits
+      - run: cargo hack test --feature-powerset --target ${{ matrix.target }} --exclude-features std
       - run: cargo test --target ${{ matrix.target }} --features std
       - run: cargo test --target ${{ matrix.target }} --all-features
       - run: cargo test --release --target ${{ matrix.target }} --all-features

--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -41,7 +41,6 @@ jobs:
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features alloc
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features arithmetic
-      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features bits
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features critical-section
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdh
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdsa-core
@@ -55,7 +54,7 @@ jobs:
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features sha256
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdsa
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdsa,sha256
-      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features bits,critical-section,ecdh,ecdsa,group-digest,pem,pkcs8,schnorr,serde,sha256
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features critical-section,ecdh,ecdsa,group-digest,pem,pkcs8,schnorr,serde,sha256
 
   benches:
     runs-on: ubuntu-latest

--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -41,7 +41,6 @@ jobs:
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features alloc
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features arithmetic
-      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features bits
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdh
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdsa-core
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdsa
@@ -52,7 +51,7 @@ jobs:
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features pkcs8
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features serde
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features sha256
-      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features alloc,bits,ecdh,ecdsa,group-digest,oprf,pem,pkcs8,serde,sha256
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features alloc,ecdh,ecdsa,group-digest,oprf,pem,pkcs8,serde,sha256
 
   benches:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 4
 
 [[package]]
-name = "addchain"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e33f6a175ec6a9e0aca777567f9ff7c3deefc255660df887e7fa3585e9801d8"
-dependencies = [
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,18 +120,6 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "blobby"
@@ -564,12 +541,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,7 +713,7 @@ dependencies = [
  "hash2curve",
  "hex",
  "hex-literal",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "primeorder",
  "proptest",
@@ -791,17 +762,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
 
 [[package]]
 name = "num-bigint"
@@ -992,7 +952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1053,7 +1013,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1082,12 +1042,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1198,25 +1152,8 @@ version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
 dependencies = [
- "bitvec",
  "rand_core 0.10.1",
- "rustcrypto-ff_derive",
  "subtle",
-]
-
-[[package]]
-name = "rustcrypto-ff_derive"
-version = "0.14.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cda22ea03582974ab5687fc131eba2dc78e258e7eef4d7e01bcd0522ed79f66"
-dependencies = [
- "addchain",
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1336,7 +1273,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1456,17 +1393,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -1475,12 +1401,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1604,7 +1524,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1715,7 +1635,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1731,7 +1651,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1774,15 +1694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
 name = "x448"
 version = "0.14.0-pre.9"
 dependencies = [
@@ -1808,7 +1719,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1828,7 +1739,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -49,7 +49,6 @@ alloc = ["elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "elliptic-curve/std", "getrandom"]
 
 arithmetic = ["dep:primefield", "dep:primeorder", "elliptic-curve/arithmetic"]
-bits = ["arithmetic", "elliptic-curve/bits"]
 ecdsa = ["arithmetic", "dep:signature", "dep:belt-hash", "dep:bign-genk", "dep:belt-block", "belt-block/cipher", "belt-hash/oid"]
 getrandom = ["elliptic-curve/getrandom"]
 pem = ["pkcs8/pem", "sec1/pem"]

--- a/bignp256/src/lib.rs
+++ b/bignp256/src/lib.rs
@@ -143,7 +143,3 @@ pub type NonZeroScalar = elliptic_curve::NonZeroScalar<BignP256>;
 /// Generic scalar type with primitive functionality.#
 #[cfg(feature = "arithmetic")]
 pub type ScalarValue = elliptic_curve::ScalarValue<BignP256>;
-
-/// Bit representation of a BIGN P-256 scalar field element.
-#[cfg(feature = "bits")]
-pub type ScalarBits = elliptic_curve::scalar::ScalarBits<BignP256>;

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -32,7 +32,6 @@ alloc = ["ecdsa?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "ecdsa?/std", "elliptic-curve/std", "getrandom"]
 
 arithmetic = ["dep:primefield", "dep:primeorder"]
-bits = ["arithmetic", "elliptic-curve/bits"]
 getrandom = ["ecdsa?/getrandom", "elliptic-curve/getrandom"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -32,7 +32,6 @@ alloc = ["ecdsa?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "ecdsa?/std", "elliptic-curve/std", "getrandom"]
 
 arithmetic = ["dep:primefield", "dep:primeorder"]
-bits = ["arithmetic", "elliptic-curve/bits"]
 getrandom = ["ecdsa?/getrandom", "elliptic-curve/getrandom"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -42,7 +42,6 @@ default = ["std", "signing", "pkcs8"]
 alloc = ["ed448?/alloc", "elliptic-curve/alloc", "serdect?/alloc", "signature?/alloc"]
 std = ["alloc", "getrandom"]
 
-bits = ["elliptic-curve/bits"]
 getrandom = ["elliptic-curve/getrandom"]
 pkcs8 = ["ed448/pkcs8", "elliptic-curve/pkcs8"]
 signing = ["dep:ed448", "dep:signature"]

--- a/ed448-goldilocks/src/decaf/scalar.rs
+++ b/ed448-goldilocks/src/decaf/scalar.rs
@@ -54,13 +54,6 @@ pub type DecafScalarBytes = ScalarBytes<Decaf448>;
 /// The number of bytes needed to represent the safely create a scalar from a random bytes
 pub type WideDecafScalarBytes = WideScalarBytes<Decaf448>;
 
-#[cfg(feature = "bits")]
-impl From<&DecafScalar> for elliptic_curve::scalar::ScalarBits<Decaf448> {
-    fn from(scalar: &DecafScalar) -> Self {
-        scalar.scalar.to_words().into()
-    }
-}
-
 impl Reduce<Array<u8, U64>> for DecafScalar {
     fn reduce(value: &Array<u8, U64>) -> Self {
         const SEMI_WIDE_MODULUS: NonZero<U512> = NonZero::<U512>::new_unwrap(U512::from_be_hex(

--- a/ed448-goldilocks/src/edwards/scalar.rs
+++ b/ed448-goldilocks/src/edwards/scalar.rs
@@ -72,13 +72,6 @@ pub type EdwardsScalarBytes = ScalarBytes<Ed448>;
 /// The number of bytes needed to represent the safely create a scalar from a random bytes
 pub type WideEdwardsScalarBytes = WideScalarBytes<Ed448>;
 
-#[cfg(feature = "bits")]
-impl From<&EdwardsScalar> for elliptic_curve::scalar::ScalarBits<Ed448> {
-    fn from(scalar: &EdwardsScalar) -> Self {
-        scalar.scalar.to_words().into()
-    }
-}
-
 impl Reduce<Array<u8, U84>> for EdwardsScalar {
     fn reduce(value: &Array<u8, U84>) -> Self {
         const SEMI_WIDE_MODULUS: NonZero<U704> = NonZero::<U704>::new_unwrap(U704::from_be_hex(

--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -26,9 +26,6 @@ use elliptic_curve::{
 use rand_core::{CryptoRng, Rng, TryCryptoRng, TryRng};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, CtOption};
 
-#[cfg(feature = "bits")]
-use elliptic_curve::ff::{FieldBits, PrimeFieldBits};
-
 /// Shared scalar for [`Ed448`] and [`Decaf448`].
 /// Use [`EdwardsScalar`] and [`DecafScalar`] directly.
 ///
@@ -547,19 +544,6 @@ impl<C: CurveWithScalar> Retrieve for Scalar<C> {
 
     fn retrieve(&self) -> U448 {
         U448::from_le_byte_array(self.to_bytes().into())
-    }
-}
-
-#[cfg(feature = "bits")]
-impl<C: CurveWithScalar> PrimeFieldBits for Scalar<C> {
-    type ReprBits = [Word; U448::LIMBS];
-
-    fn to_le_bits(&self) -> FieldBits<Self::ReprBits> {
-        self.scalar.to_words().into()
-    }
-
-    fn char_le_bits() -> FieldBits<Self::ReprBits> {
-        ORDER.to_words().into()
     }
 }
 

--- a/ed448-goldilocks/src/lib.rs
+++ b/ed448-goldilocks/src/lib.rs
@@ -93,12 +93,8 @@ use shake::Shake256;
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Ed448;
 
-/// Bytes of the Ed448 field
+/// Serialized byte representation of an Ed448 field element.
 pub type Ed448FieldBytes = elliptic_curve::FieldBytes<Ed448>;
-
-/// Scalar bits of the Ed448 scalar
-#[cfg(feature = "bits")]
-pub type Ed448ScalarBits = elliptic_curve::scalar::ScalarBits<Ed448>;
 
 /// Non-zero scalar of the Ed448 scalar
 pub type Ed448NonZeroScalar = elliptic_curve::NonZeroScalar<Ed448>;
@@ -147,10 +143,6 @@ pub struct Decaf448;
 
 /// Bytes of the Decaf448 field
 pub type Decaf448FieldBytes = elliptic_curve::FieldBytes<Decaf448>;
-
-/// Scalar bits of the Decaf448 scalar
-#[cfg(feature = "bits")]
-pub type Decaf448ScalarBits = elliptic_curve::scalar::ScalarBits<Decaf448>;
 
 /// Non-zero scalar of the Decaf448 scalar
 pub type Decaf448NonZeroScalar = elliptic_curve::NonZeroScalar<Decaf448>;

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -47,7 +47,6 @@ alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std", "getrandom"]
 
 arithmetic = ["elliptic-curve/arithmetic"]
-bits = ["arithmetic", "elliptic-curve/bits"]
 critical-section = ["elliptic-curve/critical-section", "precomputed-tables"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -34,8 +34,6 @@ pub(crate) use self::wide::WideScalar;
 
 #[cfg(feature = "serde")]
 use serdect::serde::{Deserialize, Serialize, de, ser};
-#[cfg(feature = "bits")]
-use {crate::ScalarBits, elliptic_curve::group::ff::PrimeFieldBits};
 
 #[cfg(test)]
 use num_bigint::{BigUint, ToBigUint};
@@ -66,8 +64,6 @@ const FRAC_MODULUS_2: U256 = ORDER.as_ref().shr_vartime(1);
 ///   represents elements of prime fields and provides:
 ///   - `from_repr`/`to_repr` for converting field elements from/to big integers.
 ///   - `multiplicative_generator` and `root_of_unity` constants.
-/// - [`PrimeFieldBits`](https://docs.rs/ff/latest/ff/trait.PrimeFieldBits.html) -
-///   operations over field elements represented as bits (requires `bits` feature)
 ///
 /// Please see the documentation for the relevant traits for more information.
 ///
@@ -313,30 +309,6 @@ impl PrimeField for Scalar {
 
     fn is_odd(&self) -> Choice {
         self.0.is_odd().into()
-    }
-}
-
-// Detect mismatch between our word size and bitvec's word size
-cpubits! {
-    64 => {
-        #[cfg(all(feature = "bits", target_pointer_width = "32"))]
-        compile_error!("the 'bits' feature is not supported on this target");
-    }
-}
-
-#[cfg(feature = "bits")]
-impl PrimeFieldBits for Scalar {
-    cpubits! {
-        32 => { type ReprBits = [u32; 8]; }
-        64 => { type ReprBits = [u64; 4]; }
-    }
-
-    fn to_le_bits(&self) -> ScalarBits {
-        self.into()
-    }
-
-    fn char_le_bits() -> ScalarBits {
-        ORDER.to_words().into()
     }
 }
 
@@ -711,13 +683,6 @@ impl Product for Scalar {
 impl<'a> Product<&'a Scalar> for Scalar {
     fn product<I: Iterator<Item = &'a Scalar>>(iter: I) -> Self {
         iter.copied().product()
-    }
-}
-
-#[cfg(feature = "bits")]
-impl From<&Scalar> for ScalarBits {
-    fn from(scalar: &Scalar) -> ScalarBits {
-        scalar.0.to_words().into()
     }
 }
 

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -154,7 +154,3 @@ pub type SecretKey = elliptic_curve::SecretKey<Secp256k1>;
 
 #[cfg(not(feature = "arithmetic"))]
 impl elliptic_curve::sec1::ValidatePublicKey for Secp256k1 {}
-
-/// Bit representation of a secp256k1 (K-256) scalar field element.
-#[cfg(feature = "bits")]
-pub type ScalarBits = elliptic_curve::scalar::ScalarBits<Secp256k1>;

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -37,7 +37,6 @@ alloc = ["elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "elliptic-curve/std", "getrandom"]
 
 arithmetic = ["dep:primefield", "dep:primeorder", "elliptic-curve/arithmetic"]
-bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm"]
 getrandom = ["ecdsa-core?/getrandom", "elliptic-curve/getrandom"]

--- a/p192/src/lib.rs
+++ b/p192/src/lib.rs
@@ -96,7 +96,3 @@ pub type NonZeroScalar = elliptic_curve::NonZeroScalar<NistP192>;
 
 #[cfg(not(feature = "arithmetic"))]
 impl elliptic_curve::sec1::ValidatePublicKey for NistP192 {}
-
-/// Bit representation of a NIST P-192 scalar field element.
-#[cfg(feature = "bits")]
-pub type ScalarBits = elliptic_curve::scalar::ScalarBits<NistP192>;

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -38,7 +38,6 @@ alloc = ["elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "elliptic-curve/std", "getrandom"]
 
 arithmetic = ["dep:primefield", "dep:primeorder", "elliptic-curve/arithmetic"]
-bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm", "sha224"]

--- a/p224/src/lib.rs
+++ b/p224/src/lib.rs
@@ -113,7 +113,3 @@ pub type SecretKey = elliptic_curve::SecretKey<NistP224>;
 
 #[cfg(not(feature = "arithmetic"))]
 impl elliptic_curve::sec1::ValidatePublicKey for NistP224 {}
-
-/// Bit representation of a NIST P-224 scalar field element.
-#[cfg(feature = "bits")]
-pub type ScalarBits = elliptic_curve::scalar::ScalarBits<NistP224>;

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -43,7 +43,6 @@ alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std", "getrandom"]
 
 arithmetic = ["dep:primefield", "dep:primeorder", "elliptic-curve/arithmetic"]
-bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm", "sha256"]

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -31,9 +31,6 @@ use {
     },
 };
 
-#[cfg(all(doc, feature = "bits"))]
-use elliptic_curve::ff::PrimeFieldBits;
-
 /// Constant representing the modulus: p = 2^{224}(2^{32} − 1) + 2^{192} + 2^{96} − 1
 const MODULUS_HEX: &str = "ffffffff00000001000000000000000000000000ffffffffffffffffffffffff";
 

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -33,9 +33,6 @@ cpubits! {
     }
 }
 
-#[cfg(feature = "bits")]
-use {crate::ScalarBits, elliptic_curve::group::ff::PrimeFieldBits};
-
 #[cfg(feature = "serde")]
 use {
     elliptic_curve::ScalarValue,
@@ -314,30 +311,6 @@ impl PrimeField for Scalar {
     }
 }
 
-// Detect mismatch between our word size and bitvec's word size
-cpubits! {
-    64 => {
-        #[cfg(all(feature = "bits", target_pointer_width = "32"))]
-        compile_error!("the 'bits' feature is not supported on this target");
-    }
-}
-
-#[cfg(feature = "bits")]
-impl PrimeFieldBits for Scalar {
-    cpubits! {
-        32 => { type ReprBits = [u32; 8]; }
-        64 => { type ReprBits = [u64; 4]; }
-    }
-
-    fn to_le_bits(&self) -> ScalarBits {
-        self.into()
-    }
-
-    fn char_le_bits() -> ScalarBits {
-        NistP256::ORDER.to_words().into()
-    }
-}
-
 impl Retrieve for Scalar {
     type Output = U256;
 
@@ -464,13 +437,6 @@ impl FromUniformBytes<64> for Scalar {
             U256::from_be_slice(&bytes[32..]),
             U256::from_be_slice(&bytes[..32]),
         ))
-    }
-}
-
-#[cfg(feature = "bits")]
-impl From<&Scalar> for ScalarBits {
-    fn from(scalar: &Scalar) -> ScalarBits {
-        scalar.0.to_words().into()
     }
 }
 
@@ -710,7 +676,6 @@ mod tests {
     use elliptic_curve::{
         Curve,
         array::Array,
-        bigint::cpubits,
         group::ff::PrimeField,
         ops::{BatchInvert, ReduceNonZero},
     };
@@ -752,30 +717,6 @@ mod tests {
         let secret = SecretKey::from_bytes(&scalar.to_bytes()).unwrap();
         let rederived_scalar = Scalar::from(&secret);
         assert_eq!(scalar.0, rederived_scalar.0);
-    }
-
-    cpubits! {
-        32 => {
-            #[test]
-            #[cfg(feature = "bits")]
-            fn scalar_into_scalarbits() {
-                use crate::ScalarBits;
-
-                let minus_one = ScalarBits::from([
-                    0xfc63_2550,
-                    0xf3b9_cac2,
-                    0xa717_9e84,
-                    0xbce6_faad,
-                    0xffff_ffff,
-                    0xffff_ffff,
-                    0x0000_0000,
-                    0xffff_ffff,
-                ]);
-
-                let scalar_bits = ScalarBits::from(&-Scalar::from(1u32));
-                assert_eq!(minus_one, scalar_bits);
-            }
-        }
     }
 
     #[test]

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -171,10 +171,6 @@ pub type SecretKey = elliptic_curve::SecretKey<NistP256>;
 #[cfg(not(feature = "arithmetic"))]
 impl elliptic_curve::sec1::ValidatePublicKey for NistP256 {}
 
-/// Bit representation of a NIST P-256 scalar field element.
-#[cfg(feature = "bits")]
-pub type ScalarBits = elliptic_curve::scalar::ScalarBits<NistP256>;
-
 #[cfg(feature = "oprf")]
 impl hash2curve::OprfParameters for NistP256 {
     /// See <https://www.rfc-editor.org/rfc/rfc9497.html#section-4.3-1>.

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -50,7 +50,6 @@ arithmetic = [
     "elliptic-curve/arithmetic",
     "elliptic-curve/digest"
 ]
-bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm", "sha384"]

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -149,10 +149,6 @@ pub type SecretKey = elliptic_curve::SecretKey<NistP384>;
 #[cfg(not(feature = "arithmetic"))]
 impl elliptic_curve::sec1::ValidatePublicKey for NistP384 {}
 
-/// Bit representation of a NIST P-384 scalar field element.
-#[cfg(feature = "bits")]
-pub type ScalarBits = elliptic_curve::scalar::ScalarBits<NistP384>;
-
 #[cfg(feature = "oprf")]
 impl hash2curve::OprfParameters for NistP384 {
     /// See <https://www.rfc-editor.org/rfc/rfc9497.html#section-4.4-1>.

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -43,7 +43,6 @@ alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std", "getrandom"]
 
 arithmetic = ["dep:primefield", "dep:primeorder"]
-bits = ["arithmetic", "elliptic-curve/bits"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm", "sha512"]

--- a/primefield/src/macros.rs
+++ b/primefield/src/macros.rs
@@ -357,19 +357,6 @@ macro_rules! monty_field_element {
             }
         }
 
-        #[cfg(feature = "bits")]
-        impl $crate::ff::PrimeFieldBits for $fe {
-            type ReprBits = [$crate::bigint::Word; <$uint>::LIMBS];
-
-            fn to_le_bits(&self) -> $crate::ff::FieldBits<Self::ReprBits> {
-                self.to_canonical().to_words().into()
-            }
-
-            fn char_le_bits() -> $crate::ff::FieldBits<Self::ReprBits> {
-                Self::PARAMS.modulus().to_words().into()
-            }
-        }
-
         $crate::field_op!($fe, Add, add, add);
         $crate::field_op!($fe, Sub, sub, sub);
         $crate::field_op!($fe, Mul, mul, multiply);

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -43,7 +43,6 @@ alloc = ["elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "elliptic-curve/std"]
 
 arithmetic = ["dep:primefield", "dep:primeorder", "elliptic-curve/arithmetic"]
-bits = ["arithmetic", "elliptic-curve/bits"]
 dsa = ["arithmetic", "dep:rfc6979", "dep:signature", "dep:sm3"]
 getrandom = ["elliptic-curve/getrandom"]
 pke = ["arithmetic", "dep:sm3"]

--- a/sm2/src/lib.rs
+++ b/sm2/src/lib.rs
@@ -159,7 +159,3 @@ pub type SecretKey = elliptic_curve::SecretKey<Sm2>;
 
 #[cfg(not(feature = "arithmetic"))]
 impl elliptic_curve::sec1::ValidatePublicKey for Sm2 {}
-
-/// Bit representation of a SM2 scalar field element.
-#[cfg(feature = "bits")]
-pub type ScalarBits = elliptic_curve::scalar::ScalarBits<Sm2>;


### PR DESCRIPTION
Upstream support was removed in RustCrypto/traits#2417.

See also: zkcrypto/ff#157