### PR TITLE
primeorder: use `wnaf` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.17.0-rc.18"
-source = "git+https://github.com/RustCrypto/signatures.git#a8c7206efe6ad9e9f9a1166eae3565e7dac093d6"
+source = "git+https://github.com/RustCrypto/signatures#a8c7206efe6ad9e9f9a1166eae3565e7dac093d6"
 dependencies = [
  "der",
  "digest",
@@ -478,8 +478,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102d3643d30dd8b559613c5cced68317199597fffb278cdc88daa2ef7fafc935"
+source = "git+https://github.com/RustCrypto/traits#2032ddfec78963abdc4f412e8bb165da3117e621"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -497,6 +496,7 @@ dependencies = [
  "sec1",
  "serdect",
  "subtle",
+ "wnaf",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,7 @@ ed448-goldilocks = { path = "ed448-goldilocks" }
 hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
+wnaf = { path = "wnaf" }
 
-ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
+ecdsa = { git = "https://github.com/RustCrypto/signatures" }
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -24,7 +24,7 @@ elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features 
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [features]
-alloc = ["elliptic-curve/alloc"]
+alloc = ["elliptic-curve/wnaf"]
 std = ["alloc", "elliptic-curve/std"]
 
 basepoint-table = ["elliptic-curve/basepoint-table"]

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -28,7 +28,7 @@ use elliptic_curve::{
 #[cfg(feature = "alloc")]
 use {
     alloc::vec::Vec,
-    elliptic_curve::{Wnaf, WnafBase, WnafGroup, WnafScalar},
+    elliptic_curve::wnaf::{Wnaf, WnafBase, WnafGroup, WnafScalar},
 };
 
 #[cfg(all(feature = "alloc", feature = "basepoint-table"))]


### PR DESCRIPTION
Uses the w-NAF implementation extracted into the `wnaf` crate in #1777