### PR TITLE
primeorder: add `BasepointTable::mul_vartime`

### DIFF
--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -71,17 +71,6 @@ impl PrimeCurveParams for NistP256 {
 
     #[cfg(feature = "precomputed-tables")]
     fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
-        // NOTE: the constant-time basepoint table is ~70% faster than the variable-time one for
-        // a single scalar multiplication
-        tables::BASEPOINT_TABLE.mul(k)
-    }
-
-    #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
-    fn mul_by_generator_and_mul_add_vartime(
-        a: &Scalar,
-        b_scalar: &Scalar,
-        b_point: &ProjectivePoint,
-    ) -> ProjectivePoint {
-        tables::BASEPOINT_TABLE_VARTIME.lincomb(a, &[(*b_point, *b_scalar)])
+        tables::BASEPOINT_TABLE.mul_vartime(k)
     }
 }

--- a/p256/src/arithmetic/tables.rs
+++ b/p256/src/arithmetic/tables.rs
@@ -4,9 +4,6 @@ use super::NistP256;
 use crate::ProjectivePoint;
 use primeorder::PrimeCurveWithBasepointTable;
 
-#[cfg(feature = "alloc")]
-pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
-
 /// Window size for the basepoint table.
 const WINDOW_SIZE: usize = 33;
 
@@ -63,6 +60,15 @@ mod tests {
         fn basepoint_table_mul(x in scalar()) {
             let expected = ProjectivePoint::GENERATOR * &x;
             let actual = BASEPOINT_TABLE.mul(&x);
+            prop_assert_eq!(expected, actual);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn basepoint_table_mul_vartime(x in scalar()) {
+            let expected = ProjectivePoint::GENERATOR * &x;
+            let actual = BASEPOINT_TABLE.mul_vartime(&x);
             prop_assert_eq!(expected, actual);
         }
     }

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -77,15 +77,6 @@ impl PrimeCurveParams for NistP384 {
     fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
         // NOTE: the constant-time basepoint table is ~70% faster than the variable-time one for
         // a single scalar multiplication
-        tables::BASEPOINT_TABLE.mul(k)
-    }
-
-    #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
-    fn mul_by_generator_and_mul_add_vartime(
-        a: &Scalar,
-        b_scalar: &Scalar,
-        b_point: &ProjectivePoint,
-    ) -> ProjectivePoint {
-        tables::BASEPOINT_TABLE_VARTIME.lincomb(a, &[(*b_point, *b_scalar)])
+        tables::BASEPOINT_TABLE.mul_vartime(k)
     }
 }

--- a/p384/src/arithmetic/tables.rs
+++ b/p384/src/arithmetic/tables.rs
@@ -4,9 +4,6 @@ use super::NistP384;
 use crate::ProjectivePoint;
 use primeorder::PrimeCurveWithBasepointTable;
 
-#[cfg(feature = "alloc")]
-pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
-
 /// Window size for the basepoint table.
 const WINDOW_SIZE: usize = 49;
 

--- a/p521/src/arithmetic.rs
+++ b/p521/src/arithmetic.rs
@@ -80,17 +80,6 @@ impl PrimeCurveParams for NistP521 {
 
     #[cfg(feature = "precomputed-tables")]
     fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
-        // NOTE: the constant-time basepoint table is ~70% faster than the variable-time one for
-        // a single scalar multiplication
-        tables::BASEPOINT_TABLE.mul(k)
-    }
-
-    #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
-    fn mul_by_generator_and_mul_add_vartime(
-        a: &Scalar,
-        b_scalar: &Scalar,
-        b_point: &ProjectivePoint,
-    ) -> ProjectivePoint {
-        tables::BASEPOINT_TABLE_VARTIME.lincomb(a, &[(*b_point, *b_scalar)])
+        tables::BASEPOINT_TABLE.mul_vartime(k)
     }
 }

--- a/p521/src/arithmetic/tables.rs
+++ b/p521/src/arithmetic/tables.rs
@@ -4,9 +4,6 @@ use super::NistP521;
 use crate::ProjectivePoint;
 use primeorder::PrimeCurveWithBasepointTable;
 
-#[cfg(feature = "alloc")]
-pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
-
 /// Window size for the basepoint table.
 const WINDOW_SIZE: usize = 67;
 

--- a/primeorder/src/basepoint_table.rs
+++ b/primeorder/src/basepoint_table.rs
@@ -96,6 +96,33 @@ impl<C: PrimeCurveParams, const WINDOW_SIZE: usize>
 
         acc + acc2
     }
