### PR TITLE
primeorder: simplify `FieldBytesSize` bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.34"
-source = "git+https://github.com/RustCrypto/traits#471ced1111b31be239002037a3104ffc10751257"
+source = "git+https://github.com/RustCrypto/traits#a4525fbbe6edaead3a78d7ba4981175fa574f2d8"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1423,7 +1423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -98,8 +98,8 @@ where
     type FieldRepr = FieldBytes<C>;
 
     fn from_coordinates(x: &Self::FieldRepr, y: &Self::FieldRepr) -> CtOption<Self> {
-        C::FieldElement::from_repr(y.clone()).and_then(|y| {
-            C::FieldElement::from_repr(x.clone()).and_then(|x| {
+        C::FieldElement::from_repr(*y).and_then(|y| {
+            C::FieldElement::from_repr(*x).and_then(|x| {
                 let lhs = y * &y;
                 let rhs = x * &x * &x + &(C::EQUATION_A * &x) + &C::EQUATION_B;
                 CtOption::new(Self { x, y, infinity: 0 }, lhs.ct_eq(&rhs))
@@ -181,7 +181,7 @@ where
     C: PrimeCurveParams,
 {
     fn decompress(x_bytes: &FieldBytes<C>, y_is_odd: Choice) -> CtOption<Self> {
-        C::FieldElement::from_repr(x_bytes.clone()).and_then(|x| {
+        C::FieldElement::from_repr(*x_bytes).and_then(|x| {
             let alpha = x * &x * &x + &(C::EQUATION_A * &x) + &C::EQUATION_B;
             let beta = alpha.sqrt();
 

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -38,7 +38,7 @@ pub use elliptic_curve::{
 
 use elliptic_curve::{
     Curve, CurveArithmetic, Generate,
-    ops::{Add, Invert, LinearCombination, MulVartime},
+    ops::{Invert, LinearCombination, MulVartime},
     sec1,
     subtle::CtOption,
 };
@@ -46,13 +46,11 @@ use elliptic_curve::{
 #[cfg(feature = "basepoint-table")]
 pub use crate::tables::BasepointTable;
 
-/// Parameters for elliptic curves of prime order which can be described by the
-/// short Weierstrass equation.
+/// Parameters for elliptic curves of prime order which can be described by the short
+/// Weierstrass equation.
 pub trait PrimeCurveParams:
-    Curve<
-        FieldBytesSize: Add<Output: Add<U1, Output: ArraySize>> // Radix16Digits
-                            + sec1::ModulusSize<CompressedPointSize: ArraySize<ArrayType<u8>: Copy>>,
-    > + PrimeCurve
+    Curve<FieldBytesSize: sec1::ModulusSize>
+    + PrimeCurve
     + CurveArithmetic<AffinePoint = AffinePoint<Self>, ProjectivePoint = ProjectivePoint<Self>>
 {
     /// Base field element type.


### PR DESCRIPTION
This is possible after RustCrypto/traits#2448.

Alternative to #1800.