### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "bignp256"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 dependencies = [
  "belt-block",
  "belt-hash",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "bp256"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "bp384"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -366,8 +366,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.4"
-source = "git+https://github.com/RustCrypto/crypto-bigint#ec6615fad09d26f8518378f1fdfe96a635ddab2d"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -426,8 +427,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.20"
-source = "git+https://github.com/RustCrypto/signatures#9556832958dbdeb804f0291a4e81ee1ec2ecf677"
+version = "0.17.0-rc.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c49632b5dd114acd72982823888124a7f25c97801e6e38df893548f3c45b3b"
 dependencies = [
  "der",
  "digest",
@@ -453,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "ed448-goldilocks"
-version = "0.14.0-pre.13"
+version = "0.14.0-pre.14"
 dependencies = [
  "chacha20",
  "criterion",
@@ -481,8 +483,9 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.35"
-source = "git+https://github.com/RustCrypto/traits#5b2a9dc34790d9aee0daaff8d87dcf6c50630654"
+version = "0.14.0-rc.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abda41bf4d801bd9bfe2ef26ab37ae40d8c703374985b5c642e141d23de3f556"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -612,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "hash2curve"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 dependencies = [
  "digest",
  "elliptic-curve",
@@ -699,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 dependencies = [
  "cpubits",
  "criterion",
@@ -793,7 +796,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p192"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -805,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "p224"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -818,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -834,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -851,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 dependencies = [
  "base16ct",
  "criterion",
@@ -937,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 dependencies = [
  "crypto-bigint",
  "crypto-common",
@@ -949,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 dependencies = [
  "elliptic-curve",
  "once_cell",
@@ -1306,7 +1309,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sm2"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 dependencies = [
  "criterion",
  "der",
@@ -1372,7 +1375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1527,7 +1530,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wnaf"
-version = "0.14.0-pre.0"
+version = "0.14.0-rc.0"
 dependencies = [
  "ff",
  "group",
@@ -1536,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "x448"
-version = "0.14.0-pre.10"
+version = "0.14.0-pre.11"
 dependencies = [
  "ed448-goldilocks",
  "serdect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,3 @@ hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
 wnaf = { path = "wnaf" }
-
-crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint" }
-ecdsa = { git = "https://github.com/RustCrypto/signatures" }
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bignp256"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 description = """
 Pure Rust implementation of the Bign P-256 (a.k.a. bign-curve256v1)
 elliptic curve as defined in STB 34.101.45-2013, with
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.35", features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.36", features = ["sec1"] }
 
 # optional dependencies
 belt-block = { version = "0.2", optional = true }
@@ -31,18 +31,18 @@ hkdf = { version = "0.13", optional = true }
 hmac = { version = "0.13", optional = true }
 rand_core = "0.10"
 pkcs8 = { version = "0.11", optional = true }
-primefield = { version = "0.14.0-rc.12", optional = true }
-primeorder = { version = "0.14.0-rc.12", optional = true }
+primefield = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.13", optional = true }
 sec1 = { version = "0.8.1", optional = true }
-hash2curve = { version = "0.14.0-rc.12", optional = true }
+hash2curve = { version = "0.14.0-rc.13", optional = true }
 belt-kwp = { version = "0.2", optional = true }
 signature = { version = "3", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.12", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.13", features = ["dev"] }
 proptest = "1"
 
 [features]

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp256"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 description = "Brainpool P-256 (brainpoolP256r1 and brainpoolP256t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -14,17 +14,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.20", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "0.14.0-rc.12", optional = true }
-primeorder = { version = "0.14.0-rc.12", optional = true }
+ecdsa = { version = "0.17.0-rc.21", optional = true, default-features = false, features = ["der"] }
+primefield = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.13", optional = true }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp384"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -14,17 +14,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.20", optional = true, default-features = false, features = ["der"] }
-primefield = { version = "0.14.0-rc.12", optional = true }
-primeorder = { version = "0.14.0-rc.12", optional = true }
+ecdsa = { version = "0.17.0-rc.21", optional = true, default-features = false, features = ["der"] }
+primefield = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.13", optional = true }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed448-goldilocks"
-version = "0.14.0-pre.13"
+version = "0.14.0-pre.14"
 authors = ["RustCrypto Developers"]
 categories = ["cryptography"]
 keywords = ["cryptography", "decaf", "ed448", "ed448-goldilocks"]
@@ -16,8 +16,8 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.35", features = ["arithmetic", "pkcs8"] }
-hash2curve = "0.14.0-rc.12"
+elliptic-curve = { version = "0.14.0-rc.36", features = ["arithmetic", "pkcs8"] }
+hash2curve = "0.14.0-rc.13"
 rand_core = { version = "0.10", default-features = false }
 shake = { version = "0.1", default-features = false }
 subtle = { version = "2.6", default-features = false }

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash2curve"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 description = "hash2curve algorithm implementation"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = { version = "0.11" }
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["arithmetic"] }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification/public-key recovery, Taproot Schnorr signatures (BIP340),
@@ -20,21 +20,21 @@ rust-version = "1.85"
 
 [dependencies]
 cpubits = "0.1"
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
-hash2curve = { version = "0.14.0-rc.12", optional = true }
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["sec1"] }
+hash2curve = { version = "0.14.0-rc.13", optional = true }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.21", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primeorder = { version = "0.14.0-rc.12", optional = true }
+primeorder = { version = "0.14.0-rc.13", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 signature = { version = "3", optional = true }
-wnaf = { version = "0.14.0-pre.0", default-features = false }
+wnaf = { version = "0.14.0-rc.0", default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.21", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4.3"
 hex-literal = "1"
 num-bigint = "0.4"

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p192"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 description = """
 Pure Rust implementation of the NIST P-192 (a.k.a. secp192r1) elliptic curve
 as defined in SP 800-186
@@ -17,19 +17,19 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.21", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.12", optional = true }
-primeorder = { version = "0.14.0-rc.12", optional = true }
+primefield = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.13", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.21", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.12", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.13", features = ["dev"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p224"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 description = """
 Pure Rust implementation of the NIST P-224 (a.k.a. secp224r1) elliptic curve
 as defined in SP 800-186
@@ -17,20 +17,20 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.21", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.12", optional = true }
-primeorder = { version = "0.14.0-rc.12", optional = true }
+primefield = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.13", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.21", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.12", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.13", features = ["dev"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve as defined in SP 800-186, with support for ECDH, ECDSA
@@ -18,23 +18,23 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.12", optional = true }
+ecdsa-core = { version = "0.17.0-rc.21", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+hash2curve = { version = "0.14.0-rc.13", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.12", optional = true }
-primeorder = { version = "0.14.0-rc.12", optional = true }
+primefield = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.13", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.21", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primefield = { version = "0.14.0-rc.12" }
-primeorder = { version = "0.14.0-rc.12", features = ["dev"] }
+primefield = { version = "0.14.0-rc.13" }
+primeorder = { version = "0.14.0-rc.13", features = ["dev"] }
 proptest = "1"
 
 [features]

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p384"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 description = """
 Pure Rust implementation of the NIST P-384 (a.k.a. secp384r1) elliptic curve
 as defined in SP 800-186 with support for ECDH, ECDSA signing/verification,
@@ -18,14 +18,14 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.12", optional = true }
+ecdsa-core = { version = "0.17.0-rc.21", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+hash2curve = { version = "0.14.0-rc.13", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.12", optional = true }
-primeorder = { version = "0.14.0-rc.12", optional = true }
+primefield = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.13", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
@@ -34,9 +34,9 @@ fiat-crypto = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.21", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.12", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.13", features = ["dev"] }
 proptest = "1.11"
 
 [features]

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p521"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 description = """
 Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve
 as defined in SP 800-186
@@ -18,23 +18,23 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "1"
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.12", optional = true }
+ecdsa-core = { version = "0.17.0-rc.21", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+hash2curve = { version = "0.14.0-rc.13", optional = true }
 hex-literal = { version = "1", optional = true }
-primefield = { version = "0.14.0-rc.12", optional = true }
-primeorder = { version = "0.14.0-rc.12", optional = true }
+primefield = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.13", optional = true }
 rand_core = { version = "0.10", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.20", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.21", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.12", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.13", features = ["dev"] }
 proptest = "1.11"
 
 [features]

--- a/primefield/Cargo.toml
+++ b/primefield/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primefield"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 description = """
 Generic implementation of prime fields built on `crypto-bigint`, along with macros for writing
 field element newtypes including ones with formally verified arithmetic using `fiat-crypto`
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-bigint = { version = "0.7.4", package = "crypto-bigint", default-features = false, features = ["rand_core", "hybrid-array", "subtle"] }
+bigint = { version = "0.7.5", package = "crypto-bigint", default-features = false, features = ["rand_core", "hybrid-array", "subtle"] }
 common = { package = "crypto-common", version = "0.2", features = ["rand_core"] }
 ff = { version = "0.14", default-features = false }
 subtle = { version = "2.6", default-features = false, features = ["const-generics"] }

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve
@@ -18,8 +18,8 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["arithmetic", "sec1"] }
-primefield = "0.14.0-rc.12"
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["arithmetic", "sec1"] }
+primefield = "0.14.0-rc.13"
 
 # optional dependencies
 once_cell = { version = "1.21", optional = true, default-features = false }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm2"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.13"
 description = """
 Pure Rust implementation of the SM2 elliptic curve as defined in the Chinese
 national standard GM/T 0003-2012 as well as ISO/IEC 14888. Includes support for
@@ -18,14 +18,14 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
 rand_core = { version = "0.10", default-features = false }
 
 # optional dependencies
 der = { version = "0.8", optional = true }
-primefield = { version = "0.14.0-rc.12", optional = true }
-primeorder = { version = "0.14.0-rc.12", optional = true }
+primefield = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.13", optional = true }
 rfc6979 = { version = "0.6.0-pre.0", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 signature = { version = "3", optional = true, features = ["rand_core"] }
@@ -33,7 +33,7 @@ sm3 = { version = "0.5", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14.0-rc.35", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.36", default-features = false, features = ["dev"] }
 hex-literal = "1"
 proptest = "1"
 

--- a/wnaf/Cargo.toml
+++ b/wnaf/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "wnaf"
-version = "0.14.0-pre.0"
+version = "0.14.0-rc.0"
 description = """
 w-NAF (w-ary non-adjacent form) variable-time scalar multiplication implemented generically
-over elliptic curve groups, including multiscalar multiplication using Straus's interleaved window
-method. Contains an implementation adapted from the `group` crate which has been forked and enhanced
-but is otherwise compatible with that crate's traits, along with the `ff` crate's traits for finite
-field representations
+over elliptic curve groups with full `no_alloc` support, including multiscalar multiplication using
+Straus's interleaved window method. Contains an implementation adapted from the `group` crate which
+has been forked and enhanced but is otherwise compatible with that crate's traits, along with the
+`ff` crate's traits for finite field representations
 """
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -15,7 +15,7 @@ homepage = "https://github.com/RustCrypto/elliptic-curves/tree/master/wnaf"
 repository = "https://github.com/RustCrypto/elliptic-curves"
 readme = "README.md"
 categories = ["cryptography", "no-std"]
-keywords = ["crypto", "ecc", "field", "prime"]
+keywords = ["crypto", "ecc", "multiscalar", "no_alloc"]
 edition = "2024"
 rust-version = "1.85"
 

--- a/x448/Cargo.toml
+++ b/x448/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x448"
-version = "0.14.0-pre.10"
+version = "0.14.0-pre.11"
 authors = ["RustCrypto Developers"]
 categories = ["cryptography"]
 keywords = ["cryptography", "crypto", "x448", "diffie-hellman", "curve448", ]
@@ -14,7 +14,7 @@ readme = "README.md"
 description = "Pure Rust implementation of X448, an elliptic curve Diffie-Hellman function"
 
 [dependencies]
-ed448-goldilocks = { version = "0.14.0-pre.13", default-features = false }
+ed448-goldilocks = { version = "0.14.0-pre.14", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
 # optional dependencies


### PR DESCRIPTION
Releases the following:

- `bignp256` v0.14.0-rc.13
- `bp256` v0.14.0-rc.13
- `bp384` v0.14.0-rc.13
- `ed448-goldilocks` v0.14.0-pre.14
- `hash2curve` v0.14.0-rc.13
- `k256` v0.14.0-rc.13
- `p192` v0.14.0-rc.13
- `p224` v0.14.0-rc.13
- `p256` v0.14.0-rc.13
- `p384` v0.14.0-rc.13
- `p521` v0.14.0-rc.13
- `primefield` v0.14.0-rc.13
- `primeorder` v0.14.0-rc.13
- `sm2` v0.14.0-rc.13
- `wnaf` v0.14.0-rc.0
- `x448` v0.14.0-pre.11