### PR TITLE
hash2curve v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "hash2curve"
-version = "0.14.0-rc.13"
+version = "0.14.0"
 dependencies = [
  "digest",
  "elliptic-curve",

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -34,7 +34,7 @@ pkcs8 = { version = "0.11", optional = true }
 primefield = { version = "0.14", optional = true }
 primeorder = { version = "0.14.0-rc.13", optional = true }
 sec1 = { version = "0.8.1", optional = true }
-hash2curve = { version = "0.14.0-rc.13", optional = true }
+hash2curve = { version = "0.14", optional = true }
 belt-kwp = { version = "0.2", optional = true }
 signature = { version = "3", optional = true }
 

--- a/hash2curve/CHANGELOG.md
+++ b/hash2curve/CHANGELOG.md
@@ -4,6 +4,5 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
-- Initial release
-
+## 0.14.0 (2026-06-23)
+- Initial release (complete rewrite versus v0.1)

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash2curve"
-version = "0.14.0-rc.13"
+version = "0.14.0"
 description = "hash2curve algorithm implementation"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.85"
 [dependencies]
 cpubits = "0.1"
 elliptic-curve = { version = "0.14", default-features = false, features = ["sec1"] }
-hash2curve = { version = "0.14.0-rc.13", optional = true }
+hash2curve = { version = "0.14", optional = true }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -22,7 +22,7 @@ elliptic-curve = { version = "0.14", default-features = false, features = ["sec1
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.13", optional = true }
+hash2curve = { version = "0.14", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14", optional = true }
 primeorder = { version = "0.14.0-rc.13", optional = true }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -22,7 +22,7 @@ elliptic-curve = { version = "0.14", default-features = false, features = ["sec1
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.13", optional = true }
+hash2curve = { version = "0.14", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14", optional = true }
 primeorder = { version = "0.14.0-rc.13", optional = true }

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -22,7 +22,7 @@ elliptic-curve = { version = "0.14", default-features = false, features = ["sec1
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hash2curve = { version = "0.14.0-rc.13", optional = true }
+hash2curve = { version = "0.14", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14", optional = true }
 primeorder = { version = "0.14.0-rc.13", optional = true }


### PR DESCRIPTION
Initial release (complete rewrite versus v0.1)