### PR TITLE
k256: test all scalar multiplication feature combos

### DIFF
--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -101,6 +101,9 @@ jobs:
           targets: ${{ matrix.target }}
       - run: cargo check --target ${{ matrix.target }} --all-features
       - run: cargo test --release --target ${{ matrix.target }} --no-default-features
+      - run: cargo test --release --target ${{ matrix.target }} --no-default-features --features arithmetic
+      - run: cargo test --release --target ${{ matrix.target }} --no-default-features --features alloc,arithmetic
+      - run: cargo test --release --target ${{ matrix.target }} --no-default-features --features arithmetic,critical-section,precomputed-tables
       - run: cargo test --release --target ${{ matrix.target }}
       - run: cargo test --release --target ${{ matrix.target }} --all-features
 

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -510,18 +510,18 @@ impl<'a> Product<&'a FieldElement> for FieldElement {
 
 #[cfg(test)]
 mod tests {
-    use elliptic_curve::Generate;
-    use elliptic_curve::ff::{Field, PrimeField};
-    use elliptic_curve::ops::BatchInvert;
-    use num_bigint::{BigUint, ToBigUint};
-    use proptest::prelude::*;
-
     use super::FieldElement;
     use crate::{
         FieldBytes,
         arithmetic::dev::{biguint_to_bytes, bytes_to_biguint},
         test_vectors::field::DBL_TEST_VECTORS,
     };
+    use elliptic_curve::ff::{Field, PrimeField};
+    use num_bigint::{BigUint, ToBigUint};
+    use proptest::prelude::*;
+
+    #[cfg(feature = "getrandom")]
+    use elliptic_curve::{Generate, ops::BatchInvert};
 
     impl From<&BigUint> for FieldElement {
         fn from(x: &BigUint) -> Self {

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -560,6 +560,8 @@ impl MulAssign<&Scalar> for ProjectivePoint {
 mod tests {
     use super::*;
     use crate::arithmetic::{ProjectivePoint, Scalar};
+
+    #[cfg(feature = "getrandom")]
     use elliptic_curve::Generate;
 
     #[test]

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -728,13 +728,12 @@ mod tests {
         Scalar,
         test_vectors::group::{ADD_TEST_VECTORS, MUL_TEST_VECTORS},
     };
-    use elliptic_curve::{
-        BatchNormalize, CurveGroup, Generate,
-        group::{CurveAffine, ff::PrimeField},
-    };
+    use elliptic_curve::group::{CurveAffine, ff::PrimeField};
 
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "getrandom"))]
     use alloc::vec::Vec;
+    #[cfg(feature = "getrandom")]
+    use elliptic_curve::{BatchNormalize, CurveGroup, Generate};
 
     #[test]
     fn affine_to_projective() {
@@ -756,8 +755,8 @@ mod tests {
     #[test]
     #[cfg(feature = "getrandom")]
     fn batch_normalize_array() {
-        let k: Scalar = Scalar::generate();
-        let l: Scalar = Scalar::generate();
+        let k = Scalar::generate();
+        let l = Scalar::generate();
         let g = ProjectivePoint::mul_by_generator(&k);
         let h = ProjectivePoint::mul_by_generator(&l);
 

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -740,7 +740,7 @@ mod tests {
         array::Array,
         bigint::{ArrayEncoding, U256, U512},
         ff::{Field, PrimeField},
-        ops::{BatchInvert, Reduce},
+        ops::Reduce,
         scalar::IsHigh,
     };
     use num_bigint::{BigUint, ToBigUint};
@@ -748,7 +748,7 @@ mod tests {
     use proptest::prelude::*;
 
     #[cfg(feature = "getrandom")]
-    use elliptic_curve::{Generate, common::getrandom::SysRng};
+    use elliptic_curve::{Generate, common::getrandom::SysRng, ops::BatchInvert};
 
     impl From<&BigUint> for Scalar {
         fn from(x: &BigUint) -> Self {


### PR DESCRIPTION
This crate now has varying strategies for scalar multiplication depending on whether or not the `alloc` and `precomputed-tables` features are available (or both).

This ensures CI runs tests against all of these possible combinations.

~~TODO: actually get CI to pass, this just edits the config~~