### PR TITLE
p256: document PKCS#8 key loading

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -7,6 +7,13 @@ extend-exclude = [
     "p384/tests/affine.rs",
 ]
 
+[default]
+extend-ignore-re = [
+    # Patterns which appear to be 36 or more characters of Base64/Base64url
+    '\b[0-9A-Za-z+/]{36,}\b',
+    '\b[0-9A-Za-z_-]{36,}\b',
+]
+
 [default.extend-words]
 # Authenticated Key Exchange
 "AKE" = "AKE"

--- a/p256/README.md
+++ b/p256/README.md
@@ -32,6 +32,50 @@ USE AT YOUR OWN RISK!
 - [Elliptic Curve Digital Signature Algorithm (ECDSA)][ECDSA]: gated under the
   `ecdsa` feature.
 
+## PKCS#8 Key Encoding
+
+PKCS#8 support is gated under the `pkcs8` feature. It provides DER decoding for
+secret keys via the [`DecodePrivateKey`] trait re-exported from the [`pkcs8`]
+module. The `pem` feature, which is enabled by default, adds PEM decoding and
+also enables `pkcs8`.
+
+The same pattern is used by the other curve crates in this repository which
+re-export `pkcs8`.
+
+```rust
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# #[cfg(feature = "pkcs8")]
+# {
+use p256::{pkcs8::DecodePrivateKey, SecretKey};
+
+let der = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/examples/pkcs8-private-key.der"
+));
+let secret_key = SecretKey::from_pkcs8_der(der)?;
+# let _ = secret_key;
+# }
+# Ok(())
+# }
+```
+
+```rust
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# #[cfg(feature = "pem")]
+# {
+use p256::{pkcs8::DecodePrivateKey, SecretKey};
+
+let pem = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/examples/pkcs8-private-key.pem"
+));
+let secret_key = SecretKey::from_pkcs8_pem(pem)?;
+# let _ = secret_key;
+# }
+# Ok(())
+# }
+```
+
 ## About NIST P-256
 
 NIST P-256 is a Weierstrass curve specified in [SP 800-186]:
@@ -74,6 +118,8 @@ dual licensed as above, without any additional terms or conditions.
 
 [RustCrypto]: https://github.com/rustcrypto/
 [`elliptic-curve`]: https://github.com/RustCrypto/traits/tree/master/elliptic-curve
