### PR TITLE
primeorder: use `FieldArithmetic` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.35"
-source = "git+https://github.com/RustCrypto/traits#d1ca96d9a456337c74e1aa8e1582a7e26447dbef"
+source = "git+https://github.com/RustCrypto/traits#5b2a9dc34790d9aee0daaff8d87dcf6c50630654"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1372,7 +1372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/bignp256/src/arithmetic.rs
+++ b/bignp256/src/arithmetic.rs
@@ -8,13 +8,12 @@
 pub(crate) mod field;
 pub(crate) mod scalar;
 
-pub use self::scalar::Scalar;
-
-pub use self::field::FieldElement;
-use crate::BignP256;
-pub use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
-use primeorder::backend;
+pub use self::{field::FieldElement, scalar::Scalar};
+pub use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
 pub use primeorder::{PrimeCurveParams, point_arithmetic};
+
+use crate::BignP256;
+use primeorder::backend;
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<BignP256>;
@@ -28,12 +27,15 @@ impl CurveArithmetic for BignP256 {
     type Scalar = Scalar;
 }
 
+impl FieldArithmetic for BignP256 {
+    type FieldElement = FieldElement;
+}
+
 impl PrimeCurveArithmetic for BignP256 {
     type CurveGroup = ProjectivePoint;
 }
 
 impl PrimeCurveParams for BignP256 {
-    type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
     type Backend = backend::VariableOnly;
 

--- a/bp256/benches/field.rs
+++ b/bp256/benches/field.rs
@@ -2,9 +2,9 @@
 
 use bp256::BrainpoolP256r1;
 use criterion::{criterion_group, criterion_main};
-use primeorder::PrimeCurveParams;
+use elliptic_curve::hazmat::FieldArithmetic;
 
-type FieldElement = <BrainpoolP256r1 as PrimeCurveParams>::FieldElement;
+type FieldElement = <BrainpoolP256r1 as FieldArithmetic>::FieldElement;
 
 const FE_A: FieldElement = FieldElement::from_hex_vartime(
     "8bd2aeb9cb7e57cb2c4b482ffc81b7afb9de27e1e3bd23c23a4453bd9ace3262",

--- a/bp256/src/r1/arithmetic.rs
+++ b/bp256/src/r1/arithmetic.rs
@@ -2,7 +2,7 @@
 
 use super::BrainpoolP256r1;
 use crate::{FieldElement, Scalar};
-use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
 use primeorder::{PrimeCurveParams, backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -23,12 +23,15 @@ impl CurveArithmetic for BrainpoolP256r1 {
     type Scalar = Scalar;
 }
 
+impl FieldArithmetic for BrainpoolP256r1 {
+    type FieldElement = FieldElement;
+}
+
 impl PrimeCurveArithmetic for BrainpoolP256r1 {
     type CurveGroup = ProjectivePoint;
 }
 
 impl PrimeCurveParams for BrainpoolP256r1 {
-    type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
     type Backend = backend::VariableOnly;
 

--- a/bp256/src/t1/arithmetic.rs
+++ b/bp256/src/t1/arithmetic.rs
@@ -2,7 +2,7 @@
 
 use super::BrainpoolP256t1;
 use crate::{FieldElement, Scalar};
-use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
 use primeorder::{PrimeCurveParams, backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -27,8 +27,11 @@ impl PrimeCurveArithmetic for BrainpoolP256t1 {
     type CurveGroup = ProjectivePoint;
 }
 
-impl PrimeCurveParams for BrainpoolP256t1 {
+impl FieldArithmetic for BrainpoolP256t1 {
     type FieldElement = FieldElement;
+}
+
+impl PrimeCurveParams for BrainpoolP256t1 {
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
     type Backend = backend::VariableOnly;
 

--- a/bp384/benches/field.rs
+++ b/bp384/benches/field.rs
@@ -2,9 +2,9 @@
 
 use bp384::BrainpoolP384r1;
 use criterion::{criterion_group, criterion_main};
-use primeorder::PrimeCurveParams;
+use elliptic_curve::hazmat::FieldArithmetic;
 
-type FieldElement = <BrainpoolP384r1 as PrimeCurveParams>::FieldElement;
+type FieldElement = <BrainpoolP384r1 as FieldArithmetic>::FieldElement;
 
 const FE_A: FieldElement = FieldElement::from_hex_vartime(
     "1d1c64f068cf45ffa2a63a81b7c13f6b8847a3e77ef14fe3db7fcafe0cbd10e8e826e03436d646aaef87b2e247d4af1e",

--- a/bp384/src/r1/arithmetic.rs
+++ b/bp384/src/r1/arithmetic.rs
@@ -2,7 +2,7 @@
 
 use super::BrainpoolP384r1;
 use crate::{FieldElement, Scalar};
-use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
 use primeorder::{PrimeCurveParams, backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -23,12 +23,15 @@ impl CurveArithmetic for BrainpoolP384r1 {
     type Scalar = Scalar;
 }
 
+impl FieldArithmetic for BrainpoolP384r1 {
+    type FieldElement = FieldElement;
+}
+
 impl PrimeCurveArithmetic for BrainpoolP384r1 {
     type CurveGroup = ProjectivePoint;
 }
 
 impl PrimeCurveParams for BrainpoolP384r1 {
-    type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
     type Backend = backend::VariableOnly;
 

--- a/bp384/src/t1/arithmetic.rs
+++ b/bp384/src/t1/arithmetic.rs
@@ -2,7 +2,7 @@
 
 use super::BrainpoolP384t1;
 use crate::{FieldElement, Scalar};
-use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
 use primeorder::{PrimeCurveParams, backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -23,12 +23,15 @@ impl CurveArithmetic for BrainpoolP384t1 {
     type Scalar = Scalar;
 }
 
+impl FieldArithmetic for BrainpoolP384t1 {
+    type FieldElement = FieldElement;
+}
+
 impl PrimeCurveArithmetic for BrainpoolP384t1 {
     type CurveGroup = ProjectivePoint;
 }
 
 impl PrimeCurveParams for BrainpoolP384t1 {
-    type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
     type Backend = backend::VariableOnly;
 

--- a/k256/src/arithmetic.rs
+++ b/k256/src/arithmetic.rs
@@ -17,12 +17,16 @@ pub use field::FieldElement;
 
 use self::{affine::AffinePoint, projective::ProjectivePoint, scalar::Scalar};
 use crate::Secp256k1;
-use elliptic_curve::CurveArithmetic;
+use elliptic_curve::{CurveArithmetic, hazmat::FieldArithmetic};
 
 impl CurveArithmetic for Secp256k1 {
     type AffinePoint = AffinePoint;
     type ProjectivePoint = ProjectivePoint;
     type Scalar = Scalar;
+}
+
+impl FieldArithmetic for Secp256k1 {
+    type FieldElement = FieldElement;
 }
 
 const CURVE_EQUATION_B_SINGLE: u32 = 7u32;

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -42,6 +42,14 @@ use num_bigint::{BigUint, ToBigUint};
 const MODULUS_HEX: &str = "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f";
 
 /// An element in the finite field used for curve coordinates.
+///
+/// <div class="warning">
+/// <b>Security Warning</b>
+///
+/// This type implements lazy normalization. Failure to use it correctly can lead to miscomputation!
+/// Please be extremely sure you understand how this normalization works before you do ANYTHING
+/// with this type.
+/// </div>
 #[derive(Clone, Copy, Debug)]
 pub struct FieldElement(FieldElementImpl);
 

--- a/p192/src/arithmetic.rs
+++ b/p192/src/arithmetic.rs
@@ -9,7 +9,7 @@ pub(crate) mod scalar;
 
 use self::{field::FieldElement, scalar::Scalar};
 use crate::NistP192;
-use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
 use primeorder::{PrimeCurveParams, backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -24,6 +24,10 @@ impl CurveArithmetic for NistP192 {
     type Scalar = Scalar;
 }
 
+impl FieldArithmetic for NistP192 {
+    type FieldElement = FieldElement;
+}
+
 impl PrimeCurveArithmetic for NistP192 {
     type CurveGroup = ProjectivePoint;
 }
@@ -32,7 +36,6 @@ impl PrimeCurveArithmetic for NistP192 {
 ///
 /// [FIPS 186-4]: https://csrc.nist.gov/publications/detail/fips/186/4/final
 impl PrimeCurveParams for NistP192 {
-    type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
     type Backend = backend::VariableOnly;
 

--- a/p224/src/arithmetic.rs
+++ b/p224/src/arithmetic.rs
@@ -11,7 +11,7 @@ pub use self::scalar::Scalar;
 
 use self::field::FieldElement;
 use crate::NistP224;
-use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
 use primeorder::{PrimeCurveParams, backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -26,6 +26,10 @@ impl CurveArithmetic for NistP224 {
     type Scalar = Scalar;
 }
 
+impl FieldArithmetic for NistP224 {
+    type FieldElement = FieldElement;
+}
+
 impl PrimeCurveArithmetic for NistP224 {
     type CurveGroup = ProjectivePoint;
 }
@@ -34,7 +38,6 @@ impl PrimeCurveArithmetic for NistP224 {
 ///
 /// [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
 impl PrimeCurveParams for NistP224 {
-    type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
     type Backend = backend::VariableOnly;
 

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -14,7 +14,7 @@ mod tables;
 
 use self::{field::FieldElement, scalar::Scalar};
 use crate::NistP256;
-use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
 use primeorder::{PrimeCurveParams, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -29,6 +29,10 @@ impl CurveArithmetic for NistP256 {
     type Scalar = Scalar;
 }
 
+impl FieldArithmetic for NistP256 {
+    type FieldElement = FieldElement;
+}
+
 impl PrimeCurveArithmetic for NistP256 {
     type CurveGroup = ProjectivePoint;
 }
@@ -37,7 +41,6 @@ impl PrimeCurveArithmetic for NistP256 {
 ///
 /// [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
 impl PrimeCurveParams for NistP256 {
-    type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
 
     #[cfg(not(feature = "precomputed-tables"))]

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -14,7 +14,7 @@ mod tables;
 
 use self::{field::FieldElement, scalar::Scalar};
 use crate::NistP384;
-use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
 use primeorder::{PrimeCurveParams, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -29,6 +29,10 @@ impl CurveArithmetic for NistP384 {
     type Scalar = Scalar;
 }
 
+impl FieldArithmetic for NistP384 {
+    type FieldElement = FieldElement;
+}
+
 impl PrimeCurveArithmetic for NistP384 {
     type CurveGroup = ProjectivePoint;
 }
@@ -37,7 +41,6 @@ impl PrimeCurveArithmetic for NistP384 {
 ///
 /// [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
 impl PrimeCurveParams for NistP384 {
-    type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
 
     #[cfg(not(feature = "precomputed-tables"))]

--- a/p521/src/arithmetic.rs
+++ b/p521/src/arithmetic.rs
@@ -16,7 +16,7 @@ pub use self::scalar::Scalar;
 
 use self::field::FieldElement;
 use crate::NistP521;
-use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
 use primeorder::{PrimeCurveParams, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -31,6 +31,10 @@ impl CurveArithmetic for NistP521 {
     type Scalar = Scalar;
 }
 
+impl FieldArithmetic for NistP521 {
+    type FieldElement = FieldElement;
+}
+
 impl PrimeCurveArithmetic for NistP521 {
     type CurveGroup = ProjectivePoint;
 }
@@ -39,7 +43,6 @@ impl PrimeCurveArithmetic for NistP521 {
 ///
 /// [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
 impl PrimeCurveParams for NistP521 {
-    type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
 
     #[cfg(not(feature = "precomputed-tables"))]

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -35,16 +35,12 @@ pub use elliptic_curve::{
     self, Field, FieldBytes, PrimeCurve, PrimeField, Scalar,
     array::{self, ArraySize, sizes::U1},
     bigint::{ByteOrder, modular::Retrieve},
+    hazmat::FieldArithmetic,
     point::Double,
 };
 pub use primefield::PrimeFieldExt;
 
-use elliptic_curve::{
-    Curve, CurveArithmetic, Generate,
-    ops::{BatchInvert, Invert},
-    sec1,
-    subtle::CtOption,
-};
+use elliptic_curve::{Curve, CurveArithmetic, sec1};
 
 #[cfg(feature = "basepoint-table")]
 pub use crate::tables::BasepointTable;
@@ -53,20 +49,13 @@ pub use crate::tables::BasepointTable;
 /// equation.
 pub trait PrimeCurveParams:
     Curve<FieldBytesSize: sec1::ModulusSize>
-    + PrimeCurve
     + CurveArithmetic<
         AffinePoint = AffinePoint<Self>,
         ProjectivePoint = ProjectivePoint<Self>,
         Scalar: PrimeFieldExt,
-    >
+    > + FieldArithmetic
+    + PrimeCurve
 {
-    /// Base field element type.
-    type FieldElement: BatchInvert
-        + Generate
-        + Invert<Output = CtOption<Self::FieldElement>>
-        + PrimeField<Repr = FieldBytes<Self>>
-        + Retrieve<Output = Self::Uint>;
-
     /// [Point arithmetic](point_arithmetic) implementation, might be optimized for this specific curve
     type PointArithmetic: point_arithmetic::PointArithmetic<Self>;
 

--- a/primeorder/src/osswu.rs
+++ b/primeorder/src/osswu.rs
@@ -2,19 +2,25 @@
 //!
 //! <https://www.rfc-editor.org/rfc/rfc9380.html#name-simplified-swu-method>
 
-use elliptic_curve::Field;
-use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+use elliptic_curve::{
+    Field,
+    hazmat::FieldArithmetic,
+    subtle::{Choice, ConditionallySelectable, ConstantTimeEq},
+};
 
 use crate::{AffinePoint, PrimeCurveParams};
 
 /// [`OsswuMap`] for [`AffinePoint`].
-pub trait AffineOsswuMap<C: PrimeCurveParams<FieldElement: OsswuMap>> {
+pub trait AffineOsswuMap<C: PrimeCurveParams + FieldArithmetic<FieldElement: OsswuMap>> {
     /// [`OsswuMap::osswu()`] to [`AffinePoint`].
     fn osswu(u: &C::FieldElement) -> Self;
 }
 
-impl<C: PrimeCurveParams<FieldElement: OsswuMap>> AffineOsswuMap<C> for AffinePoint<C> {
-    fn osswu(u: &<C as PrimeCurveParams>::FieldElement) -> Self {
+impl<C> AffineOsswuMap<C> for AffinePoint<C>
+where
+    C: PrimeCurveParams + FieldArithmetic<FieldElement: OsswuMap>,
+{
+    fn osswu(u: &<C as FieldArithmetic>::FieldElement) -> Self {
         let (x, y) = u.osswu();
         Self { x, y, infinity: 0 }
     }

--- a/sm2/benches/field.rs
+++ b/sm2/benches/field.rs
@@ -1,10 +1,10 @@
 //! sm2 `FieldElement` benchmarks
 
 use criterion::{criterion_group, criterion_main};
-use primeorder::PrimeCurveParams;
+use elliptic_curve::hazmat::FieldArithmetic;
 use sm2::Sm2;
 
-type FieldElement = <Sm2 as PrimeCurveParams>::FieldElement;
+type FieldElement = <Sm2 as FieldArithmetic>::FieldElement;
 
 const FE_A: FieldElement = FieldElement::from_hex_vartime(
     "32C4AE2C1F1981195F9904466A39C9948FE30BBFF2660BE1715A4589334C74C7",

--- a/sm2/src/arithmetic.rs
+++ b/sm2/src/arithmetic.rs
@@ -15,7 +15,7 @@ pub use self::scalar::Scalar;
 
 use self::field::FieldElement;
 use crate::Sm2;
-use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic};
+use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
 use primeorder::{PrimeCurveParams, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
@@ -30,6 +30,10 @@ impl CurveArithmetic for Sm2 {
     type Scalar = Scalar;
 }
 
+impl FieldArithmetic for Sm2 {
+    type FieldElement = FieldElement;
+}
+
 impl PrimeCurveArithmetic for Sm2 {
     type CurveGroup = ProjectivePoint;
 }
@@ -38,7 +42,6 @@ impl PrimeCurveArithmetic for Sm2 {
 ///
 /// [draft-shen-sm2-ecdsa Appendix D]: https://datatracker.ietf.org/doc/html/draft-shen-sm2-ecdsa-02#appendix-D
 impl PrimeCurveParams for Sm2 {
-    type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
 
     #[cfg(not(feature = "precomputed-tables"))]


### PR DESCRIPTION
Uses the new `hazmat` trait added to `elliptic-curve` in RustCrypto/traits#2458 to define the associated `FieldElement` type for a given curve.