### PR TITLE
[WIP] primefield: add "fused" ops to `FieldExt`

### DIFF
--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -531,7 +531,16 @@ impl Field for FieldElement {
     }
 }
 
-impl FieldExt for FieldElement {}
+impl FieldExt for FieldElement {
+    fn add_mul(&self, x: &Self, y: &Self) -> Self {
+        self.add_loose(x).multiply(&y.relax())
+    }
+
+    fn sub_mul(&self, x: &Self, y: &Self) -> Self {
+        self.sub_loose(x).multiply(&y.relax())
+    }
+}
+
 impl PrimeFieldExt for FieldElement {}
 
 impl Generate for FieldElement {

--- a/primefield/src/traits.rs
+++ b/primefield/src/traits.rs
@@ -6,7 +6,17 @@ use crate::ByteOrder;
 /// field arithmetic like `primeorder`'s RCB implementation, and `primefield` can potentially
 /// automatically plug in optimized implementations when available.
 // TODO(tarcieri): add some methods to this trait, e.g. `add_and_mul`, `mul_and_add`
-pub trait FieldExt: ff::Field {}
+pub trait FieldExt: ff::Field {
+    /// Compute `(self + x) * y`
+    fn add_mul(&self, x: &Self, y: &Self) -> Self {
+        (*self + x) * y
+    }
+
+    /// Compute `(self - x) * y`
+    fn sub_mul(&self, x: &Self, y: &Self) -> Self {
+        (*self - x) * y
+    }
+}
 
 /// Extension trait for [`ff::PrimeField`] which enables specifying the endianness in which
 /// [`ff::PrimeField::Repr`] is encoded.


### PR DESCRIPTION
Exploring what might make sense here. Starting with:

- `add_mul`: (a + b) * c
- `sub_mul`: (a - b) * c

The only field backend where I've done an optimization for these is `p521`. Notably its multiply takes a `LooseFieldElement` so there is further potential for another add/sub operation in place of `c`, e.g. `(a + b) * (c + d)`.

Before going any farther down this road it would be good to look at:
- what works well for the `k256` field element implementation
- what we could potentially add to `primefield::MontyFieldElement` in a generic implementation