### PR TITLE
k256: fix `BatchInvert` for `FieldElement`

### DIFF
--- a/k256/benches/field.rs
+++ b/k256/benches/field.rs
@@ -3,7 +3,7 @@
 use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
-use elliptic_curve::hazmat::FieldArithmetic;
+use elliptic_curve::{hazmat::FieldArithmetic, ops::BatchInvert};
 use k256::Secp256k1;
 use std::hint::black_box;
 
@@ -64,6 +64,16 @@ fn bench_field_element_sqrt<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M
 fn bench_field_element_invert<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let x = test_field_element_x();
     group.bench_function("invert", |b| b.iter(|| black_box(x).invert()));
+    group.bench_function("invert_vartime", |b| {
+        b.iter(|| black_box(x).invert_vartime())
+    });
+    group.bench_function("batch_invert_in_place", |b| {
+        let points = [test_field_element_x(), test_field_element_y()];
+        let scratch = [FieldElement::ZERO; 2];
+        b.iter(|| {
+            FieldElement::batch_invert_in_place(&mut black_box(points), &mut black_box(scratch))
+        })
+    });
 }
 
 fn bench_field_element_to_bytes<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -157,6 +157,7 @@ impl FieldElement {
     ///
     /// Brings the magnitude to 1 (but doesn't normalize the result).
     /// The magnitudes of arguments should be <= 8.
+    #[inline]
     pub fn square(&self) -> Self {
         Self(self.0.square())
     }
@@ -173,6 +174,7 @@ impl FieldElement {
     /// Returns the multiplicative inverse of self, if self is non-zero.
     ///
     /// The result has magnitude 1 and is normalized.
+    #[inline]
     pub fn invert(&self) -> CtOption<Self> {
         let inv = self
             .retrieve()
@@ -184,6 +186,7 @@ impl FieldElement {
     /// Returns the multiplicative inverse of self in variable-time, if self is non-zero.
     ///
     /// The result has magnitude 1 and is normalized.
+    #[inline]
     pub fn invert_vartime(&self) -> CtOption<Self> {
         let inv = self
             .retrieve()
@@ -239,13 +242,25 @@ impl FieldElement {
 }
 
 impl BatchInvert for FieldElement {
-    fn batch_invert_in_place(elements: &mut [Self], scratch: &mut [Self]) -> Self {
-        // The only difference from the default impl: we need to normalize the elements first
-        for e in elements.iter_mut() {
-            *e = e.normalize();
+    fn batch_invert_in_place(elements: &mut [Self], scratch_space: &mut [Self]) -> Self {
+        assert_eq!(elements.len(), scratch_space.len());
+
+        let mut acc = Self::ONE;
+        for (p, scratch) in elements.iter().zip(scratch_space.iter_mut()) {
+            *scratch = acc;
+            acc = Self::conditional_select(&(acc * *p), &acc, p.normalizes_to_zero());
+        }
+        acc = acc.invert().unwrap();
+        let allinv = acc;
+
+        for (p, scratch) in elements.iter_mut().zip(scratch_space.iter()).rev() {
+            let tmp = *scratch * &acc;
+            let skip = p.normalizes_to_zero();
+            acc = Self::conditional_select(&(acc * *p), &acc, skip);
+            *p = Self::conditional_select(&tmp, p, skip).normalize();
         }
 
-        ff::BatchInverter::invert_with_external_scratch(elements, scratch)
+        allinv
     }
 }
 


### PR DESCRIPTION
Followup to #1830, that tried to fix batch normalization but was incomplete.

Normalizing on the way in worked around the need for a normalized input when calling `is_zero` during the first selection pass, but later (after the inversion, which also normalizes) it multiplies the scratch element by the accumulator which can also return a non-normalized result.

To avoid normalizing twice while always returning a normalized result, this defers normalization until the very end when it's populating a given inverted element, ensuring even given non-normalized inputs it will always return a normalized result, while only calling `normalize` once per input element.

To fix the `is_zero` issue, it uses `normalizes_to_zero`.