### PR TITLE
Bump `elliptic-curve` dependency to v0.14.0-rc.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,8 +478,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.32"
-source = "git+http://github.com/RustCrypto/traits.git#83fa3770435d7e34e8c9a27d68839120912248a6"
+version = "0.14.0-rc.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "102d3643d30dd8b559613c5cced68317199597fffb278cdc88daa2ef7fafc935"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1410,7 +1411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,3 @@ ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
-
-elliptic-curve = { git = "http://github.com/RustCrypto/traits.git" }

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.32", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.33", features = ["sec1"] }
 
 # optional dependencies
 belt-block = { version = "0.2", optional = true }
@@ -38,7 +38,7 @@ signature = { version = "3", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.9", features = ["dev"] }
 proptest = "1"

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.18", optional = true, default-features = false, features = ["der"] }
@@ -24,7 +24,7 @@ sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.18", optional = true, default-features = false, features = ["der"] }
@@ -24,7 +24,7 @@ sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -16,7 +16,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.32", features = ["arithmetic", "pkcs8"] }
+elliptic-curve = { version = "0.14.0-rc.33", features = ["arithmetic", "pkcs8"] }
 hash2curve = "0.14.0-rc.12"
 rand_core = { version = "0.10", default-features = false }
 shake = { version = "0.1", default-features = false }

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = { version = "0.11" }
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["arithmetic"] }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85"
 
 [dependencies]
 cpubits = "0.1"
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
 hash2curve = { version = "0.14.0-rc.12", optional = true }
 
 # optional dependencies

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "1"
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true, default-features = false }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
 rand_core = { version = "0.10", default-features = false }
 
@@ -33,7 +33,7 @@ sm3 = { version = "0.5", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["dev"] }
 hex-literal = "1"
 proptest = "1"
 


### PR DESCRIPTION
This uses upstream `ff`/`group` v0.14