### PR TITLE
primeorder: use `elliptic_curve::point::LookupTable`

### DIFF
--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -20,6 +20,7 @@ mod affine;
 #[cfg(feature = "dev")]
 mod dev;
 mod projective;
+mod radix16;
 
 pub use crate::{affine::AffinePoint, projective::ProjectivePoint};
 pub use elliptic_curve::{

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -2,12 +2,11 @@
 
 #![allow(clippy::needless_range_loop, clippy::op_ref)]
 
+use crate::radix16::Radix16Decomposition;
 use crate::{AffinePoint, Field, PrimeCurveParams, point_arithmetic::PointArithmetic};
-use core::{array, borrow::Borrow, iter::Sum};
+use core::{array, borrow::Borrow, iter::Sum, iter::zip};
 use elliptic_curve::{
-    BatchNormalize, CurveGroup, Error, FieldBytesSize, Generate, PrimeField, PublicKey, Result,
-    Scalar,
-    bigint::{ArrayEncoding, ByteArray},
+    BatchNormalize, CurveGroup, Error, FieldBytesSize, Generate, PublicKey, Result, Scalar,
     ctutils,
     group::{
         Group, GroupEncoding,
@@ -18,7 +17,7 @@ use elliptic_curve::{
         Add, AddAssign, BatchInvert, LinearCombination, Mul, MulAssign, MulByGeneratorVartime,
         MulVartime, Neg, Sub, SubAssign,
     },
-    point::{Double, NonIdentity},
+    point::{Double, LookupTable, NonIdentity},
     rand_core::{TryCryptoRng, TryRng},
     sec1::{CompressedPoint, FromSec1Point, ModulusSize, Sec1Point, ToSec1Point},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
@@ -115,10 +114,10 @@ where
     where
         Self: Double,
     {
-        let mut k = Into::<C::Uint>::into(*k).to_le_byte_array();
-        let mut pc = LookupTable::new(*self);
+        let table = LookupTable::new(*self);
+        let digits = Radix16Decomposition::new::<C>(k);
 
-        lincomb(array::from_mut(&mut k), array::from_mut(&mut pc))
+        lincomb::<C>(&[table], &[digits])
     }
 
     /// Returns `[k] self` computed in variable time.
@@ -481,17 +480,16 @@ where
 {
     #[cfg(feature = "alloc")]
     fn lincomb(points_and_scalars: &[(Self, Scalar<C>)]) -> Self {
-        let (mut ks, mut pcs): (Vec<_>, Vec<_>) = points_and_scalars
+        let tables: Vec<_> = points_and_scalars
             .iter()
-            .map(|(point, scalar)| {
-                (
-                    Into::<C::Uint>::into(*scalar).to_le_byte_array(),
-                    LookupTable::new(*point),
-                )
-            })
-            .unzip();
+            .map(|(point, _)| LookupTable::new(*point))
+            .collect();
+        let digits: Vec<_> = points_and_scalars
+            .iter()
+            .map(|(_, scalar)| Radix16Decomposition::new::<C>(scalar))
+            .collect();
 
-        lincomb::<C>(&mut ks, &mut pcs)
+        lincomb::<C>(&tables, &digits)
     }
 
     #[cfg(feature = "alloc")]
@@ -519,12 +517,11 @@ where
     FieldBytesSize<C>: ModulusSize,
 {
     fn lincomb(points_and_scalars: &[(Self, Scalar<C>); N]) -> Self {
-        let mut ks: [_; N] = array::from_fn(|index| {
-            Into::<C::Uint>::into(points_and_scalars[index].1).to_le_byte_array()
-        });
-        let mut pcs: [_; N] = array::from_fn(|index| LookupTable::new(points_and_scalars[index].0));
+        let tables: [_; N] = array::from_fn(|index| LookupTable::new(points_and_scalars[index].0));
+        let digits: [_; N] =
+            array::from_fn(|index| Radix16Decomposition::new::<C>(&points_and_scalars[index].1));
 
-        lincomb::<C>(&mut ks, &mut pcs)
+        lincomb::<C>(&tables, &digits)
     }
 
     #[cfg(feature = "alloc")]
@@ -534,60 +531,28 @@ where
 }
 
 fn lincomb<C: PrimeCurveParams>(
-    ks: &mut [ByteArray<C::Uint>],
-    pcs: &mut [LookupTable<C>],
+    tables: &[LookupTable<ProjectivePoint<C>>],
+    digits: &[Radix16Decomposition],
 ) -> ProjectivePoint<C> {
+    debug_assert_eq!(tables.len(), digits.len());
+    debug_assert!(!digits.is_empty());
+
+    let d = digits[0].len();
     let mut q = ProjectivePoint::IDENTITY;
-    let mut pos = (<Scalar<C> as PrimeField>::NUM_BITS.div_ceil(8) * 8) as usize - 4;
 
-    loop {
-        for (k, pc) in ks.iter().zip(pcs.iter()) {
-            let slot = (k[pos >> 3] >> (pos & 7)) & 0xf;
-            q = q.add(&pc.select(slot));
-        }
+    for (table, digit) in zip(tables, digits) {
+        q = q.add(&table.select(digit.digit(d - 1)));
+    }
 
-        if pos == 0 {
-            break;
-        }
-
+    for i in (0..d - 1).rev() {
         q = Double::double(&Double::double(&Double::double(&Double::double(&q))));
-        pos -= 4;
+
+        for (table, digit) in zip(tables, digits) {
+            q = q.add(&table.select(digit.digit(i)));
+        }
     }
 
     q
-}
-
-struct LookupTable<C: PrimeCurveParams>([ProjectivePoint<C>; 16]);
-
-impl<C: PrimeCurveParams> LookupTable<C> {
-    fn new(point: ProjectivePoint<C>) -> Self {
-        let mut pc = [ProjectivePoint::default(); 16];
-        pc[0] = ProjectivePoint::IDENTITY;
-        pc[1] = point;
-
-        for i in 2..16 {
-            pc[i] = if i % 2 == 0 {
-                Double::double(&pc[i / 2])
-            } else {
-                pc[i - 1].add(point)
-            };
-        }
-
-        Self(pc)
-    }
-
-    fn select(&self, slot: u8) -> ProjectivePoint<C> {
-        let mut t = ProjectivePoint::IDENTITY;
-
-        for i in 1..16 {
-            t.conditional_assign(
-                &self.0[i],
-                Choice::from(((slot as usize ^ i).wrapping_sub(1) >> 8) as u8 & 1),
-            );
-        }
-
-        t
-    }
 }
 
 impl<C> PartialEq for ProjectivePoint<C>

--- a/primeorder/src/radix16.rs
+++ b/primeorder/src/radix16.rs
@@ -1,0 +1,206 @@
+//! Radix-16 signed-digit decomposition for constant-time scalar multiplication.
+
+use core::ops::Add;
+
+use elliptic_curve::{
+    CurveArithmetic, PrimeCurve, PrimeField, Scalar,
+    array::typenum::{Prod, U1, U2, Unsigned},
+    bigint::ArrayEncoding,
+    consts::U66,
+};
+
+/// Largest scalar `FieldBytes` size among primeorder curves (P-521).
+type MaxScalarFieldBytes = U66;
+
+/// Two nibbles per scalar byte, plus one carry digit for signed recentering.
+type MaxDigits = <Prod<MaxScalarFieldBytes, U2> as Add<U1>>::Output;
+
+const MAX_DIGITS: usize = MaxDigits::USIZE;
+
+/// Signed radix-16 decomposition of a scalar
+/// Produces `[a_0, ..., a_{len-1}]` such that
+/// `scalar = sum(a_j * 16^j)` and each `a_j` is in `[-8, 8]`.
+/// `a_0` is the least significant position; `a_{len-1}` absorbs carry.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Radix16Decomposition {
+    digits: [i8; MAX_DIGITS],
+    len: usize,
+}
+
+impl Radix16Decomposition {
+    /// Decompose a scalar into signed radix-16 digits.
+    ///
+    /// Uses the scalar's canonical integer encoding in **big-endian** byte order,
+    /// matching k256's `Scalar::to_bytes()` layout regardless of a curve's
+    /// `FieldBytes` endianness (e.g. bignp256 uses LE `to_repr()`).
+    pub(crate) fn new<C>(scalar: &Scalar<C>) -> Self
+    where
+        C: PrimeCurve + CurveArithmetic,
+        Scalar<C>: PrimeField + Into<C::Uint>,
+        C::Uint: ArrayEncoding,
+    {
+        let num_bits = Scalar::<C>::NUM_BITS;
+        let byte_len = num_bits.div_ceil(8) as usize;
+        let len = 2 * byte_len + 1;
+
+        debug_assert!(len <= MAX_DIGITS);
+
+        let bytes = Into::<C::Uint>::into(*scalar).to_be_byte_array();
+        let bytes: &[u8] = bytes.as_ref();
+        let uint_byte_len = bytes.len();
+        debug_assert!(uint_byte_len >= byte_len);
+
+        let mut digits = [0i8; MAX_DIGITS];
+
+        // Step 1: change radix — BE bytes, LSB byte first in digit order (matches k256).
+        // `C::Uint` may be wider than `NUM_BITS` (e.g. p224 in U256, p521 in 72-byte Uint).
+        for i in 0..byte_len {
+            let b = bytes[uint_byte_len - 1 - i];
+            digits[2 * i] = (b & 0xf) as i8;
+            digits[2 * i + 1] = ((b >> 4) & 0xf) as i8;
+        }
+
+        // Step 2: recenter coefficients from [0, 16) to [-8, 8)
+        for i in 0..(len - 1) {
+            let carry = (digits[i] + 8) >> 4;
+            digits[i] -= carry << 4;
+            digits[i + 1] += carry;
+        }
+
+        Self { digits, len }
+    }
+
+    /// Number of digit slots for this decomposition.
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Digit at index `i` (`0` = least significant position).
+    #[inline]
+    pub(crate) fn digit(&self, i: usize) -> i8 {
+        self.digits[i]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mirror [`Radix16Decomposition::new`] byte extraction for raw BE `Uint` buffers.
+    fn decompose_from_padded_be_uint(bytes: &[u8], byte_len: usize) -> Radix16Decomposition {
+        let uint_byte_len = bytes.len();
+        assert!(uint_byte_len >= byte_len);
+
+        let len = 2 * byte_len + 1;
+        let mut digits = [0i8; MAX_DIGITS];
+
+        for i in 0..byte_len {
+            let b = bytes[uint_byte_len - 1 - i];
+            digits[2 * i] = (b & 0xf) as i8;
+            digits[2 * i + 1] = ((b >> 4) & 0xf) as i8;
+        }
+
+        for i in 0..(len - 1) {
+            let carry = (digits[i] + 8) >> 4;
+            digits[i] -= carry << 4;
+            digits[i + 1] += carry;
+        }
+
+        Radix16Decomposition { digits, len }
+    }
+
+    fn decompose_be_bytes(bytes: &[u8]) -> Radix16Decomposition {
+        decompose_from_padded_be_uint(bytes, bytes.len())
+    }
+
+    fn assert_digits_in_range(d: &Radix16Decomposition) {
+        for i in 0..d.len() {
+            let digit = d.digit(i);
+            assert!((-8..=8).contains(&digit), "digit[{i}] = {digit}");
+        }
+    }
+
+    #[test]
+    fn digit_range() {
+        let d = decompose_be_bytes(&[0xabu8; 32]);
+        assert_digits_in_range(&d);
+    }
+
+    /// p224 stores 224-bit scalars in a wider `Uint` (e.g. 32-byte U256 on 64-bit).
+    #[test]
+    fn p224_padded_uint_ignores_high_prefix() {
+        let mut bytes = [0xffu8; 32];
+        bytes[4..32].fill(0);
+        bytes[31] = 2;
+
+        let d = decompose_from_padded_be_uint(&bytes, 28);
+        assert_eq!(d.len(), 57);
+        assert_eq!(d.digit(0), 2);
+        assert_digits_in_range(&d);
+        for i in 1..d.len() {
+            assert_eq!(d.digit(i), 0);
+        }
+    }
+
+    /// p521 uses a 72-byte `Uint` for a 521-bit (66-byte) scalar field.
+    #[test]
+    fn p521_padded_uint_ignores_high_prefix() {
+        let mut bytes = [0xffu8; 72];
+        bytes[6..72].fill(0);
+        bytes[71] = 3;
+
+        let d = decompose_from_padded_be_uint(&bytes, 66);
+        assert_eq!(d.len(), 133);
+        assert_eq!(d.digit(0), 3);
+        assert_digits_in_range(&d);
+        for i in 1..d.len() {
+            assert_eq!(d.digit(i), 0);
+        }
+    }
+
+    #[test]
+    fn len_formula_p192_p384() {
+        assert_eq!(decompose_from_padded_be_uint(&[0u8; 24], 24).len(), 49);
+        assert_eq!(decompose_from_padded_be_uint(&[0u8; 48], 48).len(), 97);
+    }
+
+    #[test]
+    fn reconstruction() {
+        let bytes: [u8; 8] = [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef];
+        let d = decompose_be_bytes(&bytes);
+
+        let mut acc: i128 = 0;
+        let mut radix: i128 = 1;
+        for i in 0..d.len() {
+            acc += i128::from(d.digit(i)) * radix;
+            radix *= 16;
+        }
+
+        let mut expected: i128 = 0;
+        for b in bytes {
+            expected = (expected << 8) | i128::from(b);
+        }
+
+        assert_eq!(acc, expected);
+    }
+
+    #[test]
+    fn len_formula() {
+        // 256-bit → 32 bytes → 65 digits
+        let d = decompose_be_bytes(&[0u8; 32]);
+        assert_eq!(d.len(), 65);
+
+        // 521-bit → 66 bytes → 133 digits
+        let d = decompose_be_bytes(&[0u8; 66]);
+        assert_eq!(d.len(), 133);
+    }
+
+    #[test]
+    fn zero_scalar() {
+        let d = decompose_be_bytes(&[0u8; 32]);
+        for i in 0..d.len() {
+            assert_eq!(d.digit(i), 0);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1657
- Add `Radix16Decomposition` in primeorder: generic signed radix-16 digit
  decomposition before the main multiplication loop, matching k256's approach.
- Refactor `ProjectivePoint::mul` and `lincomb` to use
  `elliptic_curve::point::LookupTable` (8-entry signed) instead of the private
  16-entry unsigned table.
- Decode scalars via `Into::<Uint>::into(scalar).to_be_byte_array()` so
  decomposition is correct for LE `FieldBytes` curves (bignp256) and curves
  whose `Uint` is wider than the scalar field (p224, p521).

No new dependencies; radix16 edge cases are covered by unit tests in primeorder
and by existing lincomb proptests in the curve crates.

