### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "bignp256"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 dependencies = [
  "belt-block",
  "belt-hash",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "bp256"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "bp384"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "ed448-goldilocks"
-version = "0.14.0-pre.14"
+version = "0.14.0-pre.15"
 dependencies = [
  "chacha20",
  "criterion",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 dependencies = [
  "cpubits",
  "criterion",
@@ -796,7 +796,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p192"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "p224"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 dependencies = [
  "criterion",
  "ecdsa",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 dependencies = [
  "base16ct",
  "criterion",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 dependencies = [
  "elliptic-curve",
  "once_cell",
@@ -1309,7 +1309,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sm2"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 dependencies = [
  "criterion",
  "der",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "x448"
-version = "0.14.0-pre.11"
+version = "0.14.0-pre.12"
 dependencies = [
  "ed448-goldilocks",
  "serdect",

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bignp256"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 description = """
 Pure Rust implementation of the Bign P-256 (a.k.a. bign-curve256v1)
 elliptic curve as defined in STB 34.101.45-2013, with
@@ -32,7 +32,7 @@ hmac = { version = "0.13", optional = true }
 rand_core = "0.10"
 pkcs8 = { version = "0.11", optional = true }
 primefield = { version = "0.14", optional = true }
-primeorder = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.14", optional = true }
 sec1 = { version = "0.8.1", optional = true }
 hash2curve = { version = "0.14", optional = true }
 belt-kwp = { version = "0.2", optional = true }
@@ -42,7 +42,7 @@ signature = { version = "3", optional = true }
 criterion = "0.7"
 elliptic-curve = { version = "0.14", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.13", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.14", features = ["dev"] }
 proptest = "1"
 
 [features]

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp256"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 description = "Brainpool P-256 (brainpoolP256r1 and brainpoolP256t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -19,7 +19,7 @@ elliptic-curve = { version = "0.14", default-features = false, features = ["sec1
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.22", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14", optional = true }
-primeorder = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.14", optional = true }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp384"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 description = "Brainpool P-384 (brainpoolP384r1 and brainpoolP384t1) elliptic curves"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -19,7 +19,7 @@ elliptic-curve = { version = "0.14", default-features = false, features = ["sec1
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.22", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14", optional = true }
-primeorder = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.14", optional = true }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed448-goldilocks"
-version = "0.14.0-pre.14"
+version = "0.14.0-pre.15"
 authors = ["RustCrypto Developers"]
 categories = ["cryptography"]
 keywords = ["cryptography", "decaf", "ed448", "ed448-goldilocks"]
@@ -17,7 +17,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 
 [dependencies]
 elliptic-curve = { version = "0.14", features = ["arithmetic", "pkcs8"] }
-hash2curve = "0.14.0-rc.13"
+hash2curve = "0.14"
 rand_core = { version = "0.10", default-features = false }
 shake = { version = "0.1", default-features = false }
 subtle = { version = "2.6", default-features = false }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k256"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 description = """
 secp256k1 elliptic curve library written in pure Rust with support for ECDSA
 signing/verification/public-key recovery, Taproot Schnorr signatures (BIP340),
@@ -26,7 +26,7 @@ hash2curve = { version = "0.14", optional = true }
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
-primeorder = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.14", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 signature = { version = "3", optional = true }

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p192"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 description = """
 Pure Rust implementation of the NIST P-192 (a.k.a. secp192r1) elliptic curve
 as defined in SP 800-186
@@ -23,13 +23,13 @@ elliptic-curve = { version = "0.14", default-features = false, features = ["sec1
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14", optional = true }
-primeorder = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.14", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.13", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.14", features = ["dev"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p224"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 description = """
 Pure Rust implementation of the NIST P-224 (a.k.a. secp224r1) elliptic curve
 as defined in SP 800-186
@@ -23,14 +23,14 @@ elliptic-curve = { version = "0.14", default-features = false, features = ["sec1
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14", optional = true }
-primeorder = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.14", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.13", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.14", features = ["dev"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 description = """
 Pure Rust implementation of the NIST P-256 (a.k.a. secp256r1, prime256v1)
 elliptic curve as defined in SP 800-186, with support for ECDH, ECDSA
@@ -25,7 +25,7 @@ ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, def
 hash2curve = { version = "0.14", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14", optional = true }
-primeorder = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.14", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
@@ -33,8 +33,8 @@ sha2 = { version = "0.11", optional = true, default-features = false }
 criterion = "0.7"
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primefield = { version = "0.14.0-rc.13" }
-primeorder = { version = "0.14.0-rc.13", features = ["dev"] }
+primefield = { version = "0.14" }
+primeorder = { version = "0.14.0-rc.14", features = ["dev"] }
 proptest = "1"
 
 [features]

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p384"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 description = """
 Pure Rust implementation of the NIST P-384 (a.k.a. secp384r1) elliptic curve
 as defined in SP 800-186 with support for ECDH, ECDSA signing/verification,
@@ -25,7 +25,7 @@ ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, def
 hash2curve = { version = "0.14", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14", optional = true }
-primeorder = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.14", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
@@ -36,7 +36,7 @@ fiat-crypto = { version = "0.3", default-features = false }
 criterion = "0.7"
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.13", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.14", features = ["dev"] }
 proptest = "1.11"
 
 [features]

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p521"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 description = """
 Pure Rust implementation of the NIST P-521 (a.k.a. secp521r1) elliptic curve
 as defined in SP 800-186
@@ -25,7 +25,7 @@ ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, def
 hash2curve = { version = "0.14", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14", optional = true }
-primeorder = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.14", optional = true }
 rand_core = { version = "0.10", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
@@ -34,7 +34,7 @@ sha2 = { version = "0.11", optional = true, default-features = false }
 criterion = "0.7"
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
-primeorder = { version = "0.14.0-rc.13", features = ["dev"] }
+primeorder = { version = "0.14.0-rc.14", features = ["dev"] }
 proptest = "1.11"
 
 [features]

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primeorder"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 description = """
 Pure Rust implementation of complete addition formulas for prime order elliptic
 curves (Renes-Costello-Batina 2015). Generic over field elements and curve
@@ -19,7 +19,7 @@ rust-version = "1.85"
 
 [dependencies]
 elliptic-curve = { version = "0.14", default-features = false, features = ["arithmetic", "sec1"] }
-primefield = "0.14.0-rc.13"
+primefield = "0.14"
 
 # optional dependencies
 once_cell = { version = "1.21", optional = true, default-features = false }

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm2"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.14"
 description = """
 Pure Rust implementation of the SM2 elliptic curve as defined in the Chinese
 national standard GM/T 0003-2012 as well as ISO/IEC 14888. Includes support for
@@ -25,7 +25,7 @@ rand_core = { version = "0.10", default-features = false }
 # optional dependencies
 der = { version = "0.8", optional = true }
 primefield = { version = "0.14", optional = true }
-primeorder = { version = "0.14.0-rc.13", optional = true }
+primeorder = { version = "0.14.0-rc.14", optional = true }
 rfc6979 = { version = "0.6.0-pre.0", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 signature = { version = "3", optional = true, features = ["rand_core"] }

--- a/x448/Cargo.toml
+++ b/x448/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x448"
-version = "0.14.0-pre.11"
+version = "0.14.0-pre.12"
 authors = ["RustCrypto Developers"]
 categories = ["cryptography"]
 keywords = ["cryptography", "crypto", "x448", "diffie-hellman", "curve448", ]
@@ -14,7 +14,7 @@ readme = "README.md"
 description = "Pure Rust implementation of X448, an elliptic curve Diffie-Hellman function"
 
 [dependencies]
-ed448-goldilocks = { version = "0.14.0-pre.14", default-features = false }
+ed448-goldilocks = { version = "0.14.0-pre.15", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
 # optional dependencies


### PR DESCRIPTION
Releases the following:

- `bignp256` v0.14.0-rc.14
- `bp256` v0.14.0-rc.14
- `bp384` v0.14.0-rc.14
- `ed448-goldilocks` v0.14.0-pre.15
- `k256` v0.14.0-rc.14
- `p192` v0.14.0-rc.14
- `p224` v0.14.0-rc.14
- `p256` v0.14.0-rc.14
- `p384` v0.14.0-rc.14
- `p521` v0.14.0-rc.14
- `primeorder` v0.14.0-rc.14
- `sm2` v0.14.0-rc.14
- `x448` v0.14.0-pre.12