### PR TITLE
k256: add `decompose_glv_wnaf_into`

### DIFF
--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -202,7 +202,6 @@ fn decompose_scalar(k: &Scalar) -> (Scalar, Scalar) {
     let c2 = WideScalar::mul_shift_vartime(k, &G2, 384) * MINUS_B2;
     let r2 = c1 + c2;
     let r1 = k + r2 * MINUS_LAMBDA;
-
     (r1, r2)
 }
 
@@ -381,24 +380,42 @@ fn mul(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
 /// Variable-time `k * self` using width-5 wNAF + GLV endomorphism.
 #[inline]
 fn mul_vartime(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
-    lincomb_vartime_glv_wnaf(&[decompose_glv_wnaf(x, k)])
+    let mut bases = [WnafBase::default(), WnafBase::default()];
+    let mut scalars = [WnafScalar::default(), WnafScalar::default()];
+    decompose_glv_wnaf_into(x, k, &mut bases, &mut scalars);
+    WnafBase::multiscalar_mul([(&bases[0], &scalars[0]), (&bases[1], &scalars[1])].into_iter())
 }
 
 /// GLV-decompose `k` for `x`: two `(WnafBase, WnafScalar)` pairs representing `r1 * self_signed`
 /// and `r2 * endomorphism(self_signed)`, with signs folded into the points.
-fn decompose_glv_wnaf(x: &ProjectivePoint, k: &Scalar) -> ([WnafBase; 2], [WnafScalar; 2]) {
+#[inline]
+fn decompose_glv_wnaf_into(
+    x: &ProjectivePoint,
+    k: &Scalar,
+    bases: &mut [WnafBase; 2],
+    scalars: &mut [WnafScalar; 2],
+) {
     let (r1, r2) = decompose_scalar(k);
     let r1_neg = bool::from(r1.is_high());
     let r2_neg = bool::from(r2.is_high());
     let r1 = if r1_neg { -r1 } else { r1 };
     let r2 = if r2_neg { -r2 } else { r2 };
+    scalars[0].init_from_le_bytes(&r1.to_le_repr()[..GLV_LE_BYTES]);
+    scalars[1].init_from_le_bytes(&r2.to_le_repr()[..GLV_LE_BYTES]);
 
     let p1 = if r1_neg { -*x } else { *x };
     let p_beta = x.endomorphism();
     let p2 = if r2_neg { -p_beta } else { p_beta };
+    bases[0].init_from_base(p1);
+    bases[1].init_from_base(p2);
+}
 
-    let bases = [WnafBase::new(p1), WnafBase::new(p2)];
-    let scalars = [r1, r2].map(|r| WnafScalar::from_le_bytes(&r.to_le_repr()[..GLV_LE_BYTES]));
+/// Perform GLV decomposition and return the resulting w-NAF bases and scalars.
+#[inline]
+fn decompose_glv_wnaf(x: &ProjectivePoint, k: &Scalar) -> ([WnafBase; 2], [WnafScalar; 2]) {
+    let mut bases = [WnafBase::default(), WnafBase::default()];
+    let mut scalars = [WnafScalar::default(), WnafScalar::default()];
+    decompose_glv_wnaf_into(x, k, &mut bases, &mut scalars);
     (bases, scalars)
 }
 

--- a/wnaf/src/base.rs
+++ b/wnaf/src/base.rs
@@ -38,11 +38,15 @@ impl<G: Group, W: WindowSize> WnafBase<G, W> {
     /// Computes a window table for the given base with the specified window size `W`.
     #[inline]
     pub fn new(base: G) -> Self {
-        let mut ret = Self {
-            table: Array::from_fn(|_| G::generator()),
-        };
-        wnaf_table(&mut ret.table, base, W::USIZE);
+        let mut ret = Self::default();
+        ret.init_from_base(base);
         ret
+    }
+
+    /// Initialize an already allocated window table from the given base.
+    #[inline]
+    pub fn init_from_base(&mut self, base: G) {
+        wnaf_table(&mut self.table, base, W::USIZE);
     }
 
     /// Perform a multiscalar multiplication.
@@ -56,6 +60,14 @@ impl<G: Group, W: WindowSize> WnafBase<G, W> {
         I: Clone + Iterator<Item = (&'a Self, &'a WnafScalar<G::Scalar, W, WnafStorage>)>,
     {
         wnaf_multi_exp(pairs.map(|(b, s)| (b.table.as_slice(), s.wnaf.as_slice(), s.digits)))
+    }
+}
+
+impl<G: Group, W: WindowSize> Default for WnafBase<G, W> {
+    fn default() -> Self {
+        Self {
+            table: Array::from_fn(|_| G::generator()),
+        }
     }
 }
 

--- a/wnaf/src/scalar.rs
+++ b/wnaf/src/scalar.rs
@@ -11,7 +11,7 @@ use crate::WnafBase;
 /// # Examples
 ///
 /// See [`WnafBase`] for usage examples.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct WnafScalar<F: PrimeField, W: WindowSize, WnafStorage: ArraySize> {
     pub(crate) wnaf: Array<Digit, WnafStorage>,
     pub(crate) digits: usize,
@@ -39,11 +39,7 @@ impl<F: PrimeField, W: WindowSize, WnafStorage: ArraySize> WnafScalar<F, W, Wnaf
     #[inline]
     pub fn from_le_bytes(bytes: &[u8]) -> Self {
         debug_assert!(bytes.len() * 8 < WnafStorage::USIZE);
-        let mut wnaf = Self {
-            wnaf: Array::default(),
-            digits: 0,
-            _field: PhantomData,
-        };
+        let mut wnaf = Self::default();
         wnaf.init_from_le_bytes(bytes);
         wnaf
     }


### PR DESCRIPTION
Adds an in-place version of GLV decomposition that avoids potential `memcpy`s from returning `WnafBase`/`WnafScalar`