### PR TITLE
wnaf: add `WnafSize` trait

### DIFF
--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -40,7 +40,7 @@ use super::{
 };
 use core::array;
 use elliptic_curve::{
-    array::sizes::{U5, U33, U257},
+    array::sizes::{U5, U33},
     ops::{LinearCombination, Mul, MulAssign, MulByGeneratorVartime, MulVartime},
     scalar::IsHigh,
     subtle::ConditionallySelectable,
@@ -55,11 +55,14 @@ use {super::tables::BASEPOINT_TABLE, elliptic_curve::array::sizes::U65};
 /// Lookup table for multiples of a given point.
 type LookupTable = primeorder::LookupTable<ProjectivePoint>;
 
+/// w-NAF window size to use by default.
+type WnafWindowSize = U5;
+
 /// `WnafBase` specialized for `k256`.
-type WnafBase = wnaf::WnafBase<ProjectivePoint, U5>;
+type WnafBase = wnaf::WnafBase<ProjectivePoint, WnafWindowSize>;
 
 /// `WnafScalar` specialized for `k256`.
-type WnafScalar = wnaf::WnafScalar<Scalar, U5, U257>;
+type WnafScalar = wnaf::WnafScalar<Scalar, WnafWindowSize>;
 
 const MINUS_LAMBDA: Scalar = Scalar::from_bytes_unchecked(&[
     0xac, 0x9c, 0x52, 0xb3, 0x3f, 0xa3, 0xcf, 0x1f, 0x5a, 0xd9, 0xe3, 0xfd, 0x77, 0xed, 0x9b, 0xa4,

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -3,7 +3,7 @@
 use crate::{FieldBytes, NonZeroScalar, ORDER, ORDER_HEX, Secp256k1, WideBytes};
 use core::iter::{Product, Sum};
 use elliptic_curve::{
-    Curve, Error, Generate, ScalarValue,
+    Curve, Error, Generate, ScalarValue, array,
     bigint::{ArrayEncoding, Limb, U256, U512, Word, cpubits, modular::Retrieve},
     ctutils,
     ff::{self, Field, FromUniformBytes, PrimeField},
@@ -20,6 +20,7 @@ use elliptic_curve::{
     zeroize::DefaultIsZeroes,
 };
 use primeorder::{FieldExt, PrimeFieldExt};
+use wnaf::WnafSize;
 
 cpubits! {
     32 => {
@@ -313,6 +314,11 @@ impl PrimeField for Scalar {
 
 impl FieldExt for Scalar {}
 impl PrimeFieldExt for Scalar {}
+
+impl WnafSize for Scalar {
+    // Scalar::NUM_BITS + 1
+    type StorageSize = array::sizes::U257;
+}
 
 impl From<u32> for Scalar {
     fn from(k: u32) -> Self {

--- a/wnaf/src/base.rs
+++ b/wnaf/src/base.rs
@@ -1,5 +1,5 @@
-use crate::{WindowSize, WnafScalar, wnaf_multi_exp, wnaf_table};
-use array::{Array, ArraySize};
+use crate::{WindowSize, WnafScalar, WnafSize, wnaf_multi_exp, wnaf_table};
+use array::Array;
 use core::iter;
 use core::ops::Mul;
 use group::Group;
@@ -54,10 +54,10 @@ impl<G: Group, W: WindowSize> WnafBase<G, W> {
     /// Computes a sum-of-products `aA + bB + ...` in variable time with w-NAF multi-exponentiation
     /// using the interleaved window method, also known as Straus's method.
     #[must_use]
-    pub fn multiscalar_mul<'a, S, I>(pairs: I) -> G
+    pub fn multiscalar_mul<'a, I>(pairs: I) -> G
     where
-        S: ArraySize,
-        I: Clone + Iterator<Item = (&'a Self, &'a WnafScalar<G::Scalar, W, S>)>,
+        G::Scalar: WnafSize,
+        I: Clone + Iterator<Item = (&'a Self, &'a WnafScalar<G::Scalar, W>)>,
     {
         wnaf_multi_exp(pairs.map(|(b, s)| (b.table.as_slice(), s.wnaf.as_slice(), s.digits)))
     }
@@ -71,28 +71,40 @@ impl<G: Group, W: WindowSize> Default for WnafBase<G, W> {
     }
 }
 
-impl<G: Group, W: WindowSize, S: ArraySize> Mul<&WnafScalar<G::Scalar, W, S>> for &WnafBase<G, W> {
+impl<G, W> Mul<&WnafScalar<G::Scalar, W>> for &WnafBase<G, W>
+where
+    G: Group<Scalar: WnafSize>,
+    W: WindowSize,
+{
     type Output = G;
 
-    fn mul(self, rhs: &WnafScalar<G::Scalar, W, S>) -> Self::Output {
+    fn mul(self, rhs: &WnafScalar<G::Scalar, W>) -> Self::Output {
         WnafBase::multiscalar_mul(iter::once((self, rhs)))
     }
 }
 
-impl<G: Group, W: WindowSize, S: ArraySize> Mul<&WnafScalar<G::Scalar, W, S>> for WnafBase<G, W> {
+impl<G, W> Mul<&WnafScalar<G::Scalar, W>> for WnafBase<G, W>
+where
+    G: Group<Scalar: WnafSize>,
+    W: WindowSize,
+{
     type Output = G;
 
     #[inline]
-    fn mul(self, rhs: &WnafScalar<G::Scalar, W, S>) -> Self::Output {
+    fn mul(self, rhs: &WnafScalar<G::Scalar, W>) -> Self::Output {
         &self * rhs
     }
 }
 
-impl<G: Group, W: WindowSize, S: ArraySize> Mul<WnafScalar<G::Scalar, W, S>> for WnafBase<G, W> {
+impl<G, W> Mul<WnafScalar<G::Scalar, W>> for WnafBase<G, W>
+where
+    G: Group<Scalar: WnafSize>,
+    W: WindowSize,
+{
     type Output = G;
 
     #[inline]
-    fn mul(self, rhs: WnafScalar<G::Scalar, W, S>) -> Self::Output {
+    fn mul(self, rhs: WnafScalar<G::Scalar, W>) -> Self::Output {
         &self * &rhs
     }
 }

--- a/wnaf/src/lib.rs
+++ b/wnaf/src/lib.rs
@@ -4,6 +4,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
+#![allow(clippy::int_plus_one, reason = "clearer for our use cases  ")]
 #![forbid(unsafe_code)]
 #![doc = include_str!("../README.md")]
 
@@ -22,7 +23,7 @@ mod boxed;
 pub use crate::{
     base::WnafBase,
     scalar::WnafScalar,
-    traits::{WindowSize, WnafGroup},
+    traits::{WindowSize, WnafGroup, WnafSize},
 };
 pub use group::Group;
 
@@ -69,7 +70,7 @@ fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut [Digit], c: S, window: usize) -> usize {
     debug_assert!(window >= 2);
     debug_assert!(window <= W_MAX);
 
-    let bit_len = c.as_ref().len() * 8;
+    let bit_len = c.as_ref().len() * 8 + 1;
     debug_assert!(wnaf.len() > bit_len, "wnaf storage too small");
 
     let width = 1u64 << window;

--- a/wnaf/src/scalar.rs
+++ b/wnaf/src/scalar.rs
@@ -1,5 +1,5 @@
-use crate::{Digit, WindowSize, le_repr, wnaf_form};
-use array::{Array, ArraySize};
+use crate::{Digit, WindowSize, WnafSize, le_repr, wnaf_form};
+use array::{Array, typenum::Unsigned};
 use core::marker::PhantomData;
 use ff::PrimeField;
 
@@ -8,17 +8,21 @@ use crate::WnafBase;
 
 /// A "w-ary non-adjacent form" scalar, precomputed to improve the speed of scalar multiplication.
 ///
+/// The w-NAF representation is represented by a table of [`Digit`]s which includes one for each
+/// bit of the original scalar, plus an additional bit for any remaining carry, i.e.
+/// `F::NUM_BITS + 1`.
+///
 /// # Examples
 ///
 /// See [`WnafBase`] for usage examples.
 #[derive(Clone, Debug, Default)]
-pub struct WnafScalar<F: PrimeField, W: WindowSize, S: ArraySize> {
-    pub(crate) wnaf: Array<Digit, S>,
+pub struct WnafScalar<F: PrimeField + WnafSize, W: WindowSize> {
+    pub(crate) wnaf: Array<Digit, F::StorageSize>,
     pub(crate) digits: usize,
     _field: PhantomData<(F, W)>,
 }
 
-impl<F: PrimeField, W: WindowSize, S: ArraySize> WnafScalar<F, W, S> {
+impl<F: PrimeField + WnafSize, W: WindowSize> WnafScalar<F, W> {
     /// Computes the w-NAF representation of the given scalar with window size `W`.
     #[inline]
     pub fn new(scalar: &F) -> Self {
@@ -38,7 +42,6 @@ impl<F: PrimeField, W: WindowSize, S: ArraySize> WnafScalar<F, W, S> {
     /// If `bytes*8+1 > S::USIZE`.
     #[inline]
     pub fn from_le_bytes(bytes: &[u8]) -> Self {
-        debug_assert!(bytes.len() * 8 < S::USIZE);
         let mut wnaf = Self::default();
         wnaf.init_from_le_bytes(bytes);
         wnaf
@@ -54,7 +57,8 @@ impl<F: PrimeField, W: WindowSize, S: ArraySize> WnafScalar<F, W, S> {
     /// If `bytes*8+1 > S::USIZE`.
     #[inline]
     pub fn init_from_le_bytes(&mut self, bytes: &[u8]) {
-        debug_assert!(bytes.len() * 8 < S::USIZE);
+        debug_assert_eq!(F::NUM_BITS + 1, F::StorageSize::U32);
+        debug_assert!(bytes.len() * 8 + 1 <= F::StorageSize::USIZE);
         self.digits = wnaf_form(&mut self.wnaf, bytes, W::USIZE);
     }
 }

--- a/wnaf/src/traits.rs
+++ b/wnaf/src/traits.rs
@@ -4,6 +4,7 @@ use array::{
     ArraySize,
     typenum::{U1, U2, U3, U4, U5, U6, U7, U8, U16, U32, U64, Unsigned},
 };
+use ff::PrimeField;
 use group::Group;
 
 /// Extension trait on a [`Group`] that provides helpers used by [`crate::BoxedWnaf`].
@@ -11,6 +12,13 @@ pub trait WnafGroup: Group {
     /// Recommends a wNAF window size given the number of scalars you intend to multiply
     /// a base by. Always returns a number between 2 and [`W_MAX`][`crate::W_MAX`], inclusive.
     fn recommended_wnaf_for_num_scalars(num_scalars: usize) -> usize;
+}
+
+/// Size of the w-NAF representation: this should be the type-level equivalent of
+/// `PrimeField::NUM_BITS + 1`, which includes an extra entry for any remaining carry.
+pub trait WnafSize: PrimeField {
+    /// Number of digits in the w-NAF representation.
+    type StorageSize: ArraySize;
 }
 
 /// Allowed w-NAF window size: we use this to precompute the window point sizes, because it's


### PR DESCRIPTION
Adds a trait to be defined on `G::Scalar` which associates an `ArraySize` equivalent to `G::Scalar::NUM_BITS + 1` as `StorageSize`, which is used to size the w-NAF `Digit` storage array.

This removes the associated `S` type parameter from `WnafScalar` as well, which makes it easier to use.