### PR TITLE
primefield: source `ByteOrder` from `crypto-bigint`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,9 +372,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "97bb4a855e3b10f84c4e7e895a7de01db7f9a7b7eb7f73ed9773fd52ac686451"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -672,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "subtle",
  "typenum",
@@ -1423,7 +1423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1441,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-bigint = { version = "0.7.1", package = "crypto-bigint", default-features = false, features = ["rand_core", "hybrid-array", "subtle"] }
+bigint = { version = "0.7.4", package = "crypto-bigint", default-features = false, features = ["rand_core", "hybrid-array", "subtle"] }
 common = { package = "crypto-common", version = "0.2", features = ["rand_core"] }
 ff = { version = "0.14", default-features = false }
 subtle = { version = "2.6", default-features = false, features = ["const-generics"] }

--- a/primefield/src/lib.rs
+++ b/primefield/src/lib.rs
@@ -19,19 +19,10 @@ pub use crate::{
 };
 pub use array::typenum::consts;
 pub use bigint;
+pub use bigint::ByteOrder;
 pub use bigint::hybrid_array as array;
 pub use common;
 pub use ff;
 pub use rand_core;
 pub use subtle;
 pub use zeroize;
-
-/// Byte order used when encoding/decoding field elements as bytestrings.
-#[derive(Debug)]
-pub enum ByteOrder {
-    /// Big endian.
-    BigEndian,
-
-    /// Little endian.
-    LittleEndian,
-}


### PR DESCRIPTION
Added in RustCrypto/crypto-bigint#1293