### PR TITLE
wnaf: rename `Wnaf` => `BoxedWnaf`

### DIFF
--- a/wnaf/src/base.rs
+++ b/wnaf/src/base.rs
@@ -6,24 +6,19 @@ use group::Group;
 
 /// Fixed window table for a group element, precomputed to improve scalar multiplication speed.
 ///
-/// This struct is designed for usage patterns that have long-term cached bases and/or
-/// scalars, or [Cartesian products] of bases and scalars. The [`Wnaf`] API enables one or
-/// the other to be cached, but requires either the base window tables or the scalar w-NAF
-/// forms to be computed repeatedly on the fly, which can become a significant performance
-/// issue for some use cases.
+/// By fixing the window size at compile time, we are able to support fully `no_alloc`
+/// stack-allocated operation, and also use the type system to ensure [`WnafBase`] and
+/// [`WnafScalar`] are using the same window size.
 ///
-/// `WnafBase` and [`WnafScalar`] enable an alternative trade-off: by fixing the window
-/// size at compile time, the precomputations are guaranteed to only occur once per base
-/// and once per scalar. Users should select their window size based on how long the bases
-/// are expected to live; a larger window size will consume more memory and take longer to
-/// precompute, but result in faster scalar multiplications.
-///
-/// [Cartesian products]: https://en.wikipedia.org/wiki/Cartesian_product
+/// Precomputations are guaranteed to only occur once per base and once per scalar. Users should
+/// select their window size based on how long the bases are expected to live; a larger window size
+/// will consume more memory and take longer to precompute, but result in faster scalar
+/// multiplications.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// type MyWnafBase   = WnafBase<ProjectivePoint, U5, U8>;
+/// type MyWnafBase = WnafBase<ProjectivePoint, U5, U8>;
 /// type MyWnafScalar = WnafScalar<Scalar, U5, U129>;
 ///
 /// let base = MyWnafBase::new(ProjectivePoint::GENERATOR);

--- a/wnaf/src/boxed.rs
+++ b/wnaf/src/boxed.rs
@@ -4,8 +4,10 @@ use crate::{Digit, WnafGroup, le_repr, wnaf_form, wnaf_multi_exp, wnaf_table};
 use alloc::vec::Vec;
 use group::Group;
 
-/// A "w-ary non-adjacent form" scalar multiplication (also known as exponentiation)
-/// context.
+#[cfg(doc)]
+use crate::{WnafBase, WnafScalar};
+
+/// A "w-ary non-adjacent form" scalar multiplication (also known as exponentiation) context.
 ///
 /// # Examples
 ///
@@ -13,10 +15,10 @@ use group::Group;
 ///
 /// ## One base, one scalar
 ///
-/// For this pattern, you can use a transient `Wnaf` context:
+/// For this pattern, you can use a transient [`BoxedWnaf`] context:
 ///
 /// ```ignore
-/// use group::Wnaf;
+/// use wnaf::BoxedWnaf;
 ///
 /// let result = Wnaf::new().scalar(&scalar).base(base);
 /// ```
@@ -27,9 +29,9 @@ use group::Group;
 /// process each base in turn:
 ///
 /// ```ignore
-/// use group::Wnaf;
+/// use wnaf::BoxedWnaf;
 ///
-/// let mut wnaf = Wnaf::new();
+/// let mut wnaf = BoxedWnaf::new();
 /// let mut wnaf_scalar = wnaf.scalar(&scalar);
 /// let results: Vec<_> = bases
 ///     .into_iter()
@@ -43,9 +45,9 @@ use group::Group;
 /// each scalar in turn:
 ///
 /// ```ignore
-/// use group::Wnaf;
+/// use wnaf::BoxedWnaf;
 ///
-/// let mut wnaf = Wnaf::new();
+/// let mut wnaf = BoxedWnaf::new();
 /// let mut wnaf_base = wnaf.base(base, scalars.len());
 /// let results: Vec<_> = scalars
 ///     .iter()
@@ -60,9 +62,9 @@ use group::Group;
 /// form of the scalars on the fly for every base, or vice versa:
 ///
 /// ```ignore
-/// use group::Wnaf;
+/// use wnaf::BoxedWnaf;
 ///
-/// let mut wnaf_contexts: Vec<_> = (0..bases.len()).map(|_| Wnaf::new()).collect();
+/// let mut wnaf_contexts: Vec<_> = (0..bases.len()).map(|_| BoxedWnaf::new()).collect();
 /// let mut wnaf_bases: Vec<_> = wnaf_contexts
 ///     .iter_mut()
 ///     .zip(bases)
