### PR TITLE
wnaf: attempt to make `WnafBase::new` more inline-friendly

### DIFF
--- a/wnaf/src/base.rs
+++ b/wnaf/src/base.rs
@@ -41,10 +41,13 @@ pub struct WnafBase<G: Group, W: WindowSize> {
 
 impl<G: Group, W: WindowSize> WnafBase<G, W> {
     /// Computes a window table for the given base with the specified window size `W`.
+    #[inline]
     pub fn new(base: G) -> Self {
-        let mut table = Array::from_fn(|_| G::generator());
-        wnaf_table(&mut table, base, W::USIZE);
-        WnafBase { table }
+        let mut ret = Self {
+            table: Array::from_fn(|_| G::generator()),
+        };
+        wnaf_table(&mut ret.table, base, W::USIZE);
+        ret
     }
 
     /// Perform a multiscalar multiplication.

--- a/wnaf/src/scalar.rs
+++ b/wnaf/src/scalar.rs
@@ -8,7 +8,7 @@ use ff::PrimeField;
 /// # Examples
 ///
 /// See [`WnafBase`] for usage examples.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct WnafScalar<F: PrimeField, W: WindowSize, WnafStorage: ArraySize> {
     pub(crate) wnaf: Array<Digit, WnafStorage>,
     pub(crate) digits: usize,
@@ -36,7 +36,11 @@ impl<F: PrimeField, W: WindowSize, WnafStorage: ArraySize> WnafScalar<F, W, Wnaf
     #[inline]
     pub fn from_le_bytes(bytes: &[u8]) -> Self {
         debug_assert!(bytes.len() * 8 < WnafStorage::USIZE);
-        let mut wnaf = Self::default();
+        let mut wnaf = Self {
+            wnaf: Array::default(),
+            digits: 0,
+            _field: PhantomData,
+        };
         wnaf.init_from_le_bytes(bytes);
         wnaf
     }


### PR DESCRIPTION
Still seeing memcpys in the decompiled ASM