### PR TITLE
workspace: bump rfc6979 to 0.6.0-pre.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,8 +423,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.17.0-rc.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fb064faabbee66e1fc8e5c5a9458d4269dc2d8b638fe86a425adb2510d1a96"
+source = "git+https://github.com/RustCrypto/signatures.git#a8c7206efe6ad9e9f9a1166eae3565e7dac093d6"
 dependencies = [
  "der",
  "digest",
@@ -1160,12 +1159,12 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0"
+version = "0.6.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5236ce872cac07e0fb3969b0cbf468c7d2f37d432f1b627dcb7b8d34563fb0c3"
+checksum = "9935425142ac6e252364413291d96c8bc9898d0876a801824c7af4eae397b689"
 dependencies = [
+ "ctutils",
  "hmac",
- "subtle",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,5 @@ ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
+
+ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -26,7 +26,7 @@ rand_core = { version = "0.10", default-features = false }
 der = { version = "0.8", optional = true }
 primefield = { version = "0.14.0-rc.10", optional = true }
 primeorder = { version = "0.14.0-rc.10", optional = true }
-rfc6979 = { version = "0.5", optional = true }
+rfc6979 = { version = "0.6.0-pre.0", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 signature = { version = "3", optional = true, features = ["rand_core"] }
 sm3 = { version = "0.5", optional = true, default-features = false }


### PR DESCRIPTION
This brings a git-pin of ecdsa to get the update of rfc6979 through it.