### PR TITLE
k256: initial `no_alloc` support for w-NAF

### DIFF
--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -34,7 +34,6 @@
 //! (Note that 'd' is also equal to the curve order here because `[a1,b1]` and `[a2,b2]` are found
 //! as outputs of the Extended Euclidean Algorithm on inputs 'order' and 'lambda').
 
-#[cfg(feature = "alloc")]
 mod wnaf;
 
 use super::{
@@ -43,24 +42,26 @@ use super::{
 };
 use core::array;
 use elliptic_curve::{
-    array::sizes::U33,
+    array::sizes::{U5, U8, U33, U257},
     ops::{LinearCombination, Mul, MulAssign, MulByGeneratorVartime, MulVartime},
     scalar::IsHigh,
     subtle::ConditionallySelectable,
 };
-use primeorder::Radix16Decomposition;
+use primeorder::{PrimeFieldExt, Radix16Decomposition};
 
 #[cfg(feature = "alloc")]
-use {
-    self::wnaf::{WnafBase, WnafScalar},
-    alloc::vec::Vec,
-    primeorder::PrimeFieldExt,
-};
+use alloc::vec::Vec;
 #[cfg(feature = "precomputed-tables")]
 use {super::tables::BASEPOINT_TABLE, elliptic_curve::array::sizes::U65};
 
 /// Lookup table for multiples of a given point.
 type LookupTable = primeorder::LookupTable<ProjectivePoint>;
+
+/// `WnafBase` specialized for `k256`.
+type WnafBase = wnaf::WnafBase<ProjectivePoint, U5, U8>;
+
+/// `WnafScalar` specialized for `k256`.
+type WnafScalar = wnaf::WnafScalar<Scalar, U5, U257>;
 
 const MINUS_LAMBDA: Scalar = Scalar::from_bytes_unchecked(&[
     0xac, 0x9c, 0x52, 0xb3, 0x3f, 0xa3, 0xcf, 0x1f, 0x5a, 0xd9, 0xe3, 0xfd, 0x77, 0xed, 0x9b, 0xa4,
@@ -87,16 +88,11 @@ const G2: Scalar = Scalar::from_bytes_unchecked(&[
     0x22, 0x12, 0x08, 0xac, 0x9d, 0xf5, 0x06, 0xc6, 0x15, 0x71, 0xb4, 0xae, 0x8a, 0xc4, 0x7f, 0x71,
 ]);
 
-/// wNAF window width for GLV vartime multiplication.
-#[cfg(feature = "alloc")]
-const WNAF_WINDOW: usize = 5;
-
 /// Number of little-endian bytes to feed into `WnafScalar::from_le_bytes` for a GLV half-scalar.
 /// GLV guarantees magnitude < 2^128 (16 bytes).
 ///
 /// We use 17 bytes (136 bits) to give headroom for its carry bit without relying on the
 /// trailing-carry special case.
-#[cfg(feature = "alloc")]
 const GLV_LE_BYTES: usize = 17;
 
 /*
@@ -398,8 +394,8 @@ fn lincomb_vartime(
 /// This implementation uses w-NAF and provides the best performance but requires `alloc`.
 #[cfg(feature = "alloc")]
 fn lincomb_vartime(xks: &[(ProjectivePoint, Scalar)]) -> ProjectivePoint {
-    let mut bases: Vec<WnafBase<ProjectivePoint, WNAF_WINDOW>> = Vec::with_capacity(xks.len() * 2);
-    let mut scalars: Vec<WnafScalar<Scalar, WNAF_WINDOW>> = Vec::with_capacity(xks.len() * 2);
+    let mut bases: Vec<WnafBase> = Vec::with_capacity(xks.len() * 2);
+    let mut scalars: Vec<WnafScalar> = Vec::with_capacity(xks.len() * 2);
 
     for (x, k) in xks {
         let ([b0, b1], [s0, s1]) = decompose_glv_wnaf(x, k);
@@ -409,7 +405,7 @@ fn lincomb_vartime(xks: &[(ProjectivePoint, Scalar)]) -> ProjectivePoint {
         scalars.push(s1);
     }
 
-    WnafBase::multiscalar_mul(scalars, bases)
+    WnafBase::multiscalar_mul(&scalars, &bases)
 }
 
 impl ProjectivePoint {
@@ -473,14 +469,7 @@ fn mul(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
     ProjectivePoint::lincomb(&[(*x, *k)])
 }
 
-#[inline]
-#[cfg(not(feature = "alloc"))]
-fn mul_vartime(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
-    ProjectivePoint::lincomb_vartime(&[(*x, *k)])
-}
-
 /// Variable-time `k * self` using width-5 wNAF + GLV endomorphism.
-#[cfg(feature = "alloc")]
 fn mul_vartime(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
     let (bases, scalars) = decompose_glv_wnaf(x, k);
     WnafBase::multiscalar_mul_array(&scalars, &bases)
@@ -488,14 +477,7 @@ fn mul_vartime(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
 
 /// GLV-decompose `k` for `x`: two `(WnafBase, WnafScalar)` pairs representing `r1 * self_signed`
 /// and `r2 * endomorphism(self_signed)`, with signs folded into the points.
-#[cfg(feature = "alloc")]
-fn decompose_glv_wnaf(
-    x: &ProjectivePoint,
-    k: &Scalar,
-) -> (
-    [WnafBase<ProjectivePoint, WNAF_WINDOW>; 2],
-    [WnafScalar<Scalar, WNAF_WINDOW>; 2],
-) {
+fn decompose_glv_wnaf(x: &ProjectivePoint, k: &Scalar) -> ([WnafBase; 2], [WnafScalar; 2]) {
     let (r1, r2) = decompose_scalar(k);
     let r1_neg = bool::from(r1.is_high());
     let r2_neg = bool::from(r2.is_high());
@@ -576,7 +558,6 @@ impl MulByGeneratorVartime for ProjectivePoint {
         Self::mul_by_generator_vartime(k)
     }
 
-    #[cfg(feature = "alloc")]
     fn mul_by_generator_and_mul_add_vartime(a: &Self::Scalar, b: &Self::Scalar, p: &Self) -> Self {
         let ([gb0, gb1], [gs0, gs1]) = decompose_glv_wnaf(&ProjectivePoint::GENERATOR, a);
         let ([pb0, pb1], [ps0, ps1]) = decompose_glv_wnaf(p, b);

--- a/k256/src/arithmetic/mul/wnaf.rs
+++ b/k256/src/arithmetic/mul/wnaf.rs
@@ -5,10 +5,15 @@
 //! goal is to eventually get onto the implementation in the `wnaf` crate (and ideally, eventually
 //! get onto the implementation in `group`).
 
-use alloc::vec::Vec;
-use core::{marker::PhantomData, ops::Mul};
-use elliptic_curve::group::Group;
+use core::{marker::PhantomData, ops::Mul, slice};
+use elliptic_curve::{
+    array::{Array, ArraySize, typenum::Unsigned},
+    group::Group,
+};
 use primeorder::{PrimeField, PrimeFieldExt};
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 /// A fixed window table for a group element, precomputed to improve the speed of scalar
 /// multiplication.
@@ -30,99 +35,107 @@ use primeorder::{PrimeField, PrimeFieldExt};
 /// # Examples
 ///
 /// ```ignore
-/// use group::{WnafBase, WnafScalar};
+/// type MyWnafBase   = WnafBase<ProjectivePoint, U5, U8>;
+/// type MyWnafScalar = WnafScalar<Scalar, U5, U129>;
 ///
-/// let wnaf_bases: Vec<_> = bases.into_iter().map(WnafBase::<_, 4>::new).collect();
-/// let wnaf_scalars: Vec<_> = scalars.iter().map(WnafScalar::new).collect();
-/// let results: Vec<_> = wnaf_bases
-///     .iter()
-///     .flat_map(|base| wnaf_scalars.iter().map(|scalar| base * scalar))
-///     .collect();
+/// let base = MyWnafBase::new(ProjectivePoint::GENERATOR);
+/// let scalar = MyWnafScalar::new(&s);
+/// let result = base * scalar;
 /// ```
 ///
-/// Note that this pattern requires specifying a fixed window size (unlike previous
-/// patterns that picked a suitable window size internally). This is necessary to ensure
+/// Note that this pattern requires specifying a fixed window size `W`. This is necessary to ensure
 /// in the type system that the base and scalar `Wnaf`s were computed with the same window
 /// size, allowing the result to be computed infallibly.
 #[derive(Clone, Debug)]
-pub(super) struct WnafBase<G: Group, const WINDOW_SIZE: usize> {
-    table: Vec<G>,
+pub(super) struct WnafBase<G: Group, W: Unsigned, TableSize: ArraySize> {
+    table: Array<G, TableSize>,
+    _window: PhantomData<W>,
 }
 
-impl<G: Group, const WINDOW_SIZE: usize> WnafBase<G, WINDOW_SIZE> {
-    /// Computes a window table for the given base with the specified `WINDOW_SIZE`.
+impl<G: Group, W: Unsigned, TableSize: ArraySize> WnafBase<G, W, TableSize> {
+    /// Computes a window table for the given base with the specified window size `W`.
     pub fn new(base: G) -> Self {
-        let mut table = vec![];
+        const {
+            assert!(
+                TableSize::USIZE == 1 << (W::USIZE - 2),
+                "provided `TableSize` is incorrect"
+            );
+        }
 
-        // Compute a window table for the provided base and window size.
-        wnaf_table(&mut table, base, WINDOW_SIZE);
-
-        WnafBase { table }
+        WnafBase {
+            table: wnaf_table(base, W::USIZE),
+            _window: PhantomData,
+        }
     }
 
     /// Perform a multiscalar multiplication.
     ///
     /// Computes a sum-of-products `aA + bB + ...` in variable time with w-NAF multi-exponentiation
-    /// using the interleaved window method, also known as Straus' method.
-    pub fn multiscalar_mul<I, J>(scalars: I, bases: J) -> G
-    where
-        I: IntoIterator<Item = WnafScalar<G::Scalar, WINDOW_SIZE>>,
-        J: IntoIterator<Item = Self>,
-    {
-        let wnafs = scalars.into_iter().map(|s| s.wnaf).collect::<Vec<_>>();
-        let tables = bases.into_iter().map(|b| b.table).collect::<Vec<_>>();
-        wnaf_multi_exp(tables.as_slice(), wnafs.as_slice())
+    /// using the interleaved window method, also known as Straus's method.
+    ///
+    /// `scalars` and `bases` must have the same length.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn multiscalar_mul<WnafStorage: ArraySize>(
+        scalars: &[WnafScalar<G::Scalar, W, WnafStorage>],
+        bases: &[Self],
+    ) -> G {
+        debug_assert_eq!(scalars.len(), bases.len());
+        let wnafs: Vec<_> = scalars
+            .iter()
+            .map(|s| (s.wnaf.as_slice(), s.digits))
+            .collect();
+        let tables: Vec<_> = bases.iter().map(|b| b.table.as_slice()).collect();
+        wnaf_multi_exp(&tables, &wnafs, W::USIZE)
     }
 
     /// Perform a multiscalar multiplication with fixed-size array arguments.
     ///
     /// Computes a sum-of-products `aA + bB + ...` in variable time with w-NAF multi-exponentiation
-    /// using the interleaved window method, also known as Straus' method.
+    /// using the interleaved window method, also known as Straus's method.
     #[must_use]
-    pub fn multiscalar_mul_array<const N: usize>(
-        scalars: &[WnafScalar<G::Scalar, WINDOW_SIZE>; N],
+    pub fn multiscalar_mul_array<WnafStorage: ArraySize, const N: usize>(
+        scalars: &[WnafScalar<G::Scalar, W, WnafStorage>; N],
         bases: &[Self; N],
     ) -> G {
-        let wnafs = scalars.each_ref().map(|s| s.wnaf.as_slice());
+        let wnafs = scalars.each_ref().map(|s| (s.wnaf.as_slice(), s.digits));
         let tables = bases.each_ref().map(|b| b.table.as_slice());
-        wnaf_multi_exp(&tables, &wnafs)
+        wnaf_multi_exp(&tables, &wnafs, W::USIZE)
     }
 }
 
-impl<G: Group, const WINDOW_SIZE: usize> Mul<&WnafScalar<G::Scalar, WINDOW_SIZE>>
-    for &WnafBase<G, WINDOW_SIZE>
+impl<G: Group, W: Unsigned, TableSize: ArraySize, WnafStorage: ArraySize>
+    Mul<&WnafScalar<G::Scalar, W, WnafStorage>> for &WnafBase<G, W, TableSize>
 {
     type Output = G;
 
-    fn mul(self, rhs: &WnafScalar<G::Scalar, WINDOW_SIZE>) -> Self::Output {
-        wnaf_exp(&self.table, &rhs.wnaf)
+    fn mul(self, rhs: &WnafScalar<G::Scalar, W, WnafStorage>) -> Self::Output {
+        wnaf_exp(&self.table, &rhs.wnaf, rhs.digits, W::USIZE)
     }
 }
 
-/// A "w-ary non-adjacent form" scalar, that uses precomputation to improve the speed of
+/// A "w-ary non-adjacent form" scalar, precomputed to improve the speed of
 /// scalar multiplication.
 ///
 /// # Examples
 ///
 /// See [`WnafBase`] for usage examples.
 #[derive(Clone, Debug)]
-pub(super) struct WnafScalar<F: PrimeField, const WINDOW_SIZE: usize> {
-    pub(crate) wnaf: Vec<i64>,
-    field: PhantomData<F>,
+pub(super) struct WnafScalar<F: PrimeField, W: Unsigned, WnafStorage: ArraySize> {
+    wnaf: Array<i64, WnafStorage>,
+    digits: usize,
+    _field: PhantomData<(F, W)>,
 }
 
-impl<F: PrimeFieldExt, const WINDOW_SIZE: usize> WnafScalar<F, WINDOW_SIZE> {
-    /// Computes the w-NAF representation of the given scalar with the specified
-    /// `WINDOW_SIZE`.
+impl<F: PrimeFieldExt, W: Unsigned, WnafStorage: ArraySize> WnafScalar<F, W, WnafStorage> {
+    /// Computes the w-NAF representation of the given scalar with window size `W`.
     pub fn new(scalar: &F) -> Self {
-        let mut wnaf = vec![];
-
-        // Compute the w-NAF form of the scalar.
-        wnaf_form(&mut wnaf, scalar.to_le_repr(), WINDOW_SIZE);
-
+        let mut wnaf = Array::from_fn(|_| 0i64);
+        let len = wnaf_form(&mut wnaf, scalar.to_le_repr(), W::USIZE);
         WnafScalar {
             wnaf,
-            field: PhantomData,
+            digits: len,
+            _field: PhantomData,
         }
     }
 
@@ -145,13 +158,18 @@ impl<F: PrimeFieldExt, const WINDOW_SIZE: usize> WnafScalar<F, WINDOW_SIZE> {
     ///
     /// # Errors
     ///
-    /// Returns `None` if `bytes` is longer than the field's canonical representation, or if
-    /// the encoded integer is greater than or equal to the field modulus.
+    /// Returns `None` if `bytes` is longer than the field's canonical representation, if the
+    /// encoded integer is greater than or equal to the field modulus, or if `bytes.len() * 8 + 1`
+    /// exceeds `WnafStorage::USIZE` (which would overflow the fixed-size `wnaf` storage).
     pub fn from_le_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() * 8 + 1 > WnafStorage::USIZE {
+            return None;
+        }
+
         // Validate that `bytes` encodes a canonical field element by round-tripping it through
-        // `F::from_repr`, which returns `None` for any integer greater than or equal to the
-        // modulus. `from_repr` consumes the canonical representation, assumed big-endian to match
-        // `le_repr` below, so reverse the little-endian input into a zero-extended `F::Repr`.
+        // `F::from_repr`, which returns `None` for any integer >= the modulus. `from_repr`
+        // consumes the canonical big-endian representation, so reverse the little-endian input
+        // into a zero-extended `F::Repr`.
         let mut repr = F::Repr::default();
         let repr_len = repr.as_ref().len();
 
@@ -168,14 +186,13 @@ impl<F: PrimeFieldExt, const WINDOW_SIZE: usize> WnafScalar<F, WINDOW_SIZE> {
             return None;
         }
 
-        let mut wnaf = vec![];
-
-        // Compute the w-NAF form directly from the provided little-endian bytes.
-        wnaf_form(&mut wnaf, bytes, WINDOW_SIZE);
+        let mut wnaf = Array::default();
+        let digits = wnaf_form(&mut wnaf, bytes, W::USIZE);
 
         Some(WnafScalar {
             wnaf,
-            field: PhantomData,
+            digits,
+            _field: PhantomData,
         })
     }
 }
@@ -192,7 +209,7 @@ struct LimbBuffer<'a> {
 }
 
 impl<'a> LimbBuffer<'a> {
-    pub(crate) fn new(buf: &'a [u8]) -> Self {
+    fn new(buf: &'a [u8]) -> Self {
         let mut ret = Self {
             buf,
             cur_idx: 0,
@@ -208,7 +225,7 @@ impl<'a> LimbBuffer<'a> {
         ret
     }
 
-    pub(crate) fn increment_limb(&mut self) {
+    fn increment_limb(&mut self) {
         self.cur_idx += 1;
         self.cur_limb = self.next_limb;
         match self.buf.len() {
@@ -241,7 +258,7 @@ impl<'a> LimbBuffer<'a> {
         }
     }
 
-    pub(crate) fn get(&mut self, idx: usize) -> (u64, u64) {
+    fn get(&mut self, idx: usize) -> (u64, u64) {
         assert!([self.cur_idx, self.cur_idx + 1].contains(&idx));
         if idx > self.cur_idx {
             self.increment_limb();
@@ -250,46 +267,48 @@ impl<'a> LimbBuffer<'a> {
     }
 }
 
-/// Replaces the contents of `table` with a w-NAF window table for the given window size.
+/// Computes a w-NAF window table for the given base and window size.
 ///
-/// For a window of size `w`, non-zero wNAF digits are odd and have magnitude at most
+/// For a window of size `w`, non-zero w-NAF digits are odd and have magnitude at most
 /// `2^(w-1) - 1`. The table is indexed by `|digit| / 2`, so the required size is
 /// `(2^(w-1) - 1) / 2 + 1 = 2^(w-2)` entries.
-fn wnaf_table<G: Group>(table: &mut Vec<G>, mut base: G, window: usize) {
-    let table_len = 1 << (window - 2);
-    table.clear();
-    table.reserve(table_len);
+fn wnaf_table<G: Group, TableSize: ArraySize>(base: G, window: usize) -> Array<G, TableSize> {
+    debug_assert_eq!(TableSize::USIZE, 1 << (window - 2));
 
     let dbl = base.double();
+    let mut cur = base;
 
-    for _ in 0..table_len {
-        table.push(base);
-        base.add_assign(&dbl);
-    }
+    Array::from_fn(|_| {
+        let entry = cur;
+        cur.add_assign(&dbl);
+        entry
+    })
 }
 
-/// Replaces the contents of `wnaf` with the w-NAF representation of a little-endian
-/// scalar.
+/// Fills `wnaf` with the w-NAF representation of a little-endian scalar, and returns the
+/// number of digits written.
 #[allow(clippy::cast_possible_wrap)]
-fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut Vec<i64>, c: S, window: usize) {
-    // Required by the NAF definition
+fn wnaf_form<S: AsRef<[u8]>, WnafStorage: ArraySize>(
+    wnaf: &mut Array<i64, WnafStorage>,
+    c: S,
+    window: usize,
+) -> usize {
+    // Required by the NAF definition.
     debug_assert!(window >= 2);
-    // Required so that the NAF digits fit in i64
+    // Required so that the NAF digits fit in i64.
     debug_assert!(window <= 64);
 
     let bit_len = c.as_ref().len() * 8;
-
-    wnaf.clear();
-    wnaf.reserve(bit_len);
-
-    // Initialise the current and next limb buffers.
-    let mut limbs = LimbBuffer::new(c.as_ref());
+    debug_assert!(WnafStorage::USIZE > bit_len, "wnaf storage too small");
 
     let width = 1u64 << window;
     let window_mask = width - 1;
 
+    let mut limbs = LimbBuffer::new(c.as_ref());
     let mut pos = 0;
     let mut carry = 0;
+    let mut cursor = 0;
+
     while pos < bit_len {
         // Construct a buffer of bits of the scalar, starting at bit `pos`
         let u64_idx = pos / 64;
@@ -308,38 +327,56 @@ fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut Vec<i64>, c: S, window: usize) {
 
         if window_val & 1 == 0 {
             // If the window value is even, preserve the carry and emit 0.
-            // Why is the carry preserved?
-            // If carry == 0 and window_val & 1 == 0, then the next carry should be 0
-            // If carry == 1 and window_val & 1 == 0, then bit_buf & 1 == 1 so the next carry should be 1
-            wnaf.push(0);
+            // If carry == 0 and window_val & 1 == 0, then the next carry should be 0.
+            // If carry == 1 and window_val & 1 == 0, then bit_buf & 1 == 1 so the next carry should
+            // be 1.
+            wnaf[cursor] = 0;
+            cursor += 1;
             pos += 1;
         } else {
-            wnaf.push(if window_val < width / 2 {
+            wnaf[cursor] = if window_val < width / 2 {
                 carry = 0;
                 window_val as i64
             } else {
                 carry = 1;
                 (window_val as i64).wrapping_sub(width as i64)
-            });
-            wnaf.extend(core::iter::repeat_n(0, window - 1));
+            };
+            cursor += 1;
+            for _ in 1..window {
+                wnaf[cursor] = 0;
+                cursor += 1;
+            }
             pos += window;
         }
     }
 
-    // If there is a remaining carry (the scalar used all `bit_len` bit and the last wNAF digit was
-    // negative), emit it so the representation is exact.
+    // If there is a remaining carry (the scalar used all `bit_len` bits and the last w-NAF digit
+    // was negative), emit it so the representation is exact.
     if carry != 0 {
-        wnaf.push(carry as i64);
+        wnaf[cursor] = carry as i64;
+        cursor += 1;
     }
+
+    cursor
 }
 
 /// Performs w-NAF exponentiation with the provided window table and w-NAF form scalar.
 ///
-/// This function must be provided a `table` and `wnaf` that were constructed with
-/// the same window size; otherwise, it may panic or produce invalid results.
+/// `window` must match the window size used to construct both `table` and `wnaf`.
 #[inline]
-fn wnaf_exp<G: Group>(table: &[G], wnaf: &[i64]) -> G {
-    wnaf_multi_exp(&[table], &[wnaf])
+fn wnaf_exp<G: Group, TableSize: ArraySize, WnafStorage: ArraySize>(
+    table: &Array<G, TableSize>,
+    wnaf: &Array<i64, WnafStorage>,
+    wnaf_len: usize,
+    window: usize,
+) -> G {
+    let table_slice: &[G] = table.as_slice();
+    let wnaf_entry: (&[i64], usize) = (wnaf.as_slice(), wnaf_len);
+    wnaf_multi_exp(
+        slice::from_ref(&table_slice),
+        slice::from_ref(&wnaf_entry),
+        window,
+    )
 }
 
 /// Performs w-NAF multi-exponentiation using the interleaved window method, also known as
@@ -348,16 +385,18 @@ fn wnaf_exp<G: Group>(table: &[G], wnaf: &[i64]) -> G {
 /// The key insight is that when computing this sum by means of additions and doublings, the
 /// doublings can be shared by performing the additions within an inner loop.
 ///
-/// This function must be provided with `tables` and `wnafs` that were constructed with
-/// the same window size; otherwise, it may panic or produce invalid results.
+/// `tables` and `wnafs` must have been constructed with the same window size `window`;
+/// otherwise this function may panic or produce invalid results.
 #[allow(
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
     clippy::cast_sign_loss
 )]
-fn wnaf_multi_exp<G: Group, T: AsRef<[G]>, W: AsRef<[i64]>>(tables: &[T], wnafs: &[W]) -> G {
+fn wnaf_multi_exp<G: Group>(tables: &[&[G]], wnafs: &[(&[i64], usize)], window: usize) -> G {
     debug_assert_eq!(tables.len(), wnafs.len());
-    let window_size = wnafs.iter().map(|w| w.as_ref().len()).max().unwrap_or(0);
+    debug_assert!(tables.iter().all(|t| t.len() == 1 << (window - 2)));
+
+    let window_size = wnafs.iter().map(|(_, len)| *len).max().unwrap_or(0);
 
     let mut result = G::identity();
     let mut found_one = false;
@@ -368,15 +407,14 @@ fn wnaf_multi_exp<G: Group, T: AsRef<[G]>, W: AsRef<[i64]>>(tables: &[T], wnafs:
             result = result.double();
         }
 
-        for (table, wnaf) in tables.iter().zip(wnafs.iter()) {
-            let n = wnaf.as_ref().get(i).copied().unwrap_or(0);
+        for (&table, (wnaf, _)) in tables.iter().zip(wnafs.iter()) {
+            let n = wnaf.get(i).copied().unwrap_or(0);
             if n != 0 {
                 found_one = true;
-
                 if n > 0 {
-                    result += table.as_ref()[(n / 2) as usize];
+                    result += table[(n / 2) as usize];
                 } else {
-                    result -= table.as_ref()[((-n) / 2) as usize];
+                    result -= table[((-n) / 2) as usize];
                 }
             }
         }


### PR DESCRIPTION
Adds initial support for using w-NAF multiplications in heapless `no_alloc` contexts.

This doesn't help performance but makes the higher performance implementation available in more settings, and eliminates having two different variable-time scalar multiplication paths depending on whether or not the `alloc` feature is enabled. Instead w-NAF is now always available.

For now this doesn't support w-NAF linear combinations / multiscalar multiplications without `alloc`. It should be possible but due to the GLV endomorphism we need temporary arrays twice the size of the input array, which will need to loop in `typenum` size calulations around a const generic input using `typenum::U` or something, which seems a bit tricky so I deferred it for now, but it should be possible.

To make this work I looped in `hybrid-array` and added a `TableSize` parameter to `WnafBase`/`WnafScalar`. I was originally trying to use a type-level calculation for the table size, which needs to be `1 << (W-2)`. Unfortunately I couldn't actually get this to work in a bound or even as the size of `table` without the compiler exploding while recursing infinitely trying to evaluate the requirements.

It could probably be rewritten (back) to const generics, but I would like to keep playing with type-level calculations so I've left it using `hybrid-array` for now.

Whenever I'm actually happy with the implementation we can extract it back out into the `wnaf` crate so it can have `no_alloc` support too.