### PR TITLE
wnaf: initial crate

### DIFF
--- a/.github/workflows/p256.yml
+++ b/.github/workflows/p256.yml
@@ -4,8 +4,11 @@ on:
   pull_request:
     paths:
       - ".github/workflows/p256.yml"
-      - "p256/**"
       - "hash2curve/**"
+      - "p256/**"
+      - "primefield/**"
+      - "primeorder/**"
+      - "wnaf/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
     paths:
       - ".github/workflows/p384.yml"
-      - "p384/**"
       - "hash2curve/**"
+      - "p384/**"
       - "primefield/**"
       - "primeorder/**"
+      - "wnaf/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/p521.yml
+++ b/.github/workflows/p521.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
     paths:
       - ".github/workflows/p521.yml"
-      - "p521/**"
       - "hash2curve/**"
+      - "p521/**"
       - "primefield/**"
       - "primeorder/**"
+      - "wnaf/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/wnaf.yml
+++ b/.github/workflows/wnaf.yml
@@ -1,0 +1,57 @@
+name: wnaf
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/wnaf.yml"
+      - "wnaf/**"
+      - "Cargo.*"
+  push:
+    branches: master
+
+defaults:
+  run:
+    working-directory: wnaf
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+  RUSTDOCFLAGS: "-Dwarnings"
+
+# Cancels CI jobs when new commits are pushed to a PR branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  no_std:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.85.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - run: cargo build --target ${{ matrix.target }} --release
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.85.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,6 +1696,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.0.0"
+dependencies = [
+ "ff",
+ "group",
+]
+
+[[package]]
 name = "x448"
 version = "0.14.0-pre.10"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "primefield",
     "primeorder",
     "sm2",
+    "wnaf",
     "x448"
 ]
 

--- a/wnaf/CHANGELOG.md
+++ b/wnaf/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/wnaf/Cargo.toml
+++ b/wnaf/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "wnaf"
+version = "0.0.0"
+description = """
+w-NAF (w-ary non-adjacent form) variable-time scalar multiplication implemented generically
+over elliptic curve groups, including multiscalar multiplication using Straus's interleaved window
+method. Contains an implementation adapted from the `group` crate which has been forked and enhanced
+but is otherwise compatible with that crate's traits, along with the `ff` crate's traits for finite
+field representations
+"""
+authors = ["RustCrypto Developers"]
+license = "Apache-2.0 OR MIT"
+documentation = "https://docs.rs/wnaf"
+homepage = "https://github.com/RustCrypto/elliptic-curves/tree/master/wnaf"
+repository = "https://github.com/RustCrypto/elliptic-curves"
+readme = "README.md"
+categories = ["cryptography", "no-std"]
+keywords = ["crypto", "ecc", "field", "prime"]
+edition = "2024"
+rust-version = "1.85"
+
+[dependencies]
+ff = { version = "0.14", default-features = false }
+group = { version = "0.14", default-features = false }

