### PR TITLE
primeorder: add `BasepointTable::mul`

### DIFF
--- a/p256/src/arithmetic/tables.rs
+++ b/p256/src/arithmetic/tables.rs
@@ -3,6 +3,23 @@
 #[cfg(feature = "alloc")]
 pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
 
+use super::NistP256;
+use crate::ProjectivePoint;
+use primeorder::PrimeCurveWithBasepointTable;
+
+/// Window size for the basepoint table.
+const WINDOW_SIZE: usize = 33;
+
+/// Basepoint table for multiples of secp256r1's generator.
+type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
+
+/// Lazily computed basepoint table.
+pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
+
+impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for NistP256 {
+    const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
+}
+
 #[cfg(feature = "alloc")]
 mod vartime {
     use crate::{NistP256, ProjectivePoint};
@@ -20,5 +37,33 @@ mod vartime {
 
     impl PrimeCurveWithBasepointTableVartime<WINDOW_SIZE_VARTIME> for NistP256 {
         const BASEPOINT_TABLE_VARTIME: &'static BasepointTableVartime = &BASEPOINT_TABLE_VARTIME;
+    }
+}
+
+/// These are the main tests for `primeorder::BasepointTable` as we need a concrete curve to test
+/// against.
+#[cfg(test)]
+mod tests {
+    use super::BASEPOINT_TABLE;
+    use crate::{ProjectivePoint, Scalar};
+    use elliptic_curve::{
+        array::{Array, sizes::U32},
+        ops::Reduce,
+    };
+    use proptest::prelude::*;
+
+    prop_compose! {
+        fn scalar()(bytes in any::<[u8; 32]>()) -> Scalar {
+            Scalar::reduce(&Array::<u8, U32>::from(bytes))
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn basepoint_table_mul(x in scalar()) {
+            let expected = ProjectivePoint::GENERATOR * &x;
+            let actual = BASEPOINT_TABLE.mul(&x);
+            prop_assert_eq!(expected, actual);
+        }
     }
 }

--- a/primeorder/src/basepoint_table.rs
+++ b/primeorder/src/basepoint_table.rs
@@ -5,9 +5,13 @@
 #[cfg(not(any(feature = "critical-section", feature = "std")))]
 compile_error!("`basepoint-table` feature requires either `critical-section` or `std`");
 
-use super::LookupTable;
+use super::{LookupTable, Radix16Decomposition, Radix16Digits};
+use crate::{PrimeCurveParams, ProjectivePoint, Scalar};
 use core::ops::Deref;
-use elliptic_curve::{ff::PrimeField, group::Group, subtle::ConditionallySelectable};
+use elliptic_curve::{
+    FieldBytesSize, array::typenum::Unsigned, ff::PrimeField, group::Group,
+    subtle::ConditionallySelectable,
+};
 
 #[cfg(feature = "critical-section")]
 use once_cell::sync::Lazy as LazyLock;
@@ -53,6 +57,7 @@ where
 
             for i in 0..N {
                 res[i] = LookupTable::new(generator);
+
                 // We are storing tables spaced by two radix steps,
                 // to decrease the size of the precomputed data.
                 for _ in 0..8 {
@@ -66,6 +71,30 @@ where
         Self {
             tables: LazyLock::new(init_table),
         }
+    }
+}
+
+impl<C: PrimeCurveParams, const WINDOW_SIZE: usize>
+    BasepointTable<ProjectivePoint<C>, WINDOW_SIZE>
+{
+    /// Multiply `Point::generator` by the given scalar in constant-time, using the precomputed
+    /// basepoint table to accelerate the scalar multiplication.
+    pub fn mul(&self, k: &Scalar<C>) -> ProjectivePoint<C> {
+        let digits = Radix16Decomposition::<Radix16Digits<C>>::new(k, true);
+        let len = FieldBytesSize::<C>::USIZE;
+        let mut acc = self[len].select(digits[len * 2]);
+        let mut acc2 = ProjectivePoint::<C>::IDENTITY;
+        for i in (0..len).rev() {
+            acc2 += &self[i].select(digits[i * 2 + 1]);
+            acc += &self[i].select(digits[i * 2]);
+        }
+
+        // This is the price of halving the precomputed table size.
+        for _ in 0..4 {
+            acc2 = acc2.double();
+        }
+
+        acc + acc2
     }
 }
 


### PR DESCRIPTION
Adds a generic implementation of constant-time scalar multiplication which uses `BasepointTable` for acceleration, adapted from the implementation in `k256` and made generic.

This also defines a `BASEPOINT_TABLE` constant in `p256` which is used to test `BasepointTable::mul`, although it's not actually used to accelerate scalar multiplication in the crate's public API yet.