### PR TITLE
Rename `cfg(*_backend="bignum")` to `bigint`

### DIFF
--- a/.github/workflows/bp256.yml
+++ b/.github/workflows/bp256.yml
@@ -78,6 +78,6 @@ jobs:
       - run: cargo test
       - run: cargo test --all-features
       - env:
-          RUSTFLAGS: '--cfg bp256_backend="bignum"'
-          RUSTDOCFLAGS: '--cfg bp256_backend="bignum"'
+          RUSTFLAGS: '--cfg bp256_backend="bigint"'
+          RUSTDOCFLAGS: '--cfg bp256_backend="bigint"'
         run: cargo test --release --all-features

--- a/.github/workflows/bp384.yml
+++ b/.github/workflows/bp384.yml
@@ -78,6 +78,6 @@ jobs:
       - run: cargo test
       - run: cargo test --all-features
       - env:
-          RUSTFLAGS: '--cfg bp384_backend="bignum"'
-          RUSTDOCFLAGS: '--cfg bp384_backend="bignum"'
+          RUSTFLAGS: '--cfg bp384_backend="bigint"'
+          RUSTDOCFLAGS: '--cfg bp384_backend="bigint"'
         run: cargo test --release --all-features

--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -100,8 +100,8 @@ jobs:
       - run: cargo test --release --target ${{ matrix.target }}
       - run: cargo test --release --target ${{ matrix.target }} --all-features
       - env:
-          RUSTFLAGS: '--cfg p384_backend="bignum"'
-          RUSTDOCFLAGS: '--cfg p384_backend="bignum"'
+          RUSTFLAGS: '--cfg p384_backend="bigint"'
+          RUSTDOCFLAGS: '--cfg p384_backend="bigint"'
         run: cargo test --release --target ${{ matrix.target }} --all-features
 
   cross:

--- a/.github/workflows/sm2.yml
+++ b/.github/workflows/sm2.yml
@@ -91,6 +91,6 @@ jobs:
       - run: cargo test --release --target ${{ matrix.target }}
       - run: cargo test --release --target ${{ matrix.target }} --all-features
       - env:
