### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "bignp256"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 dependencies = [
  "belt-block",
  "belt-hash",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "bp256"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "bp384"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.19"
+version = "0.17.0-rc.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcddae1289a08e614a83d155a070f54c1803196e92089b8299e2738eb74d3e4"
+checksum = "0f7195c1205cec99025b3004e8034e1ddc12746333aa0a3945df7f9b80882ca2"
 dependencies = [
  "der",
  "digest",
@@ -489,8 +489,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.34"
-source = "git+https://github.com/RustCrypto/traits#a4525fbbe6edaead3a78d7ba4981175fa574f2d8"
+version = "0.14.0-rc.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c58d86e2f3cebbf2dfd94c4bf049585c7def71058ba506bfdafcb57652a34b"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -735,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 dependencies = [
  "cpubits",
  "criterion",
@@ -840,7 +841,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p192"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -852,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "p224"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -865,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -881,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -898,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 dependencies = [
  "base16ct",
  "criterion",
@@ -988,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 dependencies = [
  "crypto-bigint",
  "crypto-common",
@@ -1000,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 dependencies = [
  "elliptic-curve",
  "once_cell",
@@ -1357,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "sm2"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 dependencies = [
  "criterion",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,3 @@ hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
 wnaf = { path = "wnaf" }
-
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bignp256"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 description = """
 Pure Rust implementation of the Bign P-256 (a.k.a. bign-curve256v1)
 elliptic curve as defined in STB 34.101.45-2013, with
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.34", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.35", features = ["sec1"] }
 
 # optional dependencies
 belt-block = { version = "0.2", optional = true }
@@ -31,8 +31,8 @@ hkdf = { version = "0.13", optional = true }
 hmac = { version = "0.13", optional = true }
 rand_core = "0.10"
 pkcs8 = { version = "0.11", optional = true }
-primefield = { version = "0.14.0-rc.11", optional = true }
-primeorder = { version = "0.14.0-rc.11", optional = true }
+primefield = { version = "0.14.0-rc.12", optional = true }
+primeorder = { version = "0.14.0-rc.12", optional = true }
 sec1 = { version = "0.8.1", optional = true }
 hash2curve = { version = "0.14.0-rc.12", optional = true }
 belt-kwp = { version = "0.2", optional = true }
@@ -40,9 +40,9 @@ signature = { version = "3", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.11", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.12", features = ["dev"] }
 proptest = "1"
 
 [features]

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp256"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 description = "Brainpool P-256 (brainpoolP256r1 and brainpoolP256t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -14,17 +14,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.19", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "0.14.0-rc.11", optional = true }
-primeorder = { version = "0.14.0-rc.11", optional = true }
+ecdsa = { version = "0.17.0-rc.20", optional = true, default-features = false, features = ["der"] }
+primefield = { version = "0.14.0-rc.12", optional = true }
+primeorder = { version = "0.14.0-rc.12", optional = true }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp384"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -14,17 +14,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.19", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "0.14.0-rc.11", optional = true }
-primeorder = { version = "0.14.0-rc.11", optional = true }
+ecdsa = { version = "0.17.0-rc.20", optional = true, default-features = false, features = ["der"] }
+primefield = { version = "0.14.0-rc.12", optional = true }
+primeorder = { version = "0.14.0-rc.12", optional = true }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -16,7 +16,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.34", features = ["arithmetic", "pkcs8"] }
+elliptic-curve = { version = "0.14.0-rc.35", features = ["arithmetic", "pkcs8"] }
 hash2curve = "0.14.0-rc.12"
 rand_core = { version = "0.10", default-features = false }
 shake = { version = "0.1", default-features = false }

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = { version = "0.11" }
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["arithmetic"] }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification/public-key recovery, Taproot Schnorr signatures (BIP340),
@@ -20,20 +20,20 @@ rust-version = "1.85"
 
 [dependencies]
 cpubits = "0.1"
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
 hash2curve = { version = "0.14.0-rc.12", optional = true }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primeorder = { version = "0.14.0-rc.11", optional = true }
+primeorder = { version = "0.14.0-rc.12", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 signature = { version = "3", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4.3"
 hex-literal = "1"
 num-bigint = "0.4"

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -31,7 +31,6 @@
 #[allow(unused_imports)]
 #[macro_use]
 extern crate alloc;
-
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p192"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 description = """
 Pure Rust implementation of the NIST P-192 (a.k.a. secp192r1) elliptic curve
 as defined in SP 800-186
@@ -17,19 +17,19 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.11", optional = true }
-primeorder = { version = "0.14.0-rc.11", optional = true }
+primefield = { version = "0.14.0-rc.12", optional = true }
+primeorder = { version = "0.14.0-rc.12", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.11", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.12", features = ["dev"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p224"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 description = """
 Pure Rust implementation of the NIST P-224 (a.k.a. secp224r1) elliptic curve
 as defined in SP 800-186
@@ -17,20 +17,20 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.11", optional = true }
-primeorder = { version = "0.14.0-rc.11", optional = true }
+primefield = { version = "0.14.0-rc.12", optional = true }
+primeorder = { version = "0.14.0-rc.12", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.11", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.12", features = ["dev"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve as defined in SP 800-186, with support for ECDH, ECDSA
@@ -18,23 +18,23 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.12", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.11", optional = true }
-primeorder = { version = "0.14.0-rc.11", optional = true }
+primefield = { version = "0.14.0-rc.12", optional = true }
+primeorder = { version = "0.14.0-rc.12", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primefield = { version = "0.14.0-rc.11" }
-primeorder = { version = "0.14.0-rc.11", features = ["dev"] }
+primefield = { version = "0.14.0-rc.12" }
+primeorder = { version = "0.14.0-rc.12", features = ["dev"] }
 proptest = "1"
 
 [features]

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p384"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 description = """
 Pure Rust implementation of the NIST P-384 (a.k.a. secp384r1) elliptic curve
 as defined in SP 800-186 with support for ECDH, ECDSA signing/verification,
@@ -18,14 +18,14 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.12", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.11", optional = true }
-primeorder = { version = "0.14.0-rc.11", optional = true }
+primefield = { version = "0.14.0-rc.12", optional = true }
+primeorder = { version = "0.14.0-rc.12", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
@@ -34,9 +34,9 @@ fiat-crypto = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.11", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.12", features = ["dev"] }
 proptest = "1.11"
 
 [features]

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p521"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 description = """
 Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve
 as defined in SP 800-186
@@ -18,23 +18,23 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "1"
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14.0-rc.12", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.11", optional = true }
-primeorder = { version = "0.14.0-rc.11", optional = true }
+primefield = { version = "0.14.0-rc.12", optional = true }
+primeorder = { version = "0.14.0-rc.12", optional = true }
 rand_core = { version = "0.10", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.19", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.11", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.12", features = ["dev"] }
 proptest = "1.11"
 
 [features]

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primefield"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 description = """
 Generic implementation of prime fields built on `crypto-bigint`, along with macros for writing
 field element newtypes including ones with formally verified arithmetic using `fiat-crypto`

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve
@@ -18,8 +18,8 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["arithmetic", "sec1"] }
-primefield = "0.14.0-rc.11"
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["arithmetic", "sec1"] }
+primefield = "0.14.0-rc.12"
 
 # optional dependencies
 once_cell = { version = "1.21", optional = true, default-features = false }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm2"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.12"
 description = """
 Pure Rust implementation of the SM2 elliptic curve as defined in the Chinese
 national standard GM/T 0003-2012 as well as ISO/IEC 14888. Includes support for
@@ -18,14 +18,14 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
 rand_core = { version = "0.10", default-features = false }
 
 # optional dependencies
 der = { version = "0.8", optional = true }
-primefield = { version = "0.14.0-rc.11", optional = true }
-primeorder = { version = "0.14.0-rc.11", optional = true }
+primefield = { version = "0.14.0-rc.12", optional = true }
+primeorder = { version = "0.14.0-rc.12", optional = true }
 rfc6979 = { version = "0.6.0-pre.0", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 signature = { version = "3", optional = true, features = ["rand_core"] }
@@ -33,7 +33,7 @@ sm3 = { version = "0.5", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.34", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["dev"] }
 hex-literal = "1"
 proptest = "1"
 


### PR DESCRIPTION
Releases the following:

- `bignp256` v0.14.0-rc.12
- `bp256` v0.14.0-rc.12
- `bp384` v0.14.0-rc.12
- `k256` v0.14.0-rc.12
- `p192` v0.14.0-rc.12
- `p224` v0.14.0-rc.12
- `p256` v0.14.0-rc.12
- `p384` v0.14.0-rc.12
- `p521` v0.14.0-rc.12
- `primefield` v0.14.0-rc.12
- `primeorder` v0.14.0-rc.12
- `sm2` v0.14.0-rc.12