### PR TITLE
primeorder: encode field size bounds in `PrimeCurveParams`

### DIFF
--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -5,17 +5,14 @@
 use crate::{PrimeCurveParams, ProjectivePoint};
 use core::borrow::Borrow;
 use elliptic_curve::{
-    Error, FieldBytes, FieldBytesEncoding, FieldBytesSize, Generate, PublicKey, Result, Scalar,
+    Error, FieldBytes, FieldBytesEncoding, Generate, PublicKey, Result, Scalar,
     ctutils::{self, CtGt as _, CtSelect as _},
     ff::{Field, PrimeField},
     group::{CurveAffine, GroupEncoding},
     ops::{Mul, MulVartime, Neg},
     point::{AffineCoordinates, DecompactPoint, DecompressPoint, Double, NonIdentity},
     rand_core::{TryCryptoRng, TryRng},
-    sec1::{
-        self, CompressedPoint, FromSec1Point, ModulusSize, Sec1Point, ToCompactSec1Point,
-        ToSec1Point,
-    },
+    sec1::{self, CompressedPoint, FromSec1Point, Sec1Point, ToCompactSec1Point, ToSec1Point},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
 };
@@ -215,7 +212,6 @@ impl<C> Eq for AffinePoint<C> where C: PrimeCurveParams {}
 impl<C> FromSec1Point<C> for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytesSize<C>: ModulusSize,
 {
     /// Attempts to parse the given [`Sec1Point`] as an SEC1-encoded
     /// [`AffinePoint`].
@@ -283,8 +279,6 @@ where
 impl<C> From<AffinePoint<C>> for Sec1Point<C>
 where
     C: PrimeCurveParams,
-    FieldBytesSize<C>: ModulusSize,
-    CompressedPoint<C>: Copy,
 {
     fn from(affine: AffinePoint<C>) -> Sec1Point<C> {
         affine.to_sec1_point(false)
@@ -305,8 +299,6 @@ where
 impl<C> GroupEncoding for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy,
-    FieldBytesSize<C>: ModulusSize,
 {
     type Repr = CompressedPoint<C>;
 
@@ -350,8 +342,6 @@ where
 impl<C> CurveAffine for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy,
-    FieldBytesSize<C>: ModulusSize,
 {
     type Curve = ProjectivePoint<C>;
     type Scalar = Scalar<C>;
@@ -376,8 +366,6 @@ where
 impl<C> ToCompactSec1Point<C> for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytesSize<C>: ModulusSize,
-    CompressedPoint<C>: Copy,
 {
     /// Serialize this value as a  SEC1 compact [`Sec1Point`]
     fn to_compact_encoded_point(&self) -> ctutils::CtOption<Sec1Point<C>> {
@@ -397,8 +385,6 @@ where
 impl<C> ToSec1Point<C> for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytesSize<C>: ModulusSize,
-    CompressedPoint<C>: Copy,
 {
     fn to_sec1_point(&self, compress: bool) -> Sec1Point<C> {
         Sec1Point::<C>::ct_select(
@@ -428,8 +414,6 @@ where
 impl<C> TryFrom<Sec1Point<C>> for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytesSize<C>: ModulusSize,
-    CompressedPoint<C>: Copy,
 {
     type Error = Error;
 
@@ -441,8 +425,6 @@ where
 impl<C> TryFrom<&Sec1Point<C>> for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytesSize<C>: ModulusSize,
-    CompressedPoint<C>: Copy,
 {
     type Error = Error;
 
@@ -565,8 +547,6 @@ where
 impl<C> Serialize for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytesSize<C>: ModulusSize,
-    CompressedPoint<C>: Copy,
 {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
@@ -580,8 +560,6 @@ where
 impl<'de, C> Deserialize<'de> for AffinePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytesSize<C>: ModulusSize,
-    CompressedPoint<C>: Copy,
 {
     fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -24,24 +24,27 @@ mod radix16;
 
 pub use crate::{affine::AffinePoint, projective::ProjectivePoint};
 pub use elliptic_curve::{
-    self, Field, FieldBytes, PrimeCurve, PrimeField, Scalar, array, bigint::modular::Retrieve,
+    self, Field, FieldBytes, PrimeCurve, PrimeField, Scalar,
+    array::{self, ArraySize},
+    bigint::modular::Retrieve,
     point::Double,
 };
 
 use elliptic_curve::{
-    CurveArithmetic, FieldBytesSize, Generate,
+    Curve, CurveArithmetic, Generate,
     ops::{Invert, LinearCombination, MulVartime},
+    sec1::ModulusSize,
     subtle::CtOption,
 };
 
 #[cfg(all(feature = "alloc", feature = "basepoint-table"))]
 use elliptic_curve::point::BasepointTableVartime;
-use elliptic_curve::sec1::{CompressedPoint, ModulusSize};
 
 /// Parameters for elliptic curves of prime order which can be described by the
 /// short Weierstrass equation.
 pub trait PrimeCurveParams:
-    PrimeCurve
+    Curve<FieldBytesSize: ModulusSize<CompressedPointSize: ArraySize<ArrayType<u8>: Copy>>>
+    + PrimeCurve
     + CurveArithmetic<AffinePoint = AffinePoint<Self>, ProjectivePoint = ProjectivePoint<Self>>
 {
     /// Base field element type.
@@ -82,11 +85,7 @@ pub trait PrimeCurveParams:
         a: &Scalar<Self>,
         b_scalar: &Scalar<Self>,
         b_point: &ProjectivePoint<Self>,
-    ) -> ProjectivePoint<Self>
-    where
-        CompressedPoint<Self>: Copy,
-        FieldBytesSize<Self>: ModulusSize,
-    {
+    ) -> ProjectivePoint<Self> {
         ProjectivePoint::<Self>::lincomb_vartime(&[
             (ProjectivePoint::GENERATOR, *a),
             (*b_point, *b_scalar),

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -6,8 +6,7 @@ use crate::radix16::Radix16Decomposition;
 use crate::{AffinePoint, Field, PrimeCurveParams, point_arithmetic::PointArithmetic};
 use core::{array, borrow::Borrow, iter::Sum, iter::zip};
 use elliptic_curve::{
-    BatchNormalize, CurveGroup, Error, FieldBytesSize, Generate, PublicKey, Result, Scalar,
-    ctutils,
+    BatchNormalize, CurveGroup, Error, Generate, PublicKey, Result, Scalar, ctutils,
     group::{
         Group, GroupEncoding,
         cofactor::CofactorGroup,
@@ -19,7 +18,7 @@ use elliptic_curve::{
     },
     point::{Double, LookupTable, NonIdentity},
     rand_core::{TryCryptoRng, TryRng},
-    sec1::{CompressedPoint, FromSec1Point, ModulusSize, Sec1Point, ToSec1Point},
+    sec1::{CompressedPoint, FromSec1Point, Sec1Point, ToSec1Point},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
 };
@@ -259,8 +258,6 @@ where
 impl<C> FromSec1Point<C> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytesSize<C>: ModulusSize,
-    CompressedPoint<C>: Copy,
 {
     fn from_sec1_point(p: &Sec1Point<C>) -> ctutils::CtOption<Self> {
         AffinePoint::<C>::from_sec1_point(p).map(Self::from)
@@ -286,8 +283,6 @@ where
 impl<C> CofactorGroup for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytesSize<C>: ModulusSize,
-    CompressedPoint<C>: Copy,
 {
     type Subgroup = ProjectivePoint<C>;
 
@@ -307,8 +302,6 @@ where
 impl<C> CurveGroup for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy,
-    FieldBytesSize<C>: ModulusSize,
 {
     type Affine = AffinePoint<C>;
 
@@ -360,8 +353,6 @@ where
 impl<C> GroupEncoding for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy,
-    FieldBytesSize<C>: ModulusSize,
 {
     type Repr = CompressedPoint<C>;
 
@@ -383,8 +374,6 @@ impl<C> PrimeCurve for ProjectivePoint<C>
 where
     Self: Double,
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy,
-    FieldBytesSize<C>: ModulusSize,
 {
 }
 
@@ -392,8 +381,6 @@ impl<C> PrimeGroup for ProjectivePoint<C>
 where
     Self: Double,
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy,
-    FieldBytesSize<C>: ModulusSize,
 {
 }
 
@@ -404,8 +391,6 @@ where
 impl<const N: usize, C> BatchNormalize<[ProjectivePoint<C>; N]> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy,
-    FieldBytesSize<C>: ModulusSize,
 {
     type Output = [<Self as CurveGroup>::Affine; N];
 
@@ -422,8 +407,6 @@ where
 impl<C> BatchNormalize<[ProjectivePoint<C>]> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy,
-    FieldBytesSize<C>: ModulusSize,
 {
     type Output = Vec<<Self as CurveGroup>::Affine>;
 
@@ -475,8 +458,6 @@ where
 impl<C> LinearCombination<[(Self, Scalar<C>)]> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy,
-    FieldBytesSize<C>: ModulusSize,
 {
     #[cfg(feature = "alloc")]
     fn lincomb(points_and_scalars: &[(Self, Scalar<C>)]) -> Self {
@@ -513,8 +494,6 @@ where
 impl<C, const N: usize> LinearCombination<[(Self, Scalar<C>); N]> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy,
-    FieldBytesSize<C>: ModulusSize,
 {
     fn lincomb(points_and_scalars: &[(Self, Scalar<C>); N]) -> Self {
         let tables: [_; N] = array::from_fn(|index| LookupTable::new(points_and_scalars[index].0));
@@ -567,8 +546,6 @@ where
 impl<C> ToSec1Point<C> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy,
-    FieldBytesSize<C>: ModulusSize,
 {
     fn to_sec1_point(&self, compress: bool) -> Sec1Point<C> {
         self.to_affine().to_sec1_point(compress)
@@ -929,8 +906,6 @@ where
 impl<C> MulByGeneratorVartime for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    CompressedPoint<C>: Copy,
-    FieldBytesSize<C>: ModulusSize,
 {
     #[inline]
     fn mul_by_generator_vartime(scalar: &Scalar<C>) -> Self {
@@ -988,8 +963,6 @@ where
 impl<C> Serialize for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytesSize<C>: ModulusSize,
-    CompressedPoint<C>: Copy,
 {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
@@ -1003,8 +976,6 @@ where
 impl<'de, C> Deserialize<'de> for ProjectivePoint<C>
 where
     C: PrimeCurveParams,
-    FieldBytesSize<C>: ModulusSize,
-    CompressedPoint<C>: Copy,
 {
     fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where


### PR DESCRIPTION
Eliminates duplicated bounds by encoding the length requirements of `Curve::FieldBytesSize` into the bounds of `PrimeCurveParams`.