### PR TITLE
p384: use `crypto-bigint` by default for field arithmetic

### DIFF
--- a/.github/workflows/p384.yml
+++ b/.github/workflows/p384.yml
@@ -100,8 +100,8 @@ jobs:
       - run: cargo test --release --target ${{ matrix.target }}
       - run: cargo test --release --target ${{ matrix.target }} --all-features
       - env:
-          RUSTFLAGS: '--cfg p384_backend="bigint"'
-          RUSTDOCFLAGS: '--cfg p384_backend="bigint"'
+          RUSTFLAGS: '--cfg p384_backend="fiat"'
+          RUSTDOCFLAGS: '--cfg p384_backend="fiat"'
         run: cargo test --release --target ${{ matrix.target }} --all-features
 
   cross:

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -29,7 +29,7 @@ primeorder = { version = "0.14.0-rc.11", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
-[target.'cfg(not(p384_backend = "bigint"))'.dependencies]
+[target.'cfg(p384_backend = "fiat")'.dependencies]
 fiat-crypto = { version = "0.3", default-features = false }
 
 [dev-dependencies]

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -19,11 +19,11 @@ use elliptic_curve::{
 // Default backend: fiat-crypto
 cpubits! {
     32 => {
-        #[cfg(not(p384_backend = "bigint"))]
+        #[cfg(p384_backend = "fiat")]
         use fiat_crypto::p384_32::*;
     }
     64 => {
-        #[cfg(not(p384_backend = "bigint"))]
+        #[cfg(p384_backend = "fiat")]
         use fiat_crypto::p384_64::*;
     }
 }
@@ -48,14 +48,14 @@ primefield::monty_field_element! {
     doc: "Element in the finite field modulo `p = 2^{384} − 2^{128} − 2^{96} + 2^{32} − 1`."
 }
 
-#[cfg(p384_backend = "bigint")]
+#[cfg(not(p384_backend = "fiat"))]
 primefield::monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
     uint: U384
 }
 
-#[cfg(not(p384_backend = "bigint"))]
+#[cfg(p384_backend = "fiat")]
 primefield::fiat_monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
@@ -78,7 +78,7 @@ primefield::fiat_monty_field_arithmetic! {
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U384};
-    #[cfg(not(p384_backend = "bigint"))]
+    #[cfg(p384_backend = "fiat")]
     use super::{
         FieldParams, fiat_p384_montgomery_domain_field_element, fiat_p384_msat,
         fiat_p384_non_montgomery_domain_field_element, fiat_p384_to_montgomery,
@@ -86,7 +86,7 @@ mod tests {
 
     primefield::test_primefield!(FieldElement, U384);
 
-    #[cfg(not(p384_backend = "bigint"))]
+    #[cfg(p384_backend = "fiat")]
     primefield::test_fiat_monty_field_arithmetic!(
         name: FieldElement,
         params: FieldParams,

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -22,11 +22,11 @@ use elliptic_curve::{
 
 cpubits! {
     32 => {
-        #[cfg(not(p384_backend = "bigint"))]
+        #[cfg(p384_backend = "fiat")]
         use fiat_crypto::p384_scalar_32::*;
     }
     64 => {
-        #[cfg(not(p384_backend = "bigint"))]
+        #[cfg(p384_backend = "fiat")]
         use fiat_crypto::p384_scalar_64::*;
     }
 }
@@ -56,14 +56,14 @@ primefield::monty_field_element! {
     doc: "Element in the NIST P-384 scalar field modulo `n`."
 }
 
-#[cfg(p384_backend = "bigint")]
+#[cfg(not(p384_backend = "fiat"))]
 primefield::monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
     uint: U384
 }
 
-#[cfg(not(p384_backend = "bigint"))]
+#[cfg(p384_backend = "fiat")]
 primefield::fiat_monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
@@ -162,7 +162,7 @@ impl<'de> Deserialize<'de> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U384};
-    #[cfg(not(p384_backend = "bigint"))]
+    #[cfg(p384_backend = "fiat")]
     use super::{
         ScalarParams, fiat_p384_scalar_montgomery_domain_field_element, fiat_p384_scalar_msat,
         fiat_p384_scalar_non_montgomery_domain_field_element, fiat_p384_scalar_to_montgomery,
@@ -178,7 +178,7 @@ mod tests {
 
     primefield::test_primefield!(Scalar, U384);
 
-    #[cfg(not(p384_backend = "bigint"))]
+    #[cfg(p384_backend = "fiat")]
     primefield::test_fiat_monty_field_arithmetic!(
         name: Scalar,
         params: ScalarParams,

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -11,23 +11,24 @@
 //! ## Backends
 //!
 //! This crate has support for two different field arithmetic backends which can be selected using
-//! `cfg(p384_backend)`, e.g. to select the `bigint` backend:
+//! `cfg(p384_backend)`, e.g. to select the formally verified `fiat` backend:
 //!
 //! ```console
-//! $ RUSTFLAGS='--cfg p384_backend="bigint"' cargo test
+//! $ RUSTFLAGS='--cfg p384_backend="fiat"' cargo test
 //! ```
 //!
 //! Or it can be set through [`.cargo/config`][buildrustflags]:
 //!
 //! ```toml
 //! [build]
-//! rustflags = ['--cfg', 'p384_backend="bigint"']
+//! rustflags = ['--cfg', 'p384_backend="fiat"']
 //! ```
 //!
 //! The available backends are:
-//! - `bigint`: experimental backend provided by [crypto-bigint]. May offer better performance in
-//!   some cases along with smaller code size, but might also have bugs.
-//! - `fiat` (default): formally verified implementation synthesized by [fiat-crypto] which should
+//! - `bigint` (default): backend provided by [crypto-bigint], which should provide better
+//!   performance as well as smaller code size and fewer dependencies, but isn't formally verified
+//!   and may contain bugs
+//! - `fiat`: formally verified implementation synthesized by [fiat-crypto] which should
 //!   be correct for all inputs (though there's a possibility of bugs in the code which glues to it)
 //!
 //! [buildrustflags]: https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags


### PR DESCRIPTION
Switches to `cfg(p384_backend="fiat")` to opt into `fiat-crypto`.

When `p384_backend="bigint"` backend was added in #1548, it was made opt-in, as were similar features added to other crates. This was largely because the `crypto-bigint` code is relatively immature and the existing `fiat-crypto` backend is formally verified.

However, the amount of code generated for `fiat-crypto` for a curve like P-384 is quite large. The 32-bit backends are >=10 klocs per field, and the 64-bit ones are nearly 4 klocs.

This is large enough to have caused issues in the past: see #906, the upstream issue rust-lang/rust#113612, and its upstream issue llvm/llvm-project#76920. Another example is #1034.

Part of the problem is `fiat-crypto` always unrolls all loops, even when the field modulus is quite large and it would make more sense both in terms of compile times and being more optimizer-friendly to reduce the generated code size by not unrolling loops.

Switching to `p384` should make the implementation both faster to compile and faster at runtime, with the downside of potential bugs in the implementation.

Below are some benchmarks showing the improvements:

    point operations/point-scalar mul
         time:   [370.08 µs 370.73 µs 371.38 µs]
         change: [−19.596% −19.042% −18.501%] (p = 0.00 < 0.05)
         Performance has improved.

    scalar operations/generator-scalar mul
         time:   [97.359 µs 97.552 µs 97.745 µs]
         change: [−13.964% −13.130% −12.088%] (p = 0.00 < 0.05)
         Performance has improved.

    scalar operations/generator-scalar mul (variable-time)
         time:   [80.252 µs 80.407 µs 80.564 µs]
         change: [−17.652% −16.304% −15.270%] (p = 0.00 < 0.05)
         Performance has improved.

    scalar operations/invert
         time:   [4.3291 µs 4.3379 µs 4.3463 µs]
         change: [−86.748% −86.646% −86.538%] (p = 0.00 < 0.05)
         Performance has improved.