### PR TITLE
p384: constant-time `BASEPOINT_TABLE`

### DIFF
--- a/p256/src/arithmetic/tables.rs
+++ b/p256/src/arithmetic/tables.rs
@@ -1,11 +1,11 @@
 //! Precomputed tables (optional).
 
-#[cfg(feature = "alloc")]
-pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
-
 use super::NistP256;
 use crate::ProjectivePoint;
 use primeorder::PrimeCurveWithBasepointTable;
+
+#[cfg(feature = "alloc")]
+pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
 
 /// Window size for the basepoint table.
 const WINDOW_SIZE: usize = 33;

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -68,6 +68,11 @@ impl PrimeCurveParams for NistP384 {
         ),
     );
 
+    #[cfg(feature = "precomputed-tables")]
+    fn mul_by_generator(k: &elliptic_curve::Scalar<Self>) -> primeorder::ProjectivePoint<Self> {
+        tables::BASEPOINT_TABLE.mul(k)
+    }
+
     #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
     fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
         tables::BASEPOINT_TABLE_VARTIME.mul(k)

--- a/p384/src/arithmetic/tables.rs
+++ b/p384/src/arithmetic/tables.rs
@@ -1,7 +1,24 @@
 //! Precomputed tables (optional).
 
+use super::NistP384;
+use crate::ProjectivePoint;
+use primeorder::PrimeCurveWithBasepointTable;
+
 #[cfg(feature = "alloc")]
 pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
+
+/// Window size for the basepoint table.
+const WINDOW_SIZE: usize = 49;
+
+/// Basepoint table for multiples of secp256r1's generator.
+type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
+
+/// Lazily computed basepoint table.
+pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
+
+impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for NistP384 {
+    const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
+}
 
 #[cfg(feature = "alloc")]
 mod vartime {


### PR DESCRIPTION
Configures and wires up a lazily computed basepoint table, like #1789 and #1790 did for `p256`.

Benchmarks:

    scalar operations/generator-scalar mul
        time:   [109.54 µs 110.08 µs 110.78 µs]
        change: [−79.159% −78.879% −78.576%] (p = 0.00 < 0.05)
        Performance has improved.