### PR TITLE
Use `elliptic-curve` with `ff`/`group` v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,12 +479,14 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.32"
-source = "git+http://github.com/RustCrypto/traits.git#95838a01bd186da138211685a338cac7185f950e"
+source = "git+http://github.com/RustCrypto/traits.git#83fa3770435d7e34e8c9a27d68839120912248a6"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "crypto-common",
  "digest",
+ "ff",
+ "group",
  "hex-literal",
  "hkdf",
  "hybrid-array",
@@ -492,8 +494,6 @@ dependencies = [
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.10.1",
- "rustcrypto-ff",
- "rustcrypto-group",
  "sec1",
  "serdect",
  "subtle",
@@ -521,6 +521,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -564,6 +574,17 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
 ]
 
 [[package]]
@@ -961,8 +982,8 @@ version = "0.14.0-rc.9"
 dependencies = [
  "crypto-bigint",
  "crypto-common",
+ "ff",
  "rand_core 0.10.1",
- "rustcrypto-ff",
  "subtle",
  "zeroize",
 ]
@@ -1143,26 +1164,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5236ce872cac07e0fb3969b0cbf468c7d2f37d432f1b627dcb7b8d34563fb0c3"
 dependencies = [
  "hmac",
- "subtle",
-]
-
-[[package]]
-name = "rustcrypto-ff"
-version = "0.14.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
-dependencies = [
- "rand_core 0.10.1",
- "subtle",
-]
-
-[[package]]
-name = "rustcrypto-group"
-version = "0.14.0-rc.1"
-source = "git+https://github.com/RustCrypto/group#d5ef2775cb66a10085c9ec48432c51cad4e7b3ee"
-dependencies = [
- "rand_core 0.10.1",
- "rustcrypto-ff",
  "subtle",
 ]
 
@@ -1409,7 +1410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,3 @@ primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
 
 elliptic-curve = { git = "http://github.com/RustCrypto/traits.git" }
-rustcrypto-group = { git = "https://github.com/RustCrypto/group" }

--- a/ed448-goldilocks/src/decaf/affine.rs
+++ b/ed448-goldilocks/src/decaf/affine.rs
@@ -1,10 +1,12 @@
+use crate::decaf::points::DecafPointRepr;
 use crate::{
     Decaf448FieldBytes, DecafPoint, DecafScalar, ORDER,
     curve::twedwards::affine::AffinePoint as InnerAffinePoint, field::FieldElement,
 };
 use elliptic_curve::{
-    Error, Generate, ctutils,
-    ops::{Mul, MulVartime},
+    CurveGroup, Error, Generate, ctutils,
+    group::{CurveAffine, GroupEncoding},
+    ops::{Mul, MulVartime, Neg},
     point::{AffineCoordinates, NonIdentity},
     zeroize::DefaultIsZeroes,
 };
@@ -102,11 +104,49 @@ impl AffineCoordinates for AffinePoint {
     }
 }
 
+impl CurveAffine for AffinePoint {
+    type Curve = DecafPoint;
+    type Scalar = DecafScalar;
+
+    fn identity() -> AffinePoint {
+        Self::IDENTITY
+    }
+
+    fn generator() -> AffinePoint {
+        DecafPoint::GENERATOR.to_affine()
+    }
+
+    fn is_identity(&self) -> Choice {
+        self.to_decaf().is_identity()
+    }
+
+    fn to_curve(&self) -> DecafPoint {
+        self.to_decaf()
+    }
+}
+
 impl DefaultIsZeroes for AffinePoint {}
 
 impl Generate for AffinePoint {
     fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         DecafPoint::try_generate_from_rng(rng).map(Into::into)
+    }
+}
+
+impl GroupEncoding for AffinePoint {
+    type Repr = DecafPointRepr;
+
+    fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
+        DecafPoint::from_bytes(bytes).map(|point| point.to_affine())
+    }
+
+    fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
+        // No unchecked conversion possible for compressed points
+        Self::from_bytes(bytes)
+    }
+
+    fn to_bytes(&self) -> Self::Repr {
+        self.to_decaf().to_bytes()
     }
 }
 
@@ -157,3 +197,11 @@ impl MulVartime<&DecafScalar> for &AffinePoint {
 }
 
 define_mul_variants!(LHS = AffinePoint, RHS = DecafScalar, Output = DecafPoint);
+
+impl Neg for AffinePoint {
+    type Output = AffinePoint;
+
+    fn neg(self) -> Self::Output {
+        self.to_decaf().neg().to_affine()
+    }
+}