+
+    /// Multiply `Point::generator` by the given scalar in constant-time, using the precomputed
+    /// basepoint table to accelerate the scalar multiplication.
+    ///
+    /// <div class = "warning">
+    /// <b>Security Warning</b>
+    ///
+    /// Variable-time scalar multiplication can potentially leak secret values and should NOT be
+    /// used with them.
+    /// </div>
+    pub fn mul_vartime(&self, k: &Scalar<C>) -> ProjectivePoint<C> {
+        let digits = Radix16Decomposition::<Radix16Digits<C>>::new(k, true);
+        let len = FieldBytesSize::<C>::USIZE;
+        let mut acc = self[len].select_vartime(digits[len * 2]);
+        let mut acc2 = ProjectivePoint::<C>::IDENTITY;
+        for i in (0..len).rev() {
+            acc2 += &self[i].select_vartime(digits[i * 2 + 1]);
+            acc += &self[i].select_vartime(digits[i * 2]);
+        }
+
+        // This is the price of halving the precomputed table size.
+        for _ in 0..4 {
+            acc2 = acc2.double();
+        }
+
+        acc + acc2
+    }
 }
 
 impl<Point, const WINDOW_SIZE: usize> Default for BasepointTable<Point, WINDOW_SIZE>

--- a/primeorder/src/lookup_table.rs
+++ b/primeorder/src/lookup_table.rs
@@ -63,4 +63,20 @@ where
 
         t
     }
+
+    /// Given `-8 <= x <= 8`, returns `x * p` in variable time.
+    #[allow(clippy::cast_sign_loss)]
+    #[inline]
+    pub fn select_vartime(&self, x: i8) -> Point {
+        debug_assert!((-8..=8).contains(&x));
+
+        let xabs = x.unsigned_abs();
+        let t = if xabs == 0 {
+            Point::identity()
+        } else {
+            self.points[xabs as usize - 1]
+        };
+
+        if x < 0 { -t } else { t }
+    }
 }

--- a/sm2/src/arithmetic.rs
+++ b/sm2/src/arithmetic.rs
@@ -71,17 +71,6 @@ impl PrimeCurveParams for Sm2 {
 
     #[cfg(feature = "precomputed-tables")]
     fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
-        // NOTE: the constant-time basepoint table is ~70% faster than the variable-time one for
-        // a single scalar multiplication
-        tables::BASEPOINT_TABLE.mul(k)
-    }
-
-    #[cfg(all(feature = "alloc", feature = "precomputed-tables"))]
-    fn mul_by_generator_and_mul_add_vartime(
-        a: &Scalar,
-        b_scalar: &Scalar,
-        b_point: &ProjectivePoint,
-    ) -> ProjectivePoint {
-        tables::BASEPOINT_TABLE_VARTIME.lincomb(a, &[(*b_point, *b_scalar)])
+        tables::BASEPOINT_TABLE.mul_vartime(k)
     }
 }

--- a/sm2/src/arithmetic/tables.rs
+++ b/sm2/src/arithmetic/tables.rs
@@ -4,9 +4,6 @@ use super::Sm2;
 use crate::ProjectivePoint;
 use primeorder::PrimeCurveWithBasepointTable;
 
-#[cfg(feature = "alloc")]
-pub(super) use vartime::BASEPOINT_TABLE_VARTIME;
-
 /// Window size for the basepoint table.
 const WINDOW_SIZE: usize = 33;
 


### PR DESCRIPTION
...as well as `LookupTable::select_vartime`.

Since we've switched to using this table for variable-time scalar multiplication anyway in #1795 since it's winning over w-NAF, we can further accelerate variable-time scalar multiplications by adding a proper variable-time multiply method to this table.

It's effectively copy/paste of the constant-time method, but using a newly introduced `LookupTable::select_vartime` to do the selection, which results in a ~18% speedup over the constant-time version when benchmarked against `p256`:

    ProjectivePoint operations/generator-scalar mul (variable-time)
        time:   [29.087 µs 29.254 µs 29.421 µs]
        change: [−18.102% −17.557% −16.974%] (p = 0.00 < 0.05)
        Performance has improved.

This also goes ahead and switches from `BasepointTableVartime` to `BasepointTable` for `mul_by_generator_and_mul_add_vartime` since the performance difference when `alloc` is available is ~4%, dropping the dependency on `BasepointTableVartime`.

We can probably further accelerate this by adding `lincomb_vartime` as a copy-paste of the existing `lincomb` but using
`LookupTable::select_vartime`, and having `mul_by_generator_and_mul_add_vartime` call that with the first precomputed `LookupTable` from `BasepointTable`, but I'll save that for another PR.