### PR TITLE
primeorder: add `Backend` trait and associated type

### DIFF
--- a/bignp256/src/arithmetic.rs
+++ b/bignp256/src/arithmetic.rs
@@ -13,6 +13,7 @@ pub use self::scalar::Scalar;
 pub use self::field::FieldElement;
 use crate::BignP256;
 pub use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use primeorder::backend;
 pub use primeorder::{PrimeCurveParams, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -34,6 +35,8 @@ impl PrimeCurveArithmetic for BignP256 {
 impl PrimeCurveParams for BignP256 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
+    type Backend = backend::VariableOnly;
+
     const EQUATION_A: Self::FieldElement = FieldElement::from_hex_vartime(
         "40FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
     );

--- a/bp256/src/r1/arithmetic.rs
+++ b/bp256/src/r1/arithmetic.rs
@@ -3,7 +3,7 @@
 use super::BrainpoolP256r1;
 use crate::{FieldElement, Scalar};
 use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
-use primeorder::{PrimeCurveParams, point_arithmetic};
+use primeorder::{PrimeCurveParams, backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<BrainpoolP256r1>;
@@ -30,6 +30,7 @@ impl PrimeCurveArithmetic for BrainpoolP256r1 {
 impl PrimeCurveParams for BrainpoolP256r1 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
+    type Backend = backend::VariableOnly;
 
     const EQUATION_A: FieldElement = FieldElement::from_hex_vartime(
         "7d5a0975fc2c3057eef67530417affe7fb8055c126dc5c6ce94a4b44f330b5d9",

--- a/bp256/src/t1/arithmetic.rs
+++ b/bp256/src/t1/arithmetic.rs
@@ -3,7 +3,7 @@
 use super::BrainpoolP256t1;
 use crate::{FieldElement, Scalar};
 use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
-use primeorder::{PrimeCurveParams, point_arithmetic};
+use primeorder::{PrimeCurveParams, backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<BrainpoolP256t1>;
@@ -30,6 +30,7 @@ impl PrimeCurveArithmetic for BrainpoolP256t1 {
 impl PrimeCurveParams for BrainpoolP256t1 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
+    type Backend = backend::VariableOnly;
 
     const EQUATION_A: FieldElement = FieldElement::from_hex_vartime(
         "a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5374",

--- a/bp384/src/r1/arithmetic.rs
+++ b/bp384/src/r1/arithmetic.rs
@@ -3,7 +3,7 @@
 use super::BrainpoolP384r1;
 use crate::{FieldElement, Scalar};
 use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
-use primeorder::{PrimeCurveParams, point_arithmetic};
+use primeorder::{PrimeCurveParams, backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<BrainpoolP384r1>;
@@ -30,6 +30,7 @@ impl PrimeCurveArithmetic for BrainpoolP384r1 {
 impl PrimeCurveParams for BrainpoolP384r1 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
+    type Backend = backend::VariableOnly;
 
     const EQUATION_A: FieldElement = FieldElement::from_hex_vartime(
         "7bc382c63d8c150c3c72080ace05afa0c2bea28e4fb22787139165efba91f90f8aa5814a503ad4eb04a8c7dd22ce2826",

--- a/bp384/src/t1/arithmetic.rs
+++ b/bp384/src/t1/arithmetic.rs
@@ -3,7 +3,7 @@
 use super::BrainpoolP384t1;
 use crate::{FieldElement, Scalar};
 use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
-use primeorder::{PrimeCurveParams, point_arithmetic};
+use primeorder::{PrimeCurveParams, backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<BrainpoolP384t1>;
@@ -30,6 +30,7 @@ impl PrimeCurveArithmetic for BrainpoolP384t1 {
 impl PrimeCurveParams for BrainpoolP384t1 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
+    type Backend = backend::VariableOnly;
 
     const EQUATION_A: FieldElement = FieldElement::from_hex_vartime(
         "8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec50",

--- a/p192/src/arithmetic.rs
+++ b/p192/src/arithmetic.rs
@@ -10,7 +10,7 @@ pub(crate) mod scalar;
 use self::{field::FieldElement, scalar::Scalar};
 use crate::NistP192;
 use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
-use primeorder::{PrimeCurveParams, point_arithmetic};
+use primeorder::{PrimeCurveParams, backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<NistP192>;
@@ -34,6 +34,7 @@ impl PrimeCurveArithmetic for NistP192 {
 impl PrimeCurveParams for NistP192 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
+    type Backend = backend::VariableOnly;
 
     /// a = -3 (=0xffffffff ffffffff ffffffff fffffffe ffffffff ffffffff fffffffe)
     const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();

--- a/p224/src/arithmetic.rs
+++ b/p224/src/arithmetic.rs
@@ -12,7 +12,7 @@ pub use self::scalar::Scalar;
 use self::field::FieldElement;
 use crate::NistP224;
 use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
-use primeorder::{PrimeCurveParams, point_arithmetic};
+use primeorder::{PrimeCurveParams, backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<NistP224>;
@@ -36,6 +36,7 @@ impl PrimeCurveArithmetic for NistP224 {
 impl PrimeCurveParams for NistP224 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
+    type Backend = backend::VariableOnly;
 
     /// a = -3 (=0xffffffff ffffffff ffffffff fffffffe ffffffff ffffffff fffffffe)
     const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -40,6 +40,12 @@ impl PrimeCurveParams for NistP256 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
 
+    #[cfg(not(feature = "precomputed-tables"))]
+    type Backend = primeorder::backend::VariableOnly;
+    // TODO(tarcieri): use `primeorder::backend::PrecomputedTables` when MSRV 1.90
+    #[cfg(feature = "precomputed-tables")]
+    type Backend = tables::backend::PrecomputedTables;
+
     /// a = -3
     const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();
 
@@ -63,14 +69,4 @@ impl PrimeCurveParams for NistP256 {
             "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
         ),
     );
-
-    #[cfg(feature = "precomputed-tables")]
-    fn mul_by_generator(k: &elliptic_curve::Scalar<Self>) -> primeorder::ProjectivePoint<Self> {
-        tables::BASEPOINT_TABLE.mul(k)
-    }
-
-    #[cfg(feature = "precomputed-tables")]
-    fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
-        tables::BASEPOINT_TABLE.mul_vartime(k)
-    }
 }

--- a/p256/src/arithmetic/tables.rs
+++ b/p256/src/arithmetic/tables.rs
@@ -5,16 +5,41 @@ use crate::ProjectivePoint;
 use primeorder::PrimeCurveWithBasepointTable;
 
 /// Window size for the basepoint table (1 + 32-byte modulus)
-const WINDOW_SIZE: usize = 33;
+pub(super) const WINDOW_SIZE: usize = 33;
 
 /// Basepoint table for multiples of NIST P-256's generator.
-type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
+pub(super) type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
 
 /// Lazily computed basepoint table.
 pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
 
 impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for NistP256 {
     const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
+}
+
+/// Workaround for rust-lang/rust#140653 to support MSRV 1.85: we can't use the generic
+/// implementation in `primeorder::backend::PrecomputedTables` until MSRV 1.90 due to restrictions
+/// on referencing a type with interior mutability from a `const`.
+// TODO(tarcieri): remove this and switch to `primeorder::backend::PrecomputedTables` when MSRV 1.90
+pub(crate) mod backend {
+    use super::BASEPOINT_TABLE;
+    use crate::{NistP256, ProjectivePoint, Scalar};
+    use primeorder::Backend;
+
+    /// Backend based on precomputed tables.
+    pub struct PrecomputedTables;
+
+    impl Backend<NistP256> for PrecomputedTables {
+        #[inline]
+        fn mul_by_generator(k: &Scalar) -> ProjectivePoint {
+            BASEPOINT_TABLE.mul(k)
+        }
+
+        #[inline]
+        fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
+            BASEPOINT_TABLE.mul_vartime(k)
+        }
+    }
 }
 
 /// These are the main tests for `primeorder::BasepointTable` as we need a concrete curve to test

--- a/p256/tests/ecdsa.rs
+++ b/p256/tests/ecdsa.rs
@@ -1,6 +1,6 @@
 //! ECDSA tests.
 
-#![cfg(feature = "arithmetic")]
+#![cfg(feature = "ecdsa")]
 
 use elliptic_curve::ops::Reduce;
 use p256::{

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -40,6 +40,12 @@ impl PrimeCurveParams for NistP384 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
 
+    #[cfg(not(feature = "precomputed-tables"))]
+    type Backend = primeorder::backend::VariableOnly;
+    // TODO(tarcieri): use `primeorder::backend::PrecomputedTables` when MSRV 1.90
+    #[cfg(feature = "precomputed-tables")]
+    type Backend = tables::backend::PrecomputedTables;
+
     /// a = -3 (0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc)
     const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();
 
@@ -67,16 +73,4 @@ impl PrimeCurveParams for NistP384 {
             "3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f",
         ),
     );
-
-    #[cfg(feature = "precomputed-tables")]
-    fn mul_by_generator(k: &elliptic_curve::Scalar<Self>) -> primeorder::ProjectivePoint<Self> {
-        tables::BASEPOINT_TABLE.mul(k)
-    }
-
-    #[cfg(feature = "precomputed-tables")]
-    fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
-        // NOTE: the constant-time basepoint table is ~70% faster than the variable-time one for
-        // a single scalar multiplication
-        tables::BASEPOINT_TABLE.mul_vartime(k)
-    }
 }

--- a/p384/src/arithmetic/tables.rs
+++ b/p384/src/arithmetic/tables.rs
@@ -5,14 +5,39 @@ use crate::ProjectivePoint;
 use primeorder::PrimeCurveWithBasepointTable;
 
 /// Window size for the basepoint table (1 + 48-byte modulus)
-const WINDOW_SIZE: usize = 49;
+pub(super) const WINDOW_SIZE: usize = 49;
 
 /// Basepoint table for multiples of NIST P-384's generator.
-type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
+pub(super) type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
 
 /// Lazily computed basepoint table.
 pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
 
 impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for NistP384 {
     const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
+}
+
+/// Workaround for rust-lang/rust#140653 to support MSRV 1.85: we can't use the generic
+/// implementation in `primeorder::backend::PrecomputedTables` until MSRV 1.90 due to restrictions
+/// on referencing a type with interior mutability from a `const`.
+// TODO(tarcieri): remove this and switch to `primeorder::backend::PrecomputedTables` when MSRV 1.90
+pub(crate) mod backend {
+    use super::BASEPOINT_TABLE;
+    use crate::{NistP384, ProjectivePoint, Scalar};
+    use primeorder::Backend;
+
+    /// Backend based on precomputed tables.
+    pub struct PrecomputedTables;
+
+    impl Backend<NistP384> for PrecomputedTables {
+        #[inline]
+        fn mul_by_generator(k: &Scalar) -> ProjectivePoint {
+            BASEPOINT_TABLE.mul(k)
+        }
+
+        #[inline]
+        fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
+            BASEPOINT_TABLE.mul_vartime(k)
+        }
+    }
 }

--- a/p521/src/arithmetic.rs
+++ b/p521/src/arithmetic.rs
@@ -42,6 +42,12 @@ impl PrimeCurveParams for NistP521 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
 
+    #[cfg(not(feature = "precomputed-tables"))]
+    type Backend = primeorder::backend::VariableOnly;
+    // TODO(tarcieri): use `primeorder::backend::PrecomputedTables` when MSRV 1.90
+    #[cfg(feature = "precomputed-tables")]
+    type Backend = tables::backend::PrecomputedTables;
+
     /// a = -3 (0x1ff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff
     ///               ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff
     ///               ffffffff ffffffff ffffffff fffffffc)
@@ -72,14 +78,4 @@ impl PrimeCurveParams for NistP521 {
             "011839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650",
         ),
     );
-
-    #[cfg(feature = "precomputed-tables")]
-    fn mul_by_generator(k: &elliptic_curve::Scalar<Self>) -> primeorder::ProjectivePoint<Self> {
-        tables::BASEPOINT_TABLE.mul(k)
-    }
-
-    #[cfg(feature = "precomputed-tables")]
-    fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
-        tables::BASEPOINT_TABLE.mul_vartime(k)
-    }
 }

--- a/p521/src/arithmetic/tables.rs
+++ b/p521/src/arithmetic/tables.rs
@@ -5,14 +5,39 @@ use crate::ProjectivePoint;
 use primeorder::PrimeCurveWithBasepointTable;
 
 /// Window size for the basepoint table.
-const WINDOW_SIZE: usize = 67;
+pub(super) const WINDOW_SIZE: usize = 67;
 
 /// Basepoint table for multiples of NIST P-521's generator.
-type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
+pub(super) type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
 
 /// Lazily computed basepoint table.
 pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
 
 impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for NistP521 {
     const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
+}
+
+/// Workaround for rust-lang/rust#140653 to support MSRV 1.85: we can't use the generic
+/// implementation in `primeorder::backend::PrecomputedTables` until MSRV 1.90 due to restrictions
+/// on referencing a type with interior mutability from a `const`.
+// TODO(tarcieri): remove this and switch to `primeorder::backend::PrecomputedTables` when MSRV 1.90
+pub(crate) mod backend {
+    use super::BASEPOINT_TABLE;
+    use crate::{NistP521, ProjectivePoint, Scalar};
+    use primeorder::Backend;
+
+    /// Backend based on precomputed tables.
+    pub struct PrecomputedTables;
+
+    impl Backend<NistP521> for PrecomputedTables {
+        #[inline]
+        fn mul_by_generator(k: &Scalar) -> ProjectivePoint {
+            BASEPOINT_TABLE.mul(k)
+        }
+
+        #[inline]
+        fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
+            BASEPOINT_TABLE.mul_vartime(k)
+        }
+    }
 }

--- a/primeorder/src/backend.rs
+++ b/primeorder/src/backend.rs
@@ -1,0 +1,46 @@
+//! Scalar multiplication backends.
+
+#[cfg(feature = "basepoint-table")]
+mod precomputed_tables;
+mod variable_only;
+
+use crate::{PrimeCurveParams, ProjectivePoint};
+use elliptic_curve::Scalar;
+use elliptic_curve::ops::LinearCombination;
+
+#[cfg(feature = "basepoint-table")]
+pub use self::precomputed_tables::PrecomputedTables;
+pub use self::variable_only::VariableOnly;
+
+/// Scalar multiplication backend.
+pub trait Backend<C: PrimeCurveParams> {
+    /// Multiplication by the generator.
+    ///
+    /// This is overridable to make it possible to plug in a basepoint table.
+    #[inline]
+    fn mul_by_generator(k: &Scalar<C>) -> ProjectivePoint<C> {
+        ProjectivePoint::GENERATOR * k
+    }
+
+    /// Variable-time multiplication by the generator.
+    ///
+    /// This is overridable to make it possible to plug in a basepoint table.
+    #[inline]
+    fn mul_by_generator_vartime(k: &Scalar<C>) -> ProjectivePoint<C> {
+        ProjectivePoint::GENERATOR.mul_vartime(k)
+    }
+
+    /// Multiply `a` by the generator of the prime-order subgroup, adding the result to the point
+    /// `P` multiplied by the scalar `b`, i.e. compute `aG + bP`.
+    #[inline]
+    fn mul_by_generator_and_mul_add_vartime(
+        a: &Scalar<C>,
+        b_scalar: &Scalar<C>,
+        b_point: &ProjectivePoint<C>,
+    ) -> ProjectivePoint<C> {
+        ProjectivePoint::<C>::lincomb_vartime(&[
+            (ProjectivePoint::GENERATOR, *a),
+            (*b_point, *b_scalar),
+        ])
+    }
+}

--- a/primeorder/src/backend/precomputed_tables.rs
+++ b/primeorder/src/backend/precomputed_tables.rs
@@ -1,0 +1,21 @@
+use super::Backend;
+use crate::{PrimeCurveParams, PrimeCurveWithBasepointTable, ProjectivePoint};
+use elliptic_curve::Scalar;
+
+/// Backend based on precomputed tables.
+pub struct PrecomputedTables<const WINDOW_SIZE: usize>;
+
+impl<C, const WINDOW_SIZE: usize> Backend<C> for PrecomputedTables<WINDOW_SIZE>
+where
+    C: PrimeCurveParams + PrimeCurveWithBasepointTable<WINDOW_SIZE>,
+{
+    #[inline]
+    fn mul_by_generator(k: &Scalar<C>) -> ProjectivePoint<C> {
+        C::BASEPOINT_TABLE.mul(k)
+    }
+
+    #[inline]
+    fn mul_by_generator_vartime(k: &Scalar<C>) -> ProjectivePoint<C> {
+        C::BASEPOINT_TABLE.mul_vartime(k)
+    }
+}

--- a/primeorder/src/backend/variable_only.rs
+++ b/primeorder/src/backend/variable_only.rs
@@ -1,0 +1,7 @@
+use super::Backend;
+use crate::PrimeCurveParams;
+
+/// Simple backend that only supports variable-base scalar multiplication.
+pub struct VariableOnly;
+
+impl<C: PrimeCurveParams> Backend<C> for VariableOnly {}

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -14,6 +14,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+pub mod backend;
 #[cfg(feature = "hash2curve")]
 pub mod osswu;
 pub mod point_arithmetic;
@@ -26,6 +27,7 @@ mod tables;
 
 pub use crate::{
     affine::AffinePoint,
+    backend::Backend,
     projective::ProjectivePoint,
     tables::{LookupTable, Radix16Decomposition, Radix16Digits},
 };
@@ -36,12 +38,7 @@ pub use elliptic_curve::{
     point::Double,
 };
 
-use elliptic_curve::{
-    Curve, CurveArithmetic, Generate,
-    ops::{Invert, LinearCombination, MulVartime},
-    sec1,
-    subtle::CtOption,
-};
+use elliptic_curve::{Curve, CurveArithmetic, Generate, ops::Invert, sec1, subtle::CtOption};
 
 #[cfg(feature = "basepoint-table")]
 pub use crate::tables::BasepointTable;
@@ -62,6 +59,9 @@ pub trait PrimeCurveParams:
     /// [Point arithmetic](point_arithmetic) implementation, might be optimized for this specific curve
     type PointArithmetic: point_arithmetic::PointArithmetic<Self>;
 
+    /// Scalar arithmetic backend implementation.
+    type Backend: Backend<Self>;
+
     /// Coefficient `a` in the curve equation.
     const EQUATION_A: Self::FieldElement;
 
@@ -74,33 +74,6 @@ pub trait PrimeCurveParams:
     /// Are field element serializations for this curve big endian?
     // TODO(tarcieri): make this a property of the scalar type, e.g. zkcrypto/ff#158
     const FIELD_REPR_IS_BE: bool = true;
-
-    /// Multiplication by the generator.
-    ///
-    /// This is overridable to make it possible to plug in a basepoint table.
-    fn mul_by_generator(k: &Scalar<Self>) -> ProjectivePoint<Self> {
-        ProjectivePoint::GENERATOR * k
-    }
-
-    /// Variable-time multiplication by the generator.
-    ///
-    /// This is overridable to make it possible to plug in a basepoint table.
-    fn mul_by_generator_vartime(k: &Scalar<Self>) -> ProjectivePoint<Self> {
-        ProjectivePoint::GENERATOR.mul_vartime(k)
-    }
-
-    /// Multiply `a` by the generator of the prime-order subgroup, adding the result to the point
-    /// `P` multiplied by the scalar `b`, i.e. compute `aG + bP`.
-    fn mul_by_generator_and_mul_add_vartime(
-        a: &Scalar<Self>,
-        b_scalar: &Scalar<Self>,
-        b_point: &ProjectivePoint<Self>,
-    ) -> ProjectivePoint<Self> {
-        ProjectivePoint::<Self>::lincomb_vartime(&[
-            (ProjectivePoint::GENERATOR, *a),
-            (*b_point, *b_scalar),
-        ])
-    }
 }
 
 /// Trait for specifying a constant-time basepoint table for a given curve.

--- a/primeorder/src/point_arithmetic.rs
+++ b/primeorder/src/point_arithmetic.rs
@@ -50,7 +50,7 @@ fn debug_assert_equation_a_is_zero<C: PrimeCurveParams>() {
 
 /// The 𝒂-coefficient of the short Weierstrass equation does not have specific
 /// properties which allow for an optimized implementation.
-pub struct EquationAIsGeneric {}
+pub struct EquationAIsGeneric;
 
 impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsGeneric {
     /// Implements complete addition for any curve
@@ -215,7 +215,7 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsGeneric {
 }
 
 /// The 𝒂-coefficient of the short Weierstrass equation is -3.
-pub struct EquationAIsMinusThree {}
+pub struct EquationAIsMinusThree;
 
 impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsMinusThree {
     /// Implements complete addition for curves with `a = -3`
@@ -325,7 +325,7 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsMinusThree {
 }
 
 /// The 𝒂-coefficient of the short Weierstrass equation is 0.
-pub struct EquationAIsZero {}
+pub struct EquationAIsZero;
 
 impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsZero {
     /// Implements complete addition for curves with `a = 0`

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -3,8 +3,8 @@
 #![allow(clippy::needless_range_loop, clippy::op_ref)]
 
 use crate::{
-    AffinePoint, Field, LookupTable, PrimeCurveParams, Radix16Decomposition, Radix16Digits,
-    point_arithmetic::PointArithmetic,
+    AffinePoint, Backend, Field, LookupTable, PrimeCurveParams, Radix16Decomposition,
+    Radix16Digits, point_arithmetic::PointArithmetic,
 };
 use core::{array, borrow::Borrow, iter::Sum, iter::zip};
 use elliptic_curve::{
@@ -319,7 +319,7 @@ where
 
     #[inline]
     fn mul_by_generator(scalar: &Self::Scalar) -> Self {
-        C::mul_by_generator(scalar)
+        C::Backend::mul_by_generator(scalar)
     }
 
     fn is_identity(&self) -> Choice {
@@ -896,7 +896,7 @@ where
 {
     #[inline]
     fn mul_by_generator_vartime(scalar: &Scalar<C>) -> Self {
-        C::mul_by_generator_vartime(scalar)
+        C::Backend::mul_by_generator_vartime(scalar)
     }
 
     #[inline]
@@ -905,7 +905,7 @@ where
         b_scalar: &Self::Scalar,
         b_point: &Self,
     ) -> Self {
-        C::mul_by_generator_and_mul_add_vartime(a, b_scalar, b_point)
+        C::Backend::mul_by_generator_and_mul_add_vartime(a, b_scalar, b_point)
     }
 }
 

--- a/sm2/src/arithmetic.rs
+++ b/sm2/src/arithmetic.rs
@@ -41,6 +41,12 @@ impl PrimeCurveParams for Sm2 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
 
+    #[cfg(not(feature = "precomputed-tables"))]
+    type Backend = primeorder::backend::VariableOnly;
+    // TODO(tarcieri): use `primeorder::backend::PrecomputedTables` when MSRV 1.90
+    #[cfg(feature = "precomputed-tables")]
+    type Backend = tables::backend::PrecomputedTables;
+
     /// a = -3 (0xFFFFFFFE FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF 00000000 FFFFFFFF FFFFFFFC)
     const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();
 
@@ -63,14 +69,4 @@ impl PrimeCurveParams for Sm2 {
             "BC3736A2F4F6779C59BDCEE36B692153D0A9877CC62A474002DF32E52139F0A0",
         ),
     );
-
-    #[cfg(feature = "precomputed-tables")]
-    fn mul_by_generator(k: &elliptic_curve::Scalar<Self>) -> primeorder::ProjectivePoint<Self> {
-        tables::BASEPOINT_TABLE.mul(k)
-    }
-
-    #[cfg(feature = "precomputed-tables")]
-    fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
-        tables::BASEPOINT_TABLE.mul_vartime(k)
-    }
 }

--- a/sm2/src/arithmetic/tables.rs
+++ b/sm2/src/arithmetic/tables.rs
@@ -5,14 +5,39 @@ use crate::ProjectivePoint;
 use primeorder::PrimeCurveWithBasepointTable;
 
 /// Window size for the basepoint table.
-const WINDOW_SIZE: usize = 33;
+pub(super) const WINDOW_SIZE: usize = 33;
 
 /// Basepoint table for multiples of NIST P-256's generator.
-type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
+pub(super) type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
 
 /// Lazily computed basepoint table.
 pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
 
 impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for Sm2 {
     const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
+}
+
+/// Workaround for rust-lang/rust#140653 to support MSRV 1.85: we can't use the generic
+/// implementation in `primeorder::backend::PrecomputedTables` until MSRV 1.90 due to restrictions
+/// on referencing a type with interior mutability from a `const`.
+// TODO(tarcieri): remove this and switch to `primeorder::backend::PrecomputedTables` when MSRV 1.90
+pub(crate) mod backend {
+    use super::BASEPOINT_TABLE;
+    use crate::{ProjectivePoint, Scalar, Sm2};
+    use primeorder::Backend;
+
+    /// Backend based on precomputed tables.
+    pub struct PrecomputedTables;
+
+    impl Backend<Sm2> for PrecomputedTables {
+        #[inline]
+        fn mul_by_generator(k: &Scalar) -> ProjectivePoint {
+            BASEPOINT_TABLE.mul(k)
+        }
+
+        #[inline]
+        fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
+            BASEPOINT_TABLE.mul_vartime(k)
+        }
+    }
 }


### PR DESCRIPTION
Similar to `PrimeCurveParams::PointArithmetic`, this adds a `PrimeCurveParams::Backend` associated type bounded by a new `Backend` trait.

Also adds two ZSTs `backend::VariableOnly` and `backend::PrecomputedTables`, where the latter is bounded on the `PrimeCurveWithBasepointTable` trait to access the basepoint table.

The specific ZST is select based on whether the `precomputed-tables` feature is enabled.

This provides a single place to generically define the interactions between the basepoint table for a particular curve and the scalar multiplication implementation in `primeorder`.

Previously there were a kitchen sink of small methods that could be overridden on `PrimeCurveParams` which have been removed, making the `PrimeCurveParams` declarative once again.

--

Unfortunately, due to rust-lang/rust#140653 the generic `PrecomputedTables` implementation is unusable until MSRV 1.90, as the `PrimeCurveWithBasepointTable::BASEPOINT_TABLE` constant cannot be accessed in Rust 1.85-1.89:

        error[E0080]: it is undefined behavior to use this value

This error occurs due to the interior mutability of `LazyLock` which made such values unusable in patterns. The solution was to permit a `const` that references a `static` with interior mutability, but disallow use in patterns, which shipped in Rust 1.90.

As a workaround for now, every crate with a basepoint table defines its own internal `PrecomputedTables` backend specific to that curve which uses its concrete `BASEPOINT_TABLE` constants. We can remove these hacks and switch to the generic version in Rust 1.90.