### PR TITLE
primefield: add `FieldExt`

### DIFF
--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -19,7 +19,7 @@ use elliptic_curve::{
     },
     zeroize::DefaultIsZeroes,
 };
-use primeorder::PrimeFieldExt;
+use primeorder::{FieldExt, PrimeFieldExt};
 
 cpubits! {
     32 => {
@@ -311,6 +311,7 @@ impl PrimeField for Scalar {
     }
 }
 
+impl FieldExt for Scalar {}
 impl PrimeFieldExt for Scalar {}
 
 impl From<u32> for Scalar {

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -21,7 +21,7 @@ use elliptic_curve::{
     },
     zeroize::DefaultIsZeroes,
 };
-use primefield::PrimeFieldExt;
+use primefield::{FieldExt, PrimeFieldExt};
 
 cpubits! {
     32 => {
@@ -308,6 +308,7 @@ impl PrimeField for Scalar {
     }
 }
 
+impl FieldExt for Scalar {}
 impl PrimeFieldExt for Scalar {}
 
 impl Retrieve for Scalar {

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -20,7 +20,7 @@ use core::{
 use elliptic_curve::{
     Error, Generate,
     array::Array,
-    bigint::{Word, cpubits, modular::Retrieve},
+    bigint::{self, Limb, Odd, Word, cpubits, modular::Retrieve},
     ff::{self, Field, PrimeField},
     field::bytes_to_uint,
     ops::{BatchInvert, Invert},
@@ -28,7 +28,7 @@ use elliptic_curve::{
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, CtOption},
     zeroize::DefaultIsZeroes,
 };
-use primefield::bigint::{self, Limb, Odd};
+use primefield::{FieldExt, PrimeFieldExt};
 
 // TODO(tarcieri): remove `allow(dead_code)` when we can use `const _` to silence warnings
 cpubits! {
@@ -530,6 +530,9 @@ impl Field for FieldElement {
         ff::helpers::sqrt_ratio_generic(num, div)
     }
 }
+
+impl FieldExt for FieldElement {}
+impl PrimeFieldExt for FieldElement {}
 
 impl Generate for FieldElement {
     fn try_generate_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {

--- a/primefield/src/lib.rs
+++ b/primefield/src/lib.rs
@@ -17,7 +17,7 @@ mod traits;
 pub use crate::{
     error::{Error, Result},
     monty::{MontyFieldBytes, MontyFieldElement, MontyFieldParams, compute_t},
-    traits::PrimeFieldExt,
+    traits::{FieldExt, PrimeFieldExt},
 };
 pub use array::typenum::consts;
 pub use bigint;

--- a/primefield/src/macros.rs
+++ b/primefield/src/macros.rs
@@ -352,6 +352,8 @@ macro_rules! monty_field_element {
             }
         }
 
+        impl $crate::FieldExt for $fe {}
+
         impl $crate::PrimeFieldExt for $fe {
             const REPR_ENDIANNESS: $crate::ByteOrder =
                 <$params as $crate::MontyFieldParams<{ <$params>::LIMBS }>>::BYTE_ORDER;

--- a/primefield/src/traits.rs
+++ b/primefield/src/traits.rs
@@ -1,9 +1,17 @@
 use crate::ByteOrder;
 
+/// Extension trait for [`ff::Field`], intended as a place to put optimizable arithmetic operations.
+///
+/// The idea is future versions of this crate can add provided methods which are useful in dense
+/// field arithmetic like `primeorder`'s RCB implementation, and `primefield` can potentially
+/// automatically plug in optimized implementations when available.
+// TODO(tarcieri): add some methods to this trait, e.g. `add_and_mul`, `mul_and_add`
+pub trait FieldExt: ff::Field {}
+
 /// Extension trait for [`ff::PrimeField`] which enables specifying the endianness in which
 /// [`ff::PrimeField::Repr`] is encoded.
 // TODO(tarcieri): remove this if/whenever zkcrypto/rfcs#4 lands. See also: zkcrypto/ff#158
-pub trait PrimeFieldExt: ff::PrimeField {
+pub trait PrimeFieldExt: FieldExt + ff::PrimeField {
     /// Endianness used when encoding [`ff::PrimeField::Repr`].
     const REPR_ENDIANNESS: ByteOrder = ByteOrder::BigEndian;
 

--- a/primeorder/README.md
+++ b/primeorder/README.md
@@ -8,8 +8,9 @@
 [![Project Chat][chat-image]][chat-link]
 
 Pure Rust implementation of complete addition formulas for prime order elliptic
-curves ([Renes-Costello-Batina 2015]). Generic over field elements and curve
-equation coefficients.
+curves ([Renes-Costello-Batina 2015] a.k.a. RCB).
+
+Generic over field element implementations and curve equation coefficients.
 
 [Documentation][docs-link]
 

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -38,7 +38,7 @@ pub use elliptic_curve::{
     hazmat::FieldArithmetic,
     point::Double,
 };
-pub use primefield::PrimeFieldExt;
+pub use primefield::{FieldExt, PrimeFieldExt};
 
 use elliptic_curve::{Curve, CurveArithmetic, sec1};
 
@@ -53,7 +53,7 @@ pub trait PrimeCurveParams:
         AffinePoint = AffinePoint<Self>,
         ProjectivePoint = ProjectivePoint<Self>,
         Scalar: PrimeFieldExt,
-    > + FieldArithmetic
+    > + FieldArithmetic<FieldElement: PrimeFieldExt>
     + PrimeCurve
 {
     /// [Point arithmetic](point_arithmetic) implementation, might be optimized for this specific curve


### PR DESCRIPTION
Also bounds `PrimeFieldExt` on it, adds it to the macro boilerplate, adds manual definitions where needed, and bounds the `FieldElement` type used by `primeorder::PrimeCurveParams` on it so it needs to impl it as well.

This follows from RustCrypto/traits#1997 where we were discussing how we could better leverage the various lazy field implementations we had.

In that thread I suggested we could avoid exposing separate field element types for reduced/unreduced operations and have a simpler abstraction for eagerly versus lazily reduced field elements if we supported various "fused" operations that are useful in dense field arithmetic, e.g. add-then-mul, mul-then-add.

For example the RCB implementation in `primeorder` could migrate to using the "fused" operations which start out backed by default impls which call the individual arithmetic ops which, where applicable (mostly `k256` and `p521` for now) can be replaced by optimized implementations which can avoid unnecessary normalization/reductions when performing these sequences of operations.

This adds a `FieldExt` with no methods despite the fact we already have a `PrimeFieldExt`. The idea is `FieldExt` is an extension trait for functionality that would otherwise go on `ff::Field`, and `PrimeFieldExt` is an extension trait for `ff::PrimeField`, which in this case due to how the `ff` crate factors the relevant operations happens to be dealing with encoding, whereas `FieldExt` can have the "fused" arithmetic ops as `ff::Field` otherwise deals with the low-level arithmetic operations.

What's nice is we could stabilize it after adding this and worry about the specific arithmetic operations to add later so it doesn't block stabilization. I will follow up with a PR to propose some I think make sense looking at what sorts of operations appear frequently in RCB which remains the main candidate for these sorts of optimizations as it would improve point addition performance which improves practically every other point arithmetic operation.