### PR TITLE
wnaf: add `Digit` type alias

### DIFF
--- a/wnaf/src/lib.rs
+++ b/wnaf/src/lib.rs
@@ -32,6 +32,9 @@ pub use crate::wnaf::Wnaf;
 use crate::limb_buffer::LimbBuffer;
 use ff::PrimeField;
 
+/// Type used to represent w-NAF digits.
+pub type Digit = i64;
+
 /// Computes a w-NAF window table for the given base and window size.
 ///
 /// For a window of size `w` non-zero w-NAF digits are odd and have magnitude at most `2^(w-1) - 1`.
@@ -53,7 +56,7 @@ fn wnaf_table<G: Group>(table: &mut [G], base: G, window: usize) {
 /// Fills `wnaf` with the w-NAF representation of a little-endian scalar, and returns the
 /// number of digits written.
 #[allow(clippy::cast_possible_wrap)]
-fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut [i64], c: S, window: usize) -> usize {
+fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut [Digit], c: S, window: usize) -> usize {
     debug_assert!(window >= 2);
     debug_assert!(window <= 64);
 
@@ -95,10 +98,10 @@ fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut [i64], c: S, window: usize) -> usize {
         } else {
             wnaf[cursor] = if window_val < width / 2 {
                 carry = 0;
-                window_val as i64
+                window_val as Digit
             } else {
                 carry = 1;
-                (window_val as i64).wrapping_sub(width as i64)
+                (window_val as Digit).wrapping_sub(width as Digit)
             };
             cursor += 1;
             for _ in 1..window {
@@ -112,7 +115,7 @@ fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut [i64], c: S, window: usize) -> usize {
     // If there is a remaining carry (the scalar used all `bit_len` bits and the last w-NAF digit
     // was negative), emit it so the representation is exact.
     if carry != 0 {
-        wnaf[cursor] = carry as i64;
+        wnaf[cursor] = carry as Digit;
         cursor += 1;
     }
 
@@ -132,7 +135,7 @@ fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut [i64], c: S, window: usize) -> usize {
 fn wnaf_multi_exp<'a, G, I>(terms: I) -> G
 where
     G: Group,
-    I: Clone + IntoIterator<Item = (&'a [G], &'a [i64], usize)>,
+    I: Clone + IntoIterator<Item = (&'a [G], &'a [Digit], usize)>,
 {
     let window_size = terms
         .clone()

--- a/wnaf/src/scalar.rs
+++ b/wnaf/src/scalar.rs
@@ -1,4 +1,4 @@
-use crate::{WindowSize, le_repr, wnaf_form};
+use crate::{Digit, WindowSize, le_repr, wnaf_form};
 use array::{Array, ArraySize};
 use core::marker::PhantomData;
 use ff::PrimeField;
@@ -10,15 +10,16 @@ use ff::PrimeField;
 /// See [`WnafBase`] for usage examples.
 #[derive(Clone, Debug)]
 pub struct WnafScalar<F: PrimeField, W: WindowSize, WnafStorage: ArraySize> {
-    pub(crate) wnaf: Array<i64, WnafStorage>,
+    pub(crate) wnaf: Array<Digit, WnafStorage>,
     pub(crate) digits: usize,
     _field: PhantomData<(F, W)>,
 }
 
 impl<F: PrimeField, W: WindowSize, WnafStorage: ArraySize> WnafScalar<F, W, WnafStorage> {
     /// Computes the w-NAF representation of the given scalar with window size `W`.
+    #[inline]
     pub fn new(scalar: &F) -> Self {
-        let mut wnaf = Array::from_fn(|_| 0i64);
+        let mut wnaf = Array::default();
         let len = wnaf_form(&mut wnaf, le_repr(scalar), W::USIZE);
         WnafScalar {
             wnaf,
@@ -49,6 +50,7 @@ impl<F: PrimeField, W: WindowSize, WnafStorage: ArraySize> WnafScalar<F, W, Wnaf
     /// Returns `None` if `bytes` is longer than the field's canonical representation, if the
     /// encoded integer is greater than or equal to the field modulus, or if `bytes.len() * 8 + 1`
     /// exceeds `WnafStorage::USIZE` (which would overflow the fixed-size `wnaf` storage).
+    #[inline]
     pub fn from_le_bytes(bytes: &[u8]) -> Option<Self> {
         if bytes.len() * 8 + 1 > WnafStorage::USIZE {
             return None;

--- a/wnaf/src/wnaf.rs
+++ b/wnaf/src/wnaf.rs
@@ -1,6 +1,6 @@
 //! Dynamic w-NAF API (requires `alloc` feature).
 
-use crate::{WnafGroup, le_repr, wnaf_form, wnaf_multi_exp, wnaf_table};
+use crate::{Digit, WnafGroup, le_repr, wnaf_form, wnaf_multi_exp, wnaf_table};
 use alloc::vec::Vec;
 use group::Group;
 
@@ -85,13 +85,13 @@ pub struct Wnaf<W, B, S> {
     window_size: W,
 }
 
-impl<G: Group> Default for Wnaf<(), Vec<G>, Vec<i64>> {
+impl<G: Group> Default for Wnaf<(), Vec<G>, Vec<Digit>> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<G: Group> Wnaf<(), Vec<G>, Vec<i64>> {
+impl<G: Group> Wnaf<(), Vec<G>, Vec<Digit>> {
     #[must_use]
     pub fn new() -> Self {
         Wnaf {
@@ -102,8 +102,8 @@ impl<G: Group> Wnaf<(), Vec<G>, Vec<i64>> {
     }
 }
 
-impl<G: WnafGroup> Wnaf<(), Vec<G>, Vec<i64>> {
-    pub fn base(&mut self, base: G, num_scalars: usize) -> Wnaf<usize, &[G], &mut Vec<i64>> {
+impl<G: WnafGroup> Wnaf<(), Vec<G>, Vec<Digit>> {
+    pub fn base(&mut self, base: G, num_scalars: usize) -> Wnaf<usize, &[G], &mut Vec<Digit>> {
         let window_size = G::recommended_wnaf_for_num_scalars(num_scalars);
 
         self.base.resize_with(1 << (window_size - 2), G::identity);
@@ -116,7 +116,7 @@ impl<G: WnafGroup> Wnaf<(), Vec<G>, Vec<i64>> {
         }
     }
 
-    pub fn scalar(&mut self, scalar: &<G as Group>::Scalar) -> Wnaf<usize, &mut Vec<G>, &[i64]> {
+    pub fn scalar(&mut self, scalar: &<G as Group>::Scalar) -> Wnaf<usize, &mut Vec<G>, &[Digit]> {
         let window_size = 4;
 
         let repr = le_repr(scalar);
@@ -132,11 +132,11 @@ impl<G: WnafGroup> Wnaf<(), Vec<G>, Vec<i64>> {
     }
 }
 
-impl<'a, G: Group> Wnaf<usize, &'a [G], &'a mut Vec<i64>> {
+impl<'a, G: Group> Wnaf<usize, &'a [G], &'a mut Vec<Digit>> {
     /// Constructs new space for the scalar representation while borrowing
     /// the computed window table, for sending the window table across threads.
     #[must_use]
-    pub fn shared(&self) -> Wnaf<usize, &'a [G], Vec<i64>> {
+    pub fn shared(&self) -> Wnaf<usize, &'a [G], Vec<Digit>> {
         Wnaf {
             base: self.base,
             scalar: vec![],
@@ -145,12 +145,12 @@ impl<'a, G: Group> Wnaf<usize, &'a [G], &'a mut Vec<i64>> {
     }
 }
 
-impl<'a, G: Group> Wnaf<usize, &'a mut Vec<G>, &'a [i64]> {
+impl<'a, G: Group> Wnaf<usize, &'a mut Vec<G>, &'a [Digit]> {
     /// Constructs new space for the window table while borrowing
     /// the computed scalar representation, for sending the scalar representation
     /// across threads.
     #[must_use]
-    pub fn shared(&self) -> Wnaf<usize, Vec<G>, &'a [i64]> {
+    pub fn shared(&self) -> Wnaf<usize, Vec<G>, &'a [Digit]> {
         Wnaf {
             base: vec![],
             scalar: self.scalar,
@@ -159,7 +159,7 @@ impl<'a, G: Group> Wnaf<usize, &'a mut Vec<G>, &'a [i64]> {
     }
 }
 
-impl<B, S: AsRef<[i64]>> Wnaf<usize, B, S> {
+impl<B, S: AsRef<[Digit]>> Wnaf<usize, B, S> {
     pub fn base<G: Group>(&mut self, base: G) -> G
     where
         B: AsMut<Vec<G>>,
@@ -172,7 +172,7 @@ impl<B, S: AsRef<[i64]>> Wnaf<usize, B, S> {
     }
 }
 
-impl<B, S: AsMut<Vec<i64>>> Wnaf<usize, B, S> {
+impl<B, S: AsMut<Vec<Digit>>> Wnaf<usize, B, S> {
     pub fn scalar<G: Group>(&mut self, scalar: &<G as Group>::Scalar) -> G
     where
         B: AsRef<[G]>,
@@ -187,6 +187,6 @@ impl<B, S: AsMut<Vec<i64>>> Wnaf<usize, B, S> {
 
 /// Performs w-NAF exponentiation with the provided window table and w-NAF form scalar, whose
 /// lengths must match.
-pub(crate) fn wnaf_exp<G: Group>(table: &[G], wnaf: &[i64]) -> G {
+pub(crate) fn wnaf_exp<G: Group>(table: &[G], wnaf: &[Digit]) -> G {
     wnaf_multi_exp(core::iter::once((table, wnaf, wnaf.len())))
 }


### PR DESCRIPTION
Replaces usages of `i64` with the type alias, which makes it easier to change what type we use to represent digits.