### PR TITLE
Remove `expose-field` features; use `FieldArithmetic` trait

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -52,7 +52,6 @@ critical-section = ["primeorder/critical-section", "precomputed-tables"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm", "sha256"]
-expose-field = ["arithmetic"]
 hash2curve = ["arithmetic", "dep:hash2curve", "primeorder/hash2curve"]
 group-digest = ["hash2curve", "sha2"]
 getrandom = ["ecdsa-core?/getrandom", "elliptic-curve/getrandom"]
@@ -76,7 +75,6 @@ required-features = ["ecdsa", "sha256"]
 [[bench]]
 name = "field"
 harness = false
-required-features = ["expose-field"]
 
 [[bench]]
 name = "scalar"

--- a/k256/benches/field.rs
+++ b/k256/benches/field.rs
@@ -3,8 +3,11 @@
 use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
-use k256::FieldElement;
+use elliptic_curve::hazmat::FieldArithmetic;
+use k256::Secp256k1;
 use std::hint::black_box;
+
+type FieldElement = <Secp256k1 as FieldArithmetic>::FieldElement;
 
 fn test_field_element_x() -> FieldElement {
     FieldElement::from_bytes(

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -56,13 +56,8 @@ pub use elliptic_curve::{self, bigint::U256};
 
 #[cfg(feature = "arithmetic")]
 pub use arithmetic::{affine::AffinePoint, projective::ProjectivePoint, scalar::Scalar};
-
-#[cfg(feature = "expose-field")]
-pub use arithmetic::FieldElement;
-
 #[cfg(feature = "pkcs8")]
 pub use elliptic_curve::pkcs8;
-
 #[cfg(feature = "sha2")]
 pub use sha2;
 

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -46,7 +46,6 @@ arithmetic = ["dep:primefield", "dep:primeorder", "elliptic-curve/arithmetic"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm", "sha256"]
-expose-field = ["arithmetic"]
 hash2curve = ["arithmetic", "dep:hash2curve", "primeorder/hash2curve"]
 getrandom = ["elliptic-curve/getrandom"]
 group-digest = ["hash2curve", "sha2"]
@@ -70,7 +69,6 @@ required-features = ["ecdsa"]
 [[bench]]
 name = "field"
 harness = false
-required-features = ["expose-field"]
 
 [[bench]]
 name = "point"

--- a/p256/benches/field.rs
+++ b/p256/benches/field.rs
@@ -3,9 +3,11 @@
 use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
-use elliptic_curve::array::Array;
+use elliptic_curve::{array::Array, hazmat::FieldArithmetic};
 use hex_literal::hex;
-use p256::FieldElement;
+use p256::NistP256;
+
+type FieldElement = <NistP256 as FieldArithmetic>::FieldElement;
 
 fn test_field_element_x() -> FieldElement {
     FieldElement::from_bytes(&Array(hex!(

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -27,31 +27,24 @@
 //!
 //! Please see type-specific documentation for more information.
 
-#[cfg(feature = "arithmetic")]
-mod arithmetic;
-
 #[cfg(feature = "ecdh")]
 pub mod ecdh;
-
 #[cfg(feature = "ecdsa-core")]
 pub mod ecdsa;
-
 #[cfg(any(feature = "test-vectors", test))]
 pub mod test_vectors;
 
-#[cfg(feature = "hash2curve")]
-pub use hash2curve;
+#[cfg(feature = "arithmetic")]
+mod arithmetic;
 
 pub use elliptic_curve::{self, bigint::U256, consts::U32};
 
 #[cfg(feature = "arithmetic")]
 pub use arithmetic::{AffinePoint, ProjectivePoint, scalar::Scalar};
-
-#[cfg(feature = "expose-field")]
-pub use arithmetic::field::FieldElement;
-
 #[cfg(feature = "pkcs8")]
 pub use elliptic_curve::pkcs8;
+#[cfg(feature = "hash2curve")]
+pub use hash2curve;
 
 use elliptic_curve::{array::Array, bigint::Odd, consts::U33};
 

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -53,7 +53,6 @@ arithmetic = [
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm", "sha384"]
-expose-field = ["arithmetic"]
 hash2curve = ["arithmetic", "dep:hash2curve", "primeorder/hash2curve"]
 getrandom = ["ecdsa-core?/getrandom", "elliptic-curve/getrandom"]
 group-digest = ["hash2curve", "sha2"]
@@ -75,7 +74,6 @@ check-cfg = [
 [[bench]]
 name = "field"
 harness = false
-required-features = ["expose-field"]
 
 [[bench]]
 name = "scalar"

--- a/p384/benches/field.rs
+++ b/p384/benches/field.rs
@@ -4,8 +4,11 @@ use core::hint::black_box;
 use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
+use elliptic_curve::{ff::Field, hazmat::FieldArithmetic};
 use hex_literal::hex;
-use p384::{FieldElement, elliptic_curve::ff::Field};
+use p384::NistP384;
+
+type FieldElement = <NistP384 as FieldArithmetic>::FieldElement;
 
 fn test_field_element_x() -> FieldElement {
     black_box(FieldElement::from_bytes(

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -47,17 +47,15 @@
 //!
 //! Please see type-specific documentation for more information.
 
-#[cfg(feature = "arithmetic")]
-mod arithmetic;
-
 #[cfg(feature = "ecdh")]
 pub mod ecdh;
-
 #[cfg(feature = "ecdsa-core")]
 pub mod ecdsa;
-
 #[cfg(any(feature = "test-vectors", test))]
 pub mod test_vectors;
+
+#[cfg(feature = "arithmetic")]
+mod arithmetic;
 
 pub use elliptic_curve::{
     self,
@@ -67,15 +65,10 @@ pub use elliptic_curve::{
 
 #[cfg(feature = "arithmetic")]
 pub use arithmetic::{AffinePoint, ProjectivePoint, scalar::Scalar};
-
-#[cfg(feature = "expose-field")]
-pub use arithmetic::field::FieldElement;
-
-#[cfg(feature = "hash2curve")]
-pub use hash2curve;
-
 #[cfg(feature = "pkcs8")]
 pub use elliptic_curve::pkcs8;
+#[cfg(feature = "hash2curve")]
+pub use hash2curve;
 
 use elliptic_curve::{array::Array, consts::U49};
 

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -46,7 +46,6 @@ arithmetic = ["dep:primefield", "dep:primeorder"]
 digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm", "sha512"]
-expose-field = ["arithmetic"]
 hash2curve = ["arithmetic", "dep:hash2curve", "primeorder/hash2curve"]
 getrandom = ["ecdsa-core?/getrandom", "elliptic-curve/getrandom"]
 group-digest = ["hash2curve", "dep:sha2"]
@@ -65,7 +64,6 @@ check-cfg = ['cfg(cpubits, values("16", "32", "64"))']
 [[bench]]
 name = "field"
 harness = false
-required-features = ["expose-field"]
 
 [[bench]]
 name = "scalar"

--- a/p521/benches/field.rs
+++ b/p521/benches/field.rs
@@ -3,10 +3,12 @@
 use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
-use elliptic_curve::array::Array;
+use elliptic_curve::{array::Array, hazmat::FieldArithmetic};
 use hex_literal::hex;
-use p521::FieldElement;
+use p521::NistP521;
 use std::hint::black_box;
+
+type FieldElement = <NistP521 as FieldArithmetic>::FieldElement;
 
 fn test_field_element_x() -> FieldElement {
     black_box(FieldElement::from_bytes(

--- a/p521/src/lib.rs
+++ b/p521/src/lib.rs
@@ -26,31 +26,24 @@
 //!
 //! Please see type-specific documentation for more information.
 
-#[cfg(feature = "arithmetic")]
-mod arithmetic;
-
 #[cfg(feature = "ecdh")]
 pub mod ecdh;
-
 #[cfg(feature = "ecdsa-core")]
 pub mod ecdsa;
-
 #[cfg(any(feature = "test-vectors", test))]
 pub mod test_vectors;
 
 #[cfg(feature = "arithmetic")]
-pub use arithmetic::{AffinePoint, ProjectivePoint, scalar::Scalar};
-
-#[cfg(feature = "expose-field")]
-pub use arithmetic::field::FieldElement;
-
-#[cfg(feature = "hash2curve")]
-pub use hash2curve;
+mod arithmetic;
 
 pub use elliptic_curve;
 
+#[cfg(feature = "arithmetic")]
+pub use arithmetic::{AffinePoint, ProjectivePoint, scalar::Scalar};
 #[cfg(feature = "pkcs8")]
 pub use elliptic_curve::pkcs8;
+#[cfg(feature = "hash2curve")]
+pub use hash2curve;
 
 use elliptic_curve::{
     array::Array,


### PR DESCRIPTION
This removes the `expose-field` feature from `k256`, `p256`, `p384`, and `p521`, which previously re-exported the `FieldElement` types for these curves from the toplevel of these crates.

That's the wrong level of abstraction and mixes something which is easy to misuse with the other safe abstractions provided at the crate's toplevel.

Instead, the `FieldElement` types can always be accessed using the new `hazmat` trait: `FieldArithmetic` (see #1833)

```rust
use elliptic_curve::hazmat::FieldArithmetic;
type FieldElement = <MyCurve as FieldArithmetic>::FieldElement;
```

There's no longer any crate features to enable and it's always accessible, but must be accessed through the `hazmat` trait, which we recommend you *do not* re-export (nor should you re-export a type alias) so the "hazmat" string is always easy to search for.