-          RUSTFLAGS: '--cfg sm2_backend="bignum"'
-          RUSTDOCFLAGS: '--cfg sm2_backend="bignum"'
+          RUSTFLAGS: '--cfg sm2_backend="bigint"'
+          RUSTDOCFLAGS: '--cfg sm2_backend="bigint"'
         run: cargo test --release --target ${{ matrix.target }} --all-features

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -41,7 +41,7 @@ sha256 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(bp256_backend, values("bignum", "fiat"))', # default: "fiat"
+    'cfg(bp256_backend, values("bigint", "fiat"))', # default: "fiat"
     'cfg(cpubits, values("16", "32", "64"))'
 ]
 

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -20,7 +20,7 @@ use elliptic_curve::{
 // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 cpubits! {
     32 => {
-        #[cfg(not(bp256_backend = "bignum"))]
+        #[cfg(not(bp256_backend = "bigint"))]
         #[allow(
             dead_code,
             clippy::identity_op,
@@ -32,7 +32,7 @@ cpubits! {
         mod field_impl;
     }
     64 => {
-        #[cfg(not(bp256_backend = "bignum"))]
+        #[cfg(not(bp256_backend = "bigint"))]
         #[allow(
             dead_code,
             clippy::identity_op,
@@ -45,7 +45,7 @@ cpubits! {
     }
 }
 
-#[cfg(not(bp256_backend = "bignum"))]
+#[cfg(not(bp256_backend = "bigint"))]
 use self::field_impl::*;
 
 /// Constant representing the modulus serialized as hex.
@@ -67,14 +67,14 @@ primefield::monty_field_element! {
     doc: "Element in the brainpoolP256 finite field modulo p"
 }
 
-#[cfg(bp256_backend = "bignum")]
+#[cfg(bp256_backend = "bigint")]
 primefield::monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
     uint: U256
 }
 
-#[cfg(not(bp256_backend = "bignum"))]
+#[cfg(not(bp256_backend = "bigint"))]
 primefield::fiat_monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
@@ -97,7 +97,7 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U256};
-    #[cfg(not(bp256_backend = "bignum"))]
+    #[cfg(not(bp256_backend = "bigint"))]
     use super::{
         FieldParams, fiat_bp256_montgomery_domain_field_element, fiat_bp256_msat,
         fiat_bp256_non_montgomery_domain_field_element, fiat_bp256_to_montgomery,
@@ -105,7 +105,7 @@ mod tests {
 
     primefield::test_primefield!(FieldElement, U256);
 
-    #[cfg(not(bp256_backend = "bignum"))]
+    #[cfg(not(bp256_backend = "bigint"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: FieldElement,
         params: FieldParams,

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -21,7 +21,7 @@ use elliptic_curve::{
 // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 cpubits! {
     32 => {
-        #[cfg(not(bp256_backend = "bignum"))]
+        #[cfg(not(bp256_backend = "bigint"))]
         #[path = "scalar/bp256_scalar_32.rs"]
         #[allow(
             dead_code,
@@ -33,7 +33,7 @@ cpubits! {
         mod scalar_impl;
     }
     64 => {
-        #[cfg(not(bp256_backend = "bignum"))]
+        #[cfg(not(bp256_backend = "bigint"))]
         #[path = "scalar/bp256_scalar_64.rs"]
         #[allow(
             dead_code,
@@ -46,7 +46,7 @@ cpubits! {
     }
 }
 
-#[cfg(not(bp256_backend = "bignum"))]
+#[cfg(not(bp256_backend = "bigint"))]
 use self::scalar_impl::*;
 
 #[cfg(doc)]
@@ -68,14 +68,14 @@ primefield::monty_field_element! {
     doc: "Element in the brainpoolP256 scalar field modulo n"
 }
 
-#[cfg(bp256_backend = "bignum")]
+#[cfg(bp256_backend = "bigint")]
 primefield::monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
     uint: U256
 }
 
-#[cfg(not(bp256_backend = "bignum"))]
+#[cfg(not(bp256_backend = "bigint"))]
 primefield::fiat_monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
@@ -128,7 +128,7 @@ impl IsHigh for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U256};
-    #[cfg(not(bp256_backend = "bignum"))]
+    #[cfg(not(bp256_backend = "bigint"))]
     use super::{
         ScalarParams, fiat_bp256_scalar_montgomery_domain_field_element, fiat_bp256_scalar_msat,
         fiat_bp256_scalar_non_montgomery_domain_field_element, fiat_bp256_scalar_to_montgomery,
@@ -136,7 +136,7 @@ mod tests {
 
     primefield::test_primefield!(Scalar, U256);
 
-    #[cfg(not(bp256_backend = "bignum"))]
+    #[cfg(not(bp256_backend = "bigint"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: Scalar,
         params: ScalarParams,

--- a/bp256/src/lib.rs
+++ b/bp256/src/lib.rs
@@ -18,21 +18,21 @@
 //! ## Backends
 //!
 //! This crate has support for two different field arithmetic backends which can be selected using
-//! `cfg(bp256_backend)`, e.g. to select the `bignum` backend:
+//! `cfg(bp256_backend)`, e.g. to select the `bigint` backend:
 //!
 //! ```console
-//! $ RUSTFLAGS='--cfg bp256_backend="bignum"' cargo test
+//! $ RUSTFLAGS='--cfg bp256_backend="bigint"' cargo test
 //! ```
 //!
 //! Or it can be set through [`.cargo/config`][buildrustflags]:
 //!
 //! ```toml
 //! [build]
-//! rustflags = ['--cfg', 'bp256_backend="bignum"']
+//! rustflags = ['--cfg', 'bp256_backend="bigint"']
 //! ```
 //!
 //! The available backends are:
-//! - `bignum`: experimental backend provided by [crypto-bigint]. May offer better performance in
+//! - `bigint`: experimental backend provided by [crypto-bigint]. May offer better performance in
 //!   some cases along with smaller code size, but might also have bugs.
 //! - `fiat` (default): formally verified implementation synthesized by [fiat-crypto] which should
 //!   be correct for all inputs (though there's a possibility of bugs in the code which glues to it)

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -41,7 +41,7 @@ sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(bp384_backend, values("bignum", "fiat"))', # default: "fiat"
+    'cfg(bp384_backend, values("bigint", "fiat"))', # default: "fiat"
     'cfg(cpubits, values("16", "32", "64"))'
 ]
 

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -20,7 +20,7 @@ use elliptic_curve::{
 // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 cpubits! {
     32 => {
-        #[cfg(not(bp384_backend = "bignum"))]
+        #[cfg(not(bp384_backend = "bigint"))]
         #[path = "field/bp384_32.rs"]
         #[allow(
             dead_code,
@@ -32,7 +32,7 @@ cpubits! {
         mod field_impl;
     }
     64 => {
-        #[cfg(not(bp384_backend = "bignum"))]
+        #[cfg(not(bp384_backend = "bigint"))]
         #[path = "field/bp384_64.rs"]
         #[allow(
             dead_code,
@@ -45,7 +45,7 @@ cpubits! {
     }
 }
 
-#[cfg(not(bp384_backend = "bignum"))]
+#[cfg(not(bp384_backend = "bigint"))]
 use self::field_impl::*;
 
 /// Constant representing the modulus serialized as hex.
@@ -67,14 +67,14 @@ primefield::monty_field_element! {
     doc: "Element in the brainpoolP384 finite field modulo p"
 }
 
-#[cfg(bp384_backend = "bignum")]
+#[cfg(bp384_backend = "bigint")]
 primefield::monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
     uint: U384
 }
 
-#[cfg(not(bp384_backend = "bignum"))]
+#[cfg(not(bp384_backend = "bigint"))]
 primefield::fiat_monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
@@ -97,7 +97,7 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U384};
-    #[cfg(not(bp384_backend = "bignum"))]
+    #[cfg(not(bp384_backend = "bigint"))]
     use super::{
         FieldParams, fiat_bp384_montgomery_domain_field_element, fiat_bp384_msat,
         fiat_bp384_non_montgomery_domain_field_element, fiat_bp384_to_montgomery,
@@ -105,7 +105,7 @@ mod tests {
 
     primefield::test_primefield!(FieldElement, U384);
 
-    #[cfg(not(bp384_backend = "bignum"))]
+    #[cfg(not(bp384_backend = "bigint"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: FieldElement,
         params: FieldParams,

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -21,7 +21,7 @@ use elliptic_curve::{
 // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 cpubits! {
     32 => {
-        #[cfg(not(bp384_backend = "bignum"))]
+        #[cfg(not(bp384_backend = "bigint"))]
         #[path = "scalar/bp384_scalar_32.rs"]
         #[allow(
             dead_code,
@@ -33,7 +33,7 @@ cpubits! {
         mod scalar_impl;
     }
     64 => {
-        #[cfg(not(bp384_backend = "bignum"))]
+        #[cfg(not(bp384_backend = "bigint"))]
         #[path = "scalar/bp384_scalar_64.rs"]
         #[allow(
             dead_code,
@@ -46,7 +46,7 @@ cpubits! {
     }
 }
 
-#[cfg(not(bp384_backend = "bignum"))]
+#[cfg(not(bp384_backend = "bigint"))]
 use self::scalar_impl::*;
 
 #[cfg(doc)]
@@ -68,14 +68,14 @@ primefield::monty_field_element! {
     doc: "Element in the brainpoolP384 scalar field modulo n"
 }
 
-#[cfg(bp384_backend = "bignum")]
+#[cfg(bp384_backend = "bigint")]
 primefield::monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
     uint: U384
 }
 
-#[cfg(not(bp384_backend = "bignum"))]
+#[cfg(not(bp384_backend = "bigint"))]
 primefield::fiat_monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
@@ -128,7 +128,7 @@ impl IsHigh for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U384};
-    #[cfg(not(bp384_backend = "bignum"))]
+    #[cfg(not(bp384_backend = "bigint"))]
     use super::{
         ScalarParams, fiat_bp384_scalar_montgomery_domain_field_element, fiat_bp384_scalar_msat,
         fiat_bp384_scalar_non_montgomery_domain_field_element, fiat_bp384_scalar_to_montgomery,
@@ -136,7 +136,7 @@ mod tests {
 
     primefield::test_primefield!(Scalar, U384);
 
-    #[cfg(not(bp384_backend = "bignum"))]
+    #[cfg(not(bp384_backend = "bigint"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: Scalar,
         params: ScalarParams,

--- a/bp384/src/lib.rs
+++ b/bp384/src/lib.rs
@@ -18,21 +18,21 @@
 //! ## Backends
 //!
 //! This crate has support for two different field arithmetic backends which can be selected using
-//! `cfg(bp384_backend)`, e.g. to select the `bignum` backend:
+//! `cfg(bp384_backend)`, e.g. to select the `bigint` backend:
 //!
 //! ```console
-//! $ RUSTFLAGS='--cfg bp384_backend="bignum"' cargo test
+//! $ RUSTFLAGS='--cfg bp384_backend="bigint"' cargo test
 //! ```
 //!
 //! Or it can be set through [`.cargo/config`][buildrustflags]:
 //!
 //! ```toml
 //! [build]
-//! rustflags = ['--cfg', 'bp384_backend="bignum"']
+//! rustflags = ['--cfg', 'bp384_backend="bigint"']
 //! ```
 //!
 //! The available backends are:
-//! - `bignum`: experimental backend provided by [crypto-bigint]. May offer better performance in
+//! - `bigint`: experimental backend provided by [crypto-bigint]. May offer better performance in
 //!   some cases along with smaller code size, but might also have bugs.
 //! - `fiat` (default): formally verified implementation synthesized by [fiat-crypto] which should
 //!   be correct for all inputs (though there's a possibility of bugs in the code which glues to it)

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -48,7 +48,7 @@ test-vectors = ["hex-literal"]
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(p192_backend, values("bignum", "fiat"))', # default: "fiat"
+    'cfg(p192_backend, values("bigint", "fiat"))', # default: "fiat"
     'cfg(cpubits, values("16", "32", "64"))'
 ]
 

--- a/p192/src/arithmetic/field.rs
+++ b/p192/src/arithmetic/field.rs
@@ -20,7 +20,7 @@ use elliptic_curve::{
 // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 cpubits! {
     32 => {
-        #[cfg(not(p192_backend = "bignum"))]
+        #[cfg(not(p192_backend = "bigint"))]
         #[path = "field/p192_32.rs"]
         #[allow(
             dead_code,
@@ -32,7 +32,7 @@ cpubits! {
         mod field_impl;
     }
     64 => {
-        #[cfg(not(p192_backend = "bignum"))]
+        #[cfg(not(p192_backend = "bigint"))]
         #[path = "field/p192_64.rs"]
         #[allow(
             dead_code,
@@ -45,7 +45,7 @@ cpubits! {
     }
 }
 
-#[cfg(not(p192_backend = "bignum"))]
+#[cfg(not(p192_backend = "bigint"))]
 use self::field_impl::*;
 
 /// Constant representing the modulus serialized as hex.
@@ -68,14 +68,14 @@ primefield::monty_field_element! {
     doc: "Element in the finite field modulo `p = 2^{192} − 2^{64} - 1`."
 }
 
-#[cfg(p192_backend = "bignum")]
+#[cfg(p192_backend = "bigint")]
 primefield::monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
     uint: U192
 }
 
-#[cfg(not(p192_backend = "bignum"))]
+#[cfg(not(p192_backend = "bigint"))]
 primefield::fiat_monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
@@ -98,7 +98,7 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U192};
-    #[cfg(not(p192_backend = "bignum"))]
+    #[cfg(not(p192_backend = "bigint"))]
     use super::{
         FieldParams, fiat_p192_montgomery_domain_field_element, fiat_p192_msat,
         fiat_p192_non_montgomery_domain_field_element, fiat_p192_to_montgomery,
@@ -106,7 +106,7 @@ mod tests {
 
     primefield::test_primefield!(FieldElement, U192);
 
-    #[cfg(not(p192_backend = "bignum"))]
+    #[cfg(not(p192_backend = "bigint"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: FieldElement,
         params: FieldParams,

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -22,7 +22,7 @@ use elliptic_curve::{
 // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 cpubits! {
     32 => {
-        #[cfg(not(p192_backend = "bignum"))]
+        #[cfg(not(p192_backend = "bigint"))]
         #[path = "scalar/p192_scalar_32.rs"]
         #[allow(
             dead_code,
@@ -34,7 +34,7 @@ cpubits! {
         mod scalar_impl;
     }
     64 => {
-        #[cfg(not(p192_backend = "bignum"))]
+        #[cfg(not(p192_backend = "bigint"))]
         #[path = "scalar/p192_scalar_64.rs"]
         #[allow(
             dead_code,
@@ -47,7 +47,7 @@ cpubits! {
     }
 }
 
-#[cfg(not(p192_backend = "bignum"))]
+#[cfg(not(p192_backend = "bigint"))]
 use self::scalar_impl::*;
 
 #[cfg(feature = "serde")]
@@ -75,14 +75,14 @@ primefield::monty_field_element! {
     doc: "Element in the NIST P-192 scalar field modulo `n`."
 }
 
-#[cfg(p192_backend = "bignum")]
+#[cfg(p192_backend = "bigint")]
 primefield::monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
     uint: U192
 }
 
-#[cfg(not(p192_backend = "bignum"))]
+#[cfg(not(p192_backend = "bigint"))]
 primefield::fiat_monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
@@ -155,7 +155,7 @@ impl<'de> Deserialize<'de> for Scalar {
 mod tests {
     use super::{Scalar, U192};
 
-    #[cfg(not(p192_backend = "bignum"))]
+    #[cfg(not(p192_backend = "bigint"))]
     use super::{
         ScalarParams, fiat_p192_scalar_montgomery_domain_field_element, fiat_p192_scalar_msat,
         fiat_p192_scalar_non_montgomery_domain_field_element, fiat_p192_scalar_to_montgomery,
@@ -163,7 +163,7 @@ mod tests {
 
     primefield::test_primefield!(Scalar, U192);
 
-    #[cfg(not(p192_backend = "bignum"))]
+    #[cfg(not(p192_backend = "bigint"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: Scalar,
         params: ScalarParams,

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -51,7 +51,7 @@ test-vectors = ["dep:hex-literal"]
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(p224_backend, values("bignum", "fiat"))', # default: "fiat"
+    'cfg(p224_backend, values("bigint", "fiat"))', # default: "fiat"
     'cfg(cpubits, values("16", "32", "64"))'
 ]
 

--- a/p224/src/arithmetic/field.rs
+++ b/p224/src/arithmetic/field.rs
@@ -20,7 +20,7 @@ use elliptic_curve::{
 // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 cpubits! {
     32 => {
-        #[cfg(not(p224_backend = "bignum"))]
+        #[cfg(not(p224_backend = "bigint"))]
         #[path = "field/p224_32.rs"]
         #[allow(
             dead_code,
@@ -32,7 +32,7 @@ cpubits! {
         mod field_impl;
     }
     64 => {
-        #[cfg(not(p224_backend = "bignum"))]
+        #[cfg(not(p224_backend = "bigint"))]
         #[path = "field/p224_64.rs"]
         #[allow(
             dead_code,
@@ -45,7 +45,7 @@ cpubits! {
     }
 }
 
-#[cfg(not(p224_backend = "bignum"))]
+#[cfg(not(p224_backend = "bigint"))]
 use self::field_impl::*;
 
 /// Constant representing the modulus serialized as hex.
@@ -73,14 +73,14 @@ primefield::monty_field_element! {
     doc: "Element in the finite field modulo `p = 2^{224} − 2^{96} + 1`."
 }
 
-#[cfg(p224_backend = "bignum")]
+#[cfg(p224_backend = "bigint")]
 primefield::monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
     uint: Uint
 }
 
-#[cfg(not(p224_backend = "bignum"))]
+#[cfg(not(p224_backend = "bigint"))]
 primefield::fiat_monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
@@ -104,7 +104,7 @@ primefield::fiat_monty_field_arithmetic! {
 mod tests {
     use super::{FieldElement, Uint};
 
-    #[cfg(not(p224_backend = "bignum"))]
+    #[cfg(not(p224_backend = "bigint"))]
     use super::{
         FieldParams, fiat_p224_montgomery_domain_field_element, fiat_p224_msat,
         fiat_p224_non_montgomery_domain_field_element, fiat_p224_to_montgomery,
@@ -112,7 +112,7 @@ mod tests {
 
     primefield::test_primefield!(FieldElement, Uint);
 
-    #[cfg(not(p224_backend = "bignum"))]
+    #[cfg(not(p224_backend = "bigint"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: FieldElement,
         params: FieldParams,

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -23,7 +23,7 @@ use elliptic_curve::{
 // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 cpubits! {
     32 => {
-        #[cfg(not(p224_backend = "bignum"))]
+        #[cfg(not(p224_backend = "bigint"))]
         #[path = "scalar/p224_scalar_32.rs"]
         #[allow(
             dead_code,
@@ -35,7 +35,7 @@ cpubits! {
         mod scalar_impl;
     }
     64 => {
-        #[cfg(not(p224_backend = "bignum"))]
+        #[cfg(not(p224_backend = "bigint"))]
         #[path = "scalar/p224_scalar_64.rs"]
         #[allow(
             dead_code,
@@ -48,7 +48,7 @@ cpubits! {
     }
 }
 
-#[cfg(not(p224_backend = "bignum"))]
+#[cfg(not(p224_backend = "bigint"))]
 use self::scalar_impl::*;
 
 #[cfg(feature = "serde")]
@@ -76,14 +76,14 @@ primefield::monty_field_element! {
     doc: "Element in the NIST P-224 scalar field modulo `n`."
 }
 
-#[cfg(p224_backend = "bignum")]
+#[cfg(p224_backend = "bigint")]
 primefield::monty_field_arithmetic! {
     name: Scalar,
     params: Scalar,
     uint: Uint
 }
 
-#[cfg(not(p224_backend = "bignum"))]
+#[cfg(not(p224_backend = "bigint"))]
 primefield::fiat_monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
@@ -166,7 +166,7 @@ impl<'de> Deserialize<'de> for Scalar {
 mod tests {
     use super::{Scalar, Uint};
 
-    #[cfg(not(p224_backend = "bignum"))]
+    #[cfg(not(p224_backend = "bigint"))]
     use super::{
         ScalarParams, fiat_p224_scalar_montgomery_domain_field_element, fiat_p224_scalar_msat,
         fiat_p224_scalar_non_montgomery_domain_field_element, fiat_p224_scalar_to_montgomery,
@@ -174,7 +174,7 @@ mod tests {
 
     primefield::test_primefield!(Scalar, Uint);
 
-    #[cfg(not(p224_backend = "bignum"))]
+    #[cfg(not(p224_backend = "bigint"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: Scalar,
         params: ScalarParams,

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -29,7 +29,7 @@ primeorder = { version = "0.14.0-rc.11", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
-[target.'cfg(not(p384_backend = "bignum"))'.dependencies]
+[target.'cfg(not(p384_backend = "bigint"))'.dependencies]
 fiat-crypto = { version = "0.3", default-features = false }
 
 [dev-dependencies]
@@ -68,7 +68,7 @@ test-vectors = ["hex-literal"]
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(p384_backend, values("bignum", "fiat"))', # default: "fiat"
+    'cfg(p384_backend, values("bigint", "fiat"))', # default: "fiat"
     'cfg(cpubits, values("16", "32", "64"))'
 ]
 

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -19,11 +19,11 @@ use elliptic_curve::{
 // Default backend: fiat-crypto
 cpubits! {
     32 => {
-        #[cfg(not(p384_backend = "bignum"))]
+        #[cfg(not(p384_backend = "bigint"))]
         use fiat_crypto::p384_32::*;
     }
     64 => {
-        #[cfg(not(p384_backend = "bignum"))]
+        #[cfg(not(p384_backend = "bigint"))]
         use fiat_crypto::p384_64::*;
     }
 }
@@ -48,14 +48,14 @@ primefield::monty_field_element! {
     doc: "Element in the finite field modulo `p = 2^{384} − 2^{128} − 2^{96} + 2^{32} − 1`."
 }
 
-#[cfg(p384_backend = "bignum")]
+#[cfg(p384_backend = "bigint")]
 primefield::monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
     uint: U384
 }
 
-#[cfg(not(p384_backend = "bignum"))]
+#[cfg(not(p384_backend = "bigint"))]
 primefield::fiat_monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
@@ -78,7 +78,7 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U384};
-    #[cfg(not(p384_backend = "bignum"))]
+    #[cfg(not(p384_backend = "bigint"))]
     use super::{
         FieldParams, fiat_p384_montgomery_domain_field_element, fiat_p384_msat,
         fiat_p384_non_montgomery_domain_field_element, fiat_p384_to_montgomery,
@@ -86,7 +86,7 @@ mod tests {
 
     primefield::test_primefield!(FieldElement, U384);
 
-    #[cfg(not(p384_backend = "bignum"))]
+    #[cfg(not(p384_backend = "bigint"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: FieldElement,
         params: FieldParams,

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -22,11 +22,11 @@ use elliptic_curve::{
 
 cpubits! {
     32 => {
-        #[cfg(not(p384_backend = "bignum"))]
+        #[cfg(not(p384_backend = "bigint"))]
         use fiat_crypto::p384_scalar_32::*;
     }
     64 => {
-        #[cfg(not(p384_backend = "bignum"))]
+        #[cfg(not(p384_backend = "bigint"))]
         use fiat_crypto::p384_scalar_64::*;
     }
 }
@@ -56,14 +56,14 @@ primefield::monty_field_element! {
     doc: "Element in the NIST P-384 scalar field modulo `n`."
 }
 
-#[cfg(p384_backend = "bignum")]
+#[cfg(p384_backend = "bigint")]
 primefield::monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
     uint: U384
 }
 
-#[cfg(not(p384_backend = "bignum"))]
+#[cfg(not(p384_backend = "bigint"))]
 primefield::fiat_monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
@@ -162,7 +162,7 @@ impl<'de> Deserialize<'de> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U384};
-    #[cfg(not(p384_backend = "bignum"))]
+    #[cfg(not(p384_backend = "bigint"))]
     use super::{
         ScalarParams, fiat_p384_scalar_montgomery_domain_field_element, fiat_p384_scalar_msat,
         fiat_p384_scalar_non_montgomery_domain_field_element, fiat_p384_scalar_to_montgomery,
@@ -178,7 +178,7 @@ mod tests {
 
     primefield::test_primefield!(Scalar, U384);
 
-    #[cfg(not(p384_backend = "bignum"))]
+    #[cfg(not(p384_backend = "bigint"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: Scalar,
         params: ScalarParams,

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -11,21 +11,21 @@
 //! ## Backends
 //!
 //! This crate has support for two different field arithmetic backends which can be selected using
-//! `cfg(p384_backend)`, e.g. to select the `bignum` backend:
+//! `cfg(p384_backend)`, e.g. to select the `bigint` backend:
 //!
 //! ```console
-//! $ RUSTFLAGS='--cfg p384_backend="bignum"' cargo test
+//! $ RUSTFLAGS='--cfg p384_backend="bigint"' cargo test
 //! ```
 //!
 //! Or it can be set through [`.cargo/config`][buildrustflags]:
 //!
 //! ```toml
 //! [build]
-//! rustflags = ['--cfg', 'p384_backend="bignum"']
+//! rustflags = ['--cfg', 'p384_backend="bigint"']
 //! ```
 //!
 //! The available backends are:
-//! - `bignum`: experimental backend provided by [crypto-bigint]. May offer better performance in
+//! - `bigint`: experimental backend provided by [crypto-bigint]. May offer better performance in
 //!   some cases along with smaller code size, but might also have bugs.
 //! - `fiat` (default): formally verified implementation synthesized by [fiat-crypto] which should
 //!   be correct for all inputs (though there's a possibility of bugs in the code which glues to it)

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -78,5 +78,5 @@ all-features = true
 level = "warn"
 check-cfg = [
     'cfg(cpubits, values("16", "32", "64"))',
-    'cfg(sm2_backend, values("bignum", "fiat"))' # default: "fiat"
+    'cfg(sm2_backend, values("bigint", "fiat"))' # default: "fiat"
 ]

--- a/sm2/src/arithmetic/field.rs
+++ b/sm2/src/arithmetic/field.rs
@@ -20,11 +20,11 @@ use elliptic_curve::{
 // Default backend: fiat-crypto
 cpubits! {
     32 => {
-        #[cfg(not(sm2_backend = "bignum"))]
+        #[cfg(not(sm2_backend = "bigint"))]
         use fiat_crypto::sm2_32::*;
     }
     64 => {
-        #[cfg(not(sm2_backend = "bignum"))]
+        #[cfg(not(sm2_backend = "bigint"))]
         use fiat_crypto::sm2_64::*;
     }
 }
@@ -48,14 +48,14 @@ primefield::monty_field_element! {
     doc: "Element in the SM2 finite field modulo `p = 0xfffffffeffffffffffffffffffffffffffffffff00000000ffffffffffffffff`"
 }
 
-#[cfg(sm2_backend = "bignum")]
+#[cfg(sm2_backend = "bigint")]
 primefield::monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
     uint: U256
 }
 
-#[cfg(not(sm2_backend = "bignum"))]
+#[cfg(not(sm2_backend = "bigint"))]
 primefield::fiat_monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
@@ -78,7 +78,7 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U256};
-    #[cfg(not(sm2_backend = "bignum"))]
+    #[cfg(not(sm2_backend = "bigint"))]
     use super::{
         FieldParams, fiat_sm2_montgomery_domain_field_element, fiat_sm2_msat,
         fiat_sm2_non_montgomery_domain_field_element, fiat_sm2_to_montgomery,
@@ -86,7 +86,7 @@ mod tests {
 
     primefield::test_primefield!(FieldElement, U256);
 
-    #[cfg(not(sm2_backend = "bignum"))]
+    #[cfg(not(sm2_backend = "bigint"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: FieldElement,
         params: FieldParams,

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -22,11 +22,11 @@ use elliptic_curve::{
 // Default backend: fiat-crypto
 cpubits! {
     32 => {
-        #[cfg(not(sm2_backend = "bignum"))]
+        #[cfg(not(sm2_backend = "bigint"))]
         use fiat_crypto::sm2_scalar_32::*;
     }
     64 => {
-        #[cfg(not(sm2_backend = "bignum"))]
+        #[cfg(not(sm2_backend = "bigint"))]
         use fiat_crypto::sm2_scalar_64::*;
     }
 }
@@ -56,14 +56,14 @@ primefield::monty_field_element! {
     doc: "Element in the SM2 scalar field modulo `n`."
 }
 
-#[cfg(sm2_backend = "bignum")]
+#[cfg(sm2_backend = "bigint")]
 primefield::monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
     uint: U256
 }
 
-#[cfg(not(sm2_backend = "bignum"))]
+#[cfg(not(sm2_backend = "bigint"))]
 primefield::fiat_monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
@@ -135,14 +135,14 @@ impl<'de> Deserialize<'de> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U256};
-    #[cfg(not(sm2_backend = "bignum"))]
+    #[cfg(not(sm2_backend = "bigint"))]
     use super::{
         ScalarParams, fiat_sm2_scalar_montgomery_domain_field_element, fiat_sm2_scalar_msat,
         fiat_sm2_scalar_non_montgomery_domain_field_element, fiat_sm2_scalar_to_montgomery,
     };
 
     primefield::test_primefield!(Scalar, U256);
-    #[cfg(not(sm2_backend = "bignum"))]
+    #[cfg(not(sm2_backend = "bigint"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: Scalar,
         params: ScalarParams,

--- a/sm2/src/lib.rs
+++ b/sm2/src/lib.rs
@@ -27,21 +27,21 @@
 //! ## Backends
 //!
 //! This crate has support for two different field arithmetic backends which can be selected using
-//! `cfg(sm2_backend)`, e.g. to select the `bignum` backend:
+//! `cfg(sm2_backend)`, e.g. to select the `bigint` backend:
 //!
 //! ```console
-//! $ RUSTFLAGS='--cfg sm2_backend="bignum"' cargo test
+//! $ RUSTFLAGS='--cfg sm2_backend="bigint"' cargo test
 //! ```
 //!
 //! Or it can be set through [`.cargo/config`][buildrustflags]:
 //!
 //! ```toml
 //! [build]
-//! rustflags = ['--cfg', 'sm2_backend="bignum"']
+//! rustflags = ['--cfg', 'sm2_backend="bigint"']
 //! ```
 //!
 //! The available backends are:
-//! - `bignum`: experimental backend provided by [crypto-bigint]. May offer better performance in
+//! - `bigint`: experimental backend provided by [crypto-bigint]. May offer better performance in
 //!   some cases along with smaller code size, but might also have bugs.
 //! - `fiat` (default): formally verified implementation synthesized by [fiat-crypto] which should
 //!   be correct for all inputs (though there's a possibility of bugs in the code which glues to it)


### PR DESCRIPTION
I'm not sure why I chose `bignum` originally, but `bigint` matches `crypto-bigint` which is what it's supposed to imply.