### PR TITLE
primeorder: extract `ModulusSize` marker trait

### DIFF
--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -98,8 +98,8 @@ where
     type FieldRepr = FieldBytes<C>;
 
     fn from_coordinates(x: &Self::FieldRepr, y: &Self::FieldRepr) -> CtOption<Self> {
-        C::FieldElement::from_repr(y.clone()).and_then(|y| {
-            C::FieldElement::from_repr(x.clone()).and_then(|x| {
+        C::FieldElement::from_repr(*y).and_then(|y| {
+            C::FieldElement::from_repr(*x).and_then(|x| {
                 let lhs = y * &y;
                 let rhs = x * &x * &x + &(C::EQUATION_A * &x) + &C::EQUATION_B;
                 CtOption::new(Self { x, y, infinity: 0 }, lhs.ct_eq(&rhs))
@@ -181,7 +181,7 @@ where
     C: PrimeCurveParams,
 {
     fn decompress(x_bytes: &FieldBytes<C>, y_is_odd: Choice) -> CtOption<Self> {
-        C::FieldElement::from_repr(x_bytes.clone()).and_then(|x| {
+        C::FieldElement::from_repr(*x_bytes).and_then(|x| {
             let alpha = x * &x * &x + &(C::EQUATION_A * &x) + &C::EQUATION_B;
             let beta = alpha.sqrt();
 

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -53,10 +53,8 @@ pub use crate::basepoint_table::BasepointTable;
 /// Parameters for elliptic curves of prime order which can be described by the
 /// short Weierstrass equation.
 pub trait PrimeCurveParams:
-    Curve<
-        FieldBytesSize: Add<Output: Add<U1, Output: ArraySize>> // Radix16Digits
-                            + sec1::ModulusSize<CompressedPointSize: ArraySize<ArrayType<u8>: Copy>>,
-    > + PrimeCurve
+    Curve<FieldBytesSize: ModulusSize>
+    + PrimeCurve
     + CurveArithmetic<AffinePoint = AffinePoint<Self>, ProjectivePoint = ProjectivePoint<Self>>
 {
     /// Base field element type.
@@ -107,6 +105,22 @@ pub trait PrimeCurveParams:
             (*b_point, *b_scalar),
         ])
     }
+}
+
+/// Acceptable modulus sizes can be used as [`Radix16Digits`] and a [`sec1::ModulusSize`].
+pub trait ModulusSize:
+    ArraySize<ArrayType<u8>: Copy>
+    + Add<Output: Add<U1, Output: ArraySize>> // Radix16Digits
+    + sec1::ModulusSize<CompressedPointSize: ArraySize<ArrayType<u8>: Copy>>
+{
+}
+
+impl<T> ModulusSize for T
+where
+    T: ArraySize<ArrayType<u8>: Copy>,
+    T: Add<Output: Add<U1, Output: ArraySize>>, // Radix16Digits
+    T: sec1::ModulusSize<CompressedPointSize: ArraySize<ArrayType<u8>: Copy>>,
+{
 }
 
 /// Trait for specifying a constant-time basepoint table for a given curve.


### PR DESCRIPTION
This makes the `PrimeCurveParams` bounds slightly less atrocious.

Extracts a marker trait with a blanket impl for all types that satisfy its supertrait bounds (usable as `Radix16Digits` and `sec1::ModulusSize`)