### PR TITLE
`bignp256`: add changelog entries

### DIFF
--- a/bignp256/CHANGELOG.md
+++ b/bignp256/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ECDH and PKCS8 support ([#1046])
 - `bits`, `serde`, and `test-vectors` features ([#1062])
 
-## Changed
+### Changed
 - Update to `digest` v0.11 ([#1011])
 - Update to `pkcs8` v0.11 ([#1011])
 - Update to `sec1` v0.8 ([#1011])
@@ -17,11 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update to `hybrid-array` v0.3 ([#1125])
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1125])
 - Relax MSRV policy and allow MSRV bumps in patch releases
+- Migrate to little endian, change `rfc6979` to `bign-genk` ([#1684])
+- Add `swu` function ([#1743])
+
+### Fixed
+- `pkcs8` feature gating ([#1655])
 
 [#1011]: https://github.com/RustCrypto/elliptic-curves/pull/1011
 [#1046]: https://github.com/RustCrypto/elliptic-curves/pull/1046
 [#1062]: https://github.com/RustCrypto/elliptic-curves/pull/1062
 [#1125]: https://github.com/RustCrypto/elliptic-curves/pull/1125
+[#1655]: https://github.com/RustCrypto/elliptic-curves/pull/1655
+[#1684]: https://github.com/RustCrypto/elliptic-curves/pull/1684
+[#1743]: https://github.com/RustCrypto/elliptic-curves/pull/1743
 
 ## 0.13.1 (2024-01-05)
 ### Added


### PR DESCRIPTION
Add changelog entries for:
- `pkcs8` gating
- Little endian migration
- `bign-genk` usage instead of `rfc6979`
- `swu` function