### PR TITLE
Bump `ecdsa` => v0.17.0-rc.19; `elliptic-curve` => v0.14.0-rc.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,8 +422,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.18"
-source = "git+https://github.com/RustCrypto/signatures#a8c7206efe6ad9e9f9a1166eae3565e7dac093d6"
+version = "0.17.0-rc.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcddae1289a08e614a83d155a070f54c1803196e92089b8299e2738eb74d3e4"
 dependencies = [
  "der",
  "digest",
@@ -477,8 +478,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.33"
-source = "git+https://github.com/RustCrypto/traits#2032ddfec78963abdc4f412e8bb165da3117e621"
+version = "0.14.0-rc.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a44d097c9f3e494ddc19f77af5aab89f0b3b2652cde370ec8c6064faca5bd2"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,3 @@ hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
 wnaf = { path = "wnaf" }
-
-ecdsa = { git = "https://github.com/RustCrypto/signatures" }
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.33", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.34", features = ["sec1"] }
 
 # optional dependencies
 belt-block = { version = "0.2", optional = true }
@@ -38,7 +38,7 @@ signature = { version = "3", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.10", features = ["dev"] }
 proptest = "1"

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,17 +14,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.18", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.19", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14.0-rc.10", optional = true }
 primeorder = { version = "0.14.0-rc.10", optional = true }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,17 +14,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.18", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.19", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14.0-rc.10", optional = true }
 primeorder = { version = "0.14.0-rc.10", optional = true }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -16,7 +16,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.33", features = ["arithmetic", "pkcs8"] }
+elliptic-curve = { version = "0.14.0-rc.34", features = ["arithmetic", "pkcs8"] }
 hash2curve = "0.14.0-rc.12"
 rand_core = { version = "0.10", default-features = false }
 shake = { version = "0.1", default-features = false }

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = { version = "0.11" }
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["arithmetic"] }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,11 +20,11 @@ rust-version = "1.85"
 
 [dependencies]
 cpubits = "0.1"
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
 hash2curve = { version = "0.14.0-rc.12", optional = true }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primeorder = { version = "0.14.0-rc.10", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
@@ -33,7 +33,7 @@ signature = { version = "3", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4.3"
 hex-literal = "1"
 num-bigint = "0.4"

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -26,7 +26,7 @@ use elliptic_curve::{
 #[cfg(feature = "alloc")]
 use {
     alloc::vec::Vec,
-    elliptic_curve::group::{Wnaf, WnafGroup},
+    elliptic_curve::wnaf::{Wnaf, WnafGroup},
 };
 
 #[rustfmt::skip]

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.10", optional = true }
 primeorder = { version = "0.14.0-rc.10", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.10", features = ["dev"] }
 

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,10 +17,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.10", optional = true }
 primeorder = { version = "0.14.0-rc.10", optional = true }
@@ -28,7 +28,7 @@ serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.10", features = ["dev"] }
 

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,10 +18,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.12", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.10", optional = true }
@@ -31,7 +31,7 @@ sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primefield = { version = "0.14.0-rc.10" }
 primeorder = { version = "0.14.0-rc.10", features = ["dev"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,10 +18,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.12", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.10", optional = true }
@@ -34,7 +34,7 @@ fiat-crypto = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.10", features = ["dev"] }
 proptest = "1.11"

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -18,10 +18,10 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "1"
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.12", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14.0-rc.10", optional = true }
@@ -32,7 +32,7 @@ sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.17", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.10", features = ["dev"] }
 proptest = "1.11"

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["arithmetic", "sec1"] }
 
 # optional dependencies
 serdect = { version = "0.4", optional = true, default-features = false }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
 rand_core = { version = "0.10", default-features = false }
 
@@ -33,7 +33,7 @@ sm3 = { version = "0.5", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.33", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["dev"] }
 hex-literal = "1"
 proptest = "1"
 


### PR DESCRIPTION
These support the new `rfc6979` and `wnaf` crates respectively