### PR TITLE
primeorder: rename `backend::Backend` => `mul_backend::MulBackend`

### DIFF
--- a/bignp256/src/arithmetic.rs
+++ b/bignp256/src/arithmetic.rs
@@ -13,7 +13,7 @@ pub use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldAri
 pub use primeorder::{PrimeCurveParams, point_arithmetic};
 
 use crate::BignP256;
-use primeorder::backend;
+use primeorder::mul_backend;
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<BignP256>;
@@ -37,7 +37,7 @@ impl PrimeCurveArithmetic for BignP256 {
 
 impl PrimeCurveParams for BignP256 {
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
-    type Backend = backend::VariableOnly;
+    type Backend = mul_backend::VariableOnly;
 
     const EQUATION_A: Self::FieldElement = FieldElement::from_hex_vartime(
         "40FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",

--- a/bp256/src/r1/arithmetic.rs
+++ b/bp256/src/r1/arithmetic.rs
@@ -3,7 +3,7 @@
 use super::BrainpoolP256r1;
 use crate::{FieldElement, Scalar};
 use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
-use primeorder::{PrimeCurveParams, backend, point_arithmetic};
+use primeorder::{PrimeCurveParams, mul_backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<BrainpoolP256r1>;
@@ -33,7 +33,7 @@ impl PrimeCurveArithmetic for BrainpoolP256r1 {
 
 impl PrimeCurveParams for BrainpoolP256r1 {
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
-    type Backend = backend::VariableOnly;
+    type Backend = mul_backend::VariableOnly;
 
     const EQUATION_A: FieldElement = FieldElement::from_hex_vartime(
         "7d5a0975fc2c3057eef67530417affe7fb8055c126dc5c6ce94a4b44f330b5d9",

--- a/bp256/src/t1/arithmetic.rs
+++ b/bp256/src/t1/arithmetic.rs
@@ -3,7 +3,7 @@
 use super::BrainpoolP256t1;
 use crate::{FieldElement, Scalar};
 use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
-use primeorder::{PrimeCurveParams, backend, point_arithmetic};
+use primeorder::{PrimeCurveParams, mul_backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<BrainpoolP256t1>;
@@ -33,7 +33,7 @@ impl FieldArithmetic for BrainpoolP256t1 {
 
 impl PrimeCurveParams for BrainpoolP256t1 {
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
-    type Backend = backend::VariableOnly;
+    type Backend = mul_backend::VariableOnly;
 
     const EQUATION_A: FieldElement = FieldElement::from_hex_vartime(
         "a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5374",

--- a/bp384/src/r1/arithmetic.rs
+++ b/bp384/src/r1/arithmetic.rs
@@ -3,7 +3,7 @@
 use super::BrainpoolP384r1;
 use crate::{FieldElement, Scalar};
 use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
-use primeorder::{PrimeCurveParams, backend, point_arithmetic};
+use primeorder::{PrimeCurveParams, mul_backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<BrainpoolP384r1>;
@@ -33,7 +33,7 @@ impl PrimeCurveArithmetic for BrainpoolP384r1 {
 
 impl PrimeCurveParams for BrainpoolP384r1 {
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
-    type Backend = backend::VariableOnly;
+    type Backend = mul_backend::VariableOnly;
 
     const EQUATION_A: FieldElement = FieldElement::from_hex_vartime(
         "7bc382c63d8c150c3c72080ace05afa0c2bea28e4fb22787139165efba91f90f8aa5814a503ad4eb04a8c7dd22ce2826",

--- a/bp384/src/t1/arithmetic.rs
+++ b/bp384/src/t1/arithmetic.rs
@@ -3,7 +3,7 @@
 use super::BrainpoolP384t1;
 use crate::{FieldElement, Scalar};
 use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
-use primeorder::{PrimeCurveParams, backend, point_arithmetic};
+use primeorder::{PrimeCurveParams, mul_backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<BrainpoolP384t1>;
@@ -33,7 +33,7 @@ impl PrimeCurveArithmetic for BrainpoolP384t1 {
 
 impl PrimeCurveParams for BrainpoolP384t1 {
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
-    type Backend = backend::VariableOnly;
+    type Backend = mul_backend::VariableOnly;
 
     const EQUATION_A: FieldElement = FieldElement::from_hex_vartime(
         "8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec50",

--- a/p192/src/arithmetic.rs
+++ b/p192/src/arithmetic.rs
@@ -10,7 +10,7 @@ pub(crate) mod scalar;
 use self::{field::FieldElement, scalar::Scalar};
 use crate::NistP192;
 use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
-use primeorder::{PrimeCurveParams, backend, point_arithmetic};
+use primeorder::{PrimeCurveParams, mul_backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<NistP192>;
@@ -37,7 +37,7 @@ impl PrimeCurveArithmetic for NistP192 {
 /// [FIPS 186-4]: https://csrc.nist.gov/publications/detail/fips/186/4/final
 impl PrimeCurveParams for NistP192 {
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
-    type Backend = backend::VariableOnly;
+    type Backend = mul_backend::VariableOnly;
 
     /// a = -3 (=0xffffffff ffffffff ffffffff fffffffe ffffffff ffffffff fffffffe)
     const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();

--- a/p224/src/arithmetic.rs
+++ b/p224/src/arithmetic.rs
@@ -12,7 +12,7 @@ pub use self::scalar::Scalar;
 use self::field::FieldElement;
 use crate::NistP224;
 use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
-use primeorder::{PrimeCurveParams, backend, point_arithmetic};
+use primeorder::{PrimeCurveParams, mul_backend, point_arithmetic};
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<NistP224>;
@@ -39,7 +39,7 @@ impl PrimeCurveArithmetic for NistP224 {
 /// [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
 impl PrimeCurveParams for NistP224 {
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
-    type Backend = backend::VariableOnly;
+    type Backend = mul_backend::VariableOnly;
 
     /// a = -3 (=0xffffffff ffffffff ffffffff fffffffe ffffffff ffffffff fffffffe)
     const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -44,8 +44,8 @@ impl PrimeCurveParams for NistP256 {
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
 
     #[cfg(not(feature = "precomputed-tables"))]
-    type Backend = primeorder::backend::VariableOnly;
-    // TODO(tarcieri): use `primeorder::backend::PrecomputedTables` when MSRV 1.90
+    type Backend = primeorder::mul_backend::VariableOnly;
+    // TODO(tarcieri): use `primeorder::mul_backend::PrecomputedTables` when MSRV 1.90
     #[cfg(feature = "precomputed-tables")]
     type Backend = tables::backend::PrecomputedTables;
 

--- a/p256/src/arithmetic/tables.rs
+++ b/p256/src/arithmetic/tables.rs
@@ -18,18 +18,18 @@ impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for NistP256 {
 }
 
 /// Workaround for rust-lang/rust#140653 to support MSRV 1.85: we can't use the generic
-/// implementation in `primeorder::backend::PrecomputedTables` until MSRV 1.90 due to restrictions
+/// implementation in `primeorder::mul_backend::PrecomputedTables` until MSRV 1.90 due to restrictions
 /// on referencing a type with interior mutability from a `const`.
-// TODO(tarcieri): remove this and switch to `primeorder::backend::PrecomputedTables` when MSRV 1.90
+// TODO(tarcieri): remove this and switch to `primeorder::mul_backend::PrecomputedTables` when MSRV 1.90
 pub(crate) mod backend {
     use super::BASEPOINT_TABLE;
     use crate::{NistP256, ProjectivePoint, Scalar};
-    use primeorder::Backend;
+    use primeorder::MulBackend;
 
     /// Backend based on precomputed tables.
     pub struct PrecomputedTables;
 
-    impl Backend<NistP256> for PrecomputedTables {
+    impl MulBackend<NistP256> for PrecomputedTables {
         #[inline]
         fn mul_by_generator(k: &Scalar) -> ProjectivePoint {
             BASEPOINT_TABLE.mul(k)

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -44,8 +44,8 @@ impl PrimeCurveParams for NistP384 {
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
 
     #[cfg(not(feature = "precomputed-tables"))]
-    type Backend = primeorder::backend::VariableOnly;
-    // TODO(tarcieri): use `primeorder::backend::PrecomputedTables` when MSRV 1.90
+    type Backend = primeorder::mul_backend::VariableOnly;
+    // TODO(tarcieri): use `primeorder::mul_backend::PrecomputedTables` when MSRV 1.90
     #[cfg(feature = "precomputed-tables")]
     type Backend = tables::backend::PrecomputedTables;
 

--- a/p384/src/arithmetic/tables.rs
+++ b/p384/src/arithmetic/tables.rs
@@ -18,18 +18,18 @@ impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for NistP384 {
 }
 
 /// Workaround for rust-lang/rust#140653 to support MSRV 1.85: we can't use the generic
-/// implementation in `primeorder::backend::PrecomputedTables` until MSRV 1.90 due to restrictions
+/// implementation in `primeorder::mul_backend::PrecomputedTables` until MSRV 1.90 due to restrictions
 /// on referencing a type with interior mutability from a `const`.
-// TODO(tarcieri): remove this and switch to `primeorder::backend::PrecomputedTables` when MSRV 1.90
+// TODO(tarcieri): remove this and switch to `primeorder::mul_backend::PrecomputedTables` when MSRV 1.90
 pub(crate) mod backend {
     use super::BASEPOINT_TABLE;
     use crate::{NistP384, ProjectivePoint, Scalar};
-    use primeorder::Backend;
+    use primeorder::MulBackend;
 
     /// Backend based on precomputed tables.
     pub struct PrecomputedTables;
 
-    impl Backend<NistP384> for PrecomputedTables {
+    impl MulBackend<NistP384> for PrecomputedTables {
         #[inline]
         fn mul_by_generator(k: &Scalar) -> ProjectivePoint {
             BASEPOINT_TABLE.mul(k)

--- a/p521/src/arithmetic.rs
+++ b/p521/src/arithmetic.rs
@@ -46,8 +46,8 @@ impl PrimeCurveParams for NistP521 {
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
 
     #[cfg(not(feature = "precomputed-tables"))]
-    type Backend = primeorder::backend::VariableOnly;
-    // TODO(tarcieri): use `primeorder::backend::PrecomputedTables` when MSRV 1.90
+    type Backend = primeorder::mul_backend::VariableOnly;
+    // TODO(tarcieri): use `primeorder::mul_backend::PrecomputedTables` when MSRV 1.90
     #[cfg(feature = "precomputed-tables")]
     type Backend = tables::backend::PrecomputedTables;
 

--- a/p521/src/arithmetic/tables.rs
+++ b/p521/src/arithmetic/tables.rs
@@ -18,18 +18,18 @@ impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for NistP521 {
 }
 
 /// Workaround for rust-lang/rust#140653 to support MSRV 1.85: we can't use the generic
-/// implementation in `primeorder::backend::PrecomputedTables` until MSRV 1.90 due to restrictions
+/// implementation in `primeorder::mul_backend::PrecomputedTables` until MSRV 1.90 due to restrictions
 /// on referencing a type with interior mutability from a `const`.
-// TODO(tarcieri): remove this and switch to `primeorder::backend::PrecomputedTables` when MSRV 1.90
+// TODO(tarcieri): remove this and switch to `primeorder::mul_backend::PrecomputedTables` when MSRV 1.90
 pub(crate) mod backend {
     use super::BASEPOINT_TABLE;
     use crate::{NistP521, ProjectivePoint, Scalar};
-    use primeorder::Backend;
+    use primeorder::MulBackend;
 
     /// Backend based on precomputed tables.
     pub struct PrecomputedTables;
 
-    impl Backend<NistP521> for PrecomputedTables {
+    impl MulBackend<NistP521> for PrecomputedTables {
         #[inline]
         fn mul_by_generator(k: &Scalar) -> ProjectivePoint {
             BASEPOINT_TABLE.mul(k)

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -14,7 +14,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-pub mod backend;
+pub mod mul_backend;
 #[cfg(feature = "hash2curve")]
 pub mod osswu;
 pub mod point_arithmetic;
@@ -27,7 +27,7 @@ mod tables;
 
 pub use crate::{
     affine::AffinePoint,
-    backend::Backend,
+    mul_backend::MulBackend,
     projective::ProjectivePoint,
     tables::{LookupTable, Radix16Decomposition, Radix16Digits},
 };
@@ -60,7 +60,7 @@ pub trait PrimeCurveParams:
     type PointArithmetic: point_arithmetic::PointArithmetic<Self>;
 
     /// Scalar arithmetic backend implementation.
-    type Backend: Backend<Self>;
+    type Backend: MulBackend<Self>;
 
     /// Coefficient `a` in the curve equation.
     const EQUATION_A: Self::FieldElement;

--- a/primeorder/src/mul_backend.rs
+++ b/primeorder/src/mul_backend.rs
@@ -13,7 +13,7 @@ pub use self::precomputed_tables::PrecomputedTables;
 pub use self::variable_only::VariableOnly;
 
 /// Scalar multiplication backend.
-pub trait Backend<C: PrimeCurveParams> {
+pub trait MulBackend<C: PrimeCurveParams> {
     /// Multiplication by the generator.
     ///
     /// This is overridable to make it possible to plug in a basepoint table.

--- a/primeorder/src/mul_backend/precomputed_tables.rs
+++ b/primeorder/src/mul_backend/precomputed_tables.rs
@@ -1,11 +1,11 @@
-use super::Backend;
+use super::MulBackend;
 use crate::{PrimeCurveParams, PrimeCurveWithBasepointTable, ProjectivePoint};
 use elliptic_curve::Scalar;
 
 /// Backend based on precomputed tables.
 pub struct PrecomputedTables<const WINDOW_SIZE: usize>;
 
-impl<C, const WINDOW_SIZE: usize> Backend<C> for PrecomputedTables<WINDOW_SIZE>
+impl<C, const WINDOW_SIZE: usize> MulBackend<C> for PrecomputedTables<WINDOW_SIZE>
 where
     C: PrimeCurveParams + PrimeCurveWithBasepointTable<WINDOW_SIZE>,
 {

--- a/primeorder/src/mul_backend/variable_only.rs
+++ b/primeorder/src/mul_backend/variable_only.rs
@@ -1,7 +1,7 @@
-use super::Backend;
+use super::MulBackend;
 use crate::PrimeCurveParams;
 
 /// Simple backend that only supports variable-base scalar multiplication.
 pub struct VariableOnly;
 
-impl<C: PrimeCurveParams> Backend<C> for VariableOnly {}
+impl<C: PrimeCurveParams> MulBackend<C> for VariableOnly {}

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::needless_range_loop, clippy::op_ref)]
 
 use crate::{
-    AffinePoint, Backend, Field, LookupTable, PrimeCurveParams, Radix16Decomposition,
+    AffinePoint, Field, LookupTable, MulBackend, PrimeCurveParams, Radix16Decomposition,
     Radix16Digits, point_arithmetic::PointArithmetic,
 };
 use core::{array, borrow::Borrow, iter::Sum, iter::zip};

--- a/sm2/src/arithmetic.rs
+++ b/sm2/src/arithmetic.rs
@@ -45,8 +45,8 @@ impl PrimeCurveParams for Sm2 {
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
 
     #[cfg(not(feature = "precomputed-tables"))]
-    type Backend = primeorder::backend::VariableOnly;
-    // TODO(tarcieri): use `primeorder::backend::PrecomputedTables` when MSRV 1.90
+    type Backend = primeorder::mul_backend::VariableOnly;
+    // TODO(tarcieri): use `primeorder::mul_backend::PrecomputedTables` when MSRV 1.90
     #[cfg(feature = "precomputed-tables")]
     type Backend = tables::backend::PrecomputedTables;
 

--- a/sm2/src/arithmetic/tables.rs
+++ b/sm2/src/arithmetic/tables.rs
@@ -18,18 +18,18 @@ impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for Sm2 {
 }
 
 /// Workaround for rust-lang/rust#140653 to support MSRV 1.85: we can't use the generic
-/// implementation in `primeorder::backend::PrecomputedTables` until MSRV 1.90 due to restrictions
+/// implementation in `primeorder::mul_backend::PrecomputedTables` until MSRV 1.90 due to restrictions
 /// on referencing a type with interior mutability from a `const`.
-// TODO(tarcieri): remove this and switch to `primeorder::backend::PrecomputedTables` when MSRV 1.90
+// TODO(tarcieri): remove this and switch to `primeorder::mul_backend::PrecomputedTables` when MSRV 1.90
 pub(crate) mod backend {
     use super::BASEPOINT_TABLE;
     use crate::{ProjectivePoint, Scalar, Sm2};
-    use primeorder::Backend;
+    use primeorder::MulBackend;
 
     /// Backend based on precomputed tables.
     pub struct PrecomputedTables;
 
-    impl Backend<Sm2> for PrecomputedTables {
+    impl MulBackend<Sm2> for PrecomputedTables {
         #[inline]
         fn mul_by_generator(k: &Scalar) -> ProjectivePoint {
             BASEPOINT_TABLE.mul(k)


### PR DESCRIPTION
This is a little more specific that it's the backend for scalar multiplication.