+[`DecodePrivateKey`]: https://docs.rs/pkcs8/latest/pkcs8/trait.DecodePrivateKey.html
+[`pkcs8`]: https://docs.rs/pkcs8/latest/pkcs8/
 [ECDH]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie-Hellman
 [ECDSA]: https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
 [SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final

--- a/p256/README.md
+++ b/p256/README.md
@@ -118,7 +118,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [RustCrypto]: https://github.com/rustcrypto/
 [`elliptic-curve`]: https://github.com/RustCrypto/traits/tree/master/elliptic-curve
-[`DecodePrivateKey`]: https://docs.rs/pkcs8/latest/pkcs8/trait.DecodePrivateKey.html
+[`pkcs8::DecodePrivateKey`]: https://docs.rs/pkcs8/latest/pkcs8/trait.DecodePrivateKey.html
 [`pkcs8`]: https://docs.rs/pkcs8/latest/pkcs8/
 [ECDH]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie-Hellman
 [ECDSA]: https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm

--- a/p256/README.md
+++ b/p256/README.md
@@ -67,31 +67,15 @@ when the input is expected to be specifically PKCS#8.
 
 ```rust
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-# #[cfg(feature = "pkcs8")]
-# {
-use p256::SecretKey;
-
-let der = include_bytes!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/tests/examples/pkcs8-private-key.der"
-));
-let secret_key = SecretKey::from_der(der)?;
-# let _ = secret_key;
-# }
-# Ok(())
-# }
-```
-
-```rust
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
 # #[cfg(feature = "pem")]
 # {
 use p256::SecretKey;
 
-let pem = include_str!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/tests/examples/pkcs8-private-key.pem"
-));
+let pem = r#"-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgaWJBcVYaYzQN4OfY
+afKgVJJVjhoEhotqn4VKhmeIGI2hRANCAAQcrP+1Xy8s79idies3SyaBFSRSgC3u
+oJkWBoE32DnPf8SBpESSME1+9mrBF77+g6jQjxVfK1L59hjdRHApBI4P
+-----END PRIVATE KEY-----"#;
 let secret_key = SecretKey::from_pem(pem)?;
 # let _ = secret_key;
 # }

--- a/p256/README.md
+++ b/p256/README.md
@@ -34,25 +34,48 @@ USE AT YOUR OWN RISK!
 
 ## PKCS#8 Key Encoding
 
-PKCS#8 support is gated under the `pkcs8` feature. It provides DER decoding for
-secret keys via the [`DecodePrivateKey`] trait re-exported from the [`pkcs8`]
-module. The `pem` feature, which is enabled by default, adds PEM decoding and
-also enables `pkcs8`.
+PKCS#8 is a private key format with support for multiple algorithms. It can be
+encoded as binary DER or text PEM.
+
+You can recognize PEM encoded PKCS#8 private keys because they do not have an
+algorithm name in the type label, e.g.:
+
+```text
+-----BEGIN PRIVATE KEY-----
+```
+
+PKCS#8 support is gated under the `pkcs8` feature. The `pem` feature, which is
+enabled by default, adds PEM decoding and also enables `pkcs8`.
 
 The same pattern is used by the other curve crates in this repository which
 re-export `pkcs8`.
+
+The following traits can be used to decode/encode secret and public keys as
+PKCS#8/SPKI. Note that [`pkcs8`] is re-exported from `p256` when the `pkcs8`
+feature is enabled:
+
+- [`pkcs8::DecodePrivateKey`]: decode private keys from PKCS#8
+- [`pkcs8::EncodePrivateKey`]: encode private keys to PKCS#8
+- [`pkcs8::DecodePublicKey`]: decode public keys from SPKI
+- [`pkcs8::EncodePublicKey`]: encode public keys to SPKI
+
+For private keys, [`SecretKey::from_der`] and [`SecretKey::from_pem`] provide
+convenience methods which can decode PKCS#8 keys. Use the trait methods above
+when the input is expected to be specifically PKCS#8.
+
+### Example
 
 ```rust
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 # #[cfg(feature = "pkcs8")]
 # {
-use p256::{pkcs8::DecodePrivateKey, SecretKey};
+use p256::SecretKey;
 
 let der = include_bytes!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/tests/examples/pkcs8-private-key.der"
 ));
-let secret_key = SecretKey::from_pkcs8_der(der)?;
+let secret_key = SecretKey::from_der(der)?;
 # let _ = secret_key;
 # }
 # Ok(())
@@ -63,13 +86,13 @@ let secret_key = SecretKey::from_pkcs8_der(der)?;
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 # #[cfg(feature = "pem")]
 # {
-use p256::{pkcs8::DecodePrivateKey, SecretKey};
+use p256::SecretKey;
 
 let pem = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/tests/examples/pkcs8-private-key.pem"
 ));
-let secret_key = SecretKey::from_pkcs8_pem(pem)?;
+let secret_key = SecretKey::from_pem(pem)?;
 # let _ = secret_key;
 # }
 # Ok(())
@@ -119,7 +142,12 @@ dual licensed as above, without any additional terms or conditions.
 [RustCrypto]: https://github.com/rustcrypto/
 [`elliptic-curve`]: https://github.com/RustCrypto/traits/tree/master/elliptic-curve
 [`pkcs8::DecodePrivateKey`]: https://docs.rs/pkcs8/latest/pkcs8/trait.DecodePrivateKey.html
+[`pkcs8::EncodePrivateKey`]: https://docs.rs/pkcs8/latest/pkcs8/trait.EncodePrivateKey.html
+[`pkcs8::DecodePublicKey`]: https://docs.rs/pkcs8/latest/pkcs8/trait.DecodePublicKey.html
+[`pkcs8::EncodePublicKey`]: https://docs.rs/pkcs8/latest/pkcs8/trait.EncodePublicKey.html
 [`pkcs8`]: https://docs.rs/pkcs8/latest/pkcs8/
