### PR TITLE
p256: use basepoint table for `mul_by_generator`

### DIFF
--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -64,6 +64,11 @@ impl PrimeCurveParams for NistP256 {
         ),
     );
 
+    #[cfg(feature = "precomputed-tables")]
+    fn mul_by_generator(k: &elliptic_curve::Scalar<Self>) -> primeorder::ProjectivePoint<Self> {
+        tables::BASEPOINT_TABLE.mul(k)
+    }
+
     #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
     fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
         tables::BASEPOINT_TABLE_VARTIME.mul(k)


### PR DESCRIPTION
Actually wires up the `BASEPOINT_TABLE` added to `p256` in #1789 to use the accelerated multiplication function added in the same PR.

This results in the following performance improvement:

```
ProjectivePoint operations/generator-scalar mul
    time:   [36.266 µs 37.002 µs 37.981 µs]
    change: [−72.884% −72.379% −71.733%] (p = 0.00 < 0.05)
    Performance has improved.
```