### PR TITLE
k256: impl `BatchInvert::batch_invert_in_place_vartime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,8 +484,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3273f1195b6f6253ebda493d6742c8baa9b26a291674cd96d92a0f09e90e9b46"
+source = "git+https://github.com/RustCrypto/traits#2586aefd53a08b6cb9b686a06c5723c93c2b2eb2"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,5 @@ hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
 wnaf = { path = "wnaf" }
+
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/k256/benches/field.rs
+++ b/k256/benches/field.rs
@@ -67,11 +67,21 @@ fn bench_field_element_invert<'a, M: Measurement>(group: &mut BenchmarkGroup<'a,
     group.bench_function("invert_vartime", |b| {
         b.iter(|| black_box(x).invert_vartime())
     });
-    group.bench_function("batch_invert_in_place", |b| {
+    group.bench_function("batch_invert_in_place (2p)", |b| {
         let points = [test_field_element_x(), test_field_element_y()];
         let scratch = [FieldElement::ZERO; 2];
         b.iter(|| {
             FieldElement::batch_invert_in_place(&mut black_box(points), &mut black_box(scratch))
+        })
+    });
+    group.bench_function("batch_invert_in_place_vartime (2p)", |b| {
+        let points = [test_field_element_x(), test_field_element_y()];
+        let scratch = [FieldElement::ZERO; 2];
+        b.iter(|| {
+            FieldElement::batch_invert_in_place_vartime(
+                &mut black_box(points),
+                &mut black_box(scratch),
+            )
         })
     });
 }

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -244,20 +244,46 @@ impl FieldElement {
 impl BatchInvert for FieldElement {
     fn batch_invert_in_place(elements: &mut [Self], scratch_space: &mut [Self]) -> Self {
         assert_eq!(elements.len(), scratch_space.len());
-
         let mut acc = Self::ONE;
+
         for (p, scratch) in elements.iter().zip(scratch_space.iter_mut()) {
             *scratch = acc;
-            acc = Self::conditional_select(&(acc * *p), &acc, p.normalizes_to_zero());
+            acc.conditional_assign(&(acc * *p), !p.normalizes_to_zero());
         }
+
         acc = acc.invert().unwrap();
         let allinv = acc;
 
         for (p, scratch) in elements.iter_mut().zip(scratch_space.iter()).rev() {
-            let tmp = *scratch * &acc;
+            let tmp = (*scratch * &acc).normalize();
             let skip = p.normalizes_to_zero();
-            acc = Self::conditional_select(&(acc * *p), &acc, skip);
-            *p = Self::conditional_select(&tmp, p, skip).normalize();
+            acc.conditional_assign(&(acc * *p), !skip);
+            p.conditional_assign(&tmp, !skip);
+        }
+
+        allinv
+    }
+
+    fn batch_invert_in_place_vartime(elements: &mut [Self], scratch_space: &mut [Self]) -> Self {
+        assert_eq!(elements.len(), scratch_space.len());
+        let mut acc = Self::ONE;
+
+        for (p, scratch) in elements.iter().zip(scratch_space.iter_mut()) {
+            *scratch = acc;
+            if !bool::from(p.normalizes_to_zero()) {
+                acc *= *p;
+            }
+        }
+
+        acc = acc.invert_vartime().unwrap();
+        let allinv = acc;
+
+        for (p, scratch) in elements.iter_mut().zip(scratch_space.iter()).rev() {
+            if !bool::from(p.normalizes_to_zero()) {
+                let tmp = (*scratch * &acc).normalize();
+                acc *= *p;
+                *p = tmp;
+            }
         }
 
         allinv
@@ -550,12 +576,12 @@ mod tests {
         arithmetic::dev::{biguint_to_bytes, bytes_to_biguint},
         test_vectors::field::DBL_TEST_VECTORS,
     };
-    use elliptic_curve::ff::{Field, PrimeField};
+    use elliptic_curve::{
+        ff::{Field, PrimeField},
+        ops::BatchInvert,
+    };
     use num_bigint::{BigUint, ToBigUint};
     use proptest::prelude::*;
-
-    #[cfg(feature = "getrandom")]
-    use elliptic_curve::{Generate, ops::BatchInvert};
 
     impl From<&BigUint> for FieldElement {
         fn from(x: &BigUint) -> Self {
@@ -731,21 +757,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "getrandom")]
-    fn batch_invert() {
-        let k: FieldElement = FieldElement::generate();
-        let l: FieldElement = FieldElement::generate();
-
-        let expected = [k.invert().unwrap(), l.invert().unwrap()];
-        let mut actual = [k, l];
-        let mut scratch = [FieldElement::ZERO; 2];
-        FieldElement::batch_invert_in_place(&mut actual, &mut scratch);
-
-        assert_eq!(expected[0], actual[0].normalize());
-        assert_eq!(expected[1], actual[1].normalize());
-    }
-
-    #[test]
     fn sqrt() {
         let one = FieldElement::ONE;
         let two = one + &one;
@@ -794,9 +805,8 @@ mod tests {
     }
 
     proptest! {
-
         #[test]
-        fn fuzzy_add(
+        fn add(
             a in field_element(),
             b in field_element()
         ) {
@@ -809,7 +819,7 @@ mod tests {
         }
 
         #[test]
-        fn fuzzy_mul(
+        fn mul(
             a in field_element(),
             b in field_element()
         ) {
@@ -822,7 +832,7 @@ mod tests {
         }
 
         #[test]
-        fn fuzzy_square(
+        fn square(
             a in field_element()
         ) {
             let a_bi = a.to_biguint().unwrap();
@@ -833,7 +843,7 @@ mod tests {
         }
 
         #[test]
-        fn fuzzy_negate(
+        fn negate(
             a in field_element()
         ) {
             let m = FieldElement::modulus_as_biguint();
@@ -845,7 +855,7 @@ mod tests {
         }
 
         #[test]
-        fn fuzzy_sqrt(
+        fn sqrt_proptest(
             a in field_element()
         ) {
             let m = FieldElement::modulus_as_biguint();
@@ -862,7 +872,7 @@ mod tests {
         }
 
         #[test]
-        fn fuzzy_invert(
+        fn invert_proptest(
             a in field_element()
         ) {
             let a = if bool::from(a.is_zero()) { FieldElement::ONE } else { a };
@@ -871,6 +881,28 @@ mod tests {
             let inv_bi = inv.to_biguint().unwrap();
             let m = FieldElement::modulus_as_biguint();
             assert_eq!((&inv_bi * &a_bi) % &m, 1.to_biguint().unwrap());
+        }
+
+        #[test]
+        fn batch_invert_in_place(k in field_element(), l in field_element()) {
+            let expected = [k.invert().unwrap(), l.invert().unwrap()];
+            let mut actual = [k, l];
+            let mut scratch = [FieldElement::ZERO; 2];
+            FieldElement::batch_invert_in_place(&mut actual, &mut scratch);
+
+            assert_eq!(expected[0], actual[0].normalize());
+            assert_eq!(expected[1], actual[1].normalize());
+        }
+
+        #[test]
+        fn batch_invert_in_place_vartime(k in field_element(), l in field_element()) {
+            let expected = [k.invert().unwrap(), l.invert().unwrap()];
+            let mut actual = [k, l];
+            let mut scratch = [FieldElement::ZERO; 2];
+            FieldElement::batch_invert_in_place_vartime(&mut actual, &mut scratch);
+
+            assert_eq!(expected[0], actual[0].normalize());
+            assert_eq!(expected[1], actual[1].normalize());
         }
     }
 }


### PR DESCRIPTION
Adds support for variable-time batch inversions, a method for which was added in RustCrypto/traits#2468

Benchmarks showing it's ~20% faster than the constant-time version, and ammortized ~2X faster than the single element inversion when inverting two elements

```
field element operations/invert
                        time:   [2.5369 µs 2.5453 µs 2.5557 µs]
field element operations/invert_vartime
                        time:   [2.0041 µs 2.0076 µs 2.0111 µs]
field element operations/batch_invert_in_place (2p)
                        time:   [2.6878 µs 2.6929 µs 2.6980 µs]
field element operations/batch_invert_in_place_vartime (2p)
                        time:   [2.1331 µs 2.1379 µs 2.1426 µs]
```