### PR TITLE
wnaf: `WnafBase::multiscalar_mul` take an `Iterator`; fix `Wnaf`

### DIFF
--- a/k256/src/arithmetic/mul/wnaf.rs
+++ b/k256/src/arithmetic/mul/wnaf.rs
@@ -5,7 +5,7 @@
 //! goal is to eventually get onto the implementation in the `wnaf` crate (and ideally, eventually
 //! get onto the implementation in `group`).
 
-use core::{marker::PhantomData, ops::Mul};
+use core::{iter, marker::PhantomData, ops::Mul};
 use elliptic_curve::{
     array::{
         Array, ArraySize,
@@ -105,7 +105,7 @@ impl<G: Group, W: WindowSize, WnafStorage: ArraySize> Mul<&WnafScalar<G::Scalar,
     type Output = G;
 
     fn mul(self, rhs: &WnafScalar<G::Scalar, W, WnafStorage>) -> Self::Output {
-        WnafBase::multiscalar_mul(core::iter::once((self, rhs)))
+        WnafBase::multiscalar_mul(iter::once((self, rhs)))
     }
 }
 

--- a/wnaf/src/base.rs
+++ b/wnaf/src/base.rs
@@ -1,5 +1,6 @@
-use crate::{WindowSize, WnafScalar, wnaf_exp, wnaf_multi_exp, wnaf_table};
+use crate::{WindowSize, WnafScalar, wnaf_multi_exp, wnaf_table};
 use array::{Array, ArraySize};
+use core::iter;
 use core::ops::Mul;
 use group::Group;
 
@@ -41,28 +42,22 @@ pub struct WnafBase<G: Group, W: WindowSize> {
 impl<G: Group, W: WindowSize> WnafBase<G, W> {
     /// Computes a window table for the given base with the specified window size `W`.
     pub fn new(base: G) -> Self {
-        WnafBase {
-            table: wnaf_table(base, W::USIZE),
-        }
+        let mut table = Array::from_fn(|_| G::generator());
+        wnaf_table(&mut table, base, W::USIZE);
+        WnafBase { table }
     }
 
     /// Perform a multiscalar multiplication.
     ///
     /// Computes a sum-of-products `aA + bB + ...` in variable time with w-NAF multi-exponentiation
     /// using the interleaved window method, also known as Straus's method.
-    ///
-    /// `scalars` and `bases` must have the same length.
     #[must_use]
-    pub fn multiscalar_mul<WnafStorage: ArraySize>(
-        scalars: &[WnafScalar<G::Scalar, W, WnafStorage>],
-        bases: &[Self],
-    ) -> G {
-        let terms = bases
-            .iter()
-            .zip(scalars.iter())
-            .map(|(b, s)| (b.table.as_slice(), s.wnaf.as_slice(), s.digits));
-
-        wnaf_multi_exp(terms)
+    pub fn multiscalar_mul<'a, WnafStorage, I>(pairs: I) -> G
+    where
+        WnafStorage: ArraySize,
+        I: Clone + Iterator<Item = (&'a Self, &'a WnafScalar<G::Scalar, W, WnafStorage>)>,
+    {
+        wnaf_multi_exp(pairs.map(|(b, s)| (b.table.as_slice(), s.wnaf.as_slice(), s.digits)))
     }
 }
 
@@ -72,6 +67,6 @@ impl<G: Group, W: WindowSize, WnafStorage: ArraySize> Mul<&WnafScalar<G::Scalar,
     type Output = G;
 
     fn mul(self, rhs: &WnafScalar<G::Scalar, W, WnafStorage>) -> Self::Output {
-        wnaf_exp(&self.table, &rhs.wnaf, rhs.digits)
+        WnafBase::multiscalar_mul(iter::once((self, rhs)))
     }
 }

--- a/wnaf/src/lib.rs
+++ b/wnaf/src/lib.rs
@@ -8,15 +8,16 @@
 #![doc = include_str!("../README.md")]
 
 #[cfg(feature = "alloc")]
+#[macro_use]
 extern crate alloc;
 
 mod base;
 mod limb_buffer;
 mod scalar;
 mod traits;
-// TODO(tarcieri): update to support API changes
-// #[cfg(feature = "alloc")]
-// mod wnaf;
+
+#[cfg(feature = "alloc")]
+mod wnaf;
 
 pub use crate::{
     base::WnafBase,
@@ -25,8 +26,10 @@ pub use crate::{
 };
 pub use group::Group;
 
+#[cfg(feature = "alloc")]
+pub use crate::wnaf::Wnaf;
+
 use crate::limb_buffer::LimbBuffer;
-use array::{Array, ArraySize};
 use ff::PrimeField;
 
 /// Computes a w-NAF window table for the given base and window size.
@@ -35,34 +38,27 @@ use ff::PrimeField;
 ///
 /// The table is indexed by `|digit| / 2`, so the required size is `(2^(w-1) - 1) / 2 + 1 = 2^(w-2)`
 /// entries.
-fn wnaf_table<G: Group, TableSize: ArraySize>(base: G, window: usize) -> Array<G, TableSize> {
-    debug_assert_eq!(TableSize::USIZE, 1 << (window - 2));
+fn wnaf_table<G: Group>(table: &mut [G], base: G, window: usize) {
+    debug_assert_eq!(table.len(), 1 << (window - 2));
 
     let dbl = base.double();
     let mut cur = base;
 
-    Array::from_fn(|_| {
-        let entry = cur;
+    for entry in table {
+        *entry = cur;
         cur.add_assign(&dbl);
-        entry
-    })
+    }
 }
 
 /// Fills `wnaf` with the w-NAF representation of a little-endian scalar, and returns the
 /// number of digits written.
 #[allow(clippy::cast_possible_wrap)]
-fn wnaf_form<S: AsRef<[u8]>, WnafStorage: ArraySize>(
-    wnaf: &mut Array<i64, WnafStorage>,
-    c: S,
-    window: usize,
-) -> usize {
-    // Required by the NAF definition.
+fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut [i64], c: S, window: usize) -> usize {
     debug_assert!(window >= 2);
-    // Required so that the NAF digits fit in i64.
     debug_assert!(window <= 64);
 
     let bit_len = c.as_ref().len() * 8;
-    debug_assert!(WnafStorage::USIZE > bit_len, "wnaf storage too small");
+    debug_assert!(wnaf.len() > bit_len, "wnaf storage too small");
 
     let width = 1u64 << window;
     let window_mask = width - 1;
@@ -121,19 +117,6 @@ fn wnaf_form<S: AsRef<[u8]>, WnafStorage: ArraySize>(
     }
 
     cursor
-}
-
-/// Performs w-NAF exponentiation with the provided window table and w-NAF form scalar.
-///
-/// `window` must match the window size used to construct both `table` and `wnaf`.
-#[inline]
-fn wnaf_exp<G: Group, TableSize: ArraySize, WnafStorage: ArraySize>(
-    table: &Array<G, TableSize>,
-    wnaf: &Array<i64, WnafStorage>,
-    wnaf_len: usize,
-) -> G {
-    let terms = [(table.as_slice(), wnaf.as_slice(), wnaf_len)];
-    wnaf_multi_exp(terms.iter().copied())
 }
 
 /// Performs w-NAF multi-exponentiation using the interleaved window method, also known as

--- a/wnaf/src/wnaf.rs
+++ b/wnaf/src/wnaf.rs
@@ -1,7 +1,6 @@
 //! Dynamic w-NAF API (requires `alloc` feature).
-// TODO(tarcieri): actually make this work with the API changes to e.g. `wnaf_table`
 
-use crate::{WnafBase, WnafGroup, WnafScalar, le_repr, wnaf_exp, wnaf_form, wnaf_table};
+use crate::{WnafGroup, le_repr, wnaf_form, wnaf_multi_exp, wnaf_table};
 use alloc::vec::Vec;
 use group::Group;
 
@@ -93,7 +92,6 @@ impl<G: Group> Default for Wnaf<(), Vec<G>, Vec<i64>> {
 }
 
 impl<G: Group> Wnaf<(), Vec<G>, Vec<i64>> {
-    /// Construct a new wNAF context without allocating.
     #[must_use]
     pub fn new() -> Self {
         Wnaf {
@@ -105,17 +103,12 @@ impl<G: Group> Wnaf<(), Vec<G>, Vec<i64>> {
 }
 
 impl<G: WnafGroup> Wnaf<(), Vec<G>, Vec<i64>> {
-    /// Given a base and a number of scalars, compute a window table and return a `Wnaf` object that
-    /// can perform exponentiations with `.scalar(..)`.
     pub fn base(&mut self, base: G, num_scalars: usize) -> Wnaf<usize, &[G], &mut Vec<i64>> {
-        // Compute the appropriate window size based on the number of scalars.
         let window_size = G::recommended_wnaf_for_num_scalars(num_scalars);
 
-        // Compute a wNAF table for the provided base and window size.
+        self.base.resize_with(1 << (window_size - 2), G::identity);
         wnaf_table(&mut self.base, base, window_size);
 
-        // Return a Wnaf object that immutably borrows the computed base storage location,
-        // but mutably borrows the scalar storage location.
         Wnaf {
             base: &self.base[..],
             scalar: &mut self.scalar,
@@ -123,17 +116,14 @@ impl<G: WnafGroup> Wnaf<(), Vec<G>, Vec<i64>> {
         }
     }
 
-    /// Given a scalar, compute its wNAF representation and return a `Wnaf` object that can perform
-    /// exponentiations with `.base(..)`.
     pub fn scalar(&mut self, scalar: &<G as Group>::Scalar) -> Wnaf<usize, &mut Vec<G>, &[i64]> {
-        // We hard-code a window size of 4.
         let window_size = 4;
 
-        // Compute the wNAF form of the scalar.
-        wnaf_form(&mut self.scalar, le_repr(scalar), window_size);
+        let repr = le_repr(scalar);
+        self.scalar.resize(repr.as_ref().len() * 8 + 1, 0);
+        let digits = wnaf_form(&mut self.scalar, repr, window_size);
+        self.scalar.truncate(digits);
 
-        // Return a Wnaf object that mutably borrows the base storage location, but
-        // immutably borrows the computed wNAF form scalar location.
         Wnaf {
             base: &mut self.base,
             scalar: &self.scalar[..],
@@ -170,23 +160,33 @@ impl<'a, G: Group> Wnaf<usize, &'a mut Vec<G>, &'a [i64]> {
 }
 
 impl<B, S: AsRef<[i64]>> Wnaf<usize, B, S> {
-    /// Performs exponentiation given a base.
     pub fn base<G: Group>(&mut self, base: G) -> G
     where
         B: AsMut<Vec<G>>,
     {
+        self.base
+            .as_mut()
+            .resize_with(1 << (self.window_size - 2), G::identity);
         wnaf_table(self.base.as_mut(), base, self.window_size);
         wnaf_exp(self.base.as_mut(), self.scalar.as_ref())
     }
 }
 
 impl<B, S: AsMut<Vec<i64>>> Wnaf<usize, B, S> {
-    /// Performs exponentiation given a scalar.
     pub fn scalar<G: Group>(&mut self, scalar: &<G as Group>::Scalar) -> G
     where
         B: AsRef<[G]>,
     {
-        wnaf_form(self.scalar.as_mut(), le_repr(scalar), self.window_size);
+        let repr = le_repr(scalar);
+        self.scalar.as_mut().resize(repr.as_ref().len() * 8 + 1, 0);
+        let digits = wnaf_form(self.scalar.as_mut(), repr, self.window_size);
+        self.scalar.as_mut().truncate(digits);
         wnaf_exp(self.base.as_ref(), self.scalar.as_mut())
     }
+}
+
+/// Performs w-NAF exponentiation with the provided window table and w-NAF form scalar, whose
+/// lengths must match.
+pub(crate) fn wnaf_exp<G: Group>(table: &[G], wnaf: &[i64]) -> G {
+    wnaf_multi_exp(core::iter::once((table, wnaf, wnaf.len())))
 }


### PR DESCRIPTION
This propagates the changes from `k256` in #1825 to the `wnaf` crate, and additionally fixes the more dynamic `Wnaf` struct.

The core implementation can now be shared between `Array` and `Vec`, and the `alloc` feature of the `wnaf` crate is now useful.

I'm actually pretty happy with the `wnaf` crate in this state. Maybe we can release it and move `k256` back onto it.