### PR TITLE
k256+primeorder: support batch normalizations on hybrid `Array`s

### DIFF
--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -9,7 +9,9 @@ use core::{
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
 };
 use elliptic_curve::{
-    BatchNormalize, CurveGroup, Error, Generate, Result, ctutils,
+    BatchNormalize, CurveGroup, Error, Generate, Result,
+    array::{Array, ArraySize},
+    ctutils,
     group::{
         CurveAffine, Group, GroupEncoding,
         cofactor::CofactorGroup,
@@ -292,10 +294,10 @@ impl Generate for ProjectivePoint {
 }
 
 impl<const N: usize> BatchNormalize<[ProjectivePoint; N]> for ProjectivePoint {
-    type Output = [<Self as CurveGroup>::Affine; N];
+    type Output = [AffinePoint; N];
 
     #[inline]
-    fn batch_normalize(points: &[Self; N]) -> [<Self as CurveGroup>::Affine; N] {
+    fn batch_normalize(points: &[Self; N]) -> [AffinePoint; N] {
         let mut zs = [FieldElement::ZERO; N];
         let mut scratch = [FieldElement::ZERO; N];
         let mut affine_points = [AffinePoint::IDENTITY; N];
@@ -304,12 +306,25 @@ impl<const N: usize> BatchNormalize<[ProjectivePoint; N]> for ProjectivePoint {
     }
 }
 
-#[cfg(feature = "alloc")]
-impl BatchNormalize<[ProjectivePoint]> for ProjectivePoint {
-    type Output = Vec<<Self as CurveGroup>::Affine>;
+impl<U: ArraySize> BatchNormalize<Array<ProjectivePoint, U>> for ProjectivePoint {
+    type Output = Array<AffinePoint, U>;
 
     #[inline]
-    fn batch_normalize(points: &[Self]) -> Vec<<Self as CurveGroup>::Affine> {
+    fn batch_normalize(points: &Array<Self, U>) -> Array<AffinePoint, U> {
+        let mut zs = Array::<FieldElement, U>::default();
+        let mut scratch = Array::<FieldElement, U>::default();
+        let mut affine_points = Array::<AffinePoint, U>::default();
+        batch_normalize(points, &mut zs, &mut scratch, &mut affine_points);
+        affine_points
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl BatchNormalize<[ProjectivePoint]> for ProjectivePoint {
+    type Output = Vec<AffinePoint>;
+
+    #[inline]
+    fn batch_normalize(points: &[Self]) -> Vec<AffinePoint> {
         let mut zs = vec![FieldElement::ZERO; points.len()];
         let mut scratch = vec![FieldElement::ZERO; points.len()];
         let mut affine_points = vec![AffinePoint::IDENTITY; points.len()];

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::needless_range_loop, clippy::op_ref)]
 
 use crate::{
-    AffinePoint, Field, LookupTable, MulBackend, PrimeCurveParams, Radix16Decomposition,
+    AffinePoint, ArraySize, Field, LookupTable, MulBackend, PrimeCurveParams, Radix16Decomposition,
     Radix16Digits, point_arithmetic::PointArithmetic,
 };
 use core::{array, borrow::Borrow, iter::Sum, iter::zip};
@@ -27,6 +27,7 @@ use elliptic_curve::{
     zeroize::DefaultIsZeroes,
 };
 
+use crate::array::Array;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 #[cfg(feature = "serde")]
@@ -379,6 +380,23 @@ where
         let mut zs = [C::FieldElement::ZERO; N];
         let mut scratch = [C::FieldElement::ZERO; N];
         let mut affine_points = [C::AffinePoint::IDENTITY; N];
+        batch_normalize_generic(points, &mut zs, &mut scratch, &mut affine_points);
+        affine_points
+    }
+}
+
+impl<C, U> BatchNormalize<Array<ProjectivePoint<C>, U>> for ProjectivePoint<C>
+where
+    C: PrimeCurveParams,
+    U: ArraySize,
+{
+    type Output = Array<AffinePoint<C>, U>;
+
+    #[inline]
+    fn batch_normalize(points: &Array<Self, U>) -> Array<AffinePoint<C>, U> {
+        let mut zs = Array::<C::FieldElement, U>::default();
+        let mut scratch = Array::<C::FieldElement, U>::default();
+        let mut affine_points = Array::<AffinePoint<C>, U>::default();
         batch_normalize_generic(points, &mut zs, &mut scratch, &mut affine_points);
         affine_points
     }


### PR DESCRIPTION
I'm using `hybrid-array` to represent w-NAF window tables. I'd like to experiment with using affine rather than projective points for these window tables, since they'd make the tables smaller by getting rid of the `z` coordinate, and could leverage the mixed addition formulas which I think might result in a performance win.

However, right now I can't batch normalize the current window tables since we only support const generic arrays.

This adds `BatchNormalize` impls which accept an `Array` reference and use it to size the result array.