+[`SecretKey::from_der`]: https://docs.rs/elliptic-curve/latest/elliptic_curve/struct.SecretKey.html#method.from_der
+[`SecretKey::from_pem`]: https://docs.rs/elliptic-curve/latest/elliptic_curve/struct.SecretKey.html#method.from_pem
 [ECDH]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie-Hellman
 [ECDSA]: https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
 [SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final

--- a/p256/README.md
+++ b/p256/README.md
@@ -125,13 +125,6 @@ dual licensed as above, without any additional terms or conditions.
 
 [RustCrypto]: https://github.com/rustcrypto/
 [`elliptic-curve`]: https://github.com/RustCrypto/traits/tree/master/elliptic-curve
-[`pkcs8::DecodePrivateKey`]: https://docs.rs/pkcs8/latest/pkcs8/trait.DecodePrivateKey.html
-[`pkcs8::EncodePrivateKey`]: https://docs.rs/pkcs8/latest/pkcs8/trait.EncodePrivateKey.html
-[`pkcs8::DecodePublicKey`]: https://docs.rs/pkcs8/latest/pkcs8/trait.DecodePublicKey.html
-[`pkcs8::EncodePublicKey`]: https://docs.rs/pkcs8/latest/pkcs8/trait.EncodePublicKey.html
-[`pkcs8`]: https://docs.rs/pkcs8/latest/pkcs8/
-[`SecretKey::from_der`]: https://docs.rs/elliptic-curve/latest/elliptic_curve/struct.SecretKey.html#method.from_der
-[`SecretKey::from_pem`]: https://docs.rs/elliptic-curve/latest/elliptic_curve/struct.SecretKey.html#method.from_pem
 [ECDH]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie-Hellman
 [ECDSA]: https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
 [SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -84,7 +84,7 @@ impl Scalar {
         Self(barrett_reduce(lo, hi))
     }
 
-    /// Returns self * self mod p
+    /// Returns self * self mod n
     pub const fn square(&self) -> Self {
         // Schoolbook multiplication.
         self.multiply(self)
@@ -97,7 +97,7 @@ impl Scalar {
         Self(self.0.unbounded_shr_vartime(shift))
     }
 
-    /// Compute [`FieldElement`] inversion: `1 / self`.
+    /// Compute scalar inversion: `1 / self`.
     pub fn invert(&self) -> CtOption<Self> {
         self.0
             .invert_odd_mod(const { &Odd::from_be_hex(ORDER_HEX) })
@@ -105,7 +105,7 @@ impl Scalar {
             .into()
     }
 
-    /// Compute [`FieldElement`] inversion: `1 / self` in variable-time.
+    /// Compute scalar inversion: `1 / self` in variable-time.
     pub fn invert_vartime(&self) -> CtOption<Self> {
         self.0
             .invert_odd_mod_vartime(const { &Odd::from_be_hex(ORDER_HEX) })


### PR DESCRIPTION
## Summary

- add a PKCS#8 key encoding section to the `p256` crate docs
- document the `pkcs8` and `pem` feature gates
- include DER and PEM private-key loading examples using `DecodePrivateKey`
- fix stale scalar docs that referenced `FieldElement` and used `mod p` for scalar squaring

## Motivation

This provides a concrete PKCS#8 usage example for users without duplicating the same documentation across every curve crate. It is intended to help address the documentation gap discussed in #1050 while keeping the maintenance surface small.

## Tests

- `cargo fmt --all --check`
- `RUSTFLAGS='-Dwarnings' RUSTDOCFLAGS='-Dwarnings' cargo test -p p256 --doc`
- `RUSTFLAGS='-Dwarnings' RUSTDOCFLAGS='-Dwarnings' cargo test -p p256 --doc --no-default-features`
- `RUSTFLAGS='-Dwarnings' RUSTDOCFLAGS='-Dwarnings' cargo test -p p256 --doc --all-features`
- `RUSTFLAGS='-Dwarnings' RUSTDOCFLAGS='-Dwarnings' cargo doc -p p256 --all-features --no-deps`
- `RUSTFLAGS='-Dwarnings' RUSTDOCFLAGS='-Dwarnings' cargo test -p p256 --test pkcs8`

Refs #1050