### PR TITLE
k256: remove dead code implementation of `lincomb_vartime`

### DIFF
--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -253,25 +253,7 @@ impl LinearCombination<[(ProjectivePoint, Scalar)]> for ProjectivePoint {
 
     #[cfg(feature = "alloc")]
     fn lincomb_vartime(points_and_scalars: &[(ProjectivePoint, Scalar)]) -> Self {
-        #[cfg(not(feature = "alloc"))]
-        {
-            let mut tables =
-                vec![(LookupTable::default(), LookupTable::default()); points_and_scalars.len()];
-            let mut digits = vec![
-                (
-                    Radix16Decomposition::<U33>::default(),
-                    Radix16Decomposition::<U33>::default(),
-                );
-                points_and_scalars.len()
-            ];
-
-            lincomb_vartime(points_and_scalars, &mut tables, &mut digits)
-        }
-
-        #[cfg(feature = "alloc")]
-        {
-            lincomb_vartime(points_and_scalars)
-        }
+        lincomb_vartime(points_and_scalars)
     }
 }
 
@@ -470,6 +452,7 @@ fn mul(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
 }
 
 /// Variable-time `k * self` using width-5 wNAF + GLV endomorphism.
+#[inline]
 fn mul_vartime(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
     let (bases, scalars) = decompose_glv_wnaf(x, k);
     WnafBase::multiscalar_mul_array(&scalars, &bases)


### PR DESCRIPTION
This is the old implementation from before we added (back) w-NAF support.

It requires `alloc` anyway since it uses intermediate `Vec` for storage, however it was gated as `not(feature = "alloc")` inside of a `feature = "alloc"` block.