### PR TITLE
wnaf: initial `no_alloc` support

### DIFF
--- a/.github/workflows/wnaf.yml
+++ b/.github/workflows/wnaf.yml
@@ -54,4 +54,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - run: cargo test --no-default-features
       - run: cargo test
+      - run: cargo test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,6 +1714,7 @@ version = "0.14.0-pre.0"
 dependencies = [
  "ff",
  "group",
+ "hybrid-array",
 ]
 
 [[package]]

--- a/k256/src/arithmetic/mul/wnaf.rs
+++ b/k256/src/arithmetic/mul/wnaf.rs
@@ -378,9 +378,6 @@ fn wnaf_exp<G: Group, TableSize: ArraySize, WnafStorage: ArraySize>(
 ///
 /// The key insight is that when computing this sum by means of additions and doublings, the
 /// doublings can be shared by performing the additions within an inner loop.
-///
-/// `tables` and `wnafs` must have been constructed with the same window size `window`;
-/// otherwise this function may panic or produce invalid results.
 #[allow(
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,

--- a/wnaf/Cargo.toml
+++ b/wnaf/Cargo.toml
@@ -20,5 +20,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
+array = { version = "0.4.12", package = "hybrid-array" }
 ff = { version = "0.14", default-features = false }
 group = { version = "0.14", default-features = false }
+
+[features]
+default = ["alloc"]
+alloc = ["array/alloc", "ff/alloc", "group/alloc"]

--- a/wnaf/src/base.rs
+++ b/wnaf/src/base.rs
@@ -1,10 +1,9 @@
-use crate::{WnafScalar, wnaf_exp, wnaf_multi_exp, wnaf_table};
-use alloc::vec::Vec;
+use crate::{WindowSize, WnafScalar, wnaf_exp, wnaf_multi_exp, wnaf_table};
+use array::{Array, ArraySize};
 use core::ops::Mul;
 use group::Group;
 
-/// A fixed window table for a group element, precomputed to improve the speed of scalar
-/// multiplication.
+/// Fixed window table for a group element, precomputed to improve scalar multiplication speed.
 ///
 /// This struct is designed for usage patterns that have long-term cached bases and/or
 /// scalars, or [Cartesian products] of bases and scalars. The [`Wnaf`] API enables one or
@@ -23,79 +22,56 @@ use group::Group;
 /// # Examples
 ///
 /// ```ignore
-/// use group::{WnafBase, WnafScalar};
+/// type MyWnafBase   = WnafBase<ProjectivePoint, U5, U8>;
+/// type MyWnafScalar = WnafScalar<Scalar, U5, U129>;
 ///
-/// let wnaf_bases: Vec<_> = bases.into_iter().map(WnafBase::<_, 4>::new).collect();
-/// let wnaf_scalars: Vec<_> = scalars.iter().map(WnafScalar::new).collect();
-/// let results: Vec<_> = wnaf_bases
-///     .iter()
-///     .flat_map(|base| wnaf_scalars.iter().map(|scalar| base * scalar))
-///     .collect();
+/// let base = MyWnafBase::new(ProjectivePoint::GENERATOR);
+/// let scalar = MyWnafScalar::new(&s);
+/// let result = base * scalar;
 /// ```
 ///
-/// Note that this pattern requires specifying a fixed window size (unlike previous
-/// patterns that picked a suitable window size internally). This is necessary to ensure
+/// Note that this pattern requires specifying a fixed window size `W`. This is necessary to ensure
 /// in the type system that the base and scalar `Wnaf`s were computed with the same window
 /// size, allowing the result to be computed infallibly.
 #[derive(Clone, Debug)]
-pub struct WnafBase<G: Group, const WINDOW_SIZE: usize> {
-    table: Vec<G>,
+pub struct WnafBase<G: Group, W: WindowSize> {
+    table: Array<G, W::TableSize>,
 }
 
-impl<G: Group, const WINDOW_SIZE: usize> WnafBase<G, WINDOW_SIZE> {
-    /// Computes a window table for the given base with the specified `WINDOW_SIZE`.
+impl<G: Group, W: WindowSize> WnafBase<G, W> {
+    /// Computes a window table for the given base with the specified window size `W`.
     pub fn new(base: G) -> Self {
-        let mut table = vec![];
-
-        // Compute a window table for the provided base and window size.
-        wnaf_table(&mut table, base, WINDOW_SIZE);
-
-        WnafBase { table }
+        WnafBase {
+            table: wnaf_table(base, W::USIZE),
+        }
     }
 
     /// Perform a multiscalar multiplication.
     ///
     /// Computes a sum-of-products `aA + bB + ...` in variable time with w-NAF multi-exponentiation
-    /// using the interleaved window method, also known as Straus' method.
-    pub fn multiscalar_mul<I, J>(scalars: I, bases: J) -> G
-    where
-        I: IntoIterator<Item = WnafScalar<G::Scalar, WINDOW_SIZE>>,
-        J: IntoIterator<Item = Self>,
-    {
-        let wnafs = scalars.into_iter().map(|s| s.wnaf).collect::<Vec<_>>();
-        let tables = bases.into_iter().map(|b| b.table).collect::<Vec<_>>();
-        wnaf_multi_exp(tables.as_slice(), wnafs.as_slice())
-    }
-
-    /// Perform a multiscalar multiplication over a fixed-size set of scalars and bases.
+    /// using the interleaved window method, also known as Straus's method.
     ///
-    /// Computes a sum-of-products `aA + bB + ...` in variable time with w-NAF multi-exponentiation
-    /// using the interleaved window method, also known as Straus' method.
-    ///
-    /// This is a borrowing, fixed-arity counterpart to [`multiscalar_mul`]: it operates on
-    /// `&[_; N]` arrays and borrows the precomputed w-NAF forms and window tables in place,
-    /// avoiding the intermediate heap allocations that the iterator-based version performs. It
-    /// suits hot paths with a statically known number of terms (for example the four sub-scalars
-    /// of a GLV-decomposed `aG + bP`).
-    ///
-    /// [`multiscalar_mul`]: Self::multiscalar_mul
+    /// `scalars` and `bases` must have the same length.
     #[must_use]
-    pub fn multiscalar_mul_array<const N: usize>(
-        scalars: &[WnafScalar<G::Scalar, WINDOW_SIZE>; N],
-        bases: &[Self; N],
+    pub fn multiscalar_mul<WnafStorage: ArraySize>(
+        scalars: &[WnafScalar<G::Scalar, W, WnafStorage>],
+        bases: &[Self],
     ) -> G {
-        let wnafs = scalars.each_ref().map(|s| s.wnaf.as_slice());
-        let tables = bases.each_ref().map(|b| b.table.as_slice());
-        wnaf_multi_exp(&tables, &wnafs)
+        let terms = bases
+            .iter()
+            .zip(scalars.iter())
+            .map(|(b, s)| (b.table.as_slice(), s.wnaf.as_slice(), s.digits));
+
+        wnaf_multi_exp(terms)
     }
 }
 
-impl<G: Group, const WINDOW_SIZE: usize> Mul<&WnafScalar<G::Scalar, WINDOW_SIZE>>
-    for &WnafBase<G, WINDOW_SIZE>
+impl<G: Group, W: WindowSize, WnafStorage: ArraySize> Mul<&WnafScalar<G::Scalar, W, WnafStorage>>
+    for &WnafBase<G, W>
 {
     type Output = G;
 
-    fn mul(self, rhs: &WnafScalar<G::Scalar, WINDOW_SIZE>) -> Self::Output {
-        wnaf_exp(&self.table, &rhs.wnaf)
+    fn mul(self, rhs: &WnafScalar<G::Scalar, W, WnafStorage>) -> Self::Output {
+        wnaf_exp(&self.table, &rhs.wnaf, rhs.digits)
     }
 }

--- a/wnaf/src/lib.rs
+++ b/wnaf/src/lib.rs
@@ -7,253 +7,71 @@
 #![forbid(unsafe_code)]
 #![doc = include_str!("../README.md")]
 
-#[macro_use]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 mod base;
 mod limb_buffer;
 mod scalar;
+mod traits;
+// TODO(tarcieri): update to support API changes
+// #[cfg(feature = "alloc")]
+// mod wnaf;
 
-pub use crate::{base::WnafBase, scalar::WnafScalar};
+pub use crate::{
+    base::WnafBase,
+    scalar::WnafScalar,
+    traits::{WindowSize, WnafGroup},
+};
 pub use group::Group;
 
 use crate::limb_buffer::LimbBuffer;
-use alloc::vec::Vec;
+use array::{Array, ArraySize};
 use ff::PrimeField;
 
-/// Extension trait on a [`Group`] that provides helpers used by [`Wnaf`].
-pub trait WnafGroup: Group {
-    /// Recommends a wNAF window size given the number of scalars you intend to multiply
-    /// a base by. Always returns a number between 2 and 22, inclusive.
-    fn recommended_wnaf_for_num_scalars(num_scalars: usize) -> usize;
-}
-
-/// A "w-ary non-adjacent form" scalar multiplication (also known as exponentiation)
-/// context.
+/// Computes a w-NAF window table for the given base and window size.
 ///
-/// # Examples
+/// For a window of size `w` non-zero w-NAF digits are odd and have magnitude at most `2^(w-1) - 1`.
 ///
-/// This struct can be used to implement several patterns:
-///
-/// ## One base, one scalar
-///
-/// For this pattern, you can use a transient `Wnaf` context:
-///
-/// ```ignore
-/// use group::Wnaf;
-///
-/// let result = Wnaf::new().scalar(&scalar).base(base);
-/// ```
-///
-/// ## Many bases, one scalar
-///
-/// For this pattern, you create a `Wnaf` context, load the scalar into it, and then
-/// process each base in turn:
-///
-/// ```ignore
-/// use group::Wnaf;
-///
-/// let mut wnaf = Wnaf::new();
-/// let mut wnaf_scalar = wnaf.scalar(&scalar);
-/// let results: Vec<_> = bases
-///     .into_iter()
-///     .map(|base| wnaf_scalar.base(base))
-///     .collect();
-/// ```
-///
-/// ## One base, many scalars
-///
-/// For this pattern, you create a `Wnaf` context, load the base into it, and then process
-/// each scalar in turn:
-///
-/// ```ignore
-/// use group::Wnaf;
-///
-/// let mut wnaf = Wnaf::new();
-/// let mut wnaf_base = wnaf.base(base, scalars.len());
-/// let results: Vec<_> = scalars
-///     .iter()
-///     .map(|scalar| wnaf_base.scalar(scalar))
-///     .collect();
-/// ```
-///
-/// ## Many bases, many scalars
-///
-/// Say you have `n` bases and `m` scalars, and want to produce `n * m` results. For this
-/// pattern, you need to cache the w-NAF tables for the bases and then compute the w-NAF
-/// form of the scalars on the fly for every base, or vice versa:
-///
-/// ```ignore
-/// use group::Wnaf;
-///
-/// let mut wnaf_contexts: Vec<_> = (0..bases.len()).map(|_| Wnaf::new()).collect();
-/// let mut wnaf_bases: Vec<_> = wnaf_contexts
-///     .iter_mut()
-///     .zip(bases)
-///     .map(|(wnaf, base)| wnaf.base(base, scalars.len()))
-///     .collect();
-/// let results: Vec<_> = wnaf_bases
-///     .iter()
-///     .flat_map(|wnaf_base| scalars.iter().map(|scalar| wnaf_base.scalar(scalar)))
-///     .collect();
-/// ```
-///
-/// Alternatively, use the [`WnafBase`] and [`WnafScalar`] types, which enable the various
-/// tables and w-NAF forms to be cached individually per base and scalar. These types can
-/// then be directly multiplied without any additional runtime work, at the cost of fixing
-/// a specific window size (rather than choosing the window size dynamically).
-#[derive(Debug)]
-pub struct Wnaf<W, B, S> {
-    base: B,
-    scalar: S,
-    window_size: W,
-}
-
-impl<G: Group> Default for Wnaf<(), Vec<G>, Vec<i64>> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<G: Group> Wnaf<(), Vec<G>, Vec<i64>> {
-    /// Construct a new wNAF context without allocating.
-    #[must_use]
-    pub fn new() -> Self {
-        Wnaf {
-            base: vec![],
-            scalar: vec![],
-            window_size: (),
-        }
-    }
-}
-
-impl<G: WnafGroup> Wnaf<(), Vec<G>, Vec<i64>> {
-    /// Given a base and a number of scalars, compute a window table and return a `Wnaf` object that
-    /// can perform exponentiations with `.scalar(..)`.
-    pub fn base(&mut self, base: G, num_scalars: usize) -> Wnaf<usize, &[G], &mut Vec<i64>> {
-        // Compute the appropriate window size based on the number of scalars.
-        let window_size = G::recommended_wnaf_for_num_scalars(num_scalars);
-
-        // Compute a wNAF table for the provided base and window size.
-        wnaf_table(&mut self.base, base, window_size);
-
-        // Return a Wnaf object that immutably borrows the computed base storage location,
-        // but mutably borrows the scalar storage location.
-        Wnaf {
-            base: &self.base[..],
-            scalar: &mut self.scalar,
-            window_size,
-        }
-    }
-
-    /// Given a scalar, compute its wNAF representation and return a `Wnaf` object that can perform
-    /// exponentiations with `.base(..)`.
-    pub fn scalar(&mut self, scalar: &<G as Group>::Scalar) -> Wnaf<usize, &mut Vec<G>, &[i64]> {
-        // We hard-code a window size of 4.
-        let window_size = 4;
-
-        // Compute the wNAF form of the scalar.
-        wnaf_form(&mut self.scalar, le_repr(scalar), window_size);
-
-        // Return a Wnaf object that mutably borrows the base storage location, but
-        // immutably borrows the computed wNAF form scalar location.
-        Wnaf {
-            base: &mut self.base,
-            scalar: &self.scalar[..],
-            window_size,
-        }
-    }
-}
-
-impl<'a, G: Group> Wnaf<usize, &'a [G], &'a mut Vec<i64>> {
-    /// Constructs new space for the scalar representation while borrowing
-    /// the computed window table, for sending the window table across threads.
-    #[must_use]
-    pub fn shared(&self) -> Wnaf<usize, &'a [G], Vec<i64>> {
-        Wnaf {
-            base: self.base,
-            scalar: vec![],
-            window_size: self.window_size,
-        }
-    }
-}
-
-impl<'a, G: Group> Wnaf<usize, &'a mut Vec<G>, &'a [i64]> {
-    /// Constructs new space for the window table while borrowing
-    /// the computed scalar representation, for sending the scalar representation
-    /// across threads.
-    #[must_use]
-    pub fn shared(&self) -> Wnaf<usize, Vec<G>, &'a [i64]> {
-        Wnaf {
-            base: vec![],
-            scalar: self.scalar,
-            window_size: self.window_size,
-        }
-    }
-}
-
-impl<B, S: AsRef<[i64]>> Wnaf<usize, B, S> {
-    /// Performs exponentiation given a base.
-    pub fn base<G: Group>(&mut self, base: G) -> G
-    where
-        B: AsMut<Vec<G>>,
-    {
-        wnaf_table(self.base.as_mut(), base, self.window_size);
-        wnaf_exp(self.base.as_mut(), self.scalar.as_ref())
-    }
-}
-
-impl<B, S: AsMut<Vec<i64>>> Wnaf<usize, B, S> {
-    /// Performs exponentiation given a scalar.
-    pub fn scalar<G: Group>(&mut self, scalar: &<G as Group>::Scalar) -> G
-    where
-        B: AsRef<[G]>,
-    {
-        wnaf_form(self.scalar.as_mut(), le_repr(scalar), self.window_size);
-        wnaf_exp(self.base.as_ref(), self.scalar.as_mut())
-    }
-}
-
-/// Replaces the contents of `table` with a w-NAF window table for the given window size.
-///
-/// For a window of size `w`, non-zero wNAF digits are odd and have magnitude at most
-/// `2^(w-1) - 1`. The table is indexed by `|digit| / 2`, so the required size is
-/// `(2^(w-1) - 1) / 2 + 1 = 2^(w-2)` entries.
-fn wnaf_table<G: Group>(table: &mut Vec<G>, mut base: G, window: usize) {
-    let table_len = 1 << (window - 2);
-    table.clear();
-    table.reserve(table_len);
+/// The table is indexed by `|digit| / 2`, so the required size is `(2^(w-1) - 1) / 2 + 1 = 2^(w-2)`
+/// entries.
+fn wnaf_table<G: Group, TableSize: ArraySize>(base: G, window: usize) -> Array<G, TableSize> {
+    debug_assert_eq!(TableSize::USIZE, 1 << (window - 2));
 
     let dbl = base.double();
+    let mut cur = base;
 
-    for _ in 0..table_len {
-        table.push(base);
-        base.add_assign(&dbl);
-    }
+    Array::from_fn(|_| {
+        let entry = cur;
+        cur.add_assign(&dbl);
+        entry
+    })
 }
 
-/// Replaces the contents of `wnaf` with the w-NAF representation of a little-endian
-/// scalar.
+/// Fills `wnaf` with the w-NAF representation of a little-endian scalar, and returns the
+/// number of digits written.
 #[allow(clippy::cast_possible_wrap)]
-fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut Vec<i64>, c: S, window: usize) {
-    // Required by the NAF definition
+fn wnaf_form<S: AsRef<[u8]>, WnafStorage: ArraySize>(
+    wnaf: &mut Array<i64, WnafStorage>,
+    c: S,
+    window: usize,
+) -> usize {
+    // Required by the NAF definition.
     debug_assert!(window >= 2);
-    // Required so that the NAF digits fit in i64
+    // Required so that the NAF digits fit in i64.
     debug_assert!(window <= 64);
 
     let bit_len = c.as_ref().len() * 8;
-
-    wnaf.clear();
-    wnaf.reserve(bit_len);
-
-    // Initialise the current and next limb buffers.
-    let mut limbs = LimbBuffer::new(c.as_ref());
+    debug_assert!(WnafStorage::USIZE > bit_len, "wnaf storage too small");
 
     let width = 1u64 << window;
     let window_mask = width - 1;
 
+    let mut limbs = LimbBuffer::new(c.as_ref());
     let mut pos = 0;
     let mut carry = 0;
+    let mut cursor = 0;
+
     while pos < bit_len {
         // Construct a buffer of bits of the scalar, starting at bit `pos`
         let u64_idx = pos / 64;
@@ -272,75 +90,92 @@ fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut Vec<i64>, c: S, window: usize) {
 
         if window_val & 1 == 0 {
             // If the window value is even, preserve the carry and emit 0.
-            // Why is the carry preserved?
-            // If carry == 0 and window_val & 1 == 0, then the next carry should be 0
-            // If carry == 1 and window_val & 1 == 0, then bit_buf & 1 == 1 so the next carry should be 1
-            wnaf.push(0);
+            // If carry == 0 and window_val & 1 == 0, then the next carry should be 0.
+            // If carry == 1 and window_val & 1 == 0, then bit_buf & 1 == 1 so the next carry should
+            // be 1.
+            wnaf[cursor] = 0;
+            cursor += 1;
             pos += 1;
         } else {
-            wnaf.push(if window_val < width / 2 {
+            wnaf[cursor] = if window_val < width / 2 {
                 carry = 0;
                 window_val as i64
             } else {
                 carry = 1;
                 (window_val as i64).wrapping_sub(width as i64)
-            });
-            wnaf.extend(core::iter::repeat_n(0, window - 1));
+            };
+            cursor += 1;
+            for _ in 1..window {
+                wnaf[cursor] = 0;
+                cursor += 1;
+            }
             pos += window;
         }
     }
 
-    // If there is a remaining carry (the scalar used all `bit_len` bit and the last wNAF digit was
-    // negative), emit it so the representation is exact.
+    // If there is a remaining carry (the scalar used all `bit_len` bits and the last w-NAF digit
+    // was negative), emit it so the representation is exact.
     if carry != 0 {
-        wnaf.push(carry as i64);
+        wnaf[cursor] = carry as i64;
+        cursor += 1;
     }
+
+    cursor
 }
 
 /// Performs w-NAF exponentiation with the provided window table and w-NAF form scalar.
 ///
-/// This function must be provided a `table` and `wnaf` that were constructed with
-/// the same window size; otherwise, it may panic or produce invalid results.
+/// `window` must match the window size used to construct both `table` and `wnaf`.
 #[inline]
-fn wnaf_exp<G: Group>(table: &[G], wnaf: &[i64]) -> G {
-    wnaf_multi_exp(&[table], &[wnaf])
+fn wnaf_exp<G: Group, TableSize: ArraySize, WnafStorage: ArraySize>(
+    table: &Array<G, TableSize>,
+    wnaf: &Array<i64, WnafStorage>,
+    wnaf_len: usize,
+) -> G {
+    let terms = [(table.as_slice(), wnaf.as_slice(), wnaf_len)];
+    wnaf_multi_exp(terms.iter().copied())
 }
 
 /// Performs w-NAF multi-exponentiation using the interleaved window method, also known as
-/// Straus' method.
+/// Straus's method.
 ///
 /// The key insight is that when computing this sum by means of additions and doublings, the
 /// doublings can be shared by performing the additions within an inner loop.
-///
-/// This function must be provided with `tables` and `wnafs` that were constructed with
-/// the same window size; otherwise, it may panic or produce invalid results.
 #[allow(
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
     clippy::cast_sign_loss
 )]
-fn wnaf_multi_exp<G: Group, T: AsRef<[G]>, W: AsRef<[i64]>>(tables: &[T], wnafs: &[W]) -> G {
-    debug_assert_eq!(tables.len(), wnafs.len());
-    let window_size = wnafs.iter().map(|w| w.as_ref().len()).max().unwrap_or(0);
+fn wnaf_multi_exp<'a, G, I>(terms: I) -> G
+where
+    G: Group,
+    I: Clone + IntoIterator<Item = (&'a [G], &'a [i64], usize)>,
+{
+    let window_size = terms
+        .clone()
+        .into_iter()
+        .map(|(_, _, len)| len)
+        .max()
+        .unwrap_or(0);
 
     let mut result = G::identity();
     let mut found_one = false;
 
     for i in (0..window_size).rev() {
-        // Only double once per iteration of the loop
         if found_one {
             result = result.double();
         }
 
-        for (table, wnaf) in tables.iter().zip(wnafs.iter()) {
-            let n = wnaf.as_ref().get(i).copied().unwrap_or(0);
+        for (table, wnaf, _) in terms.clone() {
+            let n = wnaf.get(i).copied().unwrap_or(0);
+
             if n != 0 {
                 found_one = true;
 
                 if n > 0 {
-                    result += table.as_ref()[(n / 2) as usize];
+                    result += table[(n / 2) as usize];
                 } else {
-                    result -= table.as_ref()[((-n) / 2) as usize];
+                    result -= table[((-n) / 2) as usize];
                 }
             }
         }

--- a/wnaf/src/scalar.rs
+++ b/wnaf/src/scalar.rs
@@ -1,32 +1,29 @@
-use crate::{le_repr, wnaf_form};
-use alloc::vec::Vec;
+use crate::{WindowSize, le_repr, wnaf_form};
+use array::{Array, ArraySize};
 use core::marker::PhantomData;
 use ff::PrimeField;
 
-/// A "w-ary non-adjacent form" scalar, that uses precomputation to improve the speed of
-/// scalar multiplication.
+/// A "w-ary non-adjacent form" scalar, precomputed to improve the speed of scalar multiplication.
 ///
 /// # Examples
 ///
 /// See [`WnafBase`] for usage examples.
 #[derive(Clone, Debug)]
-pub struct WnafScalar<F: PrimeField, const WINDOW_SIZE: usize> {
-    pub(crate) wnaf: Vec<i64>,
-    field: PhantomData<F>,
+pub struct WnafScalar<F: PrimeField, W: WindowSize, WnafStorage: ArraySize> {
+    pub(crate) wnaf: Array<i64, WnafStorage>,
+    pub(crate) digits: usize,
+    _field: PhantomData<(F, W)>,
 }
 
-impl<F: PrimeField, const WINDOW_SIZE: usize> WnafScalar<F, WINDOW_SIZE> {
-    /// Computes the w-NAF representation of the given scalar with the specified
-    /// `WINDOW_SIZE`.
+impl<F: PrimeField, W: WindowSize, WnafStorage: ArraySize> WnafScalar<F, W, WnafStorage> {
+    /// Computes the w-NAF representation of the given scalar with window size `W`.
     pub fn new(scalar: &F) -> Self {
-        let mut wnaf = vec![];
-
-        // Compute the w-NAF form of the scalar.
-        wnaf_form(&mut wnaf, le_repr(scalar), WINDOW_SIZE);
-
+        let mut wnaf = Array::from_fn(|_| 0i64);
+        let len = wnaf_form(&mut wnaf, le_repr(scalar), W::USIZE);
         WnafScalar {
             wnaf,
-            field: PhantomData,
+            digits: len,
+            _field: PhantomData,
         }
     }
 
@@ -49,13 +46,19 @@ impl<F: PrimeField, const WINDOW_SIZE: usize> WnafScalar<F, WINDOW_SIZE> {
     ///
     /// # Errors
     ///
-    /// Returns `None` if `bytes` is longer than the field's canonical representation, or if
-    /// the encoded integer is greater than or equal to the field modulus.
+    /// Returns `None` if `bytes` is longer than the field's canonical representation, if the
+    /// encoded integer is greater than or equal to the field modulus, or if `bytes.len() * 8 + 1`
+    /// exceeds `WnafStorage::USIZE` (which would overflow the fixed-size `wnaf` storage).
     pub fn from_le_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() * 8 + 1 > WnafStorage::USIZE {
+            return None;
+        }
+
         // Validate that `bytes` encodes a canonical field element by round-tripping it through
-        // `F::from_repr`, which returns `None` for any integer greater than or equal to the
-        // modulus. `from_repr` consumes the canonical representation, assumed big-endian to match
-        // `le_repr` below, so reverse the little-endian input into a zero-extended `F::Repr`.
+        // `F::from_repr`, which returns `None` for any integer >= the modulus.
+        //
+        // `from_repr` consumes the canonical big-endian representation, so reverse the
+        // little-endian input into a zero-extended `F::Repr`.
         let mut repr = F::Repr::default();
         let repr_len = repr.as_ref().len();
 
@@ -72,14 +75,13 @@ impl<F: PrimeField, const WINDOW_SIZE: usize> WnafScalar<F, WINDOW_SIZE> {
             return None;
         }
 
-        let mut wnaf = vec![];
-
-        // Compute the w-NAF form directly from the provided little-endian bytes.
-        wnaf_form(&mut wnaf, bytes, WINDOW_SIZE);
+        let mut wnaf = Array::default();
+        let digits = wnaf_form(&mut wnaf, bytes, W::USIZE);
 
         Some(WnafScalar {
             wnaf,
-            field: PhantomData,
+            digits,
+            _field: PhantomData,
         })
     }
 }

--- a/wnaf/src/traits.rs
+++ b/wnaf/src/traits.rs
@@ -1,0 +1,34 @@
+//! Trait definitions.
+
+use array::{
+    ArraySize,
+    typenum::{U1, U2, U3, U4, U5, U6, U7, U8, U16, U32, U64, Unsigned},
+};
+use group::Group;
+
+/// Extension trait on a [`Group`] that provides helpers used by [`crate::Wnaf`].
+pub trait WnafGroup: Group {
+    /// Recommends a wNAF window size given the number of scalars you intend to multiply
+    /// a base by. Always returns a number between 2 and 22, inclusive.
+    fn recommended_wnaf_for_num_scalars(num_scalars: usize) -> usize;
+}
+
+/// Allowed w-NAF window size: we use this to precompute the window point sizes, because it's
+/// currently not possible to write bounds for them.
+pub trait WindowSize: Unsigned {
+    /// Number of precomputed points in the window table: `1 << (Self::USIZE - 2)`.
+    type TableSize: ArraySize;
+}
+
+// TODO(tarcieri): compute or failing that test window sizes
+macro_rules! impl_window_sizes {
+    ($($window_size:ty => $table_size:ty),+) => {
+        $(
+            impl WindowSize for $window_size {
+                type TableSize = $table_size;
+            }
+        )+
+    };
+}
+
+impl_window_sizes!(U2 => U1, U3 => U2, U4 => U4, U5 => U8, U6 => U16, U7 => U32, U8 => U64);

--- a/wnaf/src/wnaf.rs
+++ b/wnaf/src/wnaf.rs
@@ -1,0 +1,192 @@
+//! Dynamic w-NAF API (requires `alloc` feature).
+// TODO(tarcieri): actually make this work with the API changes to e.g. `wnaf_table`
+
+use crate::{WnafBase, WnafGroup, WnafScalar, le_repr, wnaf_exp, wnaf_form, wnaf_table};
+use alloc::vec::Vec;
+use group::Group;
+
+/// A "w-ary non-adjacent form" scalar multiplication (also known as exponentiation)
+/// context.
+///
+/// # Examples
+///
+/// This struct can be used to implement several patterns:
+///
+/// ## One base, one scalar
+///
+/// For this pattern, you can use a transient `Wnaf` context:
+///
+/// ```ignore
+/// use group::Wnaf;
+///
+/// let result = Wnaf::new().scalar(&scalar).base(base);
+/// ```
+///
+/// ## Many bases, one scalar
+///
+/// For this pattern, you create a `Wnaf` context, load the scalar into it, and then
+/// process each base in turn:
+///
+/// ```ignore
+/// use group::Wnaf;
+///
+/// let mut wnaf = Wnaf::new();
+/// let mut wnaf_scalar = wnaf.scalar(&scalar);
+/// let results: Vec<_> = bases
+///     .into_iter()
+///     .map(|base| wnaf_scalar.base(base))
+///     .collect();
+/// ```
+///
+/// ## One base, many scalars
+///
+/// For this pattern, you create a `Wnaf` context, load the base into it, and then process
+/// each scalar in turn:
+///
+/// ```ignore
+/// use group::Wnaf;
+///
+/// let mut wnaf = Wnaf::new();
+/// let mut wnaf_base = wnaf.base(base, scalars.len());
+/// let results: Vec<_> = scalars
+///     .iter()
+///     .map(|scalar| wnaf_base.scalar(scalar))
+///     .collect();
+/// ```
+///
+/// ## Many bases, many scalars
+///
+/// Say you have `n` bases and `m` scalars, and want to produce `n * m` results. For this
+/// pattern, you need to cache the w-NAF tables for the bases and then compute the w-NAF
+/// form of the scalars on the fly for every base, or vice versa:
+///
+/// ```ignore
+/// use group::Wnaf;
+///
+/// let mut wnaf_contexts: Vec<_> = (0..bases.len()).map(|_| Wnaf::new()).collect();
+/// let mut wnaf_bases: Vec<_> = wnaf_contexts
+///     .iter_mut()
+///     .zip(bases)
+///     .map(|(wnaf, base)| wnaf.base(base, scalars.len()))
+///     .collect();
+/// let results: Vec<_> = wnaf_bases
+///     .iter()
+///     .flat_map(|wnaf_base| scalars.iter().map(|scalar| wnaf_base.scalar(scalar)))
+///     .collect();
+/// ```
+///
+/// Alternatively, use the [`WnafBase`] and [`WnafScalar`] types, which enable the various
+/// tables and w-NAF forms to be cached individually per base and scalar. These types can
+/// then be directly multiplied without any additional runtime work, at the cost of fixing
+/// a specific window size (rather than choosing the window size dynamically).
+#[derive(Debug)]
+pub struct Wnaf<W, B, S> {
+    base: B,
+    scalar: S,
+    window_size: W,
+}
+
+impl<G: Group> Default for Wnaf<(), Vec<G>, Vec<i64>> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<G: Group> Wnaf<(), Vec<G>, Vec<i64>> {
+    /// Construct a new wNAF context without allocating.
+    #[must_use]
+    pub fn new() -> Self {
+        Wnaf {
+            base: vec![],
+            scalar: vec![],
+            window_size: (),
+        }
+    }
+}
+
+impl<G: WnafGroup> Wnaf<(), Vec<G>, Vec<i64>> {
+    /// Given a base and a number of scalars, compute a window table and return a `Wnaf` object that
+    /// can perform exponentiations with `.scalar(..)`.
+    pub fn base(&mut self, base: G, num_scalars: usize) -> Wnaf<usize, &[G], &mut Vec<i64>> {
+        // Compute the appropriate window size based on the number of scalars.
+        let window_size = G::recommended_wnaf_for_num_scalars(num_scalars);
+
+        // Compute a wNAF table for the provided base and window size.
+        wnaf_table(&mut self.base, base, window_size);
+
+        // Return a Wnaf object that immutably borrows the computed base storage location,
+        // but mutably borrows the scalar storage location.
+        Wnaf {
+            base: &self.base[..],
+            scalar: &mut self.scalar,
+            window_size,
+        }
+    }
+
+    /// Given a scalar, compute its wNAF representation and return a `Wnaf` object that can perform
+    /// exponentiations with `.base(..)`.
+    pub fn scalar(&mut self, scalar: &<G as Group>::Scalar) -> Wnaf<usize, &mut Vec<G>, &[i64]> {
+        // We hard-code a window size of 4.
+        let window_size = 4;
+
+        // Compute the wNAF form of the scalar.
+        wnaf_form(&mut self.scalar, le_repr(scalar), window_size);
+
+        // Return a Wnaf object that mutably borrows the base storage location, but
+        // immutably borrows the computed wNAF form scalar location.
+        Wnaf {
+            base: &mut self.base,
+            scalar: &self.scalar[..],
+            window_size,
+        }
+    }
+}
+
+impl<'a, G: Group> Wnaf<usize, &'a [G], &'a mut Vec<i64>> {
+    /// Constructs new space for the scalar representation while borrowing
+    /// the computed window table, for sending the window table across threads.
+    #[must_use]
+    pub fn shared(&self) -> Wnaf<usize, &'a [G], Vec<i64>> {
+        Wnaf {
+            base: self.base,
+            scalar: vec![],
+            window_size: self.window_size,
+        }
+    }
+}
+
+impl<'a, G: Group> Wnaf<usize, &'a mut Vec<G>, &'a [i64]> {
+    /// Constructs new space for the window table while borrowing
+    /// the computed scalar representation, for sending the scalar representation
+    /// across threads.
+    #[must_use]
+    pub fn shared(&self) -> Wnaf<usize, Vec<G>, &'a [i64]> {
+        Wnaf {
+            base: vec![],
+            scalar: self.scalar,
+            window_size: self.window_size,
+        }
+    }
+}
+
+impl<B, S: AsRef<[i64]>> Wnaf<usize, B, S> {
+    /// Performs exponentiation given a base.
+    pub fn base<G: Group>(&mut self, base: G) -> G
+    where
+        B: AsMut<Vec<G>>,
+    {
+        wnaf_table(self.base.as_mut(), base, self.window_size);
+        wnaf_exp(self.base.as_mut(), self.scalar.as_ref())
+    }
+}
+
+impl<B, S: AsMut<Vec<i64>>> Wnaf<usize, B, S> {
+    /// Performs exponentiation given a scalar.
+    pub fn scalar<G: Group>(&mut self, scalar: &<G as Group>::Scalar) -> G
+    where
+        B: AsRef<[G]>,
+    {
+        wnaf_form(self.scalar.as_mut(), le_repr(scalar), self.window_size);
+        wnaf_exp(self.base.as_ref(), self.scalar.as_mut())
+    }
+}


### PR DESCRIPTION
This incorporates the changes from the vendored w-NAF implementation in `k256`, where `no_alloc` support was added in commits like #1819 and #1823, back into the `wnaf` crate proper, just in case someone wants to submit e.g. a Pippenger implementation that they are not making it against a stale version of the crate.

Functions like `wnaf_form` and `wnaf_table` were changed to operate directly on `Array` which doesn't work with the dynamic `Wnaf` API. They'll need to be updated to write into a mutable buffer so we can use them with both `Array` and `Vec`. I didn't do it yet and just commented out the whole module and left a TODO.

We aren't yet using that API at all anywhere so it's a lower priority.