--- a/wnaf/LICENSE-APACHE
+++ b/wnaf/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/wnaf/LICENSE-MIT
+++ b/wnaf/LICENSE-MIT
@@ -1,0 +1,26 @@
+Copyright (c) 2026 RustCrypto Developers
+Copyright (c) 2018-2025 `group` crate developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/wnaf/README.md
+++ b/wnaf/README.md
@@ -1,0 +1,80 @@
+# [RustCrypto]: w-NAF scalar multiplication
+
+[![crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
+![Apache2/MIT licensed][license-image]
+![Rust Version][rustc-image]
+[![Project Chat][chat-image]][chat-link]
+
+w-NAF (w-ary non-adjacent form) variable-time scalar multiplication implemented generically
+over elliptic curve groups, including multiscalar multiplication using Straus's interleaved window
+method.
+
+[Documentation][docs-link]
+
+## About
+
+w-NAF is a signed-digit representation of a scalar with a minimal number of non-zero digits,
+reducing the number of costly group additions required during the double-and-add loop.
+
+The core idea is to represent a scalar `k` as a sequence of digits in:
+
+```text
+{-(2^(w-1)-1), ..., -1, 0, 1, ..., 2^(w-1)-1}
+```
+
+such that no two consecutive digits are non-zero.
+
+A configurable window size trades memory for speed: a larger window precomputes more multiples
+of the base point (a table of `2^(w-2)` entries) but requires fewer group additions per-bit of
+the scalar.
+
+## ⚠️ Security Warning
+
+w-NAF scalar multiplications should NOT be used with secret scalar values (i.e. elliptic curve
+private keys) because they are variable-time and can leak the secret value.
+
+## Minimum Supported Rust Version (MSRV) Policy
+
+MSRV increases are not considered breaking changes and can happen in patch
+releases.
+
+The crate MSRV accounts for all supported targets and crate feature
+combinations, excluding explicitly unstable features.
+
+## License
+
+Licensed under either of:
+
+- [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+- [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/wnaf?logo=rust
+[crate-link]: https://crates.io/crates/wnaf
+[docs-image]: https://docs.rs/wnaf/badge.svg
+[docs-link]: https://docs.rs/wnaf/
+[build-image]: https://github.com/RustCrypto/elliptic-curves/actions/workflows/wnaf.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/elliptic-curves/actions/workflows/wnaf.yml
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
+
+[//]: # (links)
+
+[RustCrypto]: https://github.com/rustcrypto/
+[`crypto-bigint`]: https://docs.rs/crypto-bigint/
+[`crypto_bigint::modular`]: https://docs.rs/crypto-bigint/latest/crypto_bigint/modular/index.html
+[`fiat-crypto`]: https://github.com/mit-plv/fiat-crypto
+[finite field]: https://en.wikipedia.org/wiki/Finite_field

--- a/wnaf/src/base.rs
+++ b/wnaf/src/base.rs
@@ -1,0 +1,101 @@
+use crate::{WnafScalar, wnaf_exp, wnaf_multi_exp, wnaf_table};
+use alloc::vec::Vec;
+use core::ops::Mul;
+use group::Group;
+
+/// A fixed window table for a group element, precomputed to improve the speed of scalar
+/// multiplication.
+///
+/// This struct is designed for usage patterns that have long-term cached bases and/or
+/// scalars, or [Cartesian products] of bases and scalars. The [`Wnaf`] API enables one or
+/// the other to be cached, but requires either the base window tables or the scalar w-NAF
+/// forms to be computed repeatedly on the fly, which can become a significant performance
+/// issue for some use cases.
+///
+/// `WnafBase` and [`WnafScalar`] enable an alternative trade-off: by fixing the window
+/// size at compile time, the precomputations are guaranteed to only occur once per base
+/// and once per scalar. Users should select their window size based on how long the bases
+/// are expected to live; a larger window size will consume more memory and take longer to
+/// precompute, but result in faster scalar multiplications.
+///
+/// [Cartesian products]: https://en.wikipedia.org/wiki/Cartesian_product
+///
+/// # Examples
+///
+/// ```ignore
+/// use group::{WnafBase, WnafScalar};
+///
+/// let wnaf_bases: Vec<_> = bases.into_iter().map(WnafBase::<_, 4>::new).collect();
+/// let wnaf_scalars: Vec<_> = scalars.iter().map(WnafScalar::new).collect();
+/// let results: Vec<_> = wnaf_bases
+///     .iter()
+///     .flat_map(|base| wnaf_scalars.iter().map(|scalar| base * scalar))
+///     .collect();
+/// ```
+///
+/// Note that this pattern requires specifying a fixed window size (unlike previous
+/// patterns that picked a suitable window size internally). This is necessary to ensure
+/// in the type system that the base and scalar `Wnaf`s were computed with the same window
+/// size, allowing the result to be computed infallibly.
+#[derive(Clone, Debug)]
+pub struct WnafBase<G: Group, const WINDOW_SIZE: usize> {
+    table: Vec<G>,
+}
+
+impl<G: Group, const WINDOW_SIZE: usize> WnafBase<G, WINDOW_SIZE> {
+    /// Computes a window table for the given base with the specified `WINDOW_SIZE`.
+    pub fn new(base: G) -> Self {
+        let mut table = vec![];
+
+        // Compute a window table for the provided base and window size.
+        wnaf_table(&mut table, base, WINDOW_SIZE);
+
+        WnafBase { table }
+    }
+
+    /// Perform a multiscalar multiplication.
+    ///
+    /// Computes a sum-of-products `aA + bB + ...` in variable time with w-NAF multi-exponentiation
+    /// using the interleaved window method, also known as Straus' method.
+    pub fn multiscalar_mul<I, J>(scalars: I, bases: J) -> G
+    where
+        I: IntoIterator<Item = WnafScalar<G::Scalar, WINDOW_SIZE>>,
+        J: IntoIterator<Item = Self>,
+    {
+        let wnafs = scalars.into_iter().map(|s| s.wnaf).collect::<Vec<_>>();
+        let tables = bases.into_iter().map(|b| b.table).collect::<Vec<_>>();
+        wnaf_multi_exp(tables.as_slice(), wnafs.as_slice())
+    }
+
+    /// Perform a multiscalar multiplication over a fixed-size set of scalars and bases.
+    ///
+    /// Computes a sum-of-products `aA + bB + ...` in variable time with w-NAF multi-exponentiation
+    /// using the interleaved window method, also known as Straus' method.
+    ///
+    /// This is a borrowing, fixed-arity counterpart to [`multiscalar_mul`]: it operates on
+    /// `&[_; N]` arrays and borrows the precomputed w-NAF forms and window tables in place,
+    /// avoiding the intermediate heap allocations that the iterator-based version performs. It
+    /// suits hot paths with a statically known number of terms (for example the four sub-scalars
+    /// of a GLV-decomposed `aG + bP`).
+    ///
+    /// [`multiscalar_mul`]: Self::multiscalar_mul
+    #[must_use]
+    pub fn multiscalar_mul_array<const N: usize>(
+        scalars: &[WnafScalar<G::Scalar, WINDOW_SIZE>; N],
+        bases: &[Self; N],
+    ) -> G {
+        let wnafs = scalars.each_ref().map(|s| s.wnaf.as_slice());
+        let tables = bases.each_ref().map(|b| b.table.as_slice());
+        wnaf_multi_exp(&tables, &wnafs)
+    }
+}
+
+impl<G: Group, const WINDOW_SIZE: usize> Mul<&WnafScalar<G::Scalar, WINDOW_SIZE>>
+    for &WnafBase<G, WINDOW_SIZE>
+{
+    type Output = G;
+
+    fn mul(self, rhs: &WnafScalar<G::Scalar, WINDOW_SIZE>) -> Self::Output {
+        wnaf_exp(&self.table, &rhs.wnaf)
+    }
+}

--- a/wnaf/src/lib.rs
+++ b/wnaf/src/lib.rs
@@ -1,0 +1,358 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
+)]
+#![forbid(unsafe_code)]
+#![doc = include_str!("../README.md")]
+
+#[macro_use]
+extern crate alloc;
+
+mod base;
+mod limb_buffer;
+mod scalar;
+
+pub use crate::{base::WnafBase, scalar::WnafScalar};
+pub use group::Group;
+
+use crate::limb_buffer::LimbBuffer;
+use alloc::vec::Vec;
+use ff::PrimeField;
+
+/// Extension trait on a [`Group`] that provides helpers used by [`Wnaf`].
+pub trait WnafGroup: Group {
+    /// Recommends a wNAF window size given the number of scalars you intend to multiply
+    /// a base by. Always returns a number between 2 and 22, inclusive.
+    fn recommended_wnaf_for_num_scalars(num_scalars: usize) -> usize;
+}
+
+/// A "w-ary non-adjacent form" scalar multiplication (also known as exponentiation)
+/// context.
+///
+/// # Examples
+///
+/// This struct can be used to implement several patterns:
+///
+/// ## One base, one scalar
+///
+/// For this pattern, you can use a transient `Wnaf` context:
+///
+/// ```ignore
+/// use group::Wnaf;
+///
+/// let result = Wnaf::new().scalar(&scalar).base(base);
+/// ```
+///
+/// ## Many bases, one scalar
+///
+/// For this pattern, you create a `Wnaf` context, load the scalar into it, and then
+/// process each base in turn:
+///
+/// ```ignore
+/// use group::Wnaf;
+///
+/// let mut wnaf = Wnaf::new();
+/// let mut wnaf_scalar = wnaf.scalar(&scalar);
+/// let results: Vec<_> = bases
+///     .into_iter()
+///     .map(|base| wnaf_scalar.base(base))
+///     .collect();
+/// ```
+///
+/// ## One base, many scalars
+///
+/// For this pattern, you create a `Wnaf` context, load the base into it, and then process
+/// each scalar in turn:
+///
+/// ```ignore
+/// use group::Wnaf;
+///
+/// let mut wnaf = Wnaf::new();
+/// let mut wnaf_base = wnaf.base(base, scalars.len());
+/// let results: Vec<_> = scalars
+///     .iter()
+///     .map(|scalar| wnaf_base.scalar(scalar))
+///     .collect();
+/// ```
+///
+/// ## Many bases, many scalars
+///
+/// Say you have `n` bases and `m` scalars, and want to produce `n * m` results. For this
+/// pattern, you need to cache the w-NAF tables for the bases and then compute the w-NAF
+/// form of the scalars on the fly for every base, or vice versa:
+///
+/// ```ignore
+/// use group::Wnaf;
+///
+/// let mut wnaf_contexts: Vec<_> = (0..bases.len()).map(|_| Wnaf::new()).collect();
+/// let mut wnaf_bases: Vec<_> = wnaf_contexts
+///     .iter_mut()
+///     .zip(bases)
+///     .map(|(wnaf, base)| wnaf.base(base, scalars.len()))
+///     .collect();
+/// let results: Vec<_> = wnaf_bases
+///     .iter()
+///     .flat_map(|wnaf_base| scalars.iter().map(|scalar| wnaf_base.scalar(scalar)))
+///     .collect();
+/// ```
+///
+/// Alternatively, use the [`WnafBase`] and [`WnafScalar`] types, which enable the various
+/// tables and w-NAF forms to be cached individually per base and scalar. These types can
+/// then be directly multiplied without any additional runtime work, at the cost of fixing
+/// a specific window size (rather than choosing the window size dynamically).
+#[derive(Debug)]
+pub struct Wnaf<W, B, S> {
+    base: B,
+    scalar: S,
+    window_size: W,
+}
+
+impl<G: Group> Default for Wnaf<(), Vec<G>, Vec<i64>> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<G: Group> Wnaf<(), Vec<G>, Vec<i64>> {
+    /// Construct a new wNAF context without allocating.
+    #[must_use]
+    pub fn new() -> Self {
+        Wnaf {
+            base: vec![],
+            scalar: vec![],
+            window_size: (),
+        }
+    }
+}
+
+impl<G: WnafGroup> Wnaf<(), Vec<G>, Vec<i64>> {
+    /// Given a base and a number of scalars, compute a window table and return a `Wnaf` object that
+    /// can perform exponentiations with `.scalar(..)`.
+    pub fn base(&mut self, base: G, num_scalars: usize) -> Wnaf<usize, &[G], &mut Vec<i64>> {
+        // Compute the appropriate window size based on the number of scalars.
+        let window_size = G::recommended_wnaf_for_num_scalars(num_scalars);
+
+        // Compute a wNAF table for the provided base and window size.
+        wnaf_table(&mut self.base, base, window_size);
+
+        // Return a Wnaf object that immutably borrows the computed base storage location,
+        // but mutably borrows the scalar storage location.
+        Wnaf {
+            base: &self.base[..],
+            scalar: &mut self.scalar,
+            window_size,
+        }
+    }
+
+    /// Given a scalar, compute its wNAF representation and return a `Wnaf` object that can perform
+    /// exponentiations with `.base(..)`.
+    pub fn scalar(&mut self, scalar: &<G as Group>::Scalar) -> Wnaf<usize, &mut Vec<G>, &[i64]> {
+        // We hard-code a window size of 4.
+        let window_size = 4;
+
+        // Compute the wNAF form of the scalar.
+        wnaf_form(&mut self.scalar, le_repr(scalar), window_size);
+
+        // Return a Wnaf object that mutably borrows the base storage location, but
+        // immutably borrows the computed wNAF form scalar location.
+        Wnaf {
+            base: &mut self.base,
+            scalar: &self.scalar[..],
+            window_size,
+        }
+    }
+}
+
+impl<'a, G: Group> Wnaf<usize, &'a [G], &'a mut Vec<i64>> {
+    /// Constructs new space for the scalar representation while borrowing
+    /// the computed window table, for sending the window table across threads.
+    #[must_use]
+    pub fn shared(&self) -> Wnaf<usize, &'a [G], Vec<i64>> {
+        Wnaf {
+            base: self.base,
+            scalar: vec![],
+            window_size: self.window_size,
+        }
+    }
+}
+
+impl<'a, G: Group> Wnaf<usize, &'a mut Vec<G>, &'a [i64]> {
+    /// Constructs new space for the window table while borrowing
+    /// the computed scalar representation, for sending the scalar representation
+    /// across threads.
+    #[must_use]
+    pub fn shared(&self) -> Wnaf<usize, Vec<G>, &'a [i64]> {
+        Wnaf {
+            base: vec![],
+            scalar: self.scalar,
+            window_size: self.window_size,
+        }
+    }
+}
+
+impl<B, S: AsRef<[i64]>> Wnaf<usize, B, S> {
+    /// Performs exponentiation given a base.
+    pub fn base<G: Group>(&mut self, base: G) -> G
+    where
+        B: AsMut<Vec<G>>,
+    {
+        wnaf_table(self.base.as_mut(), base, self.window_size);
+        wnaf_exp(self.base.as_mut(), self.scalar.as_ref())
+    }
+}
+
+impl<B, S: AsMut<Vec<i64>>> Wnaf<usize, B, S> {
+    /// Performs exponentiation given a scalar.
+    pub fn scalar<G: Group>(&mut self, scalar: &<G as Group>::Scalar) -> G
+    where
+        B: AsRef<[G]>,
+    {
+        wnaf_form(self.scalar.as_mut(), le_repr(scalar), self.window_size);
+        wnaf_exp(self.base.as_ref(), self.scalar.as_mut())
+    }
+}
+
+/// Replaces the contents of `table` with a w-NAF window table for the given window size.
+///
+/// For a window of size `w`, non-zero wNAF digits are odd and have magnitude at most
+/// `2^(w-1) - 1`. The table is indexed by `|digit| / 2`, so the required size is
+/// `(2^(w-1) - 1) / 2 + 1 = 2^(w-2)` entries.
+fn wnaf_table<G: Group>(table: &mut Vec<G>, mut base: G, window: usize) {
+    let table_len = 1 << (window - 2);
+    table.clear();
+    table.reserve(table_len);
+
+    let dbl = base.double();
+
+    for _ in 0..table_len {
+        table.push(base);
+        base.add_assign(&dbl);
+    }
+}
+
+/// Replaces the contents of `wnaf` with the w-NAF representation of a little-endian
+/// scalar.
+#[allow(clippy::cast_possible_wrap)]
+fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut Vec<i64>, c: S, window: usize) {
+    // Required by the NAF definition
+    debug_assert!(window >= 2);
+    // Required so that the NAF digits fit in i64
+    debug_assert!(window <= 64);
+
+    let bit_len = c.as_ref().len() * 8;
+
+    wnaf.clear();
+    wnaf.reserve(bit_len);
+
+    // Initialise the current and next limb buffers.
+    let mut limbs = LimbBuffer::new(c.as_ref());
+
+    let width = 1u64 << window;
+    let window_mask = width - 1;
+
+    let mut pos = 0;
+    let mut carry = 0;
+    while pos < bit_len {
+        // Construct a buffer of bits of the scalar, starting at bit `pos`
+        let u64_idx = pos / 64;
+        let bit_idx = pos % 64;
+        let (cur_u64, next_u64) = limbs.get(u64_idx);
+        let bit_buf = if bit_idx + window < 64 {
+            // This window's bits are contained in a single u64
+            cur_u64 >> bit_idx
+        } else {
+            // Combine the current u64's bits with the bits from the next u64
+            (cur_u64 >> bit_idx) | (next_u64 << (64 - bit_idx))
+        };
+
+        // Add the carry into the current window
+        let window_val = carry + (bit_buf & window_mask);
+
+        if window_val & 1 == 0 {
+            // If the window value is even, preserve the carry and emit 0.
+            // Why is the carry preserved?
+            // If carry == 0 and window_val & 1 == 0, then the next carry should be 0
+            // If carry == 1 and window_val & 1 == 0, then bit_buf & 1 == 1 so the next carry should be 1
+            wnaf.push(0);
+            pos += 1;
+        } else {
+            wnaf.push(if window_val < width / 2 {
+                carry = 0;
+                window_val as i64
+            } else {
+                carry = 1;
+                (window_val as i64).wrapping_sub(width as i64)
+            });
+            wnaf.extend(core::iter::repeat_n(0, window - 1));
+            pos += window;
+        }
+    }
+
+    // If there is a remaining carry (the scalar used all `bit_len` bit and the last wNAF digit was
+    // negative), emit it so the representation is exact.
+    if carry != 0 {
+        wnaf.push(carry as i64);
+    }
+}
+
+/// Performs w-NAF exponentiation with the provided window table and w-NAF form scalar.
+///
+/// This function must be provided a `table` and `wnaf` that were constructed with
+/// the same window size; otherwise, it may panic or produce invalid results.
+#[inline]
+fn wnaf_exp<G: Group>(table: &[G], wnaf: &[i64]) -> G {
+    wnaf_multi_exp(&[table], &[wnaf])
+}
+
+/// Performs w-NAF multi-exponentiation using the interleaved window method, also known as
+/// Straus' method.
+///
+/// The key insight is that when computing this sum by means of additions and doublings, the
+/// doublings can be shared by performing the additions within an inner loop.
+///
+/// This function must be provided with `tables` and `wnafs` that were constructed with
+/// the same window size; otherwise, it may panic or produce invalid results.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
+fn wnaf_multi_exp<G: Group, T: AsRef<[G]>, W: AsRef<[i64]>>(tables: &[T], wnafs: &[W]) -> G {
+    debug_assert_eq!(tables.len(), wnafs.len());
+    let window_size = wnafs.iter().map(|w| w.as_ref().len()).max().unwrap_or(0);
+
+    let mut result = G::identity();
+    let mut found_one = false;
+
+    for i in (0..window_size).rev() {
+        // Only double once per iteration of the loop
+        if found_one {
+            result = result.double();
+        }
+
+        for (table, wnaf) in tables.iter().zip(wnafs.iter()) {
+            let n = wnaf.as_ref().get(i).copied().unwrap_or(0);
+            if n != 0 {
+                found_one = true;
+
+                if n > 0 {
+                    result += table.as_ref()[(n / 2) as usize];
+                } else {
+                    result -= table.as_ref()[((-n) / 2) as usize];
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Get the little endian representation of a field, namely a scalar.
+fn le_repr<F: PrimeField>(fe: &F) -> F::Repr {
+    let mut ret = fe.to_repr();
+    // TODO(tarcieri): we currently assume this is always big endian. Make it configurable.
+    ret.as_mut().reverse();
+    ret
+}

--- a/wnaf/src/limb_buffer.rs
+++ b/wnaf/src/limb_buffer.rs
@@ -1,0 +1,69 @@
+/// This struct represents a view of a sequence of bytes as a sequence of
+/// `u64` limbs in little-endian byte order. It maintains a current index, and
+/// allows access to the limb at that index and the one following it. Bytes
+/// beyond the end of the original buffer are treated as zero.
+pub(crate) struct LimbBuffer<'a> {
+    buf: &'a [u8],
+    cur_idx: usize,
+    cur_limb: u64,
+    next_limb: u64,
+}
+
+impl<'a> LimbBuffer<'a> {
+    pub(crate) fn new(buf: &'a [u8]) -> Self {
+        let mut ret = Self {
+            buf,
+            cur_idx: 0,
+            cur_limb: 0,
+            next_limb: 0,
+        };
+
+        // Initialise the limb buffers.
+        ret.increment_limb();
+        ret.increment_limb();
+        ret.cur_idx = 0usize;
+
+        ret
+    }
+
+    pub(crate) fn increment_limb(&mut self) {
+        self.cur_idx += 1;
+        self.cur_limb = self.next_limb;
+        match self.buf.len() {
+            // There are no more bytes in the buffer; zero-extend.
+            0 => self.next_limb = 0,
+
+            // There are fewer bytes in the buffer than a u64 limb; zero-extend.
+            x @ 1..=7 => {
+                let mut next_limb = [0; 8];
+                next_limb[..x].copy_from_slice(self.buf);
+                self.next_limb = u64::from_le_bytes(next_limb);
+                self.buf = &[];
+            }
+
+            // There are at least eight bytes in the buffer; read the next u64 limb.
+            _ => {
+                let (next_limb, rest) = self.buf.split_at(8);
+                self.next_limb = u64::from_le_bytes([
+                    next_limb[0],
+                    next_limb[1],
+                    next_limb[2],
+                    next_limb[3],
+                    next_limb[4],
+                    next_limb[5],
+                    next_limb[6],
+                    next_limb[7],
+                ]);
+                self.buf = rest;
+            }
+        }
+    }
+
+    pub(crate) fn get(&mut self, idx: usize) -> (u64, u64) {
+        assert!([self.cur_idx, self.cur_idx + 1].contains(&idx));
+        if idx > self.cur_idx {
+            self.increment_limb();
+        }
+        (self.cur_limb, self.next_limb)
+    }
+}

--- a/wnaf/src/scalar.rs
+++ b/wnaf/src/scalar.rs
@@ -1,0 +1,85 @@
+use crate::{le_repr, wnaf_form};
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+use ff::PrimeField;
+
+/// A "w-ary non-adjacent form" scalar, that uses precomputation to improve the speed of
+/// scalar multiplication.
+///
+/// # Examples
+///
+/// See [`WnafBase`] for usage examples.
+#[derive(Clone, Debug)]
+pub struct WnafScalar<F: PrimeField, const WINDOW_SIZE: usize> {
+    pub(crate) wnaf: Vec<i64>,
+    field: PhantomData<F>,
+}
+
+impl<F: PrimeField, const WINDOW_SIZE: usize> WnafScalar<F, WINDOW_SIZE> {
+    /// Computes the w-NAF representation of the given scalar with the specified
+    /// `WINDOW_SIZE`.
+    pub fn new(scalar: &F) -> Self {
+        let mut wnaf = vec![];
+
+        // Compute the w-NAF form of the scalar.
+        wnaf_form(&mut wnaf, le_repr(scalar), WINDOW_SIZE);
+
+        WnafScalar {
+            wnaf,
+            field: PhantomData,
+        }
+    }
+
+    /// Computes the w-NAF representation directly from raw little-endian bytes.
+    ///
+    /// `bytes` is interpreted as a little-endian unsigned integer (trailing zero bytes may be
+    /// omitted), and the resulting [`WnafScalar`] evaluates to that integer times the base.
+    /// Because the number of w-NAF digits — and therefore the number of doublings in the
+    /// evaluation loop — is proportional to `bytes.len() * 8`, passing a slice shorter than the
+    /// field's canonical representation produces a faster scalar.
+    ///
+    /// This is intended for callers that have already decomposed a scalar into a value smaller
+    /// than the field modulus, e.g. the ~128-bit half-scalars produced by a GLV endomorphism
+    /// decomposition.
+    ///
+    /// The encoded integer is validated to be a canonical field element: it must be strictly
+    /// less than the field modulus. No modular reduction is performed — a value that is not
+    /// already in range is rejected rather than reduced, so the returned [`WnafScalar`] always
+    /// evaluates to the integer `bytes` encodes.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if `bytes` is longer than the field's canonical representation, or if
+    /// the encoded integer is greater than or equal to the field modulus.
+    pub fn from_le_bytes(bytes: &[u8]) -> Option<Self> {
+        // Validate that `bytes` encodes a canonical field element by round-tripping it through
+        // `F::from_repr`, which returns `None` for any integer greater than or equal to the
+        // modulus. `from_repr` consumes the canonical representation, assumed big-endian to match
+        // `le_repr` below, so reverse the little-endian input into a zero-extended `F::Repr`.
+        let mut repr = F::Repr::default();
+        let repr_len = repr.as_ref().len();
+
+        // Anything wider than the canonical representation is necessarily out of range.
+        if bytes.len() > repr_len {
+            return None;
+        }
+
+        for (i, &byte) in bytes.iter().enumerate() {
+            repr.as_mut()[repr_len - 1 - i] = byte;
+        }
+
+        if bool::from(F::from_repr(repr).is_none()) {
+            return None;
+        }
+
+        let mut wnaf = vec![];
+
+        // Compute the w-NAF form directly from the provided little-endian bytes.
+        wnaf_form(&mut wnaf, bytes, WINDOW_SIZE);
+
+        Some(WnafScalar {
+            wnaf,
+            field: PhantomData,
+        })
+    }
+}


### PR DESCRIPTION
Extracts the w-NAF implementation originally from the `group` crate, forked as `rustcrypto-group`, and then extracted into the `elliptic-curve` crate so we could migrate to upstream to `group` v0.14, into yet another new location: the `wnaf` crate.

This crate depends only on `ff` and `group`, which means the `elliptic-curve` crate can depend on it, which is needed for sharing the code for precomputed base tables between constant-time and variable-time w-NAF implementations.

Having the code here should make it easier to adapt `k256` to make use of it, and also allows it to be tested against the various elliptic curve implementations.