### PR TITLE
p256+p384+p521+sm2: use CT basepoint table for vartime mult

### DIFF
--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -69,9 +69,11 @@ impl PrimeCurveParams for NistP256 {
         tables::BASEPOINT_TABLE.mul(k)
     }
 
-    #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
+    #[cfg(feature = "precomputed-tables")]
     fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
-        tables::BASEPOINT_TABLE_VARTIME.mul(k)
+        // NOTE: the constant-time basepoint table is ~70% faster than the variable-time one for
+        // a single scalar multiplication
+        tables::BASEPOINT_TABLE.mul(k)
     }
 
     #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -73,9 +73,11 @@ impl PrimeCurveParams for NistP384 {
         tables::BASEPOINT_TABLE.mul(k)
     }
 
-    #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
+    #[cfg(feature = "precomputed-tables")]
     fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
-        tables::BASEPOINT_TABLE_VARTIME.mul(k)
+        // NOTE: the constant-time basepoint table is ~70% faster than the variable-time one for
+        // a single scalar multiplication
+        tables::BASEPOINT_TABLE.mul(k)
     }
 
     #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]

--- a/p521/src/arithmetic.rs
+++ b/p521/src/arithmetic.rs
@@ -78,9 +78,11 @@ impl PrimeCurveParams for NistP521 {
         tables::BASEPOINT_TABLE.mul(k)
     }
 
-    #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
+    #[cfg(feature = "precomputed-tables")]
     fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
-        tables::BASEPOINT_TABLE_VARTIME.mul(k)
+        // NOTE: the constant-time basepoint table is ~70% faster than the variable-time one for
+        // a single scalar multiplication
+        tables::BASEPOINT_TABLE.mul(k)
     }
 
     #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]

--- a/sm2/src/arithmetic.rs
+++ b/sm2/src/arithmetic.rs
@@ -69,9 +69,11 @@ impl PrimeCurveParams for Sm2 {
         tables::BASEPOINT_TABLE.mul(k)
     }
 
-    #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
+    #[cfg(feature = "precomputed-tables")]
     fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
-        tables::BASEPOINT_TABLE_VARTIME.mul(k)
+        // NOTE: the constant-time basepoint table is ~70% faster than the variable-time one for
+        // a single scalar multiplication
+        tables::BASEPOINT_TABLE.mul(k)
     }
 
     #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]


### PR DESCRIPTION
The new generic constant-time basepoint table significantly outperforms the variable-time one (separately this warrants some potential investigation and optimization work on the variable-time table such as tuning window sizes, but that deserves its own issue).

For now, this simply switches all of these curves to use the constant-time basepoint table for `mul_by_generator_vartime`. The result is about 3X faster, running in ~70% less time.

Benchmarks (p256):

    ProjectivePoint operations/generator-scalar mul (variable-time)
        time:   [35.521 µs 35.635 µs 35.752 µs]
        change: [−69.020% −68.578% −68.240%] (p = 0.00 < 0.05)
        Performance has improved.