### PR TITLE
k256: have `MulByGeneratorVartime` always call inherent method

### DIFF
--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -531,7 +531,7 @@ impl MulVartime<&Scalar> for ProjectivePoint {
 }
 
 impl MulByGeneratorVartime for ProjectivePoint {
-    #[cfg(feature = "precomputed-tables")]
+    #[inline]
     fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
         Self::mul_by_generator_vartime(k)
     }


### PR DESCRIPTION
Previously it was gated on `precomputed-tables`, but the inherent method is always available and always does the right thing