### PR TITLE
k256: remove `ProjectivePoint::{identity, generator}`

### DIFF
--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -60,19 +60,6 @@ impl ProjectivePoint {
         z: FieldElement::ONE,
     };
 
-    /// Returns the additive identity of SECP256k1, also known as the "neutral element" or
-    /// "point at infinity".
-    #[deprecated(since = "0.10.2", note = "use `ProjectivePoint::IDENTITY` instead")]
-    pub const fn identity() -> ProjectivePoint {
-        Self::IDENTITY
-    }
-
-    /// Returns the base point of SECP256k1.
-    #[deprecated(since = "0.10.2", note = "use `ProjectivePoint::GENERATOR` instead")]
-    pub fn generator() -> ProjectivePoint {
-        Self::GENERATOR
-    }
-
     /// Returns the affine representation of this point.
     pub fn to_affine(&self) -> AffinePoint {
         self.z


### PR DESCRIPTION
These have been deprecated since v0.10, with the `ProjectivePoint::{IDENTITY, GENERATOR}` constants the preferred alternative.