### PR TITLE
p521: constant-time `BASEPOINT_TABLE`

### DIFF
--- a/p256/src/arithmetic/tables.rs
+++ b/p256/src/arithmetic/tables.rs
@@ -10,7 +10,7 @@ pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
 /// Window size for the basepoint table.
 const WINDOW_SIZE: usize = 33;
 
-/// Basepoint table for multiples of secp256r1's generator.
+/// Basepoint table for multiples of NIST P-256's generator.
 type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
 
 /// Lazily computed basepoint table.

--- a/p384/src/arithmetic/tables.rs
+++ b/p384/src/arithmetic/tables.rs
@@ -10,7 +10,7 @@ pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
 /// Window size for the basepoint table.
 const WINDOW_SIZE: usize = 49;
 
-/// Basepoint table for multiples of secp256r1's generator.
+/// Basepoint table for multiples of NIST P-384's generator.
 type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
 
 /// Lazily computed basepoint table.

--- a/p521/src/arithmetic.rs
+++ b/p521/src/arithmetic.rs
@@ -73,6 +73,11 @@ impl PrimeCurveParams for NistP521 {
         ),
     );
 
+    #[cfg(feature = "precomputed-tables")]
+    fn mul_by_generator(k: &elliptic_curve::Scalar<Self>) -> primeorder::ProjectivePoint<Self> {
+        tables::BASEPOINT_TABLE.mul(k)
+    }
+
     #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
     fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
         tables::BASEPOINT_TABLE_VARTIME.mul(k)

--- a/p521/src/arithmetic/tables.rs
+++ b/p521/src/arithmetic/tables.rs
@@ -1,7 +1,24 @@
 //! Precomputed tables (optional).
 
+use super::NistP521;
+use crate::ProjectivePoint;
+use primeorder::PrimeCurveWithBasepointTable;
+
 #[cfg(feature = "alloc")]
 pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
+
+/// Window size for the basepoint table.
+const WINDOW_SIZE: usize = 67;
+
+/// Basepoint table for multiples of NIST P-521's generator.
+type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
+
+/// Lazily computed basepoint table.
+pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
+
+impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for NistP521 {
+    const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
+}
 
 #[cfg(feature = "alloc")]
 mod vartime {

--- a/primeorder/src/basepoint_table.rs
+++ b/primeorder/src/basepoint_table.rs
@@ -47,7 +47,7 @@ where
             // Ensure basepoint table contains the expected number of entries for the scalar's size
             const {
                 assert!(
-                    N as u32 == 1 + Point::Scalar::NUM_BITS / 8,
+                    N as u32 == 1 + Point::Scalar::NUM_BITS.div_ceil(8),
                     "incorrectly sized basepoint table"
                 );
             }


### PR DESCRIPTION
Configures and wires up a lazily computed basepoint table, like #1791 did for `p384`

Benchmarks:

    point operations/generator-scalar mul
    	time:   [99.057 µs 99.360 µs 99.712 µs]
    	change: [−78.250% −78.093% −77.895%] (p = 0.00 < 0.05)
    	Performance has improved.