@@ -79,22 +81,22 @@ use group::Group;
 /// then be directly multiplied without any additional runtime work, at the cost of fixing
 /// a specific window size (rather than choosing the window size dynamically).
 #[derive(Debug)]
-pub struct Wnaf<W, B, S> {
+pub struct BoxedWnaf<W, B, S> {
     base: B,
     scalar: S,
     window_size: W,
 }
 
-impl<G: Group> Default for Wnaf<(), Vec<G>, Vec<Digit>> {
+impl<G: Group> Default for BoxedWnaf<(), Vec<G>, Vec<Digit>> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<G: Group> Wnaf<(), Vec<G>, Vec<Digit>> {
+impl<G: Group> BoxedWnaf<(), Vec<G>, Vec<Digit>> {
     #[must_use]
     pub fn new() -> Self {
-        Wnaf {
+        BoxedWnaf {
             base: vec![],
             scalar: vec![],
             window_size: (),
@@ -102,21 +104,24 @@ impl<G: Group> Wnaf<(), Vec<G>, Vec<Digit>> {
     }
 }
 
-impl<G: WnafGroup> Wnaf<(), Vec<G>, Vec<Digit>> {
-    pub fn base(&mut self, base: G, num_scalars: usize) -> Wnaf<usize, &[G], &mut Vec<Digit>> {
+impl<G: WnafGroup> BoxedWnaf<(), Vec<G>, Vec<Digit>> {
+    pub fn base(&mut self, base: G, num_scalars: usize) -> BoxedWnaf<usize, &[G], &mut Vec<Digit>> {
         let window_size = G::recommended_wnaf_for_num_scalars(num_scalars);
 
         self.base.resize_with(1 << (window_size - 2), G::identity);
         wnaf_table(&mut self.base, base, window_size);
 
-        Wnaf {
+        BoxedWnaf {
             base: &self.base[..],
             scalar: &mut self.scalar,
             window_size,
         }
     }
 
-    pub fn scalar(&mut self, scalar: &<G as Group>::Scalar) -> Wnaf<usize, &mut Vec<G>, &[Digit]> {
+    pub fn scalar(
+        &mut self,
+        scalar: &<G as Group>::Scalar,
+    ) -> BoxedWnaf<usize, &mut Vec<G>, &[Digit]> {
         let window_size = 4;
 
         let repr = le_repr(scalar);
@@ -124,7 +129,7 @@ impl<G: WnafGroup> Wnaf<(), Vec<G>, Vec<Digit>> {
         let digits = wnaf_form(&mut self.scalar, repr, window_size);
         self.scalar.truncate(digits);
 
-        Wnaf {
+        BoxedWnaf {
             base: &mut self.base,
             scalar: &self.scalar[..],
             window_size,
@@ -132,12 +137,12 @@ impl<G: WnafGroup> Wnaf<(), Vec<G>, Vec<Digit>> {
     }
 }
 
-impl<'a, G: Group> Wnaf<usize, &'a [G], &'a mut Vec<Digit>> {
+impl<'a, G: Group> BoxedWnaf<usize, &'a [G], &'a mut Vec<Digit>> {
     /// Constructs new space for the scalar representation while borrowing
     /// the computed window table, for sending the window table across threads.
     #[must_use]
-    pub fn shared(&self) -> Wnaf<usize, &'a [G], Vec<Digit>> {
-        Wnaf {
+    pub fn shared(&self) -> BoxedWnaf<usize, &'a [G], Vec<Digit>> {
+        BoxedWnaf {
             base: self.base,
             scalar: vec![],
             window_size: self.window_size,
@@ -145,13 +150,13 @@ impl<'a, G: Group> Wnaf<usize, &'a [G], &'a mut Vec<Digit>> {
     }
 }
 
-impl<'a, G: Group> Wnaf<usize, &'a mut Vec<G>, &'a [Digit]> {
+impl<'a, G: Group> BoxedWnaf<usize, &'a mut Vec<G>, &'a [Digit]> {
     /// Constructs new space for the window table while borrowing
     /// the computed scalar representation, for sending the scalar representation
     /// across threads.
     #[must_use]
-    pub fn shared(&self) -> Wnaf<usize, Vec<G>, &'a [Digit]> {
-        Wnaf {
+    pub fn shared(&self) -> BoxedWnaf<usize, Vec<G>, &'a [Digit]> {
+        BoxedWnaf {
             base: vec![],
             scalar: self.scalar,
             window_size: self.window_size,
@@ -159,7 +164,7 @@ impl<'a, G: Group> Wnaf<usize, &'a mut Vec<G>, &'a [Digit]> {
     }
 }
 
-impl<B, S: AsRef<[Digit]>> Wnaf<usize, B, S> {
+impl<B, S: AsRef<[Digit]>> BoxedWnaf<usize, B, S> {
     pub fn base<G: Group>(&mut self, base: G) -> G
     where
         B: AsMut<Vec<G>>,
@@ -172,7 +177,7 @@ impl<B, S: AsRef<[Digit]>> Wnaf<usize, B, S> {
     }
 }
 
-impl<B, S: AsMut<Vec<Digit>>> Wnaf<usize, B, S> {
+impl<B, S: AsMut<Vec<Digit>>> BoxedWnaf<usize, B, S> {
     pub fn scalar<G: Group>(&mut self, scalar: &<G as Group>::Scalar) -> G
     where
         B: AsRef<[G]>,

--- a/wnaf/src/lib.rs
+++ b/wnaf/src/lib.rs
@@ -17,7 +17,7 @@ mod scalar;
 mod traits;
 
 #[cfg(feature = "alloc")]
-mod wnaf;
+mod boxed;
 
 pub use crate::{
     base::WnafBase,
@@ -27,7 +27,7 @@ pub use crate::{
 pub use group::Group;
 
 #[cfg(feature = "alloc")]
-pub use crate::wnaf::Wnaf;
+pub use crate::boxed::BoxedWnaf;
 
 use crate::limb_buffer::LimbBuffer;
 use ff::PrimeField;
@@ -35,12 +35,12 @@ use ff::PrimeField;
 /// Type used to represent w-NAF digits.
 ///
 /// For a window of size `w` non-zero w-NAF digits are odd and have magnitude at most `2^(w-1) - 1`
-/// and lie within `[-(2^(w-1)-1), 2^(w-1)-1]`.
+/// and lie within `{-(2^(w-1)-1), 2^(w-1)-1}`.
 pub type Digit = i8;
 
 /// Maximum supported value for `w`.
 ///
-/// This ensures `2^(8-1)-1=127`, so digits lie within `[-127,127]`, which fits in `i8`.
+/// This ensures `2^(8-1)-1=127`, so digits lie within `{-127,127}`, which fits in `i8`.
 // NOTE: this is also the maximum impl size we support for the `WindowSize` trait
 const W_MAX: usize = 8;
 

--- a/wnaf/src/scalar.rs
+++ b/wnaf/src/scalar.rs
@@ -3,6 +3,9 @@ use array::{Array, ArraySize};
 use core::marker::PhantomData;
 use ff::PrimeField;
 
+#[cfg(doc)]
+use crate::WnafBase;
+
 /// A "w-ary non-adjacent form" scalar, precomputed to improve the speed of scalar multiplication.
 ///
 /// # Examples
@@ -27,9 +30,9 @@ impl<F: PrimeField, W: WindowSize, WnafStorage: ArraySize> WnafScalar<F, W, Wnaf
     /// `bytes` is interpreted as a little-endian unsigned integer (trailing zero bytes may be
     /// omitted), and the resulting [`WnafScalar`] evaluates to that integer times the base.
     ///
-    /// Because the number of w-NAF digits — and therefore the number of doublings in the
-    /// evaluation loop — is proportional to `bytes.len() * 8`, passing a slice shorter than the
-    /// field's canonical representation is faster.
+    /// Because the number of w-NAF digits, and therefore the number of doublings, is proportional
+    /// to `bytes.len() * 8`, passing a slice shorter than the field's canonical representation is
+    /// faster.
     ///
     /// # Panics
     /// If `bytes*8+1 > WnafStorage::USIZE`.

--- a/wnaf/src/traits.rs
+++ b/wnaf/src/traits.rs
@@ -6,7 +6,7 @@ use array::{
 };
 use group::Group;
 
-/// Extension trait on a [`Group`] that provides helpers used by [`crate::Wnaf`].
+/// Extension trait on a [`Group`] that provides helpers used by [`crate::BoxedWnaf`].
 pub trait WnafGroup: Group {
     /// Recommends a wNAF window size given the number of scalars you intend to multiply
     /// a base by. Always returns a number between 2 and 22, inclusive.


### PR DESCRIPTION
Helps communicate that `BoxedWnaf` is the heap-allocated context