--- a/ed448-goldilocks/src/decaf/points.rs
+++ b/ed448-goldilocks/src/decaf/points.rs
@@ -266,7 +266,7 @@ impl Generate for DecafPoint {
 impl Group for DecafPoint {
     type Scalar = DecafScalar;
 
-    fn try_from_rng<R>(rng: &mut R) -> Result<Self, R::Error>
+    fn try_random<R>(rng: &mut R) -> Result<Self, R::Error>
     where
         R: TryRng + ?Sized,
     {
@@ -341,9 +341,9 @@ impl<const N: usize> LinearCombination<[(DecafPoint, DecafScalar); N]> for Decaf
 impl LinearCombination<[(DecafPoint, DecafScalar)]> for DecafPoint {}
 
 impl CurveGroup for DecafPoint {
-    type AffineRepr = DecafAffinePoint;
+    type Affine = DecafAffinePoint;
 
-    fn to_affine(&self) -> Self::AffineRepr {
+    fn to_affine(&self) -> Self::Affine {
         DecafAffinePoint(self.0.to_extensible().to_affine())
     }
 }

--- a/ed448-goldilocks/src/edwards/affine.rs
+++ b/ed448-goldilocks/src/edwards/affine.rs
@@ -1,9 +1,11 @@
 use crate::{field::FieldElement, *};
 use core::fmt::{Display, Formatter, LowerHex, Result as FmtResult, UpperHex};
+use elliptic_curve::array::Array;
 use elliptic_curve::{
     Error, Generate, ctutils,
-    ops::{Mul, MulVartime},
-    point::NonIdentity,
+    group::{CurveAffine, Group, GroupEncoding},
+    ops::{Mul, MulVartime, Neg},
+    point::{AffineCoordinates, NonIdentity},
     zeroize::DefaultIsZeroes,
 };
 use rand_core::{TryCryptoRng, TryRng};
@@ -105,7 +107,7 @@ impl AffinePoint {
     ///
     /// Helper method that has `TryRng` bounds so `ProjectivePoint` can call it for its `group`
     /// impls, otherwise end users should use the `Generate` trait.
-    pub(crate) fn try_from_rng<R>(rng: &mut R) -> Result<Self, R::Error>
+    pub(crate) fn try_random<R>(rng: &mut R) -> Result<Self, R::Error>
     where
         R: TryRng + ?Sized,
     {
@@ -117,6 +119,56 @@ impl AffinePoint {
                 return Ok(point);
             }
         }
+    }
+}
+
+impl AffineCoordinates for AffinePoint {
+    type FieldRepr = Ed448FieldBytes;
+
+    fn from_coordinates(x: &Self::FieldRepr, y: &Self::FieldRepr) -> CtOption<Self> {
+        let point = Self {
+            x: FieldElement::from_bytes_extended(&x.0),
+            y: FieldElement::from_bytes_extended(&y.0),
+        };
+
+        CtOption::new(point, point.is_on_curve())
+    }
+
+    fn x(&self) -> Self::FieldRepr {
+        Ed448FieldBytes::from(self.x.to_bytes_extended())
+    }
+
+    fn y(&self) -> Self::FieldRepr {
+        Ed448FieldBytes::from(self.y.to_bytes_extended())
+    }
+
+    fn x_is_odd(&self) -> Choice {
+        self.x.is_negative()
+    }
+
+    fn y_is_odd(&self) -> Choice {
+        self.y.is_negative()
+    }
+}
+
+impl CurveAffine for AffinePoint {
+    type Curve = EdwardsPoint;
+    type Scalar = EdwardsScalar;
+
+    fn identity() -> AffinePoint {
+        Self::IDENTITY
+    }
+
+    fn generator() -> AffinePoint {
+        EdwardsPoint::GENERATOR.to_affine()
+    }
+
+    fn is_identity(&self) -> Choice {
+        self.to_edwards().is_identity()
+    }
+
+    fn to_curve(&self) -> EdwardsPoint {
+        self.into()
     }
 }
 
@@ -156,6 +208,8 @@ impl ctutils::CtSelect for AffinePoint {
     }
 }
 
+impl DefaultIsZeroes for AffinePoint {}
+
 impl Eq for AffinePoint {}
 impl PartialEq for AffinePoint {
     fn eq(&self, other: &Self) -> bool {
@@ -165,40 +219,26 @@ impl PartialEq for AffinePoint {
 
 impl Generate for AffinePoint {
     fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        Self::try_from_rng(rng)
+        Self::try_random(rng)
     }
 }
 
-impl elliptic_curve::point::AffineCoordinates for AffinePoint {
-    type FieldRepr = Ed448FieldBytes;
+impl GroupEncoding for AffinePoint {
+    type Repr = Array<u8, U57>;
 
-    fn from_coordinates(x: &Self::FieldRepr, y: &Self::FieldRepr) -> CtOption<Self> {
-        let point = Self {
-            x: FieldElement::from_bytes_extended(&x.0),
-            y: FieldElement::from_bytes_extended(&y.0),
-        };
-
-        CtOption::new(point, point.is_on_curve())
+    fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
+        CompressedEdwardsY((*bytes).into()).decompress()
     }
 
-    fn x(&self) -> Self::FieldRepr {
-        Ed448FieldBytes::from(self.x.to_bytes_extended())
+    fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
+        // No unchecked conversion possible for compressed points
+        Self::from_bytes(bytes)
     }
 
-    fn y(&self) -> Self::FieldRepr {
-        Ed448FieldBytes::from(self.y.to_bytes_extended())
-    }
-
-    fn x_is_odd(&self) -> Choice {
-        self.x.is_negative()
-    }
-
-    fn y_is_odd(&self) -> Choice {
-        self.y.is_negative()
+    fn to_bytes(&self) -> Self::Repr {
+        self.compress().0.into()
     }
 }
-
-impl DefaultIsZeroes for AffinePoint {}
 
 impl From<NonIdentity<AffinePoint>> for AffinePoint {
     fn from(affine: NonIdentity<AffinePoint>) -> Self {
@@ -250,6 +290,14 @@ define_mul_variants!(
     RHS = EdwardsScalar,
     Output = EdwardsPoint
 );
+
+impl Neg for AffinePoint {
+    type Output = AffinePoint;
+
+    fn neg(self) -> Self::Output {
+        self.to_edwards().neg().to_affine()
+    }
+}
 
 /// The compressed internal representation of a point on the Twisted Edwards Curve
 pub type PointBytes = [u8; 57];

--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -129,19 +129,19 @@ impl PartialEq for EdwardsPoint {
 
 impl Generate for EdwardsPoint {
     fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        Self::try_from_rng(rng)
+        Self::try_random(rng)
     }
 }
 
 impl Group for EdwardsPoint {
     type Scalar = EdwardsScalar;
 
-    fn try_from_rng<R>(rng: &mut R) -> Result<Self, R::Error>
+    fn try_random<R>(rng: &mut R) -> Result<Self, R::Error>
     where
         R: TryRng + ?Sized,
     {
         loop {
-            let point = AffinePoint::try_from_rng(rng)?;
+            let point = AffinePoint::try_random(rng)?;
             if point != AffinePoint::IDENTITY {
                 break Ok(point.into());
             }
@@ -169,23 +169,16 @@ impl GroupEncoding for EdwardsPoint {
     type Repr = Array<u8, U57>;
 
     fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
-        let mut value = [0u8; 57];
-        value.copy_from_slice(bytes);
-        CompressedEdwardsY(value)
-            .decompress()
-            .map(|point| point.to_edwards())
+        AffinePoint::from_bytes(bytes).map(|point| point.to_edwards())
     }
 
     fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
-        let mut value = [0u8; 57];
-        value.copy_from_slice(bytes);
-        CompressedEdwardsY(value)
-            .decompress()
-            .map(|point| point.to_edwards())
+        // No unchecked conversion possible for compressed points
+        Self::from_bytes(bytes)
     }
 
     fn to_bytes(&self) -> Self::Repr {
-        Self::Repr::from(self.to_affine().compress().0)
+        self.to_affine().to_bytes()
     }
 }
 
@@ -319,7 +312,7 @@ impl<const N: usize> LinearCombination<[(EdwardsPoint, EdwardsScalar); N]> for E
 impl LinearCombination<[(EdwardsPoint, EdwardsScalar)]> for EdwardsPoint {}
 
 impl CurveGroup for EdwardsPoint {
-    type AffineRepr = AffinePoint;
+    type Affine = AffinePoint;
 
     fn to_affine(&self) -> AffinePoint {
         self.to_affine()
@@ -327,7 +320,7 @@ impl CurveGroup for EdwardsPoint {
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn batch_normalize(projective: &[Self], affine: &mut [Self::AffineRepr]) {
+    fn batch_normalize(projective: &[Self], affine: &mut [Self::Affine]) {
         assert_eq!(projective.len(), affine.len());
         let mut zs = alloc::vec![FieldElement::ONE; projective.len()];
         batch_normalize_generic(projective, zs.as_mut_slice(), affine);
@@ -771,10 +764,10 @@ impl<'de> serdect::serde::Deserialize<'de> for EdwardsPoint {
 impl elliptic_curve::zeroize::DefaultIsZeroes for EdwardsPoint {}
 
 impl<const N: usize> BatchNormalize<[EdwardsPoint; N]> for EdwardsPoint {
-    type Output = [<Self as CurveGroup>::AffineRepr; N];
+    type Output = [<Self as CurveGroup>::Affine; N];
 
     #[inline]
-    fn batch_normalize(points: &[Self; N]) -> [<Self as CurveGroup>::AffineRepr; N] {
+    fn batch_normalize(points: &[Self; N]) -> [<Self as CurveGroup>::Affine; N] {
         let zs = [FieldElement::ONE; N];
         let mut affine_points = [AffinePoint::IDENTITY; N];
         batch_normalize_generic(points, zs, &mut affine_points);
@@ -784,10 +777,10 @@ impl<const N: usize> BatchNormalize<[EdwardsPoint; N]> for EdwardsPoint {
 
 #[cfg(feature = "alloc")]
 impl BatchNormalize<[EdwardsPoint]> for EdwardsPoint {
-    type Output = Vec<<Self as CurveGroup>::AffineRepr>;
+    type Output = Vec<<Self as CurveGroup>::Affine>;
 
     #[inline]
-    fn batch_normalize(points: &[Self]) -> Vec<<Self as CurveGroup>::AffineRepr> {
+    fn batch_normalize(points: &[Self]) -> Vec<<Self as CurveGroup>::Affine> {
         use alloc::vec;
 
         let mut zs = vec![FieldElement::ONE; points.len()];

--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -238,7 +238,7 @@ impl Field for FieldElement {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut bytes = [0; 56];
 
         loop {

--- a/ed448-goldilocks/src/field/scalar.rs
+++ b/ed448-goldilocks/src/field/scalar.rs
@@ -316,7 +316,7 @@ impl<C: CurveWithScalar> Field for Scalar<C> {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut seed = WideScalarBytes::<C>::default();
         rng.try_fill_bytes(&mut seed)?;
         Ok(C::from_bytes_mod_order_wide(&seed))
@@ -373,7 +373,7 @@ impl<C: CurveWithScalar> PrimeField for Scalar<C> {
 
 impl<C: CurveWithScalar> Generate for Scalar<C> {
     fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        Self::try_from_rng(rng)
+        Self::try_random(rng)
     }
 }
 

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -7,7 +7,7 @@ use crate::{CompressedPoint, FieldBytes, PublicKey, Scalar, Sec1Point, Secp256k1
 use elliptic_curve::{
     Error, Generate, Result, ctutils,
     ff::PrimeField,
-    group::{GroupEncoding, prime::PrimeCurveAffine},
+    group::{CurveAffine, GroupEncoding},
     ops::{Mul, MulVartime, Neg},
     point::{AffineCoordinates, DecompactPoint, DecompressPoint, NonIdentity},
     rand_core::{TryCryptoRng, TryRng},
@@ -80,7 +80,7 @@ impl AffinePoint {
     ///
     /// This internal method avoids the `TryCryptoRng` bounds so it can be used in `group` impls for
     /// `ProjectivePoint`.
-    pub(crate) fn try_from_rng<R: TryRng + ?Sized>(
+    pub(crate) fn try_random<R: TryRng + ?Sized>(
         rng: &mut R,
     ) -> core::result::Result<Self, R::Error> {
         let mut bytes = FieldBytes::default();
@@ -103,7 +103,7 @@ impl AffinePoint {
     }
 }
 
-impl PrimeCurveAffine for AffinePoint {
+impl CurveAffine for AffinePoint {
     type Scalar = Scalar;
     type Curve = ProjectivePoint;
 
@@ -213,7 +213,7 @@ impl Generate for AffinePoint {
     fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(
         rng: &mut R,
     ) -> core::result::Result<Self, R::Error> {
-        Self::try_from_rng(rng)
+        Self::try_random(rng)
     }
 }
 
@@ -443,7 +443,7 @@ mod tests {
     use super::AffinePoint;
     use crate::Sec1Point;
     use elliptic_curve::{
-        group::{GroupEncoding, prime::PrimeCurveAffine},
+        group::{CurveAffine, GroupEncoding},
         sec1::{FromSec1Point, ToSec1Point},
     };
     use hex_literal::hex;

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -28,7 +28,7 @@ use core::{
 };
 use elliptic_curve::{
     Generate,
-    bigint::{ArrayEncoding, Odd, U256, modular::Retrieve},
+    bigint::{Odd, U256, modular::Retrieve},
     ff::{self, Field, PrimeField},
     ops::Invert,
     rand_core::{TryCryptoRng, TryRng},
@@ -246,7 +246,7 @@ impl Field for FieldElement {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut bytes = FieldBytes::default();
 
         loop {
@@ -280,7 +280,7 @@ impl Field for FieldElement {
 
 impl Generate for FieldElement {
     fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        Self::try_from_rng(rng)
+        Self::try_random(rng)
     }
 }
 
@@ -316,10 +316,6 @@ impl PrimeField for FieldElement {
 
     fn to_repr(&self) -> Self::Repr {
         self.to_bytes()
-    }
-
-    fn to_le_repr(&self) -> Self::Repr {
-        self.0.normalize().to_u256().to_le_byte_array()
     }
 
     fn is_odd(&self) -> Choice {

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -11,9 +11,9 @@ use core::{
 use elliptic_curve::{
     BatchNormalize, CurveGroup, Error, Generate, Result, ctutils,
     group::{
-        Group, GroupEncoding,
+        CurveAffine, Group, GroupEncoding,
         cofactor::CofactorGroup,
-        prime::{PrimeCurve, PrimeCurveAffine, PrimeGroup},
+        prime::{PrimeCurve, PrimeGroup},
     },
     ops::BatchInvert,
     point::NonIdentity,
@@ -275,10 +275,10 @@ impl Generate for ProjectivePoint {
 }
 
 impl<const N: usize> BatchNormalize<[ProjectivePoint; N]> for ProjectivePoint {
-    type Output = [<Self as CurveGroup>::AffineRepr; N];
+    type Output = [<Self as CurveGroup>::Affine; N];
 
     #[inline]
-    fn batch_normalize(points: &[Self; N]) -> [<Self as CurveGroup>::AffineRepr; N] {
+    fn batch_normalize(points: &[Self; N]) -> [<Self as CurveGroup>::Affine; N] {
         let zs = [FieldElement::ONE; N];
         let mut affine_points = [AffinePoint::IDENTITY; N];
         batch_normalize_generic(points, zs, &mut affine_points);
@@ -288,10 +288,10 @@ impl<const N: usize> BatchNormalize<[ProjectivePoint; N]> for ProjectivePoint {
 
 #[cfg(feature = "alloc")]
 impl BatchNormalize<[ProjectivePoint]> for ProjectivePoint {
-    type Output = Vec<<Self as CurveGroup>::AffineRepr>;
+    type Output = Vec<<Self as CurveGroup>::Affine>;
 
     #[inline]
-    fn batch_normalize(points: &[Self]) -> Vec<<Self as CurveGroup>::AffineRepr> {
+    fn batch_normalize(points: &[Self]) -> Vec<<Self as CurveGroup>::Affine> {
         let zs = vec![FieldElement::ONE; points.len()];
         let mut affine_points = vec![AffinePoint::IDENTITY; points.len()];
         batch_normalize_generic(points, zs, &mut affine_points);
@@ -467,7 +467,7 @@ impl CofactorGroup for ProjectivePoint {
 }
 
 impl CurveGroup for ProjectivePoint {
-    type AffineRepr = AffinePoint;
+    type Affine = AffinePoint;
 
     fn to_affine(&self) -> AffinePoint {
         ProjectivePoint::to_affine(self)
@@ -475,7 +475,7 @@ impl CurveGroup for ProjectivePoint {
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn batch_normalize(projective: &[Self], affine: &mut [Self::AffineRepr]) {
+    fn batch_normalize(projective: &[Self], affine: &mut [Self::Affine]) {
         assert_eq!(projective.len(), affine.len());
         let mut zs = vec![FieldElement::ONE; projective.len()];
         batch_normalize_generic(projective, zs.as_mut_slice(), affine);
@@ -485,8 +485,8 @@ impl CurveGroup for ProjectivePoint {
 impl Group for ProjectivePoint {
     type Scalar = Scalar;
 
-    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
-        AffinePoint::try_from_rng(rng).map(Self::from)
+    fn try_random<R: TryRng + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
+        AffinePoint::try_random(rng).map(Self::from)
     }
 
     fn identity() -> Self {
@@ -527,9 +527,7 @@ impl GroupEncoding for ProjectivePoint {
     }
 }
 
-impl PrimeCurve for ProjectivePoint {
-    type Affine = AffinePoint;
-}
+impl PrimeCurve for ProjectivePoint {}
 
 impl PrimeGroup for ProjectivePoint {}
 
@@ -764,7 +762,7 @@ mod tests {
     };
     use elliptic_curve::{
         BatchNormalize, CurveGroup, Generate,
-        group::{ff::PrimeField, prime::PrimeCurveAffine},
+        group::{CurveAffine, ff::PrimeField},
     };
 
     #[cfg(feature = "alloc")]

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -180,7 +180,7 @@ impl Field for Scalar {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         // Uses rejection sampling as the default random generation method,
         // which produces a uniformly random distribution of scalars.
         //
@@ -262,7 +262,7 @@ impl Field for Scalar {
 
 impl Generate for Scalar {
     fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        Self::try_from_rng(rng)
+        Self::try_random(rng)
     }
 }
 
@@ -301,10 +301,6 @@ impl PrimeField for Scalar {
 
     fn to_repr(&self) -> FieldBytes {
         self.to_bytes()
-    }
-
-    fn to_le_repr(&self) -> Self::Repr {
-        self.0.to_le_byte_array()
     }
 
     fn is_odd(&self) -> Choice {

--- a/k256/src/schnorr/verifying.rs
+++ b/k256/src/schnorr/verifying.rs
@@ -3,7 +3,7 @@
 use super::{CHALLENGE_TAG, Signature, tagged_hash};
 use crate::{AffinePoint, FieldBytes, ProjectivePoint, PublicKey, Scalar};
 use elliptic_curve::{
-    group::prime::PrimeCurveAffine,
+    group::CurveAffine,
     ops::{MulByGeneratorVartime, Reduce},
     point::DecompactPoint,
 };
@@ -52,14 +52,15 @@ impl VerifyingKey {
 
     /// Compute Schnorr signature.
     ///
-    /// # ⚠️ Warning
+    /// <div class="warning">
+    /// <b>Warning<b>
     ///
-    /// This is a low-level interface intended only for unusual use cases
-    /// involving verifying pre-hashed messages, or "raw" messages where the
-    /// message is not hashed at all prior to being used to generate the
-    /// Schnorr signature.
+    /// This is a low-level interface intended only for unusual use cases involving verifying
+    /// pre-hashed messages, or "raw" messages where the message is not hashed at all prior to being
+    /// used to generate the Schnorr signature.
     ///
     /// The preferred interfaces are the [`DigestVerifier`] or [`PrehashVerifier`] traits.
+    /// </div>
     pub fn verify_raw(&self, message: &[u8], signature: &Signature) -> Result<()> {
         let (r, s) = signature.split();
 

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -188,7 +188,7 @@ impl Field for Scalar {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut bytes = FieldBytes::default();
 
         // Generate a uniformly random scalar using rejection sampling,
@@ -267,7 +267,7 @@ impl Field for Scalar {
 
 impl Generate for Scalar {
     fn try_generate_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        Self::try_from_rng(rng)
+        Self::try_random(rng)
     }
 }
 
@@ -300,10 +300,6 @@ impl PrimeField for Scalar {
 
     fn to_repr(&self) -> FieldBytes {
         self.to_bytes()
-    }
-
-    fn to_le_repr(&self) -> FieldBytes {
-        self.0.to_le_byte_array()
     }
 
     fn is_odd(&self) -> Choice {

--- a/p256/tests/affine.rs
+++ b/p256/tests/affine.rs
@@ -3,7 +3,7 @@
 #![cfg(feature = "arithmetic")]
 
 use elliptic_curve::{
-    group::{GroupEncoding, prime::PrimeCurveAffine},
+    group::{CurveAffine, GroupEncoding},
     sec1::{FromSec1Point, ToCompactSec1Point, ToSec1Point},
 };
 use hex_literal::hex;

--- a/p384/tests/affine.rs
+++ b/p384/tests/affine.rs
@@ -5,7 +5,7 @@
 #![cfg(all(feature = "arithmetic", feature = "test-vectors"))]
 
 use elliptic_curve::{
-    group::{GroupEncoding, prime::PrimeCurveAffine},
+    group::{CurveAffine, GroupEncoding},
     sec1::{FromSec1Point, ToSec1Point},
 };
 use hex_literal::hex;

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -492,7 +492,7 @@ impl Field for FieldElement {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         // NOTE: can't use ScalarValue::random due to CryptoRng bound
         let mut bytes = <FieldBytes>::default();
 
@@ -531,7 +531,7 @@ impl Field for FieldElement {
 
 impl Generate for FieldElement {
     fn try_generate_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        Self::try_from_rng(rng)
+        Self::try_random(rng)
     }
 }
 
@@ -558,13 +558,6 @@ impl PrimeField for FieldElement {
     #[inline]
     fn to_repr(&self) -> FieldBytes {
         self.to_bytes()
-    }
-
-    #[inline]
-    fn to_le_repr(&self) -> FieldBytes {
-        let mut ret = [0u8; 66];
-        fiat_p521_to_bytes(&mut ret, &self.0); // natively little-endian
-        ret.into()
     }
 
     #[inline]

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.85"
 [dependencies]
 bigint = { version = "0.7.1", package = "crypto-bigint", default-features = false, features = ["rand_core", "hybrid-array", "subtle"] }
 common = { package = "crypto-common", version = "0.2", features = ["rand_core"] }
-ff = { version = "0.14.0-rc.1", package = "rustcrypto-ff", default-features = false }
+ff = { version = "0.14", default-features = false }
 subtle = { version = "2.6", default-features = false, features = ["const-generics"] }
 rand_core = { version = "0.10", default-features = false }
 zeroize = { version = "1.7", default-features = false }

--- a/primefield/src/macros.rs
+++ b/primefield/src/macros.rs
@@ -274,7 +274,7 @@ macro_rules! monty_field_element {
             fn try_generate_from_rng<R: $crate::rand_core::TryCryptoRng + ?Sized>(
                 rng: &mut R,
             ) -> ::core::result::Result<Self, R::Error> {
-                <Self as $crate::ff::Field>::try_from_rng(rng)
+                <Self as $crate::ff::Field>::try_random(rng)
             }
         }
 
@@ -282,10 +282,10 @@ macro_rules! monty_field_element {
             const ZERO: Self = Self::ZERO;
             const ONE: Self = Self::ONE;
 
-            fn try_from_rng<R: $crate::rand_core::TryRng + ?Sized>(
+            fn try_random<R: $crate::rand_core::TryRng + ?Sized>(
                 rng: &mut R,
             ) -> ::core::result::Result<Self, R::Error> {
-                $crate::MontyFieldElement::<$params, { <$params>::LIMBS }>::try_from_rng(rng)
+                $crate::MontyFieldElement::<$params, { <$params>::LIMBS }>::try_random(rng)
                     .map(Self)
             }
 
@@ -344,11 +344,6 @@ macro_rules! monty_field_element {
             #[inline]
             fn to_repr(&self) -> Self::Repr {
                 self.0.to_repr()
-            }
-
-            #[inline]
-            fn to_le_repr(&self) -> Self::Repr {
-                self.0.to_le_repr()
             }
 
             #[inline]

--- a/primefield/src/monty.rs
+++ b/primefield/src/monty.rs
@@ -413,7 +413,7 @@ where
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: rand_core::TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random<R: rand_core::TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut bytes = MontyFieldBytes::<MOD, LIMBS>::default();
 
         loop {
@@ -473,17 +473,6 @@ where
 
     fn to_repr(&self) -> Self::Repr {
         self.to_bytes()
-    }
-
-    fn to_le_repr(&self) -> Self::Repr {
-        match MOD::BYTE_ORDER {
-            ByteOrder::BigEndian => {
-                let mut bytes = self.to_bytes();
-                bytes.reverse();
-                bytes
-            }
-            ByteOrder::LittleEndian => self.to_bytes(),
-        }
     }
 
     fn is_odd(&self) -> Choice {
@@ -944,7 +933,7 @@ where
     Uint<LIMBS>: ArrayEncoding,
 {
     fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        Self::try_from_rng(rng)
+        Self::try_random(rng)
     }
 }
 

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -6,16 +6,15 @@ use crate::{PrimeCurveParams, ProjectivePoint};
 use core::borrow::Borrow;
 use elliptic_curve::{
     Error, FieldBytes, FieldBytesEncoding, FieldBytesSize, Generate, PublicKey, Result, Scalar,
-    array::ArraySize,
     ctutils::{self, CtGt as _, CtSelect as _},
     ff::{Field, PrimeField},
-    group::{GroupEncoding, prime::PrimeCurveAffine},
+    group::{CurveAffine, GroupEncoding},
     ops::{Mul, MulVartime, Neg},
     point::{AffineCoordinates, DecompactPoint, DecompressPoint, Double, NonIdentity},
     rand_core::{TryCryptoRng, TryRng},
     sec1::{
         self, CompressedPoint, FromSec1Point, ModulusSize, Sec1Point, ToCompactSec1Point,
-        ToSec1Point, UncompressedPointSize,
+        ToSec1Point,
     },
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
@@ -79,7 +78,7 @@ where
     /// Internal RNG that avoids a `TryCryptoRng` bound so we can use it with `group`.
     ///
     /// TODO(tarcieri): find some way to avoid this?
-    pub(crate) fn try_from_rng<R: TryRng + ?Sized>(
+    pub(crate) fn try_random<R: TryRng + ?Sized>(
         rng: &mut R,
     ) -> core::result::Result<Self, R::Error> {
         let mut bytes = FieldBytes::<C>::default();
@@ -286,7 +285,6 @@ where
     C: PrimeCurveParams,
     FieldBytesSize<C>: ModulusSize,
     CompressedPoint<C>: Copy,
-    <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
     fn from(affine: AffinePoint<C>) -> Sec1Point<C> {
         affine.to_sec1_point(false)
@@ -300,16 +298,15 @@ where
     fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(
         rng: &mut R,
     ) -> core::result::Result<Self, R::Error> {
-        Self::try_from_rng(rng)
+        Self::try_random(rng)
     }
 }
 
 impl<C> GroupEncoding for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy + Send + Sync,
+    CompressedPoint<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
-    <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
     type Repr = CompressedPoint<C>;
 
@@ -350,13 +347,11 @@ where
     }
 }
 
-impl<C> PrimeCurveAffine for AffinePoint<C>
+impl<C> CurveAffine for AffinePoint<C>
 where
     C: PrimeCurveParams,
     CompressedPoint<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
-    ProjectivePoint<C>: Double,
-    <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
     type Curve = ProjectivePoint<C>;
     type Scalar = Scalar<C>;
@@ -383,7 +378,6 @@ where
     C: PrimeCurveParams,
     FieldBytesSize<C>: ModulusSize,
     CompressedPoint<C>: Copy,
-    <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
     /// Serialize this value as a  SEC1 compact [`Sec1Point`]
     fn to_compact_encoded_point(&self) -> ctutils::CtOption<Sec1Point<C>> {
@@ -405,7 +399,6 @@ where
     C: PrimeCurveParams,
     FieldBytesSize<C>: ModulusSize,
     CompressedPoint<C>: Copy,
-    <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
     fn to_sec1_point(&self, compress: bool) -> Sec1Point<C> {
         Sec1Point::<C>::ct_select(
@@ -574,7 +567,6 @@ where
     C: PrimeCurveParams,
     FieldBytesSize<C>: ModulusSize,
     CompressedPoint<C>: Copy,
-    <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -28,13 +28,14 @@ pub use elliptic_curve::{
 };
 
 use elliptic_curve::{
-    CurveArithmetic, Generate,
+    CurveArithmetic, FieldBytesSize, Generate,
     ops::{Invert, LinearCombination, MulVartime},
     subtle::CtOption,
 };
 
 #[cfg(all(feature = "alloc", feature = "basepoint-table"))]
 use elliptic_curve::point::BasepointTableVartime;
+use elliptic_curve::sec1::{CompressedPoint, ModulusSize};
 
 /// Parameters for elliptic curves of prime order which can be described by the
 /// short Weierstrass equation.
@@ -80,7 +81,11 @@ pub trait PrimeCurveParams:
         a: &Scalar<Self>,
         b_scalar: &Scalar<Self>,
         b_point: &ProjectivePoint<Self>,
-    ) -> ProjectivePoint<Self> {
+    ) -> ProjectivePoint<Self>
+    where
+        CompressedPoint<Self>: Copy,
+        FieldBytesSize<Self>: ModulusSize,
+    {
         ProjectivePoint::<Self>::lincomb_vartime(&[
             (ProjectivePoint::GENERATOR, *a),
             (*b_point, *b_scalar),

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -7,7 +7,6 @@ use core::{array, borrow::Borrow, iter::Sum};
 use elliptic_curve::{
     BatchNormalize, CurveGroup, Error, FieldBytesSize, Generate, PrimeField, PublicKey, Result,
     Scalar,
-    array::ArraySize,
     bigint::{ArrayEncoding, ByteArray},
     ctutils,
     group::{
@@ -21,9 +20,7 @@ use elliptic_curve::{
     },
     point::{Double, NonIdentity},
     rand_core::{TryCryptoRng, TryRng},
-    sec1::{
-        CompressedPoint, FromSec1Point, ModulusSize, Sec1Point, ToSec1Point, UncompressedPointSize,
-    },
+    sec1::{CompressedPoint, FromSec1Point, ModulusSize, Sec1Point, ToSec1Point},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
 };
@@ -31,7 +28,7 @@ use elliptic_curve::{
 #[cfg(feature = "alloc")]
 use {
     alloc::vec::Vec,
-    elliptic_curve::group::{Wnaf, WnafBase, WnafGroup, WnafScalar},
+    elliptic_curve::{Wnaf, WnafBase, WnafGroup, WnafScalar},
 };
 
 #[cfg(all(feature = "alloc", feature = "basepoint-table"))]
@@ -290,10 +287,8 @@ where
 impl<C> CofactorGroup for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Send + Sync,
     FieldBytesSize<C>: ModulusSize,
     CompressedPoint<C>: Copy,
-    <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
     type Subgroup = ProjectivePoint<C>;
 
@@ -313,8 +308,10 @@ where
 impl<C> CurveGroup for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
+    CompressedPoint<C>: Copy,
+    FieldBytesSize<C>: ModulusSize,
 {
-    type AffineRepr = AffinePoint<C>;
+    type Affine = AffinePoint<C>;
 
     fn to_affine(&self) -> AffinePoint<C> {
         ProjectivePoint::to_affine(self)
@@ -322,7 +319,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn batch_normalize(projective: &[Self], affine: &mut [Self::AffineRepr]) {
+    fn batch_normalize(projective: &[Self], affine: &mut [Self::Affine]) {
         assert_eq!(projective.len(), affine.len());
         let mut zs = vec![C::FieldElement::ONE; projective.len()];
         batch_normalize_generic(projective, zs.as_mut_slice(), affine);
@@ -335,8 +332,8 @@ where
 {
     type Scalar = Scalar<C>;
 
-    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
-        AffinePoint::try_from_rng(rng).map(Self::from)
+    fn try_random<R: TryRng + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
+        AffinePoint::try_random(rng).map(Self::from)
     }
 
     fn identity() -> Self {
@@ -364,9 +361,8 @@ where
 impl<C> GroupEncoding for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy + Send + Sync,
+    CompressedPoint<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
-    <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
     type Repr = CompressedPoint<C>;
 
@@ -388,20 +384,17 @@ impl<C> PrimeCurve for ProjectivePoint<C>
 where
     Self: Double,
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy + Send + Sync,
+    CompressedPoint<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
-    <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
-    type Affine = AffinePoint<C>;
 }
 
 impl<C> PrimeGroup for ProjectivePoint<C>
 where
     Self: Double,
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy + Send + Sync,
+    CompressedPoint<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
-    <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
 }
 
@@ -412,11 +405,13 @@ where
 impl<const N: usize, C> BatchNormalize<[ProjectivePoint<C>; N]> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
+    CompressedPoint<C>: Copy,
+    FieldBytesSize<C>: ModulusSize,
 {
-    type Output = [<Self as CurveGroup>::AffineRepr; N];
+    type Output = [<Self as CurveGroup>::Affine; N];
 
     #[inline]
-    fn batch_normalize(points: &[Self; N]) -> [<Self as CurveGroup>::AffineRepr; N] {
+    fn batch_normalize(points: &[Self; N]) -> [<Self as CurveGroup>::Affine; N] {
         let zs = [C::FieldElement::ONE; N];
         let mut affine_points = [C::AffinePoint::IDENTITY; N];
         batch_normalize_generic(points, zs, &mut affine_points);
@@ -428,11 +423,13 @@ where
 impl<C> BatchNormalize<[ProjectivePoint<C>]> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
+    CompressedPoint<C>: Copy,
+    FieldBytesSize<C>: ModulusSize,
 {
-    type Output = Vec<<Self as CurveGroup>::AffineRepr>;
+    type Output = Vec<<Self as CurveGroup>::Affine>;
 
     #[inline]
-    fn batch_normalize(points: &[Self]) -> Vec<<Self as CurveGroup>::AffineRepr> {
+    fn batch_normalize(points: &[Self]) -> Vec<<Self as CurveGroup>::Affine> {
         let mut zs = vec![C::FieldElement::ONE; points.len()];
         let mut affine_points = vec![AffinePoint::IDENTITY; points.len()];
         batch_normalize_generic(points, zs.as_mut_slice(), &mut affine_points);
@@ -479,6 +476,8 @@ where
 impl<C> LinearCombination<[(Self, Scalar<C>)]> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
+    CompressedPoint<C>: Copy,
+    FieldBytesSize<C>: ModulusSize,
 {
     #[cfg(feature = "alloc")]
     fn lincomb(points_and_scalars: &[(Self, Scalar<C>)]) -> Self {
@@ -509,13 +508,15 @@ where
             .map(|(_, scalar)| WnafScalar::<Scalar<C>, WINDOW_SIZE>::new(scalar))
             .collect::<Vec<_>>();
 
-        WnafBase::multiscalar_mul(scalars.iter(), points.iter())
+        WnafBase::multiscalar_mul(scalars, points)
     }
 }
 
 impl<C, const N: usize> LinearCombination<[(Self, Scalar<C>); N]> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
+    CompressedPoint<C>: Copy,
+    FieldBytesSize<C>: ModulusSize,
 {
     fn lincomb(points_and_scalars: &[(Self, Scalar<C>); N]) -> Self {
         let mut ks: [_; N] = array::from_fn(|index| {
@@ -603,7 +604,6 @@ where
     C: PrimeCurveParams,
     CompressedPoint<C>: Copy,
     FieldBytesSize<C>: ModulusSize,
-    <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
     fn to_sec1_point(&self, compress: bool) -> Sec1Point<C> {
         self.to_affine().to_sec1_point(compress)
@@ -964,6 +964,8 @@ where
 impl<C> MulByGeneratorVartime for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
+    CompressedPoint<C>: Copy,
+    FieldBytesSize<C>: ModulusSize,
 {
     #[inline]
     fn mul_by_generator_vartime(scalar: &Scalar<C>) -> Self {
@@ -1023,7 +1025,6 @@ where
     C: PrimeCurveParams,
     FieldBytesSize<C>: ModulusSize,
     CompressedPoint<C>: Copy,
-    <UncompressedPointSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
Companion PR to RustCrypto/traits#2431 which migrates everything to use the upstream releases of `ff`/`group` v0.14.0.

To make this work, it's using a vendored copy of `wnaf.rs` in the `elliptic-curve` crate which has been modified to support big endian `PrimeField::Repr` as well as multiscalar multiplication.