### PR TITLE
Simplify `BatchInvert` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,8 +490,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51c58d86e2f3cebbf2dfd94c4bf049585c7def71058ba506bfdafcb57652a34b"
+source = "git+https://github.com/RustCrypto/traits#592e9c30162604e864445abef76ae13eccd7c39d"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,5 @@ hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
 wnaf = { path = "wnaf" }
+
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/bignp256/src/arithmetic/field.rs
+++ b/bignp256/src/arithmetic/field.rs
@@ -17,6 +17,7 @@ use crate::U256;
 use elliptic_curve::{
     bigint::cpubits,
     ff::PrimeField,
+    ops::BatchInvert,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
@@ -91,6 +92,8 @@ primefield::fiat_monty_field_arithmetic! {
     msat: fiat_bignp256_msat,
     selectnz: fiat_bignp256_selectznz
 }
+
+impl BatchInvert for FieldElement {}
 
 #[cfg(test)]
 mod tests {

--- a/bp256/src/arithmetic/field.rs
+++ b/bp256/src/arithmetic/field.rs
@@ -14,6 +14,7 @@ use crate::U256;
 use elliptic_curve::{
     bigint::cpubits,
     ff::PrimeField,
+    ops::BatchInvert,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
@@ -93,6 +94,8 @@ primefield::fiat_monty_field_arithmetic! {
     msat: fiat_bp256_msat,
     selectnz: fiat_bp256_selectznz
 }
+
+impl BatchInvert for FieldElement {}
 
 #[cfg(test)]
 mod tests {

--- a/bp384/src/arithmetic/field.rs
+++ b/bp384/src/arithmetic/field.rs
@@ -14,6 +14,7 @@ use crate::U384;
 use elliptic_curve::{
     bigint::cpubits,
     ff::PrimeField,
+    ops::BatchInvert,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
@@ -93,6 +94,8 @@ primefield::fiat_monty_field_arithmetic! {
     msat: fiat_bp384_msat,
     selectnz: fiat_bp384_selectznz
 }
+
+impl BatchInvert for FieldElement {}
 
 #[cfg(test)]
 mod tests {

--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -322,8 +322,9 @@ impl CurveGroup for EdwardsPoint {
     #[inline]
     fn batch_normalize(projective: &[Self], affine: &mut [Self::Affine]) {
         assert_eq!(projective.len(), affine.len());
-        let mut zs = alloc::vec![FieldElement::ONE; projective.len()];
-        batch_normalize_generic(projective, zs.as_mut_slice(), affine);
+        let mut zs = vec![FieldElement::ZERO; projective.len()];
+        let mut scratch = vec![FieldElement::ZERO; projective.len()];
+        batch_normalize_generic(projective, &mut zs, &mut scratch, affine);
     }
 }
 
@@ -768,9 +769,10 @@ impl<const N: usize> BatchNormalize<[EdwardsPoint; N]> for EdwardsPoint {
 
     #[inline]
     fn batch_normalize(points: &[Self; N]) -> [<Self as CurveGroup>::Affine; N] {
-        let zs = [FieldElement::ONE; N];
+        let mut zs = [FieldElement::ZERO; N];
+        let mut scratch = [FieldElement::ZERO; N];
         let mut affine_points = [AffinePoint::IDENTITY; N];
-        batch_normalize_generic(points, zs, &mut affine_points);
+        batch_normalize_generic(points, &mut zs, &mut scratch, &mut affine_points);
         affine_points
     }
 }
@@ -783,43 +785,36 @@ impl BatchNormalize<[EdwardsPoint]> for EdwardsPoint {
     fn batch_normalize(points: &[Self]) -> Vec<<Self as CurveGroup>::Affine> {
         use alloc::vec;
 
-        let mut zs = vec![FieldElement::ONE; points.len()];
+        let mut zs = vec![FieldElement::ZERO; points.len()];
+        let mut scratch = vec![FieldElement::ZERO; points.len()];
         let mut affine_points = vec![AffinePoint::IDENTITY; points.len()];
-        batch_normalize_generic(points, zs.as_mut_slice(), &mut affine_points);
+        batch_normalize_generic(points, &mut zs, &mut scratch, &mut affine_points);
         affine_points
     }
 }
 
-/// Generic implementation of batch normalization.
-fn batch_normalize_generic<P, Z, I, O>(points: &P, mut zs: Z, out: &mut O)
-where
-    FieldElement: BatchInvert<Z, Output = CtOption<I>>,
-    P: AsRef<[EdwardsPoint]> + ?Sized,
-    Z: AsMut<[FieldElement]>,
-    I: AsRef<[FieldElement]>,
-    O: AsMut<[AffinePoint]> + ?Sized,
-{
-    let points = points.as_ref();
-    let out = out.as_mut();
+fn batch_normalize_generic(
+    points: &[EdwardsPoint],
+    zs: &mut [FieldElement],
+    scratch: &mut [FieldElement],
+    out: &mut [AffinePoint],
+) {
+    debug_assert_eq!(points.len(), zs.len());
+    debug_assert_eq!(points.len(), scratch.len());
+    debug_assert_eq!(points.len(), out.len());
 
-    for (i, point) in points.iter().enumerate() {
-        // Even a single zero value will fail inversion for the entire batch.
-        // Put a dummy value (above `FieldElement::ONE`) so inversion succeeds
-        // and treat that case specially later-on.
-        zs.as_mut()[i].conditional_assign(&point.Z, !point.Z.ct_eq(&FieldElement::ZERO));
+    for (z, point) in zs.iter_mut().zip(points) {
+        *z = point.Z;
     }
 
-    // This is safe to unwrap since we assured that all elements are non-zero
-    let zs_inverses = <FieldElement as BatchInvert<Z>>::batch_invert(zs)
-        .expect("all elements should be non-zero");
+    // Zero `zs` (identity) are handled explicitly below, so the `Choice` here is informational only
+    let _ = FieldElement::batch_invert_in_place(zs, scratch);
 
     for i in 0..out.len() {
-        // If the `z` coordinate is non-zero, we can use it to invert;
-        // otherwise it defaults to the `IDENTITY` value.
         out[i] = AffinePoint::conditional_select(
             &AffinePoint {
-                x: points[i].X * zs_inverses.as_ref()[i],
-                y: points[i].Y * zs_inverses.as_ref()[i],
+                x: points[i].X * zs[i],
+                y: points[i].Y * zs[i],
             },
             &AffinePoint::IDENTITY,
             points[i].Z.ct_eq(&FieldElement::ZERO),

--- a/ed448-goldilocks/src/field/element.rs
+++ b/ed448-goldilocks/src/field/element.rs
@@ -7,7 +7,6 @@ use crate::{
     AffinePoint, Decaf448, DecafPoint, Ed448, EdwardsPoint,
     curve::twedwards::extended::ExtendedPoint as TwistedExtendedPoint,
 };
-use elliptic_curve::ops::Reduce;
 use elliptic_curve::{
     Field,
     array::Array,
@@ -16,6 +15,7 @@ use elliptic_curve::{
         consts::{U28, U56, U84, U88},
         modular::ConstMontyParams,
     },
+    ops::{BatchInvert, Reduce},
     zeroize::DefaultIsZeroes,
 };
 use hash2curve::MapToCurve;
@@ -51,6 +51,8 @@ impl UpperHex for FieldElement {
         write!(f, "{:X}", self.0.retrieve())
     }
 }
+
+impl BatchInvert for FieldElement {}
 
 impl ConstantTimeEq for FieldElement {
     fn ct_eq(&self, other: &Self) -> Choice {

--- a/ed448-goldilocks/src/lib.rs
+++ b/ed448-goldilocks/src/lib.rs
@@ -40,6 +40,7 @@
 //! Please see type-specific documentation for more information.
 
 #[cfg(feature = "alloc")]
+#[macro_use]
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -30,7 +30,7 @@ use elliptic_curve::{
     Generate,
     bigint::{Odd, U256, modular::Retrieve},
     ff::{self, Field, PrimeField},
-    ops::Invert,
+    ops::{BatchInvert, Invert},
     rand_core::{TryCryptoRng, TryRng},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
@@ -227,6 +227,47 @@ impl FieldElement {
     #[cfg(test)]
     pub fn modulus_as_biguint() -> BigUint {
         Self::ONE.negate(1).to_biguint().unwrap() + 1.to_biguint().unwrap()
+    }
+}
+
+impl BatchInvert for FieldElement {
+    fn batch_invert_in_place(elements: &mut [Self], scratch: &mut [Self]) -> Choice {
+        // Implements "Montgomery's trick", a trick for computing many modular inverses at once.
+        //
+        // "Montgomery's trick" works by reducing the problem of computing `n` inverses
+        // to computing a single inversion, plus some storage and `O(n)` extra multiplications.
+        //
+        // See: https://iacr.org/archive/pkc2004/29470042/29470042.pdf section 2.2.
+        assert_eq!(elements.len(), scratch.len());
+
+        // TODO(tarcieri): share implementation with `elliptic-curve` somehow
+        // The only difference from the default impl: we need to normalize the elements first
+        for e in elements.iter_mut() {
+            *e = e.normalize();
+        }
+
+        let mut acc = Self::ONE;
+        let mut all_nonzero = Choice::from(1u8);
+
+        for (tmp, e) in scratch.iter_mut().zip(elements.iter()) {
+            // $ a_n = a_{n-1}*x_n $
+            *tmp = acc;
+            let is_zero = e.ct_eq(&Self::ZERO);
+            all_nonzero &= !is_zero;
+            acc = Self::conditional_select(&(acc * e), &acc, is_zero);
+        }
+
+        // `acc` is the product of every nonzero element, so this can't fail.
+        acc = acc.invert().unwrap_or(Self::ONE);
+
+        for (e, tmp) in elements.iter_mut().zip(scratch.iter()).rev() {
+            let is_zero = e.ct_eq(&Self::ZERO);
+            let new_acc = Self::conditional_select(&(acc * *e), &acc, is_zero);
+            *e = Self::conditional_select(&(acc * *tmp), e, is_zero);
+            acc = new_acc;
+        }
+
+        all_nonzero
     }
 }
 
@@ -698,26 +739,14 @@ mod tests {
 
     #[test]
     #[cfg(feature = "getrandom")]
-    fn batch_invert_array() {
-        let k: FieldElement = FieldElement::generate();
-        let l: FieldElement = FieldElement::generate();
-
-        let expected = [k.invert().unwrap(), l.invert().unwrap()];
-        let actual = <FieldElement as BatchInvert<_>>::batch_invert([k, l]).unwrap();
-
-        assert_eq!(expected[0], actual[0].normalize());
-        assert_eq!(expected[1], actual[1].normalize());
-    }
-
-    #[test]
-    #[cfg(all(feature = "alloc", feature = "getrandom"))]
     fn batch_invert() {
         let k: FieldElement = FieldElement::generate();
         let l: FieldElement = FieldElement::generate();
 
-        let expected = vec![k.invert().unwrap(), l.invert().unwrap()];
-        let field_elements = vec![k, l]; // to test impl of `BatchInvert` for `Vec`
-        let actual = <FieldElement as BatchInvert<_>>::batch_invert(field_elements).unwrap();
+        let expected = [k.invert().unwrap(), l.invert().unwrap()];
+        let mut actual = [k, l];
+        let mut scratch = [FieldElement::ZERO; 2];
+        FieldElement::batch_invert_in_place(&mut actual, &mut scratch);
 
         assert_eq!(expected[0], actual[0].normalize());
         assert_eq!(expected[1], actual[1].normalize());

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -257,9 +257,10 @@ impl<const N: usize> BatchNormalize<[ProjectivePoint; N]> for ProjectivePoint {
 
     #[inline]
     fn batch_normalize(points: &[Self; N]) -> [<Self as CurveGroup>::Affine; N] {
-        let zs = [FieldElement::ONE; N];
+        let mut zs = [FieldElement::ZERO; N];
+        let mut scratch = [FieldElement::ZERO; N];
         let mut affine_points = [AffinePoint::IDENTITY; N];
-        batch_normalize_generic(points, zs, &mut affine_points);
+        batch_normalize(points, &mut zs, &mut scratch, &mut affine_points);
         affine_points
     }
 }
@@ -270,40 +271,34 @@ impl BatchNormalize<[ProjectivePoint]> for ProjectivePoint {
 
     #[inline]
     fn batch_normalize(points: &[Self]) -> Vec<<Self as CurveGroup>::Affine> {
-        let zs = vec![FieldElement::ONE; points.len()];
+        let mut zs = vec![FieldElement::ZERO; points.len()];
+        let mut scratch = vec![FieldElement::ZERO; points.len()];
         let mut affine_points = vec![AffinePoint::IDENTITY; points.len()];
-        batch_normalize_generic(points, zs, &mut affine_points);
+        batch_normalize(points, &mut zs, &mut scratch, &mut affine_points);
         affine_points
     }
 }
 
-fn batch_normalize_generic<P, Z, I, O>(points: &P, mut zs: Z, out: &mut O)
-where
-    FieldElement: BatchInvert<Z, Output = CtOption<I>>,
-    P: AsRef<[ProjectivePoint]> + ?Sized,
-    Z: AsMut<[FieldElement]>,
-    I: AsRef<[FieldElement]>,
-    O: AsMut<[AffinePoint]> + ?Sized,
-{
-    let points = points.as_ref();
-    let out = out.as_mut();
+fn batch_normalize(
+    points: &[ProjectivePoint],
+    zs: &mut [FieldElement],
+    scratch: &mut [FieldElement],
+    out: &mut [AffinePoint],
+) {
+    debug_assert_eq!(points.len(), zs.len());
+    debug_assert_eq!(points.len(), scratch.len());
+    debug_assert_eq!(points.len(), out.len());
 
-    for i in 0..points.len() {
-        // Even a single zero value will fail inversion for the entire batch.
-        // Put a dummy value (above `FieldElement::ONE`) so inversion succeeds
-        // and treat that case specially later-on.
-        zs.as_mut()[i].conditional_assign(&points[i].z, !points[i].z.normalizes_to_zero());
+    for (z, point) in zs.iter_mut().zip(points) {
+        *z = point.z;
     }
 
-    // This is safe to unwrap since we assured that all elements are non-zero
-    let zs_inverses = <FieldElement as BatchInvert<Z>>::batch_invert(zs)
-        .expect("all elements should be non-zero");
+    // Zero `zs` (identity) are handled explicitly below, so the `Choice` here is informational only
+    let _ = FieldElement::batch_invert_in_place(zs, scratch);
 
     for i in 0..out.len() {
-        // If the `z` coordinate is non-zero, we can use it to invert;
-        // otherwise it defaults to the `IDENTITY` value.
         out[i] = AffinePoint::conditional_select(
-            &points[i].to_affine_internal(zs_inverses.as_ref()[i]),
+            &points[i].to_affine_internal(zs[i]),
             &AffinePoint::IDENTITY,
             points[i].z.normalizes_to_zero(),
         );
@@ -455,8 +450,9 @@ impl CurveGroup for ProjectivePoint {
     #[inline]
     fn batch_normalize(projective: &[Self], affine: &mut [Self::Affine]) {
         assert_eq!(projective.len(), affine.len());
-        let mut zs = vec![FieldElement::ONE; projective.len()];
-        batch_normalize_generic(projective, zs.as_mut_slice(), affine);
+        let mut zs = vec![FieldElement::ZERO; projective.len()];
+        let mut scratch = vec![FieldElement::ZERO; projective.len()];
+        batch_normalize(projective, &mut zs, &mut scratch, affine);
     }
 }
 

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -748,7 +748,7 @@ mod tests {
     use proptest::prelude::*;
 
     #[cfg(feature = "getrandom")]
-    use elliptic_curve::{Generate, common::getrandom::SysRng, ops::BatchInvert};
+    use elliptic_curve::{Generate, common::getrandom::SysRng};
 
     impl From<&BigUint> for Scalar {
         fn from(x: &BigUint) -> Self {
@@ -894,31 +894,6 @@ mod tests {
             Scalar::ROOT_OF_UNITY.invert_vartime().unwrap(),
             Scalar::ROOT_OF_UNITY_INV
         );
-    }
-
-    #[test]
-    #[cfg(feature = "getrandom")]
-    fn batch_invert_array() {
-        let k: Scalar = Scalar::generate();
-        let l: Scalar = Scalar::generate();
-
-        let expected = [k.invert().unwrap(), l.invert().unwrap()];
-        assert_eq!(
-            <Scalar as BatchInvert<_>>::batch_invert([k, l]).unwrap(),
-            expected
-        );
-    }
-
-    #[test]
-    #[cfg(all(feature = "alloc", feature = "getrandom"))]
-    fn batch_invert() {
-        let k: Scalar = Scalar::generate();
-        let l: Scalar = Scalar::generate();
-
-        let expected = vec![k.invert().unwrap(), l.invert().unwrap()];
-        let scalars = vec![k, l];
-        let res = <Scalar as BatchInvert<_>>::batch_invert(scalars).unwrap();
-        assert_eq!(res, expected);
     }
 
     #[test]

--- a/p192/src/arithmetic/field.rs
+++ b/p192/src/arithmetic/field.rs
@@ -14,6 +14,7 @@ use crate::U192;
 use elliptic_curve::{
     bigint::cpubits,
     ff::PrimeField,
+    ops::BatchInvert,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
@@ -94,6 +95,8 @@ primefield::fiat_monty_field_arithmetic! {
     msat: fiat_p192_msat,
     selectnz: fiat_p192_selectznz
 }
+
+impl BatchInvert for FieldElement {}
 
 #[cfg(test)]
 mod tests {

--- a/p224/src/arithmetic/field.rs
+++ b/p224/src/arithmetic/field.rs
@@ -14,6 +14,7 @@ use crate::Uint;
 use elliptic_curve::{
     bigint::cpubits,
     ff::PrimeField,
+    ops::BatchInvert,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
@@ -99,6 +100,8 @@ primefield::fiat_monty_field_arithmetic! {
     msat: fiat_p224_msat,
     selectnz: fiat_p224_selectznz
 }
+
+impl BatchInvert for FieldElement {}
 
 #[cfg(test)]
 mod tests {

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::assign_op_pattern, clippy::op_ref)]
 
-use elliptic_curve::bigint::cpubits;
+use elliptic_curve::{bigint::cpubits, ops::BatchInvert};
 
 cpubits! {
     32 => {
@@ -160,6 +160,8 @@ impl FieldElement {
         >::from_montgomery(uint))
     }
 }
+
+impl BatchInvert for FieldElement {}
 
 #[cfg(test)]
 mod tests {

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -671,14 +671,8 @@ impl<'de> Deserialize<'de> for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U256};
-    use crate::{FieldBytes, NistP256, NonZeroScalar, SecretKey};
-    use elliptic_curve::{
-        Curve,
-        array::Array,
-        group::ff::PrimeField,
-        ops::{BatchInvert, ReduceNonZero},
-    };
-    use proptest::{prelude::any, prop_compose, proptest};
+    use crate::{FieldBytes, NistP256, SecretKey};
+    use elliptic_curve::{Curve, array::Array, group::ff::PrimeField, ops::ReduceNonZero};
 
     primefield::test_primefield!(Scalar, U256);
 
@@ -752,31 +746,5 @@ mod tests {
             Scalar::reduce_nonzero(&NistP256::ORDER.wrapping_add(&U256::from_u8(2))).0,
             U256::from_u8(4),
         );
-    }
-
-    prop_compose! {
-        fn non_zero_scalar()(bytes in any::<[u8; 32]>()) -> NonZeroScalar {
-            NonZeroScalar::reduce_nonzero(&FieldBytes::from(bytes))
-        }
-    }
-
-    // TODO: move to `primefield::test_field_invert`.
-    proptest! {
-        #[test]
-        fn batch_invert(
-            a in non_zero_scalar(),
-            b in non_zero_scalar(),
-            c in non_zero_scalar(),
-            d in non_zero_scalar(),
-            e in non_zero_scalar(),
-        ) {
-            let scalars: [Scalar; 5] = [*a, *b, *c, *d, *e];
-
-            let inverted_scalars = Scalar::batch_invert(scalars).unwrap();
-
-            for (scalar, inverted_scalar) in scalars.into_iter().zip(inverted_scalars) {
-                assert_eq!(inverted_scalar, scalar.invert().unwrap());
-            }
-        }
     }
 }

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -13,6 +13,7 @@
 use elliptic_curve::{
     bigint::{U384, cpubits},
     ff::PrimeField,
+    ops::BatchInvert,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
@@ -74,6 +75,8 @@ primefield::fiat_monty_field_arithmetic! {
     msat: fiat_p384_msat,
     selectnz: fiat_p384_selectznz
 }
+
+impl BatchInvert for FieldElement {}
 
 #[cfg(test)]
 mod tests {

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -168,13 +168,8 @@ mod tests {
         fiat_p384_scalar_non_montgomery_domain_field_element, fiat_p384_scalar_to_montgomery,
     };
     use crate::{FieldBytes, NistP384, NonZeroScalar};
-    use elliptic_curve::{
-        Curve,
-        array::Array,
-        ff::PrimeField,
-        ops::{BatchInvert, ReduceNonZero},
-    };
-    use proptest::{prelude::any, prop_compose, proptest};
+    use elliptic_curve::{Curve, array::Array, ff::PrimeField, ops::ReduceNonZero};
+    use proptest::{prelude::any, prop_compose};
 
     primefield::test_primefield!(Scalar, U384);
 
@@ -261,26 +256,6 @@ mod tests {
     prop_compose! {
         fn non_zero_scalar()(bytes in any::<[u8; 48]>()) -> NonZeroScalar {
             NonZeroScalar::reduce_nonzero(&FieldBytes::from(bytes))
-        }
-    }
-
-    // TODO: move to `primefield::test_field_invert`.
-    proptest! {
-        #[test]
-        fn batch_invert(
-            a in non_zero_scalar(),
-            b in non_zero_scalar(),
-            c in non_zero_scalar(),
-            d in non_zero_scalar(),
-            e in non_zero_scalar(),
-        ) {
-            let scalars: [Scalar; 5] = [*a, *b, *c, *d, *e];
-
-            let inverted_scalars = Scalar::batch_invert(scalars).unwrap();
-
-            for (scalar, inverted_scalar) in scalars.into_iter().zip(inverted_scalars) {
-                assert_eq!(inverted_scalar, scalar.invert().unwrap());
-            }
         }
     }
 }

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -22,7 +22,7 @@ use elliptic_curve::{
     array::Array,
     bigint::{Word, cpubits, modular::Retrieve},
     ff::{self, Field, PrimeField},
-    ops::Invert,
+    ops::{BatchInvert, Invert},
     rand_core::TryRng,
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, CtOption},
     zeroize::DefaultIsZeroes,
@@ -406,6 +406,8 @@ impl AsRef<fiat_p521_tight_field_element> for FieldElement {
         &self.0
     }
 }
+
+impl BatchInvert for FieldElement {}
 
 impl Default for FieldElement {
     fn default() -> Self {

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -39,7 +39,12 @@ pub use elliptic_curve::{
 };
 pub use primefield::PrimeFieldExt;
 
-use elliptic_curve::{Curve, CurveArithmetic, Generate, ops::Invert, sec1, subtle::CtOption};
+use elliptic_curve::{
+    Curve, CurveArithmetic, Generate,
+    ops::{BatchInvert, Invert},
+    sec1,
+    subtle::CtOption,
+};
 
 #[cfg(feature = "basepoint-table")]
 pub use crate::tables::BasepointTable;
@@ -56,7 +61,8 @@ pub trait PrimeCurveParams:
     >
 {
     /// Base field element type.
-    type FieldElement: Generate
+    type FieldElement: BatchInvert
+        + Generate
         + Invert<Output = CtOption<Self::FieldElement>>
         + PrimeField<Repr = FieldBytes<Self>>
         + Retrieve<Output = Self::Uint>;

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -294,8 +294,9 @@ where
     #[inline]
     fn batch_normalize(projective: &[Self], affine: &mut [Self::Affine]) {
         assert_eq!(projective.len(), affine.len());
-        let mut zs = vec![C::FieldElement::ONE; projective.len()];
-        batch_normalize_generic(projective, zs.as_mut_slice(), affine);
+        let mut zs = vec![C::FieldElement::ZERO; projective.len()];
+        let mut scratch = vec![C::FieldElement::ZERO; projective.len()];
+        batch_normalize_generic(projective, &mut zs, &mut scratch, affine);
     }
 }
 
@@ -377,9 +378,10 @@ where
 
     #[inline]
     fn batch_normalize(points: &[Self; N]) -> [<Self as CurveGroup>::Affine; N] {
-        let zs = [C::FieldElement::ONE; N];
+        let mut zs = [C::FieldElement::ZERO; N];
+        let mut scratch = [C::FieldElement::ZERO; N];
         let mut affine_points = [C::AffinePoint::IDENTITY; N];
-        batch_normalize_generic(points, zs, &mut affine_points);
+        batch_normalize_generic(points, &mut zs, &mut scratch, &mut affine_points);
         affine_points
     }
 }
@@ -393,43 +395,37 @@ where
 
     #[inline]
     fn batch_normalize(points: &[Self]) -> Vec<<Self as CurveGroup>::Affine> {
-        let mut zs = vec![C::FieldElement::ONE; points.len()];
+        let mut zs = vec![C::FieldElement::ZERO; points.len()];
+        let mut scratch = vec![C::FieldElement::ZERO; points.len()];
         let mut affine_points = vec![AffinePoint::IDENTITY; points.len()];
-        batch_normalize_generic(points, zs.as_mut_slice(), &mut affine_points);
+        batch_normalize_generic(points, &mut zs, &mut scratch, &mut affine_points);
         affine_points
     }
 }
 
 /// Generic implementation of batch normalization.
-fn batch_normalize_generic<C, P, Z, I, O>(points: &P, mut zs: Z, out: &mut O)
-where
+fn batch_normalize_generic<C>(
+    points: &[ProjectivePoint<C>],
+    zs: &mut [C::FieldElement],
+    scratch: &mut [C::FieldElement],
+    out: &mut [AffinePoint<C>],
+) where
     C: PrimeCurveParams,
-    C::FieldElement: BatchInvert<Z, Output = CtOption<I>>,
-    C::ProjectivePoint: Double,
-    P: AsRef<[ProjectivePoint<C>]> + ?Sized,
-    Z: AsMut<[C::FieldElement]>,
-    I: AsRef<[C::FieldElement]>,
-    O: AsMut<[AffinePoint<C>]> + ?Sized,
 {
-    let points = points.as_ref();
-    let out = out.as_mut();
+    debug_assert_eq!(points.len(), zs.len());
+    debug_assert_eq!(points.len(), scratch.len());
+    debug_assert_eq!(points.len(), out.len());
 
-    for i in 0..points.len() {
-        // Even a single zero value will fail inversion for the entire batch.
-        // Put a dummy value (above `FieldElement::ONE`) so inversion succeeds
-        // and treat that case specially later-on.
-        zs.as_mut()[i].conditional_assign(&points[i].z, !points[i].z.ct_eq(&C::FieldElement::ZERO));
+    for (z, point) in zs.iter_mut().zip(points) {
+        *z = point.z;
     }
 
-    // This is safe to unwrap since we assured that all elements are non-zero
-    let zs_inverses = <C::FieldElement as BatchInvert<Z>>::batch_invert(zs)
-        .expect("all elements should be non-zero");
+    // Zero `zs` (identity) are handled explicitly below, so the `Choice` here is informational only
+    let _ = C::FieldElement::batch_invert_in_place(zs, scratch);
 
     for i in 0..out.len() {
-        // If the `z` coordinate is non-zero, we can use it to invert;
-        // otherwise it defaults to the `IDENTITY` value.
         out[i] = C::AffinePoint::conditional_select(
-            &points[i].to_affine_internal(zs_inverses.as_ref()[i]),
+            &points[i].to_affine_internal(zs[i]),
             &C::AffinePoint::IDENTITY,
             points[i].z.ct_eq(&C::FieldElement::ZERO),
         );

--- a/sm2/src/arithmetic/field.rs
+++ b/sm2/src/arithmetic/field.rs
@@ -14,6 +14,7 @@ use crate::U256;
 use elliptic_curve::{
     bigint::cpubits,
     ff::PrimeField,
+    ops::BatchInvert,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
@@ -74,6 +75,8 @@ primefield::fiat_monty_field_arithmetic! {
     msat: fiat_sm2_msat,
     selectnz: fiat_sm2_selectznz
 }
+
+impl BatchInvert for FieldElement {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Companion PR to RustCrypto/traits#2455, which switches to in-place batch inversion.

This massively simplifies the batch normalization implementation which no longer requires a litany of generic parameters to abstract over slices versus arrays because it accepts a temporary storage buffer the caller can allocate however they choose.

It requires every curve add an `impl BatchInvert for FieldElement` but also lets curves provide their own implementation, which is needed for `k256` due to its lazy normalization.

Closes #1817.