### PR TITLE
K256/type safe field elements

### DIFF
--- a/ed448-goldilocks/benches/bench.rs
+++ b/ed448-goldilocks/benches/bench.rs
@@ -47,7 +47,7 @@ pub fn ed448(c: &mut Criterion) {
 
     group.bench_function("compress", |b| {
         b.iter_batched(
-            || EdwardsPoint::generate(),
+            EdwardsPoint::generate,
             |point| point.to_bytes(),
             BatchSize::SmallInput,
         )
@@ -105,7 +105,7 @@ pub fn decaf448(c: &mut Criterion) {
 
     group.bench_function("encode", |b| {
         b.iter_batched(
-            || DecafPoint::generate(),
+            DecafPoint::generate,
             |point| point.to_bytes(),
             BatchSize::SmallInput,
         )

--- a/k256/benches/schnorr.rs
+++ b/k256/benches/schnorr.rs
@@ -21,7 +21,7 @@ fn bench_schnorr(c: &mut Criterion) {
     });
 
     let sk = SigningKey::generate();
-    let vk = sk.verifying_key().clone();
+    let vk = *sk.verifying_key();
     let message = b"Schnorr benchmark message for performance testing";
 
     // Signing (deterministic)

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -13,7 +13,11 @@ mod hash2curve;
 #[cfg(feature = "precomputed-tables")]
 mod tables;
 
-pub use field::{FieldElement, LazyFieldElement};
+pub use field::FieldElement;
+#[cfg(not(feature = "expose-field"))]
+pub(crate) use field::LazyFieldElement;
+#[cfg(feature = "expose-field")]
+pub use field::LazyFieldElement;
 
 use self::{affine::AffinePoint, projective::ProjectivePoint, scalar::Scalar};
 use crate::Secp256k1;

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -13,7 +13,7 @@ mod hash2curve;
 #[cfg(feature = "precomputed-tables")]
 mod tables;
 
-pub use field::FieldElement;
+pub use field::{FieldElement, LazyFieldElement};
 
 use self::{affine::AffinePoint, projective::ProjectivePoint, scalar::Scalar};
 use crate::Secp256k1;

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::op_ref)]
 
-use super::{CURVE_EQUATION_B, FieldElement, ProjectivePoint};
+use super::{CURVE_EQUATION_B, FieldElement, LazyFieldElement, ProjectivePoint};
 use crate::{CompressedPoint, FieldBytes, PublicKey, Scalar, Sec1Point, Secp256k1};
 use elliptic_curve::{
     Error, Generate, Result, ctutils,
@@ -36,10 +36,10 @@ use serdect::serde::{Deserialize, Serialize, de, ser};
 #[derive(Clone, Copy, Debug)]
 pub struct AffinePoint {
     /// x-coordinate
-    pub(crate) x: FieldElement,
+    pub(crate) x: LazyFieldElement,
 
     /// y-coordinate
-    pub(crate) y: FieldElement,
+    pub(crate) y: LazyFieldElement,
 
     /// Is this point the point at infinity? 0 = no, 1 = yes
     ///
@@ -51,8 +51,8 @@ pub struct AffinePoint {
 impl AffinePoint {
     /// Additive identity of the group: the point at infinity.
     pub const IDENTITY: Self = Self {
-        x: FieldElement::ZERO,
-        y: FieldElement::ZERO,
+        x: LazyFieldElement::ZERO,
+        y: LazyFieldElement::ZERO,
         infinity: 1,
     };
 
@@ -63,12 +63,12 @@ impl AffinePoint {
     /// Gᵧ = 483ada77 26a3c465 5da4fbfc 0e1108a8 fd17b448 a6855419 9c47d08f fb10d4b8
     /// ```
     pub const GENERATOR: Self = Self {
-        x: FieldElement::from_bytes_unchecked(&[
+        x: LazyFieldElement::from_bytes_unchecked(&[
             0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac, 0x55, 0xa0, 0x62, 0x95, 0xce, 0x87,
             0x0b, 0x07, 0x02, 0x9b, 0xfc, 0xdb, 0x2d, 0xce, 0x28, 0xd9, 0x59, 0xf2, 0x81, 0x5b,
             0x16, 0xf8, 0x17, 0x98,
         ]),
-        y: FieldElement::from_bytes_unchecked(&[
+        y: LazyFieldElement::from_bytes_unchecked(&[
             0x48, 0x3a, 0xda, 0x77, 0x26, 0xa3, 0xc4, 0x65, 0x5d, 0xa4, 0xfb, 0xfc, 0x0e, 0x11,
             0x08, 0xa8, 0xfd, 0x17, 0xb4, 0x48, 0xa6, 0x85, 0x54, 0x19, 0x9c, 0x47, 0xd0, 0x8f,
             0xfb, 0x10, 0xd4, 0xb8,
@@ -97,9 +97,28 @@ impl AffinePoint {
 }
 
 impl AffinePoint {
-    /// Create a new [`AffinePoint`] with the given coordinates.
-    pub(crate) const fn new(x: FieldElement, y: FieldElement) -> Self {
+    /// Create a new [`AffinePoint`] with the given lazy coordinates.
+    ///
+    /// The coordinates are stored as-is; callers must ensure that
+    /// `x` and `y` represent valid curve coordinates (i.e. satisfy the
+    /// secp256k1 curve equation). The `new_lazy` constructor does not
+    /// perform any normalization or validation.
+    pub(crate) const fn new(x: LazyFieldElement, y: LazyFieldElement) -> Self {
         Self { x, y, infinity: 0 }
+    }
+
+    /// Build an [`AffinePoint`] from a pair of [`FieldElement`] coordinates.
+    ///
+    /// The coordinates are stored as normalized [`LazyFieldElement`]s.
+    /// Used by `hash2curve` and other callers that compute in the public
+    /// `FieldElement` (always-normalized) type and need to hand the result
+    /// to the point-arithmetic internals.
+    pub(crate) fn from_field_elements(x: FieldElement, y: FieldElement) -> Self {
+        Self {
+            x: LazyFieldElement::from(x),
+            y: LazyFieldElement::from(y),
+            infinity: 0,
+        }
     }
 }
 
@@ -140,18 +159,18 @@ impl AffineCoordinates for AffinePoint {
                 // Check that the point is on the curve
                 let lhs = (y * &y).negate(1);
                 let rhs = x * &x * &x + &CURVE_EQUATION_B;
-                let point = Self::new(x, y);
+                let point = Self::from_field_elements(x, y);
                 CtOption::new(point, (lhs + &rhs).normalizes_to_zero())
             })
         })
     }
 
     fn x(&self) -> FieldBytes {
-        self.x.to_bytes()
+        self.x.normalize().to_bytes()
     }
 
     fn y(&self) -> FieldBytes {
-        self.y.to_bytes()
+        self.y.normalize().to_bytes()
     }
 
     fn x_is_odd(&self) -> Choice {
@@ -166,8 +185,8 @@ impl AffineCoordinates for AffinePoint {
 impl ConditionallySelectable for AffinePoint {
     fn conditional_select(a: &AffinePoint, b: &AffinePoint, choice: Choice) -> AffinePoint {
         AffinePoint {
-            x: FieldElement::conditional_select(&a.x, &b.x, choice),
-            y: FieldElement::conditional_select(&a.y, &b.y, choice),
+            x: LazyFieldElement::conditional_select(&a.x, &b.x, choice),
+            y: LazyFieldElement::conditional_select(&a.y, &b.y, choice),
             infinity: u8::conditional_select(&a.infinity, &b.infinity, choice),
         }
     }
@@ -175,8 +194,12 @@ impl ConditionallySelectable for AffinePoint {
 
 impl ConstantTimeEq for AffinePoint {
     fn ct_eq(&self, other: &AffinePoint) -> Choice {
-        (self.x.negate(1) + &other.x).normalizes_to_zero()
-            & (self.y.negate(1) + &other.y).normalizes_to_zero()
+        // Subtract lazily. Each operand may carry an arbitrary accumulated
+        // magnitude from upstream operations; the `Neg` impl tracks the
+        // magnitude internally and produces a safe result regardless.
+        let x_diff = (-self.x).add(&other.x);
+        let y_diff = (-self.y).add(&other.y);
+        x_diff.normalizes_to_zero() & y_diff.normalizes_to_zero()
             & self.infinity.ct_eq(&other.infinity)
     }
 }
@@ -251,7 +274,7 @@ impl Neg for AffinePoint {
     fn neg(self) -> Self::Output {
         AffinePoint {
             x: self.x,
-            y: self.y.negate(1).normalize_weak(),
+            y: -self.y,
             infinity: self.infinity,
         }
     }
@@ -271,7 +294,7 @@ impl DecompressPoint<Secp256k1> for AffinePoint {
                     beta.is_odd().ct_eq(&y_is_odd),
                 );
 
-                Self::new(x, y.normalize())
+                Self::from_field_elements(x, y.normalize())
             })
         })
     }
@@ -338,7 +361,11 @@ impl FromSec1Point<Secp256k1> for AffinePoint {
 impl ToSec1Point<Secp256k1> for AffinePoint {
     fn to_sec1_point(&self, compress: bool) -> Sec1Point {
         ctutils::CtSelect::ct_select(
-            &Sec1Point::from_affine_coordinates(&self.x.to_repr(), &self.y.to_repr(), compress),
+            &Sec1Point::from_affine_coordinates(
+                &FieldElement::from(self.x).to_repr(),
+                &FieldElement::from(self.y).to_repr(),
+                compress,
+            ),
             &Sec1Point::identity(),
             self.is_identity().into(),
         )

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -199,7 +199,8 @@ impl ConstantTimeEq for AffinePoint {
         // magnitude internally and produces a safe result regardless.
         let x_diff = (-self.x).add(&other.x);
         let y_diff = (-self.y).add(&other.y);
-        x_diff.normalizes_to_zero() & y_diff.normalizes_to_zero()
+        x_diff.normalizes_to_zero()
+            & y_diff.normalizes_to_zero()
             & self.infinity.ct_eq(&other.infinity)
     }
 }

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -45,7 +45,11 @@ const MODULUS_HEX: &str = "fffffffffffffffffffffffffffffffffffffffffffffffffffff
 /// the cost of normalizing after every intermediate operation.
 ///
 /// See also `LazyFieldElement` for the lazily-normalized variant used internally.
+///
+/// `#[repr(transparent)]` ensures `FieldElement` and `LazyFieldElement` share the
+/// same layout, so the wrapper layer can be collapsed by the optimizer.
 #[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
 pub struct FieldElement(LazyFieldElement);
 
 impl FieldElement {
@@ -128,7 +132,9 @@ impl FieldElement {
     /// Brings the magnitude to 1 and modulo reduces the value.
     #[inline]
     pub fn normalize(&self) -> Self {
-        Self(self.0.normalize())
+        // FieldElement is always weakly normalized by invariant, so the inner
+        // carry-propagation pass is a no-op — just do the final-subtract step.
+        Self(self.0.normalize_canonical())
     }
 
     /// Weakly normalizes the field element.
@@ -158,23 +164,33 @@ impl FieldElement {
     /// The result is normalized.
     #[inline]
     pub fn double(&self) -> Self {
+        // `add` produces magnitude=2, so we need the full normalize (with the
+        // carry-propagation pass) here, not just `normalize_canonical`.
         Self(self.0.add(&self.0).normalize())
     }
 
     /// Returns self * rhs mod p.
     ///
     /// The result is normalized.
+    ///
+    /// `LazyFieldElement::mul` already produces a weakly-normalized result
+    /// (carries propagated as part of the multiplication), so the boundary
+    /// reduction only needs the cheap final-subtract step.
     #[inline]
     pub fn mul(&self, rhs: &Self) -> Self {
-        Self(self.0.mul(&rhs.0).normalize())
+        Self(self.0.mul(&rhs.0).normalize_canonical())
     }
 
     /// Returns self * self.
     ///
     /// The result is normalized.
+    ///
+    /// `LazyFieldElement::square` already produces a weakly-normalized result
+    /// (carries propagated as part of the squaring), so the boundary
+    /// reduction only needs the cheap final-subtract step.
     #[inline]
     pub fn square(&self) -> Self {
-        Self(self.0.square().normalize())
+        Self(self.0.square().normalize_canonical())
     }
 
     /// Raises the scalar to the power `2^k`
@@ -457,7 +473,7 @@ impl Mul<FieldElement> for FieldElement {
     type Output = FieldElement;
 
     fn mul(self, other: FieldElement) -> FieldElement {
-        FieldElement(self.0.mul(&other.0).normalize())
+        FieldElement(self.0.mul(&other.0).normalize_canonical())
     }
 }
 
@@ -466,7 +482,7 @@ impl Mul<&FieldElement> for FieldElement {
 
     #[inline(always)]
     fn mul(self, other: &FieldElement) -> FieldElement {
-        FieldElement(self.0.mul(&other.0).normalize())
+        FieldElement(self.0.mul(&other.0).normalize_canonical())
     }
 }
 
@@ -474,7 +490,7 @@ impl Mul<&FieldElement> for &FieldElement {
     type Output = FieldElement;
 
     fn mul(self, other: &FieldElement) -> FieldElement {
-        FieldElement(self.0.mul(&other.0).normalize())
+        FieldElement(self.0.mul(&other.0).normalize_canonical())
     }
 }
 

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -60,6 +60,7 @@ impl FieldElement {
     /// # Returns
     ///
     /// If zero, return `Choice(1)`.  Otherwise, return `Choice(0)`.
+    #[inline]
     pub fn is_zero(&self) -> Choice {
         self.0.is_zero()
     }
@@ -69,6 +70,7 @@ impl FieldElement {
     /// # Returns
     ///
     /// If even, return `Choice(1)`.  Otherwise, return `Choice(0)`.
+    #[inline]
     pub fn is_even(&self) -> Choice {
         !self.is_odd()
     }
@@ -78,6 +80,7 @@ impl FieldElement {
     /// # Returns
     ///
     /// If odd, return `Choice(1)`.  Otherwise, return `Choice(0)`.
+    #[inline]
     pub fn is_odd(&self) -> Choice {
         self.0.is_odd()
     }
@@ -92,6 +95,7 @@ impl FieldElement {
     ///
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
+    #[inline]
     pub fn from_bytes(bytes: &FieldBytes) -> CtOption<Self> {
         LazyFieldElement::from_bytes(bytes).map(Self)
     }
@@ -102,14 +106,19 @@ impl FieldElement {
     }
 
     /// Returns the SEC1 encoding of this field element.
+    ///
+    /// `FieldElement` is always normalized by type invariant, so this is a direct
+    /// serialization of the inner value (one full reduction, no extra pass).
+    #[inline]
     pub fn to_bytes(self) -> FieldBytes {
-        self.normalize().0.to_bytes()
+        self.0.to_bytes()
     }
 
     /// Returns -self, treating it as a value of given magnitude.
     /// The provided magnitude must be equal or greater than the actual magnitude of `self`.
     ///
     /// The result is normalized.
+    #[inline]
     pub fn negate(&self, magnitude: u32) -> Self {
         Self(self.0.negate(magnitude).normalize())
     }
@@ -117,6 +126,7 @@ impl FieldElement {
     /// Fully normalizes the field element.
     ///
     /// Brings the magnitude to 1 and modulo reduces the value.
+    #[inline]
     pub fn normalize(&self) -> Self {
         Self(self.0.normalize())
     }
@@ -124,11 +134,13 @@ impl FieldElement {
     /// Weakly normalizes the field element.
     ///
     /// Brings the magnitude to 1, but does not guarantee the value to be less than the modulus.
+    #[inline]
     pub fn normalize_weak(&self) -> Self {
         Self(self.0.normalize_weak())
     }
 
     /// Checks if the field element becomes zero if normalized.
+    #[inline]
     pub fn normalizes_to_zero(&self) -> Choice {
         self.0.normalizes_to_zero()
     }
@@ -136,6 +148,7 @@ impl FieldElement {
     /// Multiplies by a single-limb integer.
     ///
     /// The result is normalized.
+    #[inline]
     pub fn mul_single(&self, rhs: u32) -> Self {
         Self(self.0.mul_single(rhs).normalize())
     }
@@ -143,6 +156,7 @@ impl FieldElement {
     /// Returns 2*self.
     ///
     /// The result is normalized.
+    #[inline]
     pub fn double(&self) -> Self {
         Self(self.0.add(&self.0).normalize())
     }
@@ -150,6 +164,7 @@ impl FieldElement {
     /// Returns self * rhs mod p.
     ///
     /// The result is normalized.
+    #[inline]
     pub fn mul(&self, rhs: &Self) -> Self {
         Self(self.0.mul(&rhs.0).normalize())
     }
@@ -157,6 +172,7 @@ impl FieldElement {
     /// Returns self * self.
     ///
     /// The result is normalized.
+    #[inline]
     pub fn square(&self) -> Self {
         Self(self.0.square().normalize())
     }

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -659,8 +659,8 @@ mod tests {
         assert_eq!(
             FieldElement::from_bytes(
                 &[
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 1
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 1
                 ]
                 .into()
             )
@@ -678,8 +678,8 @@ mod tests {
         assert_eq!(
             FieldElement::ONE.to_bytes(),
             [
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 1
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1
             ]
         );
     }
@@ -797,8 +797,10 @@ mod tests {
         let expected = [k.invert().unwrap(), l.invert().unwrap()];
         let actual = <FieldElement as BatchInvert<_>>::batch_invert([k, l]).unwrap();
 
-        assert_eq!(expected[0], actual[0].normalize());
-        assert_eq!(expected[1], actual[1].normalize());
+        // No .normalize() — trust the FieldElement type invariant that
+        // BatchInvert always returns canonical elements.
+        assert_eq!(expected[0], actual[0]);
+        assert_eq!(expected[1], actual[1]);
     }
 
     #[test]
@@ -811,8 +813,9 @@ mod tests {
         let field_elements = [k, l];
         let actual = <FieldElement as BatchInvert<_>>::batch_invert(field_elements).unwrap();
 
-        assert_eq!(expected[0], actual[0].normalize());
-        assert_eq!(expected[1], actual[1].normalize());
+        // No .normalize() — trust the FieldElement type invariant.
+        assert_eq!(expected[0], actual[0]);
+        assert_eq!(expected[1], actual[1]);
     }
 
     #[test]

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -4,6 +4,11 @@
 
 mod lazy;
 
+// `LazyFieldElement` is always available internally.
+// It is only re-exported publicly when `expose-field` is enabled.
+#[cfg(not(feature = "expose-field"))]
+pub(crate) use lazy::LazyFieldElement;
+#[cfg(feature = "expose-field")]
 pub use lazy::LazyFieldElement;
 
 use cpubits::cpubits;

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -108,8 +108,10 @@ impl FieldElement {
 
     /// Returns -self, treating it as a value of given magnitude.
     /// The provided magnitude must be equal or greater than the actual magnitude of `self`.
+    ///
+    /// The result is normalized.
     pub fn negate(&self, magnitude: u32) -> Self {
-        Self(self.0.negate(magnitude))
+        Self(self.0.negate(magnitude).normalize())
     }
 
     /// Fully normalizes the field element.
@@ -132,25 +134,31 @@ impl FieldElement {
     }
 
     /// Multiplies by a single-limb integer.
-    /// Multiplies the magnitude by the same value.
+    ///
+    /// The result is normalized.
     pub fn mul_single(&self, rhs: u32) -> Self {
-        Self(self.0.mul_single(rhs))
+        Self(self.0.mul_single(rhs).normalize())
     }
 
     /// Returns 2*self.
-    /// Doubles the magnitude.
+    ///
+    /// The result is normalized.
     pub fn double(&self) -> Self {
-        *self + *self
+        Self(self.0.add(&self.0).normalize())
     }
 
     /// Returns self * rhs mod p.
+    ///
+    /// The result is normalized.
     pub fn mul(&self, rhs: &Self) -> Self {
-        Self(self.0.mul(&rhs.0))
+        Self(self.0.mul(&rhs.0).normalize())
     }
 
     /// Returns self * self.
+    ///
+    /// The result is normalized.
     pub fn square(&self) -> Self {
-        Self(self.0.square())
+        Self(self.0.square().normalize())
     }
 
     /// Raises the scalar to the power `2^k`
@@ -369,7 +377,7 @@ impl Add<FieldElement> for FieldElement {
     type Output = FieldElement;
 
     fn add(self, other: FieldElement) -> FieldElement {
-        FieldElement(self.0.add(&other.0))
+        FieldElement(self.0.add(&other.0).normalize())
     }
 }
 
@@ -377,7 +385,7 @@ impl Add<&FieldElement> for FieldElement {
     type Output = FieldElement;
 
     fn add(self, other: &FieldElement) -> FieldElement {
-        FieldElement(self.0.add(&other.0))
+        FieldElement(self.0.add(&other.0).normalize())
     }
 }
 
@@ -385,7 +393,7 @@ impl Add<&FieldElement> for &FieldElement {
     type Output = FieldElement;
 
     fn add(self, other: &FieldElement) -> FieldElement {
-        FieldElement(self.0.add(&other.0))
+        FieldElement(self.0.add(&other.0).normalize())
     }
 }
 
@@ -405,7 +413,7 @@ impl Sub<FieldElement> for FieldElement {
     type Output = FieldElement;
 
     fn sub(self, other: FieldElement) -> FieldElement {
-        self + -other
+        FieldElement(self.0.add(&other.0.negate(1)).normalize())
     }
 }
 
@@ -413,7 +421,7 @@ impl Sub<&FieldElement> for FieldElement {
     type Output = FieldElement;
 
     fn sub(self, other: &FieldElement) -> FieldElement {
-        self + -other
+        FieldElement(self.0.add(&other.0.negate(1)).normalize())
     }
 }
 
@@ -433,7 +441,7 @@ impl Mul<FieldElement> for FieldElement {
     type Output = FieldElement;
 
     fn mul(self, other: FieldElement) -> FieldElement {
-        FieldElement(self.0.mul(&other.0))
+        FieldElement(self.0.mul(&other.0).normalize())
     }
 }
 
@@ -442,7 +450,7 @@ impl Mul<&FieldElement> for FieldElement {
 
     #[inline(always)]
     fn mul(self, other: &FieldElement) -> FieldElement {
-        FieldElement(self.0.mul(&other.0))
+        FieldElement(self.0.mul(&other.0).normalize())
     }
 }
 
@@ -450,7 +458,7 @@ impl Mul<&FieldElement> for &FieldElement {
     type Output = FieldElement;
 
     fn mul(self, other: &FieldElement) -> FieldElement {
-        FieldElement(self.0.mul(&other.0))
+        FieldElement(self.0.mul(&other.0).normalize())
     }
 }
 
@@ -644,6 +652,50 @@ mod tests {
         );
     }
 
+    /// Regression test: every arithmetic operation on the public `FieldElement`
+    /// (the one that implements `ff::Field` / `ff::PrimeField`) must yield a value
+    /// that is in the canonical range `[0, p)`, so callers can use `is_odd`,
+    /// `to_bytes`, etc. on the result without an explicit `.normalize()`.
+    /// See the discussion on the branch `k256/type-safe-field-elements` for the
+    /// motivation (a previous lack of normalization broke #1522's use of
+    /// `BatchInvert` and other generic `ff`-based algorithms).
+    #[test]
+    fn arithmetic_ops_return_normalized() {
+        // Two arbitrary non-trivial field elements.
+        let a = FieldElement::from_u64(0xdeadbeef);
+        let b = FieldElement::from_u64(0x12345678);
+
+        // Sanity: `is_odd` / `to_bytes` work on freshly-constructed values.
+        assert!(bool::from(a.is_odd()));
+        assert_eq!(a.to_bytes()[28..], [0xde, 0xad, 0xbe, 0xef]);
+
+        // Core `core::ops` impls.
+        let sum = &a + &b;
+        assert_eq!(sum, (a.normalize() + b.normalize()).normalize());
+        let sum = a + &b;
+        assert_eq!(sum, (a.normalize() + b.normalize()).normalize());
+        let diff = a - &b;
+        assert_eq!(diff, (a.normalize() - b.normalize()).normalize());
+        let neg = -&a;
+        assert_eq!(neg, (-a.normalize()).normalize());
+        let prod = &a * &b;
+        assert_eq!(prod, (a.normalize() * b.normalize()).normalize());
+        let sq = a.square();
+        assert_eq!(sq, a.normalize().square());
+        let dbl = a.double();
+        assert_eq!(dbl, a.normalize().double());
+
+        // `ff::Field` API.
+        assert_eq!(<FieldElement as Field>::double(&a), a.double());
+        assert_eq!(<FieldElement as Field>::square(&a), a.square());
+
+        // Inherent methods that take an explicit magnitude.
+        let m3 = a.negate(2); // a + (-a) == 0
+        assert!(bool::from((a + &m3).is_zero()));
+        let m1 = b.mul_single(3);
+        assert_eq!(m1, b.normalize() * FieldElement::from_u64(3));
+    }
+
     #[test]
     fn repeated_add() {
         let mut r = FieldElement::ONE;
@@ -723,8 +775,8 @@ mod tests {
         let k: FieldElement = FieldElement::generate();
         let l: FieldElement = FieldElement::generate();
 
-        let expected = vec![k.invert().unwrap(), l.invert().unwrap()];
-        let field_elements = vec![k, l];
+        let expected = [k.invert().unwrap(), l.invert().unwrap()];
+        let field_elements = [k, l];
         let actual = <FieldElement as BatchInvert<_>>::batch_invert(field_elements).unwrap();
 
         assert_eq!(expected[0], actual[0].normalize());

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -2,23 +2,15 @@
 
 #![allow(clippy::assign_op_pattern, clippy::op_ref)]
 
-use cpubits::{cfg_if, cpubits};
+mod lazy;
+
+pub use lazy::LazyFieldElement;
+
+use cpubits::cpubits;
 
 cpubits! {
     32 => { mod field_10x26; }
     64 => { mod field_5x52; }
-}
-
-cfg_if! {
-    if #[cfg(debug_assertions)] {
-        mod field_impl;
-        use field_impl::FieldElementImpl;
-    } else {
-        cpubits! {
-            32 => { use field_10x26::FieldElement10x26 as FieldElementImpl; }
-            64 => { use field_5x52::FieldElement5x52 as FieldElementImpl; }
-        }
-    }
 }
 
 use crate::FieldBytes;
@@ -42,15 +34,26 @@ use num_bigint::{BigUint, ToBigUint};
 const MODULUS_HEX: &str = "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f";
 
 /// An element in the finite field used for curve coordinates.
+///
+/// `FieldElement` is always normalized — the represented value is guaranteed to be
+/// in the range `[0, p)`. Arithmetic operations on `FieldElement` delegate to
+/// `LazyFieldElement` internally and normalize the result, so `is_odd()`, `to_bytes()`,
+/// `retrieve()`, and all other operations that require a canonical representative
+/// are safe without explicit normalization.
+///
+/// For internal point arithmetic, `LazyFieldElement` is used directly to avoid
+/// the cost of normalizing after every intermediate operation.
+///
+/// See also `LazyFieldElement` for the lazily-normalized variant used internally.
 #[derive(Clone, Copy, Debug)]
-pub struct FieldElement(FieldElementImpl);
+pub struct FieldElement(LazyFieldElement);
 
 impl FieldElement {
     /// Zero element.
-    pub const ZERO: Self = Self(FieldElementImpl::ZERO);
+    pub const ZERO: Self = Self(LazyFieldElement::ZERO);
 
     /// Multiplicative identity.
-    pub const ONE: Self = Self(FieldElementImpl::ONE);
+    pub const ONE: Self = Self(LazyFieldElement::ONE);
 
     /// Determine if this `FieldElement` is zero.
     ///
@@ -67,7 +70,7 @@ impl FieldElement {
     ///
     /// If even, return `Choice(1)`.  Otherwise, return `Choice(0)`.
     pub fn is_even(&self) -> Choice {
-        !self.0.is_odd()
+        !self.is_odd()
     }
 
     /// Determine if this `FieldElement` is odd in the SEC1 sense: `self mod 2 == 1`.
@@ -82,7 +85,7 @@ impl FieldElement {
     /// Attempts to parse the given byte array as an SEC1-encoded field element.
     /// Does not check the result for being in the correct range.
     pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
-        Self(FieldElementImpl::from_bytes_unchecked(bytes))
+        Self(LazyFieldElement::from_bytes_unchecked(bytes))
     }
 
     /// Attempts to parse the given byte array as an SEC1-encoded field element.
@@ -90,17 +93,17 @@ impl FieldElement {
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
     pub fn from_bytes(bytes: &FieldBytes) -> CtOption<Self> {
-        FieldElementImpl::from_bytes(bytes).map(Self)
+        LazyFieldElement::from_bytes(bytes).map(Self)
     }
 
     /// Convert a `u64` to a field element.
     pub const fn from_u64(w: u64) -> Self {
-        Self(FieldElementImpl::from_u64(w))
+        Self(LazyFieldElement::from_u64(w))
     }
 
     /// Returns the SEC1 encoding of this field element.
     pub fn to_bytes(self) -> FieldBytes {
-        self.0.normalize().to_bytes()
+        self.normalize().0.to_bytes()
     }
 
     /// Returns -self, treating it as a value of given magnitude.
@@ -110,12 +113,14 @@ impl FieldElement {
     }
 
     /// Fully normalizes the field element.
+    ///
     /// Brings the magnitude to 1 and modulo reduces the value.
     pub fn normalize(&self) -> Self {
         Self(self.0.normalize())
     }
 
     /// Weakly normalizes the field element.
+    ///
     /// Brings the magnitude to 1, but does not guarantee the value to be less than the modulus.
     pub fn normalize_weak(&self) -> Self {
         Self(self.0.normalize_weak())
@@ -135,20 +140,15 @@ impl FieldElement {
     /// Returns 2*self.
     /// Doubles the magnitude.
     pub fn double(&self) -> Self {
-        Self(self.0.add(&(self.0)))
+        *self + *self
     }
 
-    /// Returns self * rhs mod p
-    /// Brings the magnitude to 1 (but doesn't normalize the result).
-    /// The magnitudes of arguments should be <= 8.
+    /// Returns self * rhs mod p.
     pub fn mul(&self, rhs: &Self) -> Self {
-        Self(self.0.mul(&(rhs.0)))
+        Self(self.0.mul(&rhs.0))
     }
 
     /// Returns self * self.
-    ///
-    /// Brings the magnitude to 1 (but doesn't normalize the result).
-    /// The magnitudes of arguments should be <= 8.
     pub fn square(&self) -> Self {
         Self(self.0.square())
     }
@@ -164,28 +164,27 @@ impl FieldElement {
 
     /// Returns the multiplicative inverse of self, if self is non-zero.
     ///
-    /// The result has magnitude 1 and is normalized.
+    /// The result is normalized.
     pub fn invert(&self) -> CtOption<Self> {
         let inv = self
             .retrieve()
             .invert_odd_mod(const { &Odd::from_be_hex(MODULUS_HEX) });
 
-        CtOption::from(inv).map(|uint| Self(FieldElementImpl::from_u256_unchecked(uint)))
+        CtOption::from(inv).map(|uint| Self(LazyFieldElement::from_u256_unchecked(uint)))
     }
 
     /// Returns the multiplicative inverse of self in variable-time, if self is non-zero.
     ///
-    /// The result has magnitude 1 and is normalized.
+    /// The result is normalized.
     pub fn invert_vartime(&self) -> CtOption<Self> {
         let inv = self
             .retrieve()
             .invert_odd_mod_vartime(const { &Odd::from_be_hex(MODULUS_HEX) });
 
-        CtOption::from(inv).map(|uint| Self(FieldElementImpl::from_u256_unchecked(uint)))
+        CtOption::from(inv).map(|uint| Self(LazyFieldElement::from_u256_unchecked(uint)))
     }
 
     /// Returns the square root of self mod p, or `None` if no square root exists.
-    /// The result has magnitude 1, but is not normalized.
     pub fn sqrt(&self) -> CtOption<Self> {
         /*
         Given that p is congruent to 3 mod 4, we can compute the square root of
@@ -291,19 +290,19 @@ impl PrimeField for FieldElement {
         "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f";
     const NUM_BITS: u32 = 256;
     const CAPACITY: u32 = 255;
-    const TWO_INV: Self = Self(FieldElementImpl::from_bytes_unchecked(&[
+    const TWO_INV: Self = Self(LazyFieldElement::from_bytes_unchecked(&[
         0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f, 0xff,
         0xfe, 0x18,
     ]));
     const MULTIPLICATIVE_GENERATOR: Self = Self::from_u64(3);
     const S: u32 = 1;
-    const ROOT_OF_UNITY: Self = Self(FieldElementImpl::from_bytes_unchecked(&[
+    const ROOT_OF_UNITY: Self = Self(LazyFieldElement::from_bytes_unchecked(&[
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0xff,
         0xfc, 0x2e,
     ]));
-    const ROOT_OF_UNITY_INV: Self = Self(FieldElementImpl::from_bytes_unchecked(&[
+    const ROOT_OF_UNITY_INV: Self = Self(LazyFieldElement::from_bytes_unchecked(&[
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0xff,
         0xfc, 0x2e,
@@ -334,13 +333,13 @@ impl Retrieve for FieldElement {
 impl ConditionallySelectable for FieldElement {
     #[inline(always)]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        Self(FieldElementImpl::conditional_select(&(a.0), &(b.0), choice))
+        Self(LazyFieldElement::conditional_select(&a.0, &b.0, choice))
     }
 }
 
 impl ConstantTimeEq for FieldElement {
     fn ct_eq(&self, other: &Self) -> Choice {
-        self.0.ct_eq(&(other.0))
+        LazyFieldElement::ct_eq(&self.0, &other.0)
     }
 }
 
@@ -356,13 +355,13 @@ impl Eq for FieldElement {}
 
 impl From<u64> for FieldElement {
     fn from(k: u64) -> Self {
-        Self(FieldElementImpl::from_u64(k))
+        Self(LazyFieldElement::from_u64(k))
     }
 }
 
 impl PartialEq for FieldElement {
     fn eq(&self, other: &Self) -> bool {
-        self.0.ct_eq(&(other.0)).into()
+        bool::from(Self::ct_eq(self, other))
     }
 }
 
@@ -370,7 +369,7 @@ impl Add<FieldElement> for FieldElement {
     type Output = FieldElement;
 
     fn add(self, other: FieldElement) -> FieldElement {
-        FieldElement(self.0.add(&(other.0)))
+        FieldElement(self.0.add(&other.0))
     }
 }
 
@@ -378,7 +377,7 @@ impl Add<&FieldElement> for FieldElement {
     type Output = FieldElement;
 
     fn add(self, other: &FieldElement) -> FieldElement {
-        FieldElement(self.0.add(&(other.0)))
+        FieldElement(self.0.add(&other.0))
     }
 }
 
@@ -386,7 +385,7 @@ impl Add<&FieldElement> for &FieldElement {
     type Output = FieldElement;
 
     fn add(self, other: &FieldElement) -> FieldElement {
-        FieldElement(self.0.add(&(other.0)))
+        FieldElement(self.0.add(&other.0))
     }
 }
 
@@ -434,7 +433,7 @@ impl Mul<FieldElement> for FieldElement {
     type Output = FieldElement;
 
     fn mul(self, other: FieldElement) -> FieldElement {
-        FieldElement(self.0.mul(&(other.0)))
+        FieldElement(self.0.mul(&other.0))
     }
 }
 
@@ -443,7 +442,7 @@ impl Mul<&FieldElement> for FieldElement {
 
     #[inline(always)]
     fn mul(self, other: &FieldElement) -> FieldElement {
-        FieldElement(self.0.mul(&(other.0)))
+        FieldElement(self.0.mul(&other.0))
     }
 }
 
@@ -451,7 +450,7 @@ impl Mul<&FieldElement> for &FieldElement {
     type Output = FieldElement;
 
     fn mul(self, other: &FieldElement) -> FieldElement {
-        FieldElement(self.0.mul(&(other.0)))
+        FieldElement(self.0.mul(&other.0))
     }
 }
 
@@ -508,6 +507,18 @@ impl<'a> Product<&'a FieldElement> for FieldElement {
     }
 }
 
+impl From<LazyFieldElement> for FieldElement {
+    fn from(lazy: LazyFieldElement) -> Self {
+        Self(lazy.normalize())
+    }
+}
+
+impl From<FieldElement> for LazyFieldElement {
+    fn from(fe: FieldElement) -> Self {
+        fe.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::FieldElement;
@@ -554,7 +565,6 @@ mod tests {
 
     #[test]
     fn root_of_unity_constant() {
-        // ROOT_OF_UNITY^{2^s} mod m == 1
         assert_eq!(
             FieldElement::ROOT_OF_UNITY
                 .pow_vartime([1u64 << FieldElement::S, 0, 0, 0])
@@ -562,7 +572,6 @@ mod tests {
             FieldElement::ONE
         );
 
-        // MULTIPLICATIVE_GENERATOR^{t} mod m == ROOT_OF_UNITY
         assert_eq!(
             FieldElement::MULTIPLICATIVE_GENERATOR
                 .pow_vartime(T)
@@ -581,7 +590,6 @@ mod tests {
 
     #[test]
     fn delta_constant() {
-        // DELTA^{t} mod m == 1
         assert_eq!(
             FieldElement::DELTA.pow_vartime(T).normalize(),
             FieldElement::ONE
@@ -611,8 +619,8 @@ mod tests {
         assert_eq!(
             FieldElement::from_bytes(
                 &[
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 1
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 1
                 ]
                 .into()
             )
@@ -630,8 +638,8 @@ mod tests {
         assert_eq!(
             FieldElement::ONE.to_bytes(),
             [
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 1
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 1
             ]
         );
     }
@@ -686,7 +694,7 @@ mod tests {
 
     #[test]
     fn invert_vartime() {
-        assert!(bool::from(FieldElement::ZERO.invert().is_none()));
+        assert!(bool::from(FieldElement::ZERO.invert_vartime().is_none()));
 
         let one = FieldElement::ONE;
         assert_eq!(one.invert_vartime().unwrap().normalize(), one);
@@ -716,7 +724,7 @@ mod tests {
         let l: FieldElement = FieldElement::generate();
 
         let expected = vec![k.invert().unwrap(), l.invert().unwrap()];
-        let field_elements = vec![k, l]; // to test impl of `BatchInvert` for `Vec`
+        let field_elements = vec![k, l];
         let actual = <FieldElement as BatchInvert<_>>::batch_invert(field_elements).unwrap();
 
         assert_eq!(expected[0], actual[0].normalize());
@@ -731,39 +739,10 @@ mod tests {
         assert_eq!(four.sqrt().unwrap().normalize(), two.normalize());
     }
 
-    #[test]
-    #[cfg_attr(
-        debug_assertions,
-        should_panic(expected = "assertion failed: self.normalized")
-    )]
-    fn unnormalized_is_odd() {
-        // This is a regression test for https://github.com/RustCrypto/elliptic-curves/issues/529
-        // where `is_odd()` in debug mode force-normalized its argument
-        // instead of checking that it is already normalized.
-        // As a result, in release (where normalization didn't happen) `is_odd()`
-        // could return an incorrect value.
-
-        let x = FieldElement::from_bytes_unchecked(&[
-            61, 128, 156, 189, 241, 12, 174, 4, 80, 52, 238, 78, 188, 251, 9, 188, 95, 115, 38, 6,
-            212, 168, 175, 174, 211, 232, 208, 14, 182, 45, 59, 122,
-        ]);
-        // Produces an unnormalized FieldElement with magnitude 1
-        // (we cannot create one directly).
-        let y = x.sqrt().unwrap();
-
-        // This is fine.
-        assert!(y.normalize().is_odd().unwrap_u8() == 0);
-
-        // This panics since `y` is not normalized.
-        let _result = y.is_odd();
-    }
-
     prop_compose! {
         fn field_element()(bytes in any::<[u8; 32]>()) -> FieldElement {
             let mut res = bytes_to_biguint(&bytes);
             let m = FieldElement::modulus_as_biguint();
-            // Modulus is 256 bit long, same as the maximum `res`,
-            // so this is guaranteed to land us in the correct range.
             if res >= m {
                 res -= m;
             }
@@ -772,7 +751,6 @@ mod tests {
     }
 
     proptest! {
-
         #[test]
         fn fuzzy_add(
             a in field_element(),
@@ -835,7 +813,6 @@ mod tests {
             let possible_sqrt = (&m - &a_bi) % &m;
             let res_ref2 = FieldElement::from(&possible_sqrt);
             let res_test = sqr.sqrt().unwrap().normalize();
-            // FIXME: is there a rule which square root is returned?
             assert!(res_test == res_ref1 || res_test == res_ref2);
         }
 

--- a/k256/src/arithmetic/field/field_10x26.rs
+++ b/k256/src/arithmetic/field/field_10x26.rs
@@ -186,6 +186,28 @@ impl FieldElement10x26 {
         Self::conditional_select(&res, &res_corrected, overflow)
     }
 
+    /// Final reduction step. Input MUST already be weakly normalized
+    /// (magnitude 1, value < 2^256) — i.e. carries have already been propagated
+    /// through the limbs. This is the case after `Inner::mul` / `Inner::square`,
+    /// which do their own carry propagation as part of the operation.
+    ///
+    /// Performs only the conditional subtract of `p` needed to bring the value
+    /// into `[0, p)` — skipping the `normalize_weak` pass that `normalize()`
+    /// would otherwise repeat.
+    #[inline]
+    pub fn normalize_canonical(&self) -> Self {
+        // Input is already weakly normalized, so skip `normalize_weak`.
+        let overflow = self.get_overflow();
+        let corrected = self.add_modulus_correction(1u32);
+        let (corrected, x) = corrected.subtract_modulus_approximation();
+
+        // If the last limb didn't carry to bit 23 already,
+        // then it should have after the final reduction.
+        debug_assert!(x == (overflow.unwrap_u8() as u32));
+
+        Self::conditional_select(self, &corrected, overflow)
+    }
+
     /// Checks if the field element becomes zero if normalized.
     pub fn normalizes_to_zero(&self) -> Choice {
         let res = self.normalize_weak();

--- a/k256/src/arithmetic/field/field_10x26.rs
+++ b/k256/src/arithmetic/field/field_10x26.rs
@@ -247,12 +247,6 @@ impl FieldElement10x26 {
         (self.0[0] as u8 & 1).into()
     }
 
-    // The maximum number `m` for which `0x3FFFFFF * 2 * (m + 1) < 2^32`
-    #[cfg(debug_assertions)]
-    pub const fn max_magnitude() -> u32 {
-        31u32
-    }
-
     /// Returns -self, treating it as a value of given magnitude.
     /// The provided magnitude must be equal or greater than the actual magnitude of `self`.
     pub const fn negate(&self, magnitude: u32) -> Self {

--- a/k256/src/arithmetic/field/field_5x52.rs
+++ b/k256/src/arithmetic/field/field_5x52.rs
@@ -154,6 +154,28 @@ impl FieldElement5x52 {
         Self::conditional_select(&res, &res_corrected, overflow)
     }
 
+    /// Final reduction step. Input MUST already be weakly normalized
+    /// (magnitude 1, value < 2^256) — i.e. carries have already been propagated
+    /// through the limbs. This is the case after `Inner::mul` / `Inner::square`,
+    /// which do their own carry propagation as part of the operation.
+    ///
+    /// Performs only the conditional subtract of `p` needed to bring the value
+    /// into `[0, p)` — skipping the `normalize_weak` pass that `normalize()`
+    /// would otherwise repeat.
+    #[inline]
+    pub fn normalize_canonical(&self) -> Self {
+        // Input is already weakly normalized, so skip `normalize_weak`.
+        let overflow = self.get_overflow();
+        let corrected = self.add_modulus_correction(1u64);
+        let (corrected, x) = corrected.subtract_modulus_approximation();
+
+        // If the last limb didn't carry to bit 48 already,
+        // then it should have after the final reduction.
+        debug_assert!(x == (overflow.unwrap_u8() as u64));
+
+        Self::conditional_select(self, &corrected, overflow)
+    }
+
     /// Checks if the field element becomes zero if normalized.
     pub fn normalizes_to_zero(&self) -> Choice {
         let res = self.normalize_weak();

--- a/k256/src/arithmetic/field/field_5x52.rs
+++ b/k256/src/arithmetic/field/field_5x52.rs
@@ -189,12 +189,6 @@ impl FieldElement5x52 {
         (self.0[0] as u8 & 1).into()
     }
 
-    /// The maximum number `m` for which `0xFFFFFFFFFFFFF * 2 * (m + 1) < 2^64`
-    #[cfg(debug_assertions)]
-    pub const fn max_magnitude() -> u32 {
-        2047u32
-    }
-
     /// Returns -self, treating it as a value of given magnitude.
     /// The provided magnitude must be equal or greater than the actual magnitude of `self`.
     /// Raises the magnitude by 1.

--- a/k256/src/arithmetic/field/lazy.rs
+++ b/k256/src/arithmetic/field/lazy.rs
@@ -11,10 +11,9 @@
 //! every operation, which is critical for performance in inner loops like point
 //! addition and scalar multiplication.
 //!
-//! Call `.normalize()` (or `.normalize_weak()`) to produce a fully reduced
-//! `FieldElement`, or use `From<LazyFieldElement> for FieldElement` to convert
-//! automatically. The `ff::Field` trait impl on `FieldElement` performs this
-//! conversion automatically, so generic code using the trait is unaffected.
+//! Call `.normalize()` to obtain a `FieldElement` with the full modular reduction
+//! applied. The `ff::Field` trait impl on `FieldElement` performs this conversion
+//! automatically, so generic code using the trait is unaffected.
 
 use crate::FieldBytes;
 use elliptic_curve::{
@@ -24,8 +23,8 @@ use elliptic_curve::{
 };
 
 cpubits::cpubits! {
-    32 => { use super::field_10x26::FieldElement10x26 as FieldElementUnsafeImpl; }
-    64 => { use super::field_5x52::FieldElement5x52 as FieldElementUnsafeImpl; }
+    32 => { pub(crate) use super::field_10x26::FieldElement10x26 as Inner; }
+    64 => { pub(crate) use super::field_5x52::FieldElement5x52 as Inner; }
 }
 
 /// Maximum magnitude for lazy field elements.
@@ -45,7 +44,7 @@ pub const MAX_MAGNITUDE: u32 = 2047;
 #[derive(Clone, Copy, Debug)]
 pub struct LazyFieldElement {
     /// Raw field element value (weakly reduced, but not guaranteed < p).
-    value: FieldElementUnsafeImpl,
+    value: Inner,
     /// Number of uncancelled additions this element has accumulated.
     /// Used to bound intermediate values and prevent overflow.
     magnitude: u32,
@@ -54,13 +53,13 @@ pub struct LazyFieldElement {
 impl LazyFieldElement {
     /// Zero element.
     pub const ZERO: Self = Self {
-        value: FieldElementUnsafeImpl::ZERO,
+        value: Inner::ZERO,
         magnitude: 1,
     };
 
     /// Multiplicative identity.
     pub const ONE: Self = Self {
-        value: FieldElementUnsafeImpl::ONE,
+        value: Inner::ONE,
         magnitude: 1,
     };
 
@@ -73,11 +72,7 @@ impl LazyFieldElement {
     }
 
     /// Construct a new lazy field element from a raw value with the given magnitude.
-    ///
-    /// # Panics
-    ///
-    /// Panics in debug builds if `magnitude > MAX_MAGNITUDE`.
-    fn new(value: &FieldElementUnsafeImpl, magnitude: u32) -> Self {
+    fn new(value: &Inner, magnitude: u32) -> Self {
         debug_assert!(magnitude <= MAX_MAGNITUDE);
         Self {
             value: *value,
@@ -85,10 +80,10 @@ impl LazyFieldElement {
         }
     }
 
-    /// Construct a normalized lazy field element.
+    /// Construct a lazy field element from an already-normalized `Inner` value.
     ///
-    /// The magnitude is set to 1 and `normalized` to `true`.
-    const fn new_normalized(value: &FieldElementUnsafeImpl) -> Self {
+    /// The value is assumed to be in range `[0, p)` with magnitude 1.
+    fn new_normalized(value: &Inner) -> Self {
         Self {
             value: *value,
             magnitude: 1,
@@ -97,34 +92,39 @@ impl LazyFieldElement {
 
     /// Construct a weakly-normalized lazy field element.
     ///
-    /// The magnitude is set to 1 but `normalized` is set to `false`, reflecting
-    /// that the value has had carries propagated but has not been reduced mod p.
-    fn new_weak_normalized(value: &FieldElementUnsafeImpl) -> Self {
+    /// The magnitude is set to 1 but the value may still be >= p.
+    fn new_weak_normalized(value: &Inner) -> Self {
         Self {
-            value: *value.normalize_weak(),
+            value: value.normalize_weak(),
             magnitude: 1,
         }
     }
 
     /// Parse a field element from bytes without validating the range.
     ///
-    /// The resulting element is normalized (fully reduced mod p).
+    /// The resulting element is normalized.
     pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
-        Self::new_normalized(&FieldElementUnsafeImpl::from_bytes_unchecked(bytes))
+        Self {
+            value: Inner::from_bytes_unchecked(bytes),
+            magnitude: 1,
+        }
     }
 
     /// Parse a field element from a `u64`.
     ///
     /// The resulting element is normalized.
     pub const fn from_u64(val: u64) -> Self {
-        Self::new_normalized(&FieldElementUnsafeImpl::from_u64(val))
+        Self {
+            value: Inner::from_u64(val),
+            magnitude: 1,
+        }
     }
 
     /// Parse a field element from bytes, validating that the value is in range.
     ///
     /// The resulting element is normalized.
     pub fn from_bytes(bytes: &FieldBytes) -> CtOption<Self> {
-        FieldElementUnsafeImpl::from_bytes(bytes).map(|x| Self::new_normalized(&x))
+        Inner::from_bytes(bytes).map(|x| Self::new_normalized(&x))
     }
 
     /// Construct a normalized element from a raw `U256` without range checking.
@@ -132,7 +132,7 @@ impl LazyFieldElement {
     /// The resulting element is normalized.
     pub(crate) const fn from_u256_unchecked(value: U256) -> Self {
         Self {
-            value: FieldElementUnsafeImpl::from_u256_unchecked(value),
+            value: Inner::from_u256_unchecked(value),
             magnitude: 1,
         }
     }
@@ -141,8 +141,14 @@ impl LazyFieldElement {
     ///
     /// This performs the expensive final modular reduction. Prefer to work with
     /// `LazyFieldElement` inside arithmetic loops and only normalize at the boundary.
-    pub fn normalize(&self) -> FieldElement {
-        FieldElement::from(Self::new_normalized(&self.value.normalize()))
+    ///
+    /// Returns a normalized `LazyFieldElement` (magnitude = 1, value < p).
+    /// Use `From<LazyFieldElement> for FieldElement` to convert to `FieldElement`.
+    pub fn normalize(&self) -> Self {
+        Self {
+            value: self.value.normalize(),
+            magnitude: 1,
+        }
     }
 
     /// Weakly normalize the element: propagate carries but do not reduce mod p.
@@ -151,7 +157,7 @@ impl LazyFieldElement {
     /// but should only be used when the caller is about to perform another
     /// arithmetic operation that will consume the excess.
     pub fn normalize_weak(&self) -> Self {
-        Self::new_weak_normalized(&self.value.normalize_weak())
+        Self::new_weak_normalized(&self.value)
     }
 
     /// Check whether this element would become zero if fully normalized.
@@ -163,8 +169,7 @@ impl LazyFieldElement {
 
     /// Determine if this element is zero.
     ///
-    /// The element **must** be normalized before calling this. In debug builds,
-    /// this is checked with a debug assertion.
+    /// The element **must** be normalized before calling this.
     pub fn is_zero(&self) -> Choice {
         debug_assert!(self.magnitude == 1, "is_zero requires normalized element");
         self.value.is_zero()
@@ -179,7 +184,7 @@ impl LazyFieldElement {
     pub fn is_odd(&self) -> Choice {
         debug_assert!(
             self.magnitude == 1,
-            "is_odd requires normalized element"
+            "is_odd requires normalized element",
         );
         self.value.is_odd()
     }
@@ -190,7 +195,7 @@ impl LazyFieldElement {
     pub fn add(&self, rhs: &Self) -> Self {
         let new_magnitude = self.magnitude + rhs.magnitude;
         debug_assert!(new_magnitude <= MAX_MAGNITUDE);
-        Self::new(&(self.value.add(&rhs.value)), new_magnitude)
+        Self::new(&self.value.add(&rhs.value), new_magnitude)
     }
 
     /// Multiplies by a single-limb integer.
@@ -199,7 +204,7 @@ impl LazyFieldElement {
     pub fn mul_single(&self, rhs: u32) -> Self {
         let new_magnitude = self.magnitude * rhs;
         debug_assert!(new_magnitude <= MAX_MAGNITUDE);
-        Self::new(&(self.value.mul_single(rhs)), new_magnitude)
+        Self::new(&self.value.mul_single(rhs), new_magnitude)
     }
 
     /// Returns `self * rhs mod p`.
@@ -229,12 +234,28 @@ impl LazyFieldElement {
         debug_assert!(self.magnitude <= magnitude);
         let new_magnitude = magnitude + 1;
         debug_assert!(new_magnitude <= MAX_MAGNITUDE);
-        Self::new(&(self.value.negate(magnitude)), new_magnitude)
+        Self::new(&self.value.negate(magnitude), new_magnitude)
     }
 
     /// Returns `2 * self`, doubling the magnitude.
     pub fn double(&self) -> Self {
         self.add(self)
+    }
+
+    /// Returns the SEC1 encoding of this element.
+    ///
+    /// Requires the element to be normalized.
+    pub fn to_bytes(&self) -> FieldBytes {
+        debug_assert!(self.magnitude == 1, "to_bytes requires normalized element");
+        self.value.normalize().to_bytes()
+    }
+
+    /// Returns the raw `U256` representation of this element.
+    ///
+    /// Requires the element to be normalized.
+    pub(crate) fn to_u256(&self) -> U256 {
+        debug_assert!(self.magnitude == 1, "to_u256 requires normalized element");
+        self.value.normalize().to_u256()
     }
 }
 
@@ -247,12 +268,9 @@ impl Default for LazyFieldElement {
 impl ConditionallySelectable for LazyFieldElement {
     #[inline(always)]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        // We take the magnitude of the selected element, since magnitude is
-        // independent from the value — it must be tracked explicitly regardless.
-        let new_magnitude = u32::conditional_select(&a.magnitude, &b.magnitude, choice);
         Self {
-            value: FieldElementUnsafeImpl::conditional_select(&a.value, &b.value, choice),
-            magnitude: new_magnitude,
+            value: Inner::conditional_select(&a.value, &b.value, choice),
+            magnitude: u32::conditional_select(&a.magnitude, &b.magnitude, choice),
         }
     }
 }
@@ -270,26 +288,7 @@ impl Zeroize for LazyFieldElement {
     }
 }
 
-impl From<FieldElement> for LazyFieldElement {
-    /// Convert a normalized `FieldElement` to a `LazyFieldElement`.
-    ///
-    /// Since `FieldElement` is always normalized, this is a zero-cost conversion
-    /// (the magnitude is simply set to 1).
-    fn from(fe: FieldElement) -> Self {
-        // SAFETY: FieldElement is always normalized, so we can construct
-        // LazyFieldElement as if it were normalized without calling normalize().
-        Self::new_normalized(&fe.0)
-    }
-}
 
-impl From<LazyFieldElement> for FieldElement {
-    /// Convert a `LazyFieldElement` to a normalized `FieldElement`.
-    ///
-    /// This calls `.normalize()`, performing the full modular reduction.
-    fn from(lazy: LazyFieldElement) -> Self {
-        lazy.normalize()
-    }
-}
 
 #[cfg(test)]
 mod tests {
@@ -297,30 +296,26 @@ mod tests {
 
     #[test]
     fn lazy_field_element_magnitude_tracking() {
-        // After 2048 additions of magnitude-1 elements, we'd overflow MAX_MAGNITUDE.
-        // Adding MAX_MAGNITUDE elements of magnitude 1 should be fine.
         let mut acc = LazyFieldElement::ONE;
         for _ in 0..(LazyFieldElement::max_magnitude() - 1) {
             acc = acc.add(&LazyFieldElement::ONE);
         }
-        // The accumulated element is still valid (weakly normalized)
         let normalized = acc.normalize();
-        // Reducing it should still produce 2047 mod p
         let expected = LazyFieldElement::from_u64(LazyFieldElement::max_magnitude() as u64);
-        assert_eq!(normalized, expected.normalize());
+        assert_eq!(normalized.to_bytes(), expected.normalize().to_bytes());
     }
 
     #[test]
     fn mul_magnitude_bounds() {
         let a = LazyFieldElement::ONE;
         let b = LazyFieldElement::ONE;
-        let _ = a.mul(&b); // should not panic
+        let _ = a.mul(&b);
     }
 
     #[test]
     fn square_magnitude_bounds() {
         let a = LazyFieldElement::ONE;
-        let _ = a.square(); // should not panic
+        let _ = a.square();
     }
 
     #[test]
@@ -328,17 +323,12 @@ mod tests {
         let one = LazyFieldElement::ONE;
         let neg = one.negate(1);
         assert_eq!(neg.magnitude, 2);
-        // one + neg should be zero after normalization
         let sum = one.add(&neg);
         assert!(bool::from(sum.normalize().is_zero()));
     }
 
     #[test]
     fn normalizes_to_zero_detects_both_zero_and_p() {
-        // Create a lazy element equal to p (mod 2^256) by taking 0 - 0 = 0,
-        // but we need something that normalizes to zero.
-        // The safest way: negate(1) on ONE gives something that normalizes_to_zero
-        // because ONE + (-ONE) = 0 mod p
         let zero = LazyFieldElement::ONE.add(&LazyFieldElement::ONE.negate(1));
         assert!(bool::from(zero.normalizes_to_zero()));
     }

--- a/k256/src/arithmetic/field/lazy.rs
+++ b/k256/src/arithmetic/field/lazy.rs
@@ -16,6 +16,8 @@
 //! automatically, so generic code using the trait is unaffected.
 
 use crate::FieldBytes;
+use core::ops::{Add, Mul, Neg, Sub};
+use super::FieldElement;
 use elliptic_curve::{
     bigint::U256,
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
@@ -256,6 +258,174 @@ impl LazyFieldElement {
     pub(crate) fn to_u256(self) -> U256 {
         debug_assert!(self.magnitude == 1, "to_u256 requires normalized element");
         self.value.normalize().to_u256()
+    }
+}
+
+//
+// Operator overloads. These mirror the inherent methods but keep the result
+// in lazy form: arithmetic on `LazyFieldElement` does not normalize, so the
+// point-addition / doubling inner loops avoid the per-op modular reduction.
+// Use `From<LazyFieldElement> for FieldElement` (or `.normalize()`) to obtain
+// a normalized value at the boundary.
+//
+
+impl Add<LazyFieldElement> for LazyFieldElement {
+    type Output = LazyFieldElement;
+
+    fn add(self, rhs: LazyFieldElement) -> LazyFieldElement {
+        LazyFieldElement::add(&self, &rhs)
+    }
+}
+
+impl Add<&LazyFieldElement> for LazyFieldElement {
+    type Output = LazyFieldElement;
+
+    fn add(self, rhs: &LazyFieldElement) -> LazyFieldElement {
+        LazyFieldElement::add(&self, rhs)
+    }
+}
+
+impl Add<LazyFieldElement> for &LazyFieldElement {
+    type Output = LazyFieldElement;
+
+    fn add(self, rhs: LazyFieldElement) -> LazyFieldElement {
+        LazyFieldElement::add(self, &rhs)
+    }
+}
+
+impl Add<&LazyFieldElement> for &LazyFieldElement {
+    type Output = LazyFieldElement;
+
+    fn add(self, rhs: &LazyFieldElement) -> LazyFieldElement {
+        LazyFieldElement::add(self, rhs)
+    }
+}
+
+impl Sub<LazyFieldElement> for LazyFieldElement {
+    type Output = LazyFieldElement;
+
+    fn sub(self, rhs: LazyFieldElement) -> LazyFieldElement {
+        LazyFieldElement::add(&self, &rhs.negate(rhs.magnitude))
+    }
+}
+
+impl Sub<&LazyFieldElement> for LazyFieldElement {
+    type Output = LazyFieldElement;
+
+    fn sub(self, rhs: &LazyFieldElement) -> LazyFieldElement {
+        LazyFieldElement::add(&self, &rhs.negate(rhs.magnitude))
+    }
+}
+
+impl Sub<LazyFieldElement> for &LazyFieldElement {
+    type Output = LazyFieldElement;
+
+    fn sub(self, rhs: LazyFieldElement) -> LazyFieldElement {
+        LazyFieldElement::add(self, &rhs.negate(rhs.magnitude))
+    }
+}
+
+impl Sub<&LazyFieldElement> for &LazyFieldElement {
+    type Output = LazyFieldElement;
+
+    fn sub(self, rhs: &LazyFieldElement) -> LazyFieldElement {
+        LazyFieldElement::add(self, &rhs.negate(rhs.magnitude))
+    }
+}
+
+impl Mul<LazyFieldElement> for LazyFieldElement {
+    type Output = LazyFieldElement;
+
+    fn mul(self, rhs: LazyFieldElement) -> LazyFieldElement {
+        LazyFieldElement::mul(&self, &rhs)
+    }
+}
+
+impl Mul<&LazyFieldElement> for LazyFieldElement {
+    type Output = LazyFieldElement;
+
+    #[inline(always)]
+    fn mul(self, rhs: &LazyFieldElement) -> LazyFieldElement {
+        LazyFieldElement::mul(&self, rhs)
+    }
+}
+
+impl Mul<LazyFieldElement> for &LazyFieldElement {
+    type Output = LazyFieldElement;
+
+    fn mul(self, rhs: LazyFieldElement) -> LazyFieldElement {
+        LazyFieldElement::mul(self, &rhs)
+    }
+}
+
+impl Mul<&LazyFieldElement> for &LazyFieldElement {
+    type Output = LazyFieldElement;
+
+    fn mul(self, rhs: &LazyFieldElement) -> LazyFieldElement {
+        LazyFieldElement::mul(self, rhs)
+    }
+}
+
+/// Boundary conversion: multiply a `LazyFieldElement` (which may carry a
+/// non-canonical magnitude) by a normalized `FieldElement`, returning a
+/// normalized `FieldElement`.
+///
+/// Use this when leaving the lazy point-arithmetic inner loops: e.g. when
+/// projecting an affine coordinate by multiplying a projective `x` or `y`
+/// (lazy) by a normalized `z^{-1}` (from `BatchInvert`), or when feeding a
+/// lazy result back into `ff::Field`-based algorithms. The multiplication
+/// itself runs lazily (cheap), and the `From` conversion performs exactly one
+/// full `normalize()` on the result.
+impl Mul<&FieldElement> for &LazyFieldElement {
+    type Output = FieldElement;
+
+    fn mul(self, rhs: &FieldElement) -> FieldElement {
+        FieldElement::from(self.mul(&rhs.0))
+    }
+}
+
+impl Mul<&FieldElement> for LazyFieldElement {
+    type Output = FieldElement;
+
+    fn mul(self, rhs: &FieldElement) -> FieldElement {
+        FieldElement::from(self.mul(&rhs.0))
+    }
+}
+
+impl Mul<FieldElement> for &LazyFieldElement {
+    type Output = FieldElement;
+
+    fn mul(self, rhs: FieldElement) -> FieldElement {
+        FieldElement::from(self.mul(&rhs.0))
+    }
+}
+
+impl Mul<FieldElement> for LazyFieldElement {
+    type Output = FieldElement;
+
+    fn mul(self, rhs: FieldElement) -> FieldElement {
+        FieldElement::from(self.mul(&rhs.0))
+    }
+}
+
+impl Neg for LazyFieldElement {
+    type Output = LazyFieldElement;
+
+    fn neg(self) -> LazyFieldElement {
+        // Use the actual magnitude so the operation is safe regardless of
+        // whether `self` is a normalized magnitude-1 value or an
+        // un-normalized accumulated-sum value.
+        let magnitude = self.magnitude;
+        self.negate(magnitude)
+    }
+}
+
+impl Neg for &LazyFieldElement {
+    type Output = LazyFieldElement;
+
+    fn neg(self) -> LazyFieldElement {
+        let magnitude = self.magnitude;
+        self.negate(magnitude)
     }
 }
 

--- a/k256/src/arithmetic/field/lazy.rs
+++ b/k256/src/arithmetic/field/lazy.rs
@@ -187,9 +187,17 @@ impl LazyFieldElement {
             self.magnitude == 1,
             "normalize_canonical requires weakly-normalized input (magnitude == 1)",
         );
-        Self {
-            value: self.value.normalize_canonical(),
-            magnitude: 1,
+        // Fast path: magnitude == 1 (always taken when invariants hold).
+        // The cold branch provides a safety net in release builds where the
+        // debug_assert is stripped — it falls back to full normalization
+        // rather than producing a silently incorrect result.
+        if self.magnitude == 1 {
+            Self {
+                value: self.value.normalize_canonical(),
+                magnitude: 1,
+            }
+        } else {
+            self.normalize()
         }
     }
 

--- a/k256/src/arithmetic/field/lazy.rs
+++ b/k256/src/arithmetic/field/lazy.rs
@@ -245,7 +245,7 @@ impl LazyFieldElement {
     /// Returns the SEC1 encoding of this element.
     ///
     /// Requires the element to be normalized.
-    pub fn to_bytes(&self) -> FieldBytes {
+    pub fn to_bytes(self) -> FieldBytes {
         debug_assert!(self.magnitude == 1, "to_bytes requires normalized element");
         self.value.normalize().to_bytes()
     }
@@ -253,7 +253,7 @@ impl LazyFieldElement {
     /// Returns the raw `U256` representation of this element.
     ///
     /// Requires the element to be normalized.
-    pub(crate) fn to_u256(&self) -> U256 {
+    pub(crate) fn to_u256(self) -> U256 {
         debug_assert!(self.magnitude == 1, "to_u256 requires normalized element");
         self.value.normalize().to_u256()
     }

--- a/k256/src/arithmetic/field/lazy.rs
+++ b/k256/src/arithmetic/field/lazy.rs
@@ -15,9 +15,9 @@
 //! applied. The `ff::Field` trait impl on `FieldElement` performs this conversion
 //! automatically, so generic code using the trait is unaffected.
 
+use super::FieldElement;
 use crate::FieldBytes;
 use core::ops::{Add, Mul, Neg, Sub};
-use super::FieldElement;
 use elliptic_curve::{
     bigint::U256,
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
@@ -29,12 +29,24 @@ cpubits::cpubits! {
     64 => { pub(crate) use super::field_5x52::FieldElement5x52 as Inner; }
 }
 
-/// Maximum magnitude for lazy field elements.
-///
-/// This is the largest magnitude `m` such that
-/// `0xFFFFFFFFFFFFF * 2 * (m + 1) < 2^64` (for 64-bit limbs), ensuring no
-/// overflow occurs in addition/subtraction chains.
-pub const MAX_MAGNITUDE: u32 = 2047;
+cpubits::cpubits! {
+    32 => {
+        /// Maximum magnitude for lazy field elements (32-bit backend).
+        ///
+        /// This is the largest magnitude `m` such that
+        /// `0x3FFFFFF * 2 * (m + 1) < 2^32` (for 32-bit limbs), ensuring no
+        /// overflow occurs in `negate()`.
+        pub const MAX_MAGNITUDE: u32 = 31;
+    }
+    64 => {
+        /// Maximum magnitude for lazy field elements (64-bit backend).
+        ///
+        /// This is the largest magnitude `m` such that
+        /// `0xFFFFFFFFFFFFF * 2 * (m + 1) < 2^64` (for 64-bit limbs), ensuring no
+        /// overflow occurs in `negate()`.
+        pub const MAX_MAGNITUDE: u32 = 2047;
+    }
+}
 
 /// A field element that may be lazily normalized — i.e. the result of arithmetic
 /// operations before a final modular reduction.
@@ -67,8 +79,10 @@ impl LazyFieldElement {
 
     /// Maximum supported magnitude.
     ///
-    /// This is the largest `m` such that `0xFFFFFFFFFFFFF * 2 * (m + 1) < 2^64`
-    /// (64-bit limbs), which ensures no overflow occurs in addition chains.
+    /// This is the largest `m` such that `max_limb * 2 * (m + 1) < 2^bits`
+    /// for the active backend's limb size, which ensures no overflow occurs
+    /// in `negate()`. The value is backend-specific: 31 for the 32-bit
+    /// backend, 2047 for the 64-bit backend.
     pub const fn max_magnitude() -> u32 {
         MAX_MAGNITUDE
     }
@@ -217,10 +231,7 @@ impl LazyFieldElement {
     /// the class of bugs this type system is designed to eliminate.)
     #[inline]
     pub fn is_odd(&self) -> Choice {
-        debug_assert!(
-            self.magnitude == 1,
-            "is_odd requires normalized element",
-        );
+        debug_assert!(self.magnitude == 1, "is_odd requires normalized element",);
         self.value.is_odd()
     }
 
@@ -514,8 +525,6 @@ impl Zeroize for LazyFieldElement {
     }
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use super::LazyFieldElement;
@@ -557,5 +566,53 @@ mod tests {
     fn normalizes_to_zero_detects_both_zero_and_p() {
         let zero = LazyFieldElement::ONE.add(&LazyFieldElement::ONE.negate(1));
         assert!(bool::from(zero.normalizes_to_zero()));
+    }
+
+    /// Verify that `normalize_canonical()` rejects an element that has not
+    /// been weakly normalized (magnitude > 1).
+    ///
+    /// `normalize_canonical` skips the carry-propagation pass that
+    /// `normalize()` performs, so feeding it an un-normalized input produces
+    /// a silently incorrect result in release builds. The `debug_assert!`
+    /// inside the method must fire in debug builds to catch this class of bug
+    /// during testing.
+    ///
+    /// This test is expected to panic in debug builds (the default test
+    /// profile). In release builds the assertion is compiled out, so the test
+    /// would not panic — it is marked `#[cfg(debug_assertions)]` to avoid a
+    /// spurious failure in that case.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "normalize_canonical requires weakly-normalized input")]
+    fn normalize_canonical_rejects_unnormalized_input() {
+        // `add` produces a magnitude-2 element whose carries have NOT been
+        // propagated (it is a raw limb-wise sum). Passing this to
+        // `normalize_canonical` violates the precondition.
+        let mag2 = LazyFieldElement::ONE.add(&LazyFieldElement::ONE);
+        assert_eq!(mag2.magnitude, 2);
+        let _ = mag2.normalize_canonical();
+    }
+
+    /// Verify that `normalize_canonical()` produces the correct result when
+    /// its precondition IS satisfied (magnitude 1, carries propagated).
+    ///
+    /// `Inner::mul` propagates carries as part of the multiplication, so its
+    // output is weakly normalized (magnitude 1). `normalize_canonical` should
+    // then produce a canonical value identical to `normalize()`.
+    #[test]
+    fn normalize_canonical_matches_normalize_on_weakly_normalized_input() {
+        // `mul` produces a magnitude-1, weakly-normalized result.
+        let weak = LazyFieldElement::ONE.mul(&LazyFieldElement::from_u64(2));
+        assert_eq!(weak.magnitude, 1);
+
+        let canonical = weak.normalize_canonical();
+        let full = weak.normalize();
+
+        // Both should produce the same canonical value (2).
+        assert_eq!(canonical.to_bytes(), full.to_bytes());
+        assert_eq!(
+            canonical.to_bytes(),
+            LazyFieldElement::from_u64(2).to_bytes()
+        );
     }
 }

--- a/k256/src/arithmetic/field/lazy.rs
+++ b/k256/src/arithmetic/field/lazy.rs
@@ -1,0 +1,345 @@
+//! Lazy (non-normalized) field elements.
+//!
+//! This module provides `LazyFieldElement`: a wrapper around the raw field backend
+//! (`FieldElement5x52` / `FieldElement10x26`) that tracks the "magnitude" of the
+//! value and whether it has been normalized.
+//!
+//! All arithmetic operations (`add`, `sub`, `mul`, `square`, `negate`, `mul_single`,
+//! `double`) produce lazy results — the magnitude is brought to 1, but the value is
+//! only *weakly* reduced (carried into the limb representation) without a final
+//! modular reduction. This avoids the expensive full normalization pass between
+//! every operation, which is critical for performance in inner loops like point
+//! addition and scalar multiplication.
+//!
+//! Call `.normalize()` (or `.normalize_weak()`) to produce a fully reduced
+//! `FieldElement`, or use `From<LazyFieldElement> for FieldElement` to convert
+//! automatically. The `ff::Field` trait impl on `FieldElement` performs this
+//! conversion automatically, so generic code using the trait is unaffected.
+
+use crate::FieldBytes;
+use elliptic_curve::{
+    bigint::U256,
+    subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
+    zeroize::Zeroize,
+};
+
+cpubits::cpubits! {
+    32 => { use super::field_10x26::FieldElement10x26 as FieldElementUnsafeImpl; }
+    64 => { use super::field_5x52::FieldElement5x52 as FieldElementUnsafeImpl; }
+}
+
+/// Maximum magnitude for lazy field elements.
+///
+/// This is the largest magnitude `m` such that
+/// `0xFFFFFFFFFFFFF * 2 * (m + 1) < 2^64` (for 64-bit limbs), ensuring no
+/// overflow occurs in addition/subtraction chains.
+pub const MAX_MAGNITUDE: u32 = 2047;
+
+/// A field element that may be lazily normalized — i.e. the result of arithmetic
+/// operations before a final modular reduction.
+///
+/// The inner value is guaranteed to be weakly normalized (all carries propagated,
+/// magnitude = 1), but it may still be >= p (i.e. in the range `[p, 2*m)` for
+/// some magnitude `m`). Use `.normalize()` to obtain a `FieldElement` with the
+/// full modular reduction applied.
+#[derive(Clone, Copy, Debug)]
+pub struct LazyFieldElement {
+    /// Raw field element value (weakly reduced, but not guaranteed < p).
+    value: FieldElementUnsafeImpl,
+    /// Number of uncancelled additions this element has accumulated.
+    /// Used to bound intermediate values and prevent overflow.
+    magnitude: u32,
+}
+
+impl LazyFieldElement {
+    /// Zero element.
+    pub const ZERO: Self = Self {
+        value: FieldElementUnsafeImpl::ZERO,
+        magnitude: 1,
+    };
+
+    /// Multiplicative identity.
+    pub const ONE: Self = Self {
+        value: FieldElementUnsafeImpl::ONE,
+        magnitude: 1,
+    };
+
+    /// Maximum supported magnitude.
+    ///
+    /// This is the largest `m` such that `0xFFFFFFFFFFFFF * 2 * (m + 1) < 2^64`
+    /// (64-bit limbs), which ensures no overflow occurs in addition chains.
+    pub const fn max_magnitude() -> u32 {
+        MAX_MAGNITUDE
+    }
+
+    /// Construct a new lazy field element from a raw value with the given magnitude.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds if `magnitude > MAX_MAGNITUDE`.
+    fn new(value: &FieldElementUnsafeImpl, magnitude: u32) -> Self {
+        debug_assert!(magnitude <= MAX_MAGNITUDE);
+        Self {
+            value: *value,
+            magnitude,
+        }
+    }
+
+    /// Construct a normalized lazy field element.
+    ///
+    /// The magnitude is set to 1 and `normalized` to `true`.
+    const fn new_normalized(value: &FieldElementUnsafeImpl) -> Self {
+        Self {
+            value: *value,
+            magnitude: 1,
+        }
+    }
+
+    /// Construct a weakly-normalized lazy field element.
+    ///
+    /// The magnitude is set to 1 but `normalized` is set to `false`, reflecting
+    /// that the value has had carries propagated but has not been reduced mod p.
+    fn new_weak_normalized(value: &FieldElementUnsafeImpl) -> Self {
+        Self {
+            value: *value.normalize_weak(),
+            magnitude: 1,
+        }
+    }
+
+    /// Parse a field element from bytes without validating the range.
+    ///
+    /// The resulting element is normalized (fully reduced mod p).
+    pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
+        Self::new_normalized(&FieldElementUnsafeImpl::from_bytes_unchecked(bytes))
+    }
+
+    /// Parse a field element from a `u64`.
+    ///
+    /// The resulting element is normalized.
+    pub const fn from_u64(val: u64) -> Self {
+        Self::new_normalized(&FieldElementUnsafeImpl::from_u64(val))
+    }
+
+    /// Parse a field element from bytes, validating that the value is in range.
+    ///
+    /// The resulting element is normalized.
+    pub fn from_bytes(bytes: &FieldBytes) -> CtOption<Self> {
+        FieldElementUnsafeImpl::from_bytes(bytes).map(|x| Self::new_normalized(&x))
+    }
+
+    /// Construct a normalized element from a raw `U256` without range checking.
+    ///
+    /// The resulting element is normalized.
+    pub(crate) const fn from_u256_unchecked(value: U256) -> Self {
+        Self {
+            value: FieldElementUnsafeImpl::from_u256_unchecked(value),
+            magnitude: 1,
+        }
+    }
+
+    /// Fully normalize the element: reduce mod p and set magnitude to 1.
+    ///
+    /// This performs the expensive final modular reduction. Prefer to work with
+    /// `LazyFieldElement` inside arithmetic loops and only normalize at the boundary.
+    pub fn normalize(&self) -> FieldElement {
+        FieldElement::from(Self::new_normalized(&self.value.normalize()))
+    }
+
+    /// Weakly normalize the element: propagate carries but do not reduce mod p.
+    ///
+    /// The result has magnitude 1 but may be >= p. This is faster than `normalize()`
+    /// but should only be used when the caller is about to perform another
+    /// arithmetic operation that will consume the excess.
+    pub fn normalize_weak(&self) -> Self {
+        Self::new_weak_normalized(&self.value.normalize_weak())
+    }
+
+    /// Check whether this element would become zero if fully normalized.
+    ///
+    /// This is useful for checking if a value is 0 or p (both normalize to 0).
+    pub fn normalizes_to_zero(&self) -> Choice {
+        self.value.normalizes_to_zero()
+    }
+
+    /// Determine if this element is zero.
+    ///
+    /// The element **must** be normalized before calling this. In debug builds,
+    /// this is checked with a debug assertion.
+    pub fn is_zero(&self) -> Choice {
+        debug_assert!(self.magnitude == 1, "is_zero requires normalized element");
+        self.value.is_zero()
+    }
+
+    /// Determine if this element is odd in the SEC1 sense: `self mod 2 == 1`.
+    ///
+    /// The element **must** be normalized before calling this. In debug builds,
+    /// this is checked with a debug assertion. (In release builds, calling this
+    /// on an unnormalized element produces incorrect results — this is precisely
+    /// the class of bugs this type system is designed to eliminate.)
+    pub fn is_odd(&self) -> Choice {
+        debug_assert!(
+            self.magnitude == 1,
+            "is_odd requires normalized element"
+        );
+        self.value.is_odd()
+    }
+
+    /// Returns `self + rhs mod p`.
+    ///
+    /// The new magnitude is `self.magnitude + rhs.magnitude`.
+    pub fn add(&self, rhs: &Self) -> Self {
+        let new_magnitude = self.magnitude + rhs.magnitude;
+        debug_assert!(new_magnitude <= MAX_MAGNITUDE);
+        Self::new(&(self.value.add(&rhs.value)), new_magnitude)
+    }
+
+    /// Multiplies by a single-limb integer.
+    ///
+    /// The magnitude is multiplied by the same value.
+    pub fn mul_single(&self, rhs: u32) -> Self {
+        let new_magnitude = self.magnitude * rhs;
+        debug_assert!(new_magnitude <= MAX_MAGNITUDE);
+        Self::new(&(self.value.mul_single(rhs)), new_magnitude)
+    }
+
+    /// Returns `self * rhs mod p`.
+    ///
+    /// Both operands must have magnitude ≤ 8. The result has magnitude 1 and is
+    /// weakly normalized (carries propagated but may still be ≥ p).
+    pub fn mul(&self, rhs: &Self) -> Self {
+        debug_assert!(self.magnitude <= 8);
+        debug_assert!(rhs.magnitude <= 8);
+        Self::new_weak_normalized(&self.value.mul(&rhs.value))
+    }
+
+    /// Returns `self * self mod p`.
+    ///
+    /// The operand must have magnitude ≤ 8. The result has magnitude 1 and is
+    /// weakly normalized.
+    pub fn square(&self) -> Self {
+        debug_assert!(self.magnitude <= 8);
+        Self::new_weak_normalized(&self.value.square())
+    }
+
+    /// Returns `-self`, treating it as having the given magnitude.
+    ///
+    /// The provided `magnitude` must be ≥ the actual magnitude of `self`.
+    /// The new magnitude is `magnitude + 1`.
+    pub fn negate(&self, magnitude: u32) -> Self {
+        debug_assert!(self.magnitude <= magnitude);
+        let new_magnitude = magnitude + 1;
+        debug_assert!(new_magnitude <= MAX_MAGNITUDE);
+        Self::new(&(self.value.negate(magnitude)), new_magnitude)
+    }
+
+    /// Returns `2 * self`, doubling the magnitude.
+    pub fn double(&self) -> Self {
+        self.add(self)
+    }
+}
+
+impl Default for LazyFieldElement {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl ConditionallySelectable for LazyFieldElement {
+    #[inline(always)]
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        // We take the magnitude of the selected element, since magnitude is
+        // independent from the value — it must be tracked explicitly regardless.
+        let new_magnitude = u32::conditional_select(&a.magnitude, &b.magnitude, choice);
+        Self {
+            value: FieldElementUnsafeImpl::conditional_select(&a.value, &b.value, choice),
+            magnitude: new_magnitude,
+        }
+    }
+}
+
+impl ConstantTimeEq for LazyFieldElement {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.value.ct_eq(&other.value) & self.magnitude.ct_eq(&other.magnitude)
+    }
+}
+
+impl Zeroize for LazyFieldElement {
+    fn zeroize(&mut self) {
+        self.value.zeroize();
+        self.magnitude.zeroize();
+    }
+}
+
+impl From<FieldElement> for LazyFieldElement {
+    /// Convert a normalized `FieldElement` to a `LazyFieldElement`.
+    ///
+    /// Since `FieldElement` is always normalized, this is a zero-cost conversion
+    /// (the magnitude is simply set to 1).
+    fn from(fe: FieldElement) -> Self {
+        // SAFETY: FieldElement is always normalized, so we can construct
+        // LazyFieldElement as if it were normalized without calling normalize().
+        Self::new_normalized(&fe.0)
+    }
+}
+
+impl From<LazyFieldElement> for FieldElement {
+    /// Convert a `LazyFieldElement` to a normalized `FieldElement`.
+    ///
+    /// This calls `.normalize()`, performing the full modular reduction.
+    fn from(lazy: LazyFieldElement) -> Self {
+        lazy.normalize()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LazyFieldElement;
+
+    #[test]
+    fn lazy_field_element_magnitude_tracking() {
+        // After 2048 additions of magnitude-1 elements, we'd overflow MAX_MAGNITUDE.
+        // Adding MAX_MAGNITUDE elements of magnitude 1 should be fine.
+        let mut acc = LazyFieldElement::ONE;
+        for _ in 0..(LazyFieldElement::max_magnitude() - 1) {
+            acc = acc.add(&LazyFieldElement::ONE);
+        }
+        // The accumulated element is still valid (weakly normalized)
+        let normalized = acc.normalize();
+        // Reducing it should still produce 2047 mod p
+        let expected = LazyFieldElement::from_u64(LazyFieldElement::max_magnitude() as u64);
+        assert_eq!(normalized, expected.normalize());
+    }
+
+    #[test]
+    fn mul_magnitude_bounds() {
+        let a = LazyFieldElement::ONE;
+        let b = LazyFieldElement::ONE;
+        let _ = a.mul(&b); // should not panic
+    }
+
+    #[test]
+    fn square_magnitude_bounds() {
+        let a = LazyFieldElement::ONE;
+        let _ = a.square(); // should not panic
+    }
+
+    #[test]
+    fn negate_magnitude() {
+        let one = LazyFieldElement::ONE;
+        let neg = one.negate(1);
+        assert_eq!(neg.magnitude, 2);
+        // one + neg should be zero after normalization
+        let sum = one.add(&neg);
+        assert!(bool::from(sum.normalize().is_zero()));
+    }
+
+    #[test]
+    fn normalizes_to_zero_detects_both_zero_and_p() {
+        // Create a lazy element equal to p (mod 2^256) by taking 0 - 0 = 0,
+        // but we need something that normalizes to zero.
+        // The safest way: negate(1) on ONE gives something that normalizes_to_zero
+        // because ONE + (-ONE) = 0 mod p
+        let zero = LazyFieldElement::ONE.add(&LazyFieldElement::ONE.negate(1));
+        assert!(bool::from(zero.normalizes_to_zero()));
+    }
+}

--- a/k256/src/arithmetic/field/lazy.rs
+++ b/k256/src/arithmetic/field/lazy.rs
@@ -74,6 +74,7 @@ impl LazyFieldElement {
     }
 
     /// Construct a new lazy field element from a raw value with the given magnitude.
+    #[inline]
     fn new(value: &Inner, magnitude: u32) -> Self {
         debug_assert!(magnitude <= MAX_MAGNITUDE);
         Self {
@@ -95,6 +96,8 @@ impl LazyFieldElement {
     /// Construct a weakly-normalized lazy field element.
     ///
     /// The magnitude is set to 1 but the value may still be >= p.
+    #[allow(dead_code)]
+    #[inline]
     fn new_weak_normalized(value: &Inner) -> Self {
         Self {
             value: value.normalize_weak(),
@@ -125,6 +128,7 @@ impl LazyFieldElement {
     /// Parse a field element from bytes, validating that the value is in range.
     ///
     /// The resulting element is normalized.
+    #[inline]
     pub fn from_bytes(bytes: &FieldBytes) -> CtOption<Self> {
         Inner::from_bytes(bytes).map(|x| Self::new_normalized(&x))
     }
@@ -132,6 +136,7 @@ impl LazyFieldElement {
     /// Construct a normalized element from a raw `U256` without range checking.
     ///
     /// The resulting element is normalized.
+    #[inline]
     pub(crate) const fn from_u256_unchecked(value: U256) -> Self {
         Self {
             value: Inner::from_u256_unchecked(value),
@@ -146,6 +151,7 @@ impl LazyFieldElement {
     ///
     /// Returns a normalized `LazyFieldElement` (magnitude = 1, value < p).
     /// Use `From<LazyFieldElement> for FieldElement` to convert to `FieldElement`.
+    #[inline]
     pub fn normalize(&self) -> Self {
         Self {
             value: self.value.normalize(),
@@ -158,13 +164,18 @@ impl LazyFieldElement {
     /// The result has magnitude 1 but may be >= p. This is faster than `normalize()`
     /// but should only be used when the caller is about to perform another
     /// arithmetic operation that will consume the excess.
+    #[inline]
     pub fn normalize_weak(&self) -> Self {
-        Self::new_weak_normalized(&self.value)
+        Self {
+            value: self.value.normalize_weak(),
+            magnitude: 1,
+        }
     }
 
     /// Check whether this element would become zero if fully normalized.
     ///
     /// This is useful for checking if a value is 0 or p (both normalize to 0).
+    #[inline]
     pub fn normalizes_to_zero(&self) -> Choice {
         self.value.normalizes_to_zero()
     }
@@ -172,6 +183,7 @@ impl LazyFieldElement {
     /// Determine if this element is zero.
     ///
     /// The element **must** be normalized before calling this.
+    #[inline]
     pub fn is_zero(&self) -> Choice {
         debug_assert!(self.magnitude == 1, "is_zero requires normalized element");
         self.value.is_zero()
@@ -183,6 +195,7 @@ impl LazyFieldElement {
     /// this is checked with a debug assertion. (In release builds, calling this
     /// on an unnormalized element produces incorrect results — this is precisely
     /// the class of bugs this type system is designed to eliminate.)
+    #[inline]
     pub fn is_odd(&self) -> Choice {
         debug_assert!(
             self.magnitude == 1,
@@ -194,6 +207,7 @@ impl LazyFieldElement {
     /// Returns `self + rhs mod p`.
     ///
     /// The new magnitude is `self.magnitude + rhs.magnitude`.
+    #[inline]
     pub fn add(&self, rhs: &Self) -> Self {
         let new_magnitude = self.magnitude + rhs.magnitude;
         debug_assert!(new_magnitude <= MAX_MAGNITUDE);
@@ -203,6 +217,7 @@ impl LazyFieldElement {
     /// Multiplies by a single-limb integer.
     ///
     /// The magnitude is multiplied by the same value.
+    #[inline]
     pub fn mul_single(&self, rhs: u32) -> Self {
         let new_magnitude = self.magnitude * rhs;
         debug_assert!(new_magnitude <= MAX_MAGNITUDE);
@@ -213,25 +228,42 @@ impl LazyFieldElement {
     ///
     /// Both operands must have magnitude ≤ 8. The result has magnitude 1 and is
     /// weakly normalized (carries propagated but may still be ≥ p).
+    ///
+    /// The inner `Inner::mul` already propagates carries as part of the
+    /// multiplication, so the result is weakly normalized without a second
+    /// `normalize_weak` pass.
+    #[inline]
     pub fn mul(&self, rhs: &Self) -> Self {
         debug_assert!(self.magnitude <= 8);
         debug_assert!(rhs.magnitude <= 8);
-        Self::new_weak_normalized(&self.value.mul(&rhs.value))
+        Self {
+            value: self.value.mul(&rhs.value),
+            magnitude: 1,
+        }
     }
 
     /// Returns `self * self mod p`.
     ///
     /// The operand must have magnitude ≤ 8. The result has magnitude 1 and is
     /// weakly normalized.
+    ///
+    /// The inner `Inner::square` already propagates carries as part of the
+    /// squaring, so the result is weakly normalized without a second
+    /// `normalize_weak` pass.
+    #[inline]
     pub fn square(&self) -> Self {
         debug_assert!(self.magnitude <= 8);
-        Self::new_weak_normalized(&self.value.square())
+        Self {
+            value: self.value.square(),
+            magnitude: 1,
+        }
     }
 
     /// Returns `-self`, treating it as having the given magnitude.
     ///
     /// The provided `magnitude` must be ≥ the actual magnitude of `self`.
     /// The new magnitude is `magnitude + 1`.
+    #[inline]
     pub fn negate(&self, magnitude: u32) -> Self {
         debug_assert!(self.magnitude <= magnitude);
         let new_magnitude = magnitude + 1;
@@ -240,16 +272,20 @@ impl LazyFieldElement {
     }
 
     /// Returns `2 * self`, doubling the magnitude.
+    #[inline]
     pub fn double(&self) -> Self {
         self.add(self)
     }
 
     /// Returns the SEC1 encoding of this element.
     ///
-    /// Requires the element to be normalized.
+    /// Requires the element to be normalized. The `magnitude == 1` invariant is
+    /// sufficient — the inner value is already reduced by the type system, so
+    /// no second `normalize()` pass is needed before serialization.
+    #[inline]
     pub fn to_bytes(self) -> FieldBytes {
         debug_assert!(self.magnitude == 1, "to_bytes requires normalized element");
-        self.value.normalize().to_bytes()
+        self.value.to_bytes()
     }
 
     /// Returns the raw `U256` representation of this element.

--- a/k256/src/arithmetic/field/lazy.rs
+++ b/k256/src/arithmetic/field/lazy.rs
@@ -159,6 +159,26 @@ impl LazyFieldElement {
         }
     }
 
+    /// Final reduction step on an element that is *already* weakly normalized
+    /// (magnitude = 1, value < 2^256). Skips the carry-propagation pass that
+    /// `normalize()` would otherwise repeat.
+    ///
+    /// The inner `Inner::mul` / `Inner::square` propagate carries as part of the
+    /// operation, so their output is weakly normalized. This method is the
+    /// cheap final-subtract step needed only at boundaries (`FieldElement::mul`
+    /// etc.) where we need a canonical `[0, p)` value.
+    #[inline]
+    pub fn normalize_canonical(&self) -> Self {
+        debug_assert!(
+            self.magnitude == 1,
+            "normalize_canonical requires weakly-normalized input (magnitude == 1)",
+        );
+        Self {
+            value: self.value.normalize_canonical(),
+            magnitude: 1,
+        }
+    }
+
     /// Weakly normalize the element: propagate carries but do not reduce mod p.
     ///
     /// The result has magnitude 1 but may be >= p. This is faster than `normalize()`

--- a/k256/src/arithmetic/hash2curve.rs
+++ b/k256/src/arithmetic/hash2curve.rs
@@ -139,12 +139,7 @@ impl MapToCurve for Secp256k1 {
         let (rx, ry) = element.osswu();
         let (qx, qy) = isogeny(rx, ry);
 
-        AffinePoint {
-            x: qx,
-            y: qy,
-            infinity: 0,
-        }
-        .into()
+        AffinePoint::from_field_elements(qx, qy).into()
     }
 }
 

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -116,9 +116,15 @@ impl ProjectivePoint {
         let n_xx_yy = (xx.add(&yy)).negate(2);
         let n_yy_zz = (yy.add(&zz)).negate(2);
         let n_xx_zz = (xx.add(&zz)).negate(2);
-        let xy_pairs = (self.x.add(&self.y)).mul(&(other.x.add(&other.y))).add(&n_xx_yy);
-        let yz_pairs = (self.y.add(&self.z)).mul(&(other.y.add(&other.z))).add(&n_yy_zz);
-        let xz_pairs = (self.x.add(&self.z)).mul(&(other.x.add(&other.z))).add(&n_xx_zz);
+        let xy_pairs = (self.x.add(&self.y))
+            .mul(&(other.x.add(&other.y)))
+            .add(&n_xx_yy);
+        let yz_pairs = (self.y.add(&self.z))
+            .mul(&(other.y.add(&other.z)))
+            .add(&n_yy_zz);
+        let xz_pairs = (self.x.add(&self.z))
+            .mul(&(other.x.add(&other.z)))
+            .add(&n_xx_zz);
 
         let bzz = zz.mul_single(CURVE_EQUATION_B_SINGLE);
         let bzz3 = bzz.double().add(&bzz).normalize_weak();
@@ -126,7 +132,9 @@ impl ProjectivePoint {
         let yy_m_bzz3 = yy.add(&bzz3.negate(1));
         let yy_p_bzz3 = yy.add(&bzz3);
 
-        let byz = yz_pairs.mul_single(CURVE_EQUATION_B_SINGLE).normalize_weak();
+        let byz = yz_pairs
+            .mul_single(CURVE_EQUATION_B_SINGLE)
+            .normalize_weak();
         let byz3 = byz.double().add(&byz).normalize_weak();
 
         let xx3 = xx.double().add(&xx);
@@ -137,9 +145,18 @@ impl ProjectivePoint {
             .mul_single(CURVE_EQUATION_B_SINGLE)
             .normalize_weak();
 
-        let new_x = xy_pairs.mul(&yy_m_bzz3).add(&byz3.mul(&xz_pairs).negate(1)).normalize_weak(); // m1
-        let new_y = yy_p_bzz3.mul(&yy_m_bzz3).add(&bxx9.mul(&xz_pairs)).normalize_weak();
-        let new_z = yz_pairs.mul(&yy_p_bzz3).add(&xx3.mul(&xy_pairs)).normalize_weak();
+        let new_x = xy_pairs
+            .mul(&yy_m_bzz3)
+            .add(&byz3.mul(&xz_pairs).negate(1))
+            .normalize_weak(); // m1
+        let new_y = yy_p_bzz3
+            .mul(&yy_m_bzz3)
+            .add(&bxx9.mul(&xz_pairs))
+            .normalize_weak();
+        let new_z = yz_pairs
+            .mul(&yy_p_bzz3)
+            .add(&xx3.mul(&xy_pairs))
+            .normalize_weak();
 
         ProjectivePoint {
             x: new_x,
@@ -159,7 +176,9 @@ impl ProjectivePoint {
 
         let xx = &self.x * &other.x;
         let yy = &self.y * &other.y;
-        let xy_pairs = (self.x.add(&self.y)).mul(&(other.x.add(&other.y))).add(&(xx.add(&yy)).negate(2));
+        let xy_pairs = (self.x.add(&self.y))
+            .mul(&(other.x.add(&other.y)))
+            .add(&(xx.add(&yy)).negate(2));
         let yz_pairs = (&other.y * &self.z).add(&self.y);
         let xz_pairs = (&other.x * &self.z).add(&self.x);
 
@@ -169,7 +188,9 @@ impl ProjectivePoint {
         let yy_m_bzz3 = yy.add(&bzz3.negate(1));
         let yy_p_bzz3 = yy.add(&bzz3);
 
-        let byz = yz_pairs.mul_single(CURVE_EQUATION_B_SINGLE).normalize_weak();
+        let byz = yz_pairs
+            .mul_single(CURVE_EQUATION_B_SINGLE)
+            .normalize_weak();
         let byz3 = byz.double().add(&byz).normalize_weak();
 
         let xx3 = xx.double().add(&xx);
@@ -181,9 +202,18 @@ impl ProjectivePoint {
             .normalize_weak();
 
         let mut ret = ProjectivePoint {
-            x: xy_pairs.mul(&yy_m_bzz3).add(&byz3.mul(&xz_pairs).negate(1)).normalize_weak(),
-            y: yy_p_bzz3.mul(&yy_m_bzz3).add(&bxx9.mul(&xz_pairs)).normalize_weak(),
-            z: yz_pairs.mul(&yy_p_bzz3).add(&xx3.mul(&xy_pairs)).normalize_weak(),
+            x: xy_pairs
+                .mul(&yy_m_bzz3)
+                .add(&byz3.mul(&xz_pairs).negate(1))
+                .normalize_weak(),
+            y: yy_p_bzz3
+                .mul(&yy_m_bzz3)
+                .add(&bxx9.mul(&xz_pairs))
+                .normalize_weak(),
+            z: yz_pairs
+                .mul(&yy_p_bzz3)
+                .add(&xx3.mul(&xy_pairs))
+                .normalize_weak(),
         };
         ret.conditional_assign(self, other.is_identity());
         ret
@@ -211,12 +241,22 @@ impl ProjectivePoint {
 
         let yy_zz = yy.mul(&zz);
         let yy_zz8 = yy_zz.double().double().double();
-        let t = yy_zz8.double().add(&yy_zz8).normalize_weak().mul_single(CURVE_EQUATION_B_SINGLE);
+        let t = yy_zz8
+            .double()
+            .add(&yy_zz8)
+            .normalize_weak()
+            .mul_single(CURVE_EQUATION_B_SINGLE);
 
         ProjectivePoint {
             x: xy2.mul(&yy_m_bzz9),
             y: yy_m_bzz9.mul(&yy_p_bzz3).add(&t).normalize_weak(),
-            z: yy.mul(&self.y).mul(&self.z).double().double().double().normalize_weak(),
+            z: yy
+                .mul(&self.y)
+                .mul(&self.z)
+                .double()
+                .double()
+                .double()
+                .normalize_weak(),
         }
     }
 

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -1048,4 +1048,53 @@ mod tests {
             AffinePoint::GENERATOR.neg()
         );
     }
+
+    /// Exercise `add`, `add_mixed`, and `double` with random points to verify
+    /// that the magnitude tracking in `LazyFieldElement` never overflows.
+    ///
+    /// The `debug_assert!` guards on every lazy arithmetic op serve as the
+    /// invariant checker — if a magnitude ever exceeds the safe bound, the
+    /// test panics in debug builds.
+    #[test]
+    #[cfg(feature = "getrandom")]
+    fn magnitude_bounds_randomized() {
+        // Generate random projective / affine points via random scalars.
+        let scalars: Vec<Scalar> = (0..12).map(|_| Scalar::generate()).collect();
+        let projective: Vec<ProjectivePoint> = scalars
+            .iter()
+            .map(|s| ProjectivePoint::GENERATOR * s)
+            .collect();
+        let affine: Vec<AffinePoint> = scalars
+            .iter()
+            .map(|s| (ProjectivePoint::GENERATOR * s).to_affine())
+            .collect();
+
+        // Mix add, add_mixed, and double in random sequences.
+        // Each formula exercises a different magnitude envelope — this test
+        // is the cheap version of a full fuzzer.
+        for i in 0..projective.len() {
+            for j in 0..projective.len() {
+                let p = projective[i];
+                let q = projective[j];
+                let a = affine[j];
+
+                // Projective + projective (full add).
+                let r_add = (p + q).to_affine();
+                let r_add_ref = (ProjectivePoint::from(p.to_affine())
+                    + ProjectivePoint::from(q.to_affine()))
+                .to_affine();
+                assert_eq!(r_add, r_add_ref);
+
+                // Projective + affine (mixed add).
+                let r_mixed = (p + a).to_affine();
+                let r_mixed_ref = (ProjectivePoint::from(p.to_affine()) + a).to_affine();
+                assert_eq!(r_mixed, r_mixed_ref);
+
+                // Doubling.
+                let r_dbl = p.double().to_affine();
+                let r_dbl_ref = ProjectivePoint::from(p.to_affine()).double().to_affine();
+                assert_eq!(r_dbl, r_dbl_ref);
+            }
+        }
+    }
 }

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::op_ref)]
 
-use super::{AffinePoint, CURVE_EQUATION_B_SINGLE, FieldElement, Scalar};
+use super::{AffinePoint, CURVE_EQUATION_B_SINGLE, FieldElement, LazyFieldElement, Scalar};
 use crate::{CompressedPoint, PublicKey, Sec1Point, Secp256k1};
 use core::{
     iter::Sum,
@@ -27,7 +27,7 @@ use elliptic_curve::{
 use alloc::vec::Vec;
 
 #[rustfmt::skip]
-const ENDOMORPHISM_BETA: FieldElement = FieldElement::from_bytes_unchecked(&[
+const ENDOMORPHISM_BETA: LazyFieldElement = LazyFieldElement::from_bytes_unchecked(&[
     0x7a, 0xe9, 0x6a, 0x2b, 0x65, 0x7c, 0x07, 0x10,
     0x6e, 0x64, 0x47, 0x9e, 0xac, 0x34, 0x34, 0xe9,
     0x9c, 0xf0, 0x49, 0x75, 0x12, 0xf5, 0x89, 0x95,
@@ -35,47 +35,66 @@ const ENDOMORPHISM_BETA: FieldElement = FieldElement::from_bytes_unchecked(&[
 ]);
 
 /// A point on the secp256k1 curve in projective coordinates.
+///
+/// Coordinates are stored as [`LazyFieldElement`]s. The point-arithmetic inner
+/// loops (`add`, `add_mixed`, `double`, `neg`, `endomorphism`) operate directly
+/// on the lazy form, accumulating magnitude without an intermediate full
+/// modular reduction. Only `.normalize_weak()` calls appear in the middle of the
+/// formulas, which keep the magnitude ≤ 8 so that the subsequent `mul` (which
+/// requires `magnitude ≤ 8`) is valid.
+///
+/// At a boundary (`to_affine`, `batch_normalize`, `ConditionallySelectable`
+/// over a non-lazy choice, etc.) the lazy coordinates are normalized via
+/// `FieldElement::from(lazy)` before crossing into the canonical-form world.
 #[derive(Clone, Copy, Debug)]
 pub struct ProjectivePoint {
-    x: FieldElement,
-    y: FieldElement,
-    pub(super) z: FieldElement,
+    x: LazyFieldElement,
+    y: LazyFieldElement,
+    pub(super) z: LazyFieldElement,
 }
 
 impl ProjectivePoint {
     /// Additive identity of the group: the point at infinity.
     pub const IDENTITY: Self = Self {
-        x: FieldElement::ZERO,
-        y: FieldElement::ONE,
-        z: FieldElement::ZERO,
+        x: LazyFieldElement::ZERO,
+        y: LazyFieldElement::ONE,
+        z: LazyFieldElement::ZERO,
     };
 
     /// Base point of secp256k1.
     pub const GENERATOR: Self = Self {
         x: AffinePoint::GENERATOR.x,
         y: AffinePoint::GENERATOR.y,
-        z: FieldElement::ONE,
+        z: LazyFieldElement::ONE,
     };
 
     /// Returns the affine representation of this point.
     pub fn to_affine(&self) -> AffinePoint {
-        self.z
-            .invert()
+        let z = FieldElement::from(self.z);
+        z.invert()
             .map(|zinv| self.to_affine_internal(zinv))
             .unwrap_or_else(|| AffinePoint::IDENTITY)
     }
 
     pub(super) fn to_affine_internal(self, zinv: FieldElement) -> AffinePoint {
-        let x = self.x * &zinv;
-        let y = self.y * &zinv;
-        AffinePoint::new(x.normalize(), y.normalize())
+        // The cross-type multiplication `LazyFieldElement * &FieldElement` runs lazily
+        // (one cheap multiplication, no per-op modular reduction) and produces a
+        // normalized `FieldElement`. Wrapping it back as `LazyFieldElement` is free
+        // (it's just the inner `FieldElement.0`); the `AffinePoint` then owns the
+        // result without any extra `.normalize()` cost.
+        let x: LazyFieldElement = (&self.x * &zinv).into();
+        let y: LazyFieldElement = (&self.y * &zinv).into();
+        AffinePoint::new(x, y)
     }
 
     /// Returns `-self`.
     fn neg(&self) -> ProjectivePoint {
+        // Negate lazily via the `Neg` impl, which tracks the operand's
+        // magnitude. `normalize_weak()` then brings the result back to
+        // magnitude 1 for the next operation in the calling code.
         ProjectivePoint {
             x: self.x,
-            y: self.y.negate(1).normalize_weak(),
+            y: (-self.y).normalize_weak(),
             z: self.z,
         }
     }
@@ -84,38 +103,43 @@ impl ProjectivePoint {
     fn add(&self, other: &ProjectivePoint) -> ProjectivePoint {
         // We implement the complete addition formula from Renes-Costello-Batina 2015
         // (https://eprint.iacr.org/2015/1060 Algorithm 7).
+        //
+        // All arithmetic here is `LazyFieldElement` so the per-op modular
+        // reductions of `FieldElement` are avoided; the only modular-reduction
+        // operations in the hot loop are the `normalize_weak()` calls that keep
+        // magnitudes ≤ 8 (a precondition of `LazyFieldElement::mul`).
 
-        let xx = self.x * &other.x;
-        let yy = self.y * &other.y;
-        let zz = self.z * &other.z;
+        let xx = &self.x * &other.x;
+        let yy = &self.y * &other.y;
+        let zz = &self.z * &other.z;
 
-        let n_xx_yy = (xx + &yy).negate(2);
-        let n_yy_zz = (yy + &zz).negate(2);
-        let n_xx_zz = (xx + &zz).negate(2);
-        let xy_pairs = ((self.x + &self.y) * &(other.x + &other.y)) + &n_xx_yy;
-        let yz_pairs = ((self.y + &self.z) * &(other.y + &other.z)) + &n_yy_zz;
-        let xz_pairs = ((self.x + &self.z) * &(other.x + &other.z)) + &n_xx_zz;
+        let n_xx_yy = (xx.add(&yy)).negate(2);
+        let n_yy_zz = (yy.add(&zz)).negate(2);
+        let n_xx_zz = (xx.add(&zz)).negate(2);
+        let xy_pairs = (self.x.add(&self.y)).mul(&(other.x.add(&other.y))).add(&n_xx_yy);
+        let yz_pairs = (self.y.add(&self.z)).mul(&(other.y.add(&other.z))).add(&n_yy_zz);
+        let xz_pairs = (self.x.add(&self.z)).mul(&(other.x.add(&other.z))).add(&n_xx_zz);
 
         let bzz = zz.mul_single(CURVE_EQUATION_B_SINGLE);
-        let bzz3 = (bzz.double() + &bzz).normalize_weak();
+        let bzz3 = bzz.double().add(&bzz).normalize_weak();
 
-        let yy_m_bzz3 = yy + &bzz3.negate(1);
-        let yy_p_bzz3 = yy + &bzz3;
+        let yy_m_bzz3 = yy.add(&bzz3.negate(1));
+        let yy_p_bzz3 = yy.add(&bzz3);
 
-        let byz = &yz_pairs
-            .mul_single(CURVE_EQUATION_B_SINGLE)
-            .normalize_weak();
-        let byz3 = (byz.double() + byz).normalize_weak();
+        let byz = yz_pairs.mul_single(CURVE_EQUATION_B_SINGLE).normalize_weak();
+        let byz3 = byz.double().add(&byz).normalize_weak();
 
-        let xx3 = xx.double() + &xx;
-        let bxx9 = (xx3.double() + &xx3)
+        let xx3 = xx.double().add(&xx);
+        let bxx9 = xx3
+            .double()
+            .add(&xx3)
             .normalize_weak()
             .mul_single(CURVE_EQUATION_B_SINGLE)
             .normalize_weak();
 
-        let new_x = ((xy_pairs * &yy_m_bzz3) + &(byz3 * &xz_pairs).negate(1)).normalize_weak(); // m1
-        let new_y = ((yy_p_bzz3 * &yy_m_bzz3) + &(bxx9 * &xz_pairs)).normalize_weak();
-        let new_z = ((yz_pairs * &yy_p_bzz3) + &(xx3 * &xy_pairs)).normalize_weak();
+        let new_x = xy_pairs.mul(&yy_m_bzz3).add(&byz3.mul(&xz_pairs).negate(1)).normalize_weak(); // m1
+        let new_y = yy_p_bzz3.mul(&yy_m_bzz3).add(&bxx9.mul(&xz_pairs)).normalize_weak();
+        let new_z = yz_pairs.mul(&yy_p_bzz3).add(&xx3.mul(&xy_pairs)).normalize_weak();
 
         ProjectivePoint {
             x: new_x,
@@ -128,34 +152,38 @@ impl ProjectivePoint {
     fn add_mixed(&self, other: &AffinePoint) -> ProjectivePoint {
         // We implement the complete addition formula from Renes-Costello-Batina 2015
         // (https://eprint.iacr.org/2015/1060 Algorithm 8).
+        //
+        // Same lazy-arithmetic strategy as `add`. The `other` operand is in
+        // affine coordinates with magnitude 1, so its operands participate in
+        // the lazy ops with no extra normalization.
 
-        let xx = self.x * &other.x;
-        let yy = self.y * &other.y;
-        let xy_pairs = ((self.x + &self.y) * &(other.x + &other.y)) + &(xx + &yy).negate(2);
-        let yz_pairs = (other.y * &self.z) + &self.y;
-        let xz_pairs = (other.x * &self.z) + &self.x;
+        let xx = &self.x * &other.x;
+        let yy = &self.y * &other.y;
+        let xy_pairs = (self.x.add(&self.y)).mul(&(other.x.add(&other.y))).add(&(xx.add(&yy)).negate(2));
+        let yz_pairs = (&other.y * &self.z).add(&self.y);
+        let xz_pairs = (&other.x * &self.z).add(&self.x);
 
-        let bzz = &self.z.mul_single(CURVE_EQUATION_B_SINGLE);
-        let bzz3 = (bzz.double() + bzz).normalize_weak();
+        let bzz = self.z.mul_single(CURVE_EQUATION_B_SINGLE);
+        let bzz3 = bzz.double().add(&bzz).normalize_weak();
 
-        let yy_m_bzz3 = yy + &bzz3.negate(1);
-        let yy_p_bzz3 = yy + &bzz3;
+        let yy_m_bzz3 = yy.add(&bzz3.negate(1));
+        let yy_p_bzz3 = yy.add(&bzz3);
 
-        let byz = &yz_pairs
-            .mul_single(CURVE_EQUATION_B_SINGLE)
-            .normalize_weak();
-        let byz3 = (byz.double() + byz).normalize_weak();
+        let byz = yz_pairs.mul_single(CURVE_EQUATION_B_SINGLE).normalize_weak();
+        let byz3 = byz.double().add(&byz).normalize_weak();
 
-        let xx3 = xx.double() + &xx;
-        let bxx9 = &(xx3.double() + &xx3)
+        let xx3 = xx.double().add(&xx);
+        let bxx9 = xx3
+            .double()
+            .add(&xx3)
             .normalize_weak()
             .mul_single(CURVE_EQUATION_B_SINGLE)
             .normalize_weak();
 
         let mut ret = ProjectivePoint {
-            x: ((xy_pairs * &yy_m_bzz3) + &(byz3 * &xz_pairs).negate(1)).normalize_weak(),
-            y: ((yy_p_bzz3 * &yy_m_bzz3) + &(bxx9 * &xz_pairs)).normalize_weak(),
-            z: ((yz_pairs * &yy_p_bzz3) + &(xx3 * &xy_pairs)).normalize_weak(),
+            x: xy_pairs.mul(&yy_m_bzz3).add(&byz3.mul(&xz_pairs).negate(1)).normalize_weak(),
+            y: yy_p_bzz3.mul(&yy_m_bzz3).add(&bxx9.mul(&xz_pairs)).normalize_weak(),
+            z: yz_pairs.mul(&yy_p_bzz3).add(&xx3.mul(&xy_pairs)).normalize_weak(),
         };
         ret.conditional_assign(self, other.is_identity());
         ret
@@ -166,32 +194,29 @@ impl ProjectivePoint {
     pub fn double(&self) -> ProjectivePoint {
         // We implement the complete addition formula from Renes-Costello-Batina 2015
         // (https://eprint.iacr.org/2015/1060 Algorithm 9).
+        //
+        // Lazy-arithmetic throughout; `.normalize_weak()` keeps magnitudes
+        // ≤ 8 for subsequent `mul`s.
 
         let yy = self.y.square();
         let zz = self.z.square();
-        let xy2 = (self.x * &self.y).double();
+        let xy2 = (&self.x * &self.y).double();
 
-        let bzz = &zz.mul_single(CURVE_EQUATION_B_SINGLE);
-        let bzz3 = (bzz.double() + bzz).normalize_weak();
-        let bzz9 = (bzz3.double() + &bzz3).normalize_weak();
+        let bzz = zz.mul_single(CURVE_EQUATION_B_SINGLE);
+        let bzz3 = bzz.double().add(&bzz).normalize_weak();
+        let bzz9 = bzz3.double().add(&bzz3).normalize_weak();
 
-        let yy_m_bzz9 = yy + &bzz9.negate(1);
-        let yy_p_bzz3 = yy + &bzz3;
+        let yy_m_bzz9 = yy.add(&bzz9.negate(1));
+        let yy_p_bzz3 = yy.add(&bzz3);
 
-        let yy_zz = yy * &zz;
+        let yy_zz = yy.mul(&zz);
         let yy_zz8 = yy_zz.double().double().double();
-        let t = (yy_zz8.double() + &yy_zz8)
-            .normalize_weak()
-            .mul_single(CURVE_EQUATION_B_SINGLE);
+        let t = yy_zz8.double().add(&yy_zz8).normalize_weak().mul_single(CURVE_EQUATION_B_SINGLE);
 
         ProjectivePoint {
-            x: xy2 * &yy_m_bzz9,
-            y: ((yy_m_bzz9 * &yy_p_bzz3) + &t).normalize_weak(),
-            z: ((yy * &self.y) * &self.z)
-                .double()
-                .double()
-                .double()
-                .normalize_weak(),
+            x: xy2.mul(&yy_m_bzz9),
+            y: yy_m_bzz9.mul(&yy_p_bzz3).add(&t).normalize_weak(),
+            z: yy.mul(&self.y).mul(&self.z).double().double().double().normalize_weak(),
         }
     }
 
@@ -208,7 +233,7 @@ impl ProjectivePoint {
     /// Calculates SECP256k1 endomorphism: `self * lambda`.
     pub fn endomorphism(&self) -> Self {
         Self {
-            x: self.x * &ENDOMORPHISM_BETA,
+            x: self.x.mul(&ENDOMORPHISM_BETA),
             y: self.y,
             z: self.z,
         }
@@ -223,10 +248,10 @@ impl ProjectivePoint {
         // that we know z = 1 for rhs and we have to check identity as a separate case.
         let both_identity = self.is_identity() & other.is_identity();
         let rhs_identity = other.is_identity();
-        let rhs_x = &other.x * &self.z;
+        let rhs_x = other.x.mul(&self.z);
         let x_eq = rhs_x.negate(1).add(&self.x).normalizes_to_zero();
 
-        let rhs_y = &other.y * &self.z;
+        let rhs_y = other.y.mul(&self.z);
         let y_eq = rhs_y.negate(1).add(&self.y).normalizes_to_zero();
 
         both_identity | (!rhs_identity & x_eq & y_eq)
@@ -238,7 +263,7 @@ impl From<AffinePoint> for ProjectivePoint {
         let projective = ProjectivePoint {
             x: p.x,
             y: p.y,
-            z: FieldElement::ONE,
+            z: LazyFieldElement::ONE,
         };
         Self::conditional_select(&projective, &Self::IDENTITY, p.is_identity())
     }
@@ -292,7 +317,17 @@ where
         // Even a single zero value will fail inversion for the entire batch.
         // Put a dummy value (above `FieldElement::ONE`) so inversion succeeds
         // and treat that case specially later-on.
-        zs.as_mut()[i].conditional_assign(&points[i].z, !points[i].z.normalizes_to_zero());
+        //
+        // The projective `z` coordinate is a `LazyFieldElement`; the `BatchInvert`
+        // trait is only impl'd for `FieldElement`, so we normalize at this
+        // boundary. Cost is one full `normalize()` per point (i.e. one modular
+        // reduction), which is negligible compared to the batch inversion itself.
+        let z_lazy = points[i].z;
+        let z_field = FieldElement::from(z_lazy);
+        let is_zero = z_lazy.normalizes_to_zero();
+        let mut slot = FieldElement::ONE;
+        slot.conditional_assign(&z_field, !is_zero);
+        zs.as_mut()[i] = slot;
     }
 
     // This is safe to unwrap since we assured that all elements are non-zero
@@ -349,9 +384,9 @@ impl ToSec1Point<Secp256k1> for ProjectivePoint {
 impl ConditionallySelectable for ProjectivePoint {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         ProjectivePoint {
-            x: FieldElement::conditional_select(&a.x, &b.x, choice),
-            y: FieldElement::conditional_select(&a.y, &b.y, choice),
-            z: FieldElement::conditional_select(&a.z, &b.z, choice),
+            x: LazyFieldElement::conditional_select(&a.x, &b.x, choice),
+            y: LazyFieldElement::conditional_select(&a.y, &b.y, choice),
+            z: LazyFieldElement::conditional_select(&a.z, &b.z, choice),
         }
     }
 }
@@ -372,12 +407,12 @@ impl ConstantTimeEq for ProjectivePoint {
         // y₂) = (0, z₂y₂) for the first point and (0 * x₂z₂, 0 * y₂z₂) = (0, 0) for the second.
         //
         // Since z₂y₂ will never be 0 they will not be equal in this case either.
-        let lhs_x = self.x * &other.z;
-        let rhs_x = other.x * &self.z;
+        let lhs_x = self.x.mul(&other.z);
+        let rhs_x = other.x.mul(&self.z);
         let x_eq = rhs_x.negate(1).add(&lhs_x).normalizes_to_zero();
 
-        let lhs_y = self.y * &other.z;
-        let rhs_y = other.y * &self.z;
+        let lhs_y = self.y.mul(&other.z);
+        let rhs_y = other.y.mul(&self.z);
         let y_eq = rhs_y.negate(1).add(&lhs_y).normalizes_to_zero();
         x_eq & y_eq
     }

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -960,12 +960,11 @@ mod tests {
     }
 
     #[cfg(feature = "getrandom")]
-    #[allow(clippy::op_ref)]
     #[test]
     fn try_generate_biased_from_rng() {
         let a = Scalar::try_generate_biased_from_rng(&mut SysRng).unwrap();
         // just to make sure `a` is not optimized out by the compiler
-        assert_eq!((a - &a).is_zero().unwrap_u8(), 1);
+        assert_eq!((a - a).is_zero().unwrap_u8(), 1);
     }
 
     #[cfg(feature = "getrandom")]
@@ -973,7 +972,7 @@ mod tests {
     fn try_generate_from_rng() {
         let a = Scalar::try_generate_from_rng(&mut SysRng).unwrap();
         // just to make sure `a` is not optimized out by the compiler
-        assert_eq!((a - &a).is_zero().unwrap_u8(), 1);
+        assert_eq!((a - a).is_zero().unwrap_u8(), 1);
     }
 
     #[test]

--- a/k256/src/schnorr/signing.rs
+++ b/k256/src/schnorr/signing.rs
@@ -3,6 +3,7 @@
 use super::{AUX_TAG, CHALLENGE_TAG, NONCE_TAG, Signature, VerifyingKey, tagged_hash};
 use crate::{
     AffinePoint, FieldBytes, NonZeroScalar, ProjectivePoint, PublicKey, Scalar, SecretKey,
+    arithmetic::FieldElement,
 };
 use elliptic_curve::{
     Generate,
@@ -101,7 +102,7 @@ impl SigningKey {
         let R = ProjectivePoint::mul_by_generator(&k).to_affine();
         let odd = R.y.normalize().is_odd();
         k.conditional_assign(&-k, odd);
-        let r = R.x.normalize();
+        let r = FieldElement::from(R.x.normalize());
 
         let e = <Scalar as Reduce<FieldBytes>>::reduce(
             &tagged_hash(CHALLENGE_TAG)

--- a/k256/src/schnorr/verifying.rs
+++ b/k256/src/schnorr/verifying.rs
@@ -181,7 +181,10 @@ impl TryFrom<PublicKey> for VerifyingKey {
     type Error = Error;
 
     fn try_from(public_key: PublicKey) -> Result<VerifyingKey> {
-        if FieldElement::from(public_key.as_affine().y.normalize()).is_even().into() {
+        if FieldElement::from(public_key.as_affine().y.normalize())
+            .is_even()
+            .into()
+        {
             Ok(Self { inner: public_key })
         } else {
             Err(Error::new())

--- a/k256/src/schnorr/verifying.rs
+++ b/k256/src/schnorr/verifying.rs
@@ -1,7 +1,9 @@
 //! Taproot Schnorr verifying key.
 
 use super::{CHALLENGE_TAG, Signature, tagged_hash};
-use crate::{AffinePoint, FieldBytes, ProjectivePoint, PublicKey, Scalar};
+use crate::{
+    AffinePoint, FieldBytes, ProjectivePoint, PublicKey, Scalar, arithmetic::FieldElement,
+};
 use elliptic_curve::{
     group::CurveAffine,
     ops::{MulByGeneratorVartime, Reduce},
@@ -79,7 +81,10 @@ impl VerifyingKey {
         )
         .to_affine();
 
-        if R.is_identity().into() || R.y.normalize().is_odd().into() || R.x.normalize() != *r {
+        if R.is_identity().into()
+            || R.y.normalize().is_odd().into()
+            || FieldElement::from(R.x.normalize()) != *r
+        {
             return Err(Error::new());
         }
 
@@ -176,7 +181,7 @@ impl TryFrom<PublicKey> for VerifyingKey {
     type Error = Error;
 
     fn try_from(public_key: PublicKey) -> Result<VerifyingKey> {
-        if public_key.as_affine().y.normalize().is_even().into() {
+        if FieldElement::from(public_key.as_affine().y.normalize()).is_even().into() {
             Ok(Self { inner: public_key })
         } else {
             Err(Error::new())

--- a/p256/src/arithmetic/tables.rs
+++ b/p256/src/arithmetic/tables.rs
@@ -63,7 +63,7 @@ mod tests {
     proptest! {
         #[test]
         fn basepoint_table_mul(x in scalar()) {
-            let expected = ProjectivePoint::GENERATOR * &x;
+            let expected = ProjectivePoint::GENERATOR * x;
             let actual = BASEPOINT_TABLE.mul(&x);
             prop_assert_eq!(expected, actual);
         }
@@ -72,7 +72,7 @@ mod tests {
     proptest! {
         #[test]
         fn basepoint_table_mul_vartime(x in scalar()) {
-            let expected = ProjectivePoint::GENERATOR * &x;
+            let expected = ProjectivePoint::GENERATOR * x;
             let actual = BASEPOINT_TABLE.mul_vartime(&x);
             prop_assert_eq!(expected, actual);
         }

--- a/x448/src/lib.rs
+++ b/x448/src/lib.rs
@@ -312,7 +312,7 @@ mod test {
         // If by chance, a low order point is generated, the clamping function will
         // remove it.
         let low_order = alice_pub.0.is_low_order() || bob_pub.0.is_low_order();
-        assert!(low_order == false);
+        assert!(!low_order);
 
         // Both Alice and Bob perform the DH key exchange.
         // As mentioned above, we unwrap because both Parties are using the API correctly.


### PR DESCRIPTION
This is the "oneshot" version of #531 and #1522 and would address the concerns on #1703. Probably unmergable  as a monolith, but happy to break it up in to logical bits if the general strategy is agreed upon. Old tests passing with what should only be mechanical changes to the callsites, and tests have been added to catch all the concerns addressed in the issues.

Lots of churn across the files because the type is everywhere, but the main points to review would be:

-  `field.rs:555` where `From<LazyFieldElement>` is the sole conversion gate.

- Every `FieldElement` arithmetic op (`Mul` , `Add`,  `Neg`, `Sub`, and `Double`) normalizes the result.  Verify no escape hatch   exists that could produce an unnormalized `FieldElement`.

- `field.rs:402` : `PartialEq` delegates to `LazyFieldElement::ct_eq`, which compares raw limb representations. Safe only because `FieldElement` is always canonical. The risk is a future code change that constructs a `FieldElement` with unpropagated carries equality would silently break.

- `field/lazy.rs:185`  normalize_canonical has a cold fallback to `normalize()`

- Perf note:  ~5–13% regression on verify (the lincomb/Straus path hits the FieldElement::from(lazy) boundary).  Still looking in to a workaround.


