### PR TITLE
sm2: constant-time `BASEPOINT_TABLE`

### DIFF
--- a/sm2/src/arithmetic.rs
+++ b/sm2/src/arithmetic.rs
@@ -64,6 +64,11 @@ impl PrimeCurveParams for Sm2 {
         ),
     );
 
+    #[cfg(feature = "precomputed-tables")]
+    fn mul_by_generator(k: &elliptic_curve::Scalar<Self>) -> primeorder::ProjectivePoint<Self> {
+        tables::BASEPOINT_TABLE.mul(k)
+    }
+
     #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
     fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
         tables::BASEPOINT_TABLE_VARTIME.mul(k)

--- a/sm2/src/arithmetic/tables.rs
+++ b/sm2/src/arithmetic/tables.rs
@@ -1,7 +1,24 @@
 //! Precomputed tables (optional).
 
+use super::Sm2;
+use crate::ProjectivePoint;
+use primeorder::PrimeCurveWithBasepointTable;
+
 #[cfg(feature = "alloc")]
 pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
+
+/// Window size for the basepoint table.
+const WINDOW_SIZE: usize = 33;
+
+/// Basepoint table for multiples of NIST P-256's generator.
+type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
+
+/// Lazily computed basepoint table.
+pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
+
+impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for Sm2 {
+    const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
+}
 
 #[cfg(feature = "alloc")]
 mod vartime {


### PR DESCRIPTION
Configures and wires up a lazily computed basepoint table, like #1791 did for `p384`

Benchmarks:

```
ProjectivePoint/generator-scalar mul
    time:   [40.535 µs 40.903 µs 41.350 µs]
    change: [−74.115% −73.836% −73.524%] (p = 0.00 < 0.05)
    Performance has improved.
```