### PR TITLE
wnaf: infallible `WnafScalar::from_le_bytes`

### DIFF
--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -398,17 +398,7 @@ fn decompose_glv_wnaf(x: &ProjectivePoint, k: &Scalar) -> ([WnafBase; 2], [WnafS
     let p2 = if r2_neg { -p_beta } else { p_beta };
 
     let bases = [WnafBase::new(p1), WnafBase::new(p2)];
-
-    // GLV guarantees each half-scalar fits in `GLV_LE_BYTES`, so the truncated little-endian
-    // encoding round-trips and `from_le_bytes`'s canonical-range check always succeeds.
-    //
-    // Should that invariant ever fail to hold, fall back to the full-width `new` rather than
-    // panicking; it produces an identical (just slower) result for any in-range scalar.
-    let scalars = [r1, r2].map(|r| {
-        WnafScalar::from_le_bytes(&r.to_le_repr()[..GLV_LE_BYTES])
-            .unwrap_or_else(|| WnafScalar::new(&r))
-    });
-
+    let scalars = [r1, r2].map(|r| WnafScalar::from_le_bytes(&r.to_le_repr()[..GLV_LE_BYTES]));
     (bases, scalars)
 }
 

--- a/wnaf/src/scalar.rs
+++ b/wnaf/src/scalar.rs
@@ -8,7 +8,7 @@ use ff::PrimeField;
 /// # Examples
 ///
 /// See [`WnafBase`] for usage examples.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct WnafScalar<F: PrimeField, W: WindowSize, WnafStorage: ArraySize> {
     pub(crate) wnaf: Array<Digit, WnafStorage>,
     pub(crate) digits: usize,
@@ -19,71 +19,39 @@ impl<F: PrimeField, W: WindowSize, WnafStorage: ArraySize> WnafScalar<F, W, Wnaf
     /// Computes the w-NAF representation of the given scalar with window size `W`.
     #[inline]
     pub fn new(scalar: &F) -> Self {
-        let mut wnaf = Array::default();
-        let len = wnaf_form(&mut wnaf, le_repr(scalar), W::USIZE);
-        WnafScalar {
-            wnaf,
-            digits: len,
-            _field: PhantomData,
-        }
+        Self::from_le_bytes(le_repr(scalar).as_ref())
     }
 
     /// Computes the w-NAF representation directly from raw little-endian bytes.
     ///
     /// `bytes` is interpreted as a little-endian unsigned integer (trailing zero bytes may be
     /// omitted), and the resulting [`WnafScalar`] evaluates to that integer times the base.
+    ///
     /// Because the number of w-NAF digits — and therefore the number of doublings in the
     /// evaluation loop — is proportional to `bytes.len() * 8`, passing a slice shorter than the
-    /// field's canonical representation produces a faster scalar.
+    /// field's canonical representation is faster.
     ///
-    /// This is intended for callers that have already decomposed a scalar into a value smaller
-    /// than the field modulus, e.g. the ~128-bit half-scalars produced by a GLV endomorphism
-    /// decomposition.
-    ///
-    /// The encoded integer is validated to be a canonical field element: it must be strictly
-    /// less than the field modulus. No modular reduction is performed — a value that is not
-    /// already in range is rejected rather than reduced, so the returned [`WnafScalar`] always
-    /// evaluates to the integer `bytes` encodes.
-    ///
-    /// # Errors
-    ///
-    /// Returns `None` if `bytes` is longer than the field's canonical representation, if the
-    /// encoded integer is greater than or equal to the field modulus, or if `bytes.len() * 8 + 1`
-    /// exceeds `WnafStorage::USIZE` (which would overflow the fixed-size `wnaf` storage).
+    /// # Panics
+    /// If `bytes*8+1 > WnafStorage::USIZE`.
     #[inline]
-    pub fn from_le_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes.len() * 8 + 1 > WnafStorage::USIZE {
-            return None;
-        }
+    pub fn from_le_bytes(bytes: &[u8]) -> Self {
+        debug_assert!(bytes.len() * 8 < WnafStorage::USIZE);
+        let mut wnaf = Self::default();
+        wnaf.init_from_le_bytes(bytes);
+        wnaf
+    }
 
-        // Validate that `bytes` encodes a canonical field element by round-tripping it through
-        // `F::from_repr`, which returns `None` for any integer >= the modulus.
-        //
-        // `from_repr` consumes the canonical big-endian representation, so reverse the
-        // little-endian input into a zero-extended `F::Repr`.
-        let mut repr = F::Repr::default();
-        let repr_len = repr.as_ref().len();
-
-        // Anything wider than the canonical representation is necessarily out of range.
-        if bytes.len() > repr_len {
-            return None;
-        }
-
-        for (i, &byte) in bytes.iter().enumerate() {
-            repr.as_mut()[repr_len - 1 - i] = byte;
-        }
-
-        if bool::from(F::from_repr(repr).is_none()) {
-            return None;
-        }
-
-        let mut wnaf = Array::default();
-        let digits = wnaf_form(&mut wnaf, bytes, W::USIZE);
-
-        Some(WnafScalar {
-            wnaf,
-            digits,
-            _field: PhantomData,
-        })
+    /// Initialize w-NAF representation directly from raw little-endian bytes, for an already
+    /// allocated [`WnafScalar`].
+    ///
+    /// This is the equivalent of [`WnafScalar::from_le_bytes`] for reusing an existing value.
+    /// See that method for full documentation.
+    ///
+    /// # Panics
+    /// If `bytes*8+1 > WnafStorage::USIZE`.
+    #[inline]
+    pub fn init_from_le_bytes(&mut self, bytes: &[u8]) {
+        debug_assert!(bytes.len() * 8 < WnafStorage::USIZE);
+        self.digits = wnaf_form(&mut self.wnaf, bytes, W::USIZE);
     }
 }


### PR DESCRIPTION
This simplifies this constructor, removing the canonicalization check as it's in the hot path of code that's already working with canonical scalars. I was the one who insisted on it originally but it's really not helping here. Removing the check allows this constructor to be infallible.

With that, `WnafScalar::new` can be composed in terms of `from_le_bytes`.

Additionally, this adds `init_from_le_bytes` which is able to reuse an existing `WnafScalar` which can potentially be used so it can be stack-allocated outside the loop and reused across iterations, whereas current Godbolt disassembly shows each allocation incurring a `memcpy`. Experimenting with this approach is left for a followup.

Once again this didn't have a visible effect on performance though.