### PR TITLE
k256+p256: point benchmark improvements

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -77,6 +77,10 @@ name = "field"
 harness = false
 
 [[bench]]
+name = "point"
+harness = false
+
+[[bench]]
 name = "scalar"
 harness = false
 

--- a/k256/benches/point.rs
+++ b/k256/benches/point.rs
@@ -1,13 +1,12 @@
-//! p256 `ProjectivePoint` benchmarks
+//! k256 `ProjectivePoint` benchmarks
 
 use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
-use hex_literal::hex;
-use p256::{
+use k256::{
     AffinePoint, ProjectivePoint, Scalar,
     elliptic_curve::{
-        BatchNormalize, Group, PrimeField,
+        BatchNormalize, PrimeField,
         ops::{LinearCombination, MulByGeneratorVartime, MulVartime},
         subtle::ConstantTimeEq,
     },
@@ -16,14 +15,24 @@ use std::hint::black_box;
 
 fn test_scalar_x() -> Scalar {
     Scalar::from_repr(
-        hex!("519b423d715f8b581f4fa8ee59f4771a5b44c8130b4e3eacca54a56dda72b464").into(),
+        [
+            0xbb, 0x48, 0x8a, 0xef, 0x41, 0x6a, 0x41, 0xd7, 0x68, 0x0d, 0x1c, 0xf0, 0x1d, 0x70,
+            0xf5, 0x9b, 0x60, 0xd7, 0xf5, 0xf7, 0x7e, 0x30, 0xe7, 0x8b, 0x8b, 0xf9, 0xd2, 0xd8,
+            0x82, 0xf1, 0x56, 0xa6,
+        ]
+        .into(),
     )
     .unwrap()
 }
 
 fn test_scalar_y() -> Scalar {
     Scalar::from_repr(
-        hex!("519b423d715f8b581f4fa8ee59f4771a5b44c8130b4e3eacca54a56dda72b464").into(),
+        [
+            0x67, 0xe2, 0xf6, 0x80, 0x71, 0xed, 0x82, 0x81, 0xe8, 0xae, 0xd6, 0xbc, 0xf1, 0xc5,
+            0x20, 0x7c, 0x5e, 0x63, 0x37, 0x22, 0xd9, 0x20, 0xaf, 0xd6, 0xae, 0x22, 0xd0, 0x6e,
+            0xeb, 0x80, 0x35, 0xe3,
+        ]
+        .into(),
     )
     .unwrap()
 }

--- a/k256/benches/scalar.rs
+++ b/k256/benches/scalar.rs
@@ -3,14 +3,7 @@
 use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
-use hex_literal::hex;
-use k256::{
-    ProjectivePoint, Scalar,
-    elliptic_curve::{
-        group::ff::PrimeField,
-        ops::{LinearCombination, MulVartime},
-    },
-};
+use k256::{Scalar, elliptic_curve::group::ff::PrimeField};
 use std::hint::black_box;
 
 fn test_scalar_x() -> Scalar {
@@ -35,66 +28,6 @@ fn test_scalar_y() -> Scalar {
         .into(),
     )
     .unwrap()
-}
-
-fn bench_point_mul<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let p = ProjectivePoint::GENERATOR;
-    let m = hex!("AA5E28D6A97A2479A65527F7290311A3624D4CC0FA1578598EE3C2613BF99522");
-    let s = Scalar::from_repr(m.into()).unwrap();
-    group.bench_function("point-scalar mul", |b| {
-        b.iter(|| black_box(p) * black_box(s))
-    });
-
-    group.bench_function("point-scalar mul (variable-time)", |b| {
-        b.iter(|| black_box(p).mul_vartime(black_box(s)))
-    });
-}
-
-fn bench_point_lincomb<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let p = ProjectivePoint::GENERATOR;
-    let m = hex!("AA5E28D6A97A2479A65527F7290311A3624D4CC0FA1578598EE3C2613BF99522");
-    let s = Scalar::from_repr(m.into()).unwrap();
-    group.bench_function("lincomb (unoptimized, 2-term)", |b| {
-        b.iter(|| black_box(p) * black_box(s) + black_box(p) * black_box(s))
-    });
-    group.bench_function("lincomb (optimized, 2-term)", |b| {
-        b.iter(|| {
-            ProjectivePoint::lincomb(&[(black_box(p), black_box(s)), (black_box(p), black_box(s))])
-        })
-    });
-    group.bench_function("lincomb_vartime (2-term)", |b| {
-        b.iter(|| {
-            ProjectivePoint::lincomb_vartime(&[
-                (black_box(p), black_box(s)),
-                (black_box(p), black_box(s)),
-            ])
-        })
-    });
-}
-
-fn bench_point_mul_by_generator<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let p = ProjectivePoint::GENERATOR;
-    let x = test_scalar_x();
-
-    group.bench_function("mul_by_generator naive", |b| {
-        b.iter(|| black_box(p) * black_box(x))
-    });
-
-    group.bench_function("mul_by_generator precomputed", |b| {
-        b.iter(|| ProjectivePoint::mul_by_generator(&black_box(x)))
-    });
-
-    group.bench_function("mul_by_generator_vartime", |b| {
-        b.iter(|| ProjectivePoint::mul_by_generator_vartime(&black_box(x)))
-    });
-}
-
-fn bench_high_level(c: &mut Criterion) {
-    let mut group = c.benchmark_group("high-level operations");
-    bench_point_mul(&mut group);
-    bench_point_mul_by_generator(&mut group);
-    bench_point_lincomb(&mut group);
-    group.finish();
 }
 
 fn bench_scalar_sub<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
@@ -135,5 +68,5 @@ fn bench_scalar(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_high_level, bench_scalar);
+criterion_group!(benches, bench_scalar);
 criterion_main!(benches);


### PR DESCRIPTION
Adapts and expands `p256`'s point benchmarks to `k256`, making them the same between the two crates, and expanding them to include addition and normalization