### PR TITLE
primeorder: use `wnaf` for vartime (multi)scalar multiplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "subtle",
  "typenum",
@@ -957,6 +957,7 @@ dependencies = [
  "once_cell",
  "primefield",
  "serdect",
+ "wnaf",
 ]
 
 [[package]]

--- a/bignp256/src/arithmetic/scalar.rs
+++ b/bignp256/src/arithmetic/scalar.rs
@@ -11,6 +11,7 @@ use elliptic_curve::{
     subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
 use primefield::ByteOrder;
+use primeorder::wnaf;
 
 cpubits! {
     32 => {
@@ -90,6 +91,8 @@ primefield::monty_field_reduce! {
 }
 
 elliptic_curve::scalar_impls!(BignP256, Scalar);
+
+wnaf::impl_wnaf_size_for_scalar!(Scalar);
 
 impl AsRef<Scalar> for Scalar {
     fn as_ref(&self) -> &Scalar {

--- a/bp256/src/arithmetic/scalar.rs
+++ b/bp256/src/arithmetic/scalar.rs
@@ -17,6 +17,7 @@ use elliptic_curve::{
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
+use primeorder::wnaf;
 
 // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 cpubits! {
@@ -103,6 +104,8 @@ primefield::monty_field_reduce! {
 
 elliptic_curve::scalar_impls!(BrainpoolP256r1, Scalar);
 elliptic_curve::scalar_impls!(BrainpoolP256t1, Scalar);
+
+wnaf::impl_wnaf_size_for_scalar!(Scalar);
 
 impl AsRef<Scalar> for Scalar {
     fn as_ref(&self) -> &Scalar {

--- a/bp384/src/arithmetic/scalar.rs
+++ b/bp384/src/arithmetic/scalar.rs
@@ -17,6 +17,7 @@ use elliptic_curve::{
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
+use primeorder::wnaf;
 
 // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 cpubits! {
@@ -103,6 +104,8 @@ primefield::monty_field_reduce! {
 
 elliptic_curve::scalar_impls!(BrainpoolP384r1, Scalar);
 elliptic_curve::scalar_impls!(BrainpoolP384t1, Scalar);
+
+wnaf::impl_wnaf_size_for_scalar!(Scalar);
 
 impl AsRef<Scalar> for Scalar {
     fn as_ref(&self) -> &Scalar {

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -3,7 +3,7 @@
 use crate::{FieldBytes, NonZeroScalar, ORDER, ORDER_HEX, Secp256k1, WideBytes};
 use core::iter::{Product, Sum};
 use elliptic_curve::{
-    Curve, Error, Generate, ScalarValue, array,
+    Curve, Error, Generate, ScalarValue,
     bigint::{ArrayEncoding, Limb, U256, U512, Word, cpubits, modular::Retrieve},
     ctutils,
     ff::{self, Field, FromUniformBytes, PrimeField},
@@ -20,7 +20,6 @@ use elliptic_curve::{
     zeroize::DefaultIsZeroes,
 };
 use primeorder::{FieldExt, PrimeFieldExt};
-use wnaf::WnafSize;
 
 cpubits! {
     32 => {
@@ -315,11 +314,6 @@ impl PrimeField for Scalar {
 impl FieldExt for Scalar {}
 impl PrimeFieldExt for Scalar {}
 
-impl WnafSize for Scalar {
-    // Scalar::NUM_BITS + 1
-    type StorageSize = array::sizes::U257;
-}
-
 impl From<u32> for Scalar {
     fn from(k: u32) -> Self {
         Self(k.into())
@@ -591,6 +585,8 @@ impl Mul<&Scalar> for Scalar {
 }
 
 elliptic_curve::scalar_mul_impls!(Secp256k1, Scalar);
+
+wnaf::impl_wnaf_size_for_scalar!(Scalar);
 
 impl MulAssign<Scalar> for Scalar {
     fn mul_assign(&mut self, rhs: Scalar) {

--- a/p192/src/arithmetic/scalar.rs
+++ b/p192/src/arithmetic/scalar.rs
@@ -18,6 +18,7 @@ use elliptic_curve::{
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
+use primeorder::wnaf;
 
 // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 cpubits! {
@@ -109,6 +110,8 @@ primefield::monty_field_reduce! {
 }
 
 elliptic_curve::scalar_impls!(NistP192, Scalar);
+
+wnaf::impl_wnaf_size_for_scalar!(Scalar);
 
 impl AsRef<Scalar> for Scalar {
     fn as_ref(&self) -> &Scalar {

--- a/p224/src/arithmetic/scalar.rs
+++ b/p224/src/arithmetic/scalar.rs
@@ -20,6 +20,7 @@ use elliptic_curve::{
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
+use primeorder::wnaf;
 
 // TODO(tarcieri): remove this when we can use `const _` to silence warnings
 cpubits! {
@@ -105,6 +106,8 @@ primefield::fiat_monty_field_arithmetic! {
 }
 
 elliptic_curve::scalar_impls!(NistP224, Scalar);
+
+wnaf::impl_wnaf_size_for_scalar!(Scalar);
 
 impl AsRef<Scalar> for Scalar {
     fn as_ref(&self) -> &Scalar {

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -22,6 +22,7 @@ use elliptic_curve::{
     zeroize::DefaultIsZeroes,
 };
 use primefield::{FieldExt, PrimeFieldExt};
+use primeorder::wnaf;
 
 cpubits! {
     32 => {
@@ -310,6 +311,8 @@ impl PrimeField for Scalar {
 
 impl FieldExt for Scalar {}
 impl PrimeFieldExt for Scalar {}
+
+wnaf::impl_wnaf_size_for_scalar!(Scalar);
 
 impl Retrieve for Scalar {
     type Output = U256;

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -19,6 +19,7 @@ use elliptic_curve::{
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
+use primeorder::wnaf;
 
 cpubits! {
     32 => {
@@ -84,6 +85,8 @@ primefield::fiat_monty_field_arithmetic! {
 }
 
 elliptic_curve::scalar_impls!(NistP384, Scalar);
+
+wnaf::impl_wnaf_size_for_scalar!(Scalar);
 
 impl AsRef<Scalar> for Scalar {
     fn as_ref(&self) -> &Scalar {

--- a/p521/src/arithmetic/scalar.rs
+++ b/p521/src/arithmetic/scalar.rs
@@ -12,6 +12,7 @@ use elliptic_curve::{
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
+use primeorder::wnaf;
 
 #[cfg(feature = "serde")]
 use {
@@ -45,6 +46,8 @@ primefield::monty_field_arithmetic! {
 }
 
 elliptic_curve::scalar_impls!(NistP521, Scalar);
+
+wnaf::impl_wnaf_size_for_scalar!(Scalar);
 
 impl AsRef<Scalar> for Scalar {
     fn as_ref(&self) -> &Scalar {

--- a/primefield/src/lib.rs
+++ b/primefield/src/lib.rs
@@ -18,10 +18,9 @@ pub use crate::{
     monty::{MontyFieldBytes, MontyFieldElement, MontyFieldParams, compute_t},
     traits::{FieldExt, PrimeFieldExt},
 };
-pub use array::typenum::consts;
 pub use bigint;
 pub use bigint::ByteOrder;
-pub use bigint::hybrid_array as array;
+pub use bigint::hybrid_array::{self as array, typenum::consts};
 pub use common;
 pub use ff;
 pub use rand_core;

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -20,6 +20,7 @@ rust-version = "1.85"
 [dependencies]
 elliptic-curve = { version = "0.14", default-features = false, features = ["arithmetic", "sec1"] }
 primefield = "0.14"
+wnaf = { version = "0.14.0-rc.1", default-features = false }
 
 # optional dependencies
 once_cell = { version = "1.21", optional = true, default-features = false }

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -39,6 +39,7 @@ pub use elliptic_curve::{
     ops::Double,
 };
 pub use primefield::{FieldExt, PrimeFieldExt};
+pub use wnaf::{self, WnafSize};
 
 use elliptic_curve::{Curve, CurveArithmetic, sec1};
 
@@ -52,7 +53,7 @@ pub trait PrimeCurveParams:
     + CurveArithmetic<
         AffinePoint = AffinePoint<Self>,
         ProjectivePoint = ProjectivePoint<Self>,
-        Scalar: PrimeFieldExt,
+        Scalar: PrimeFieldExt + WnafSize,
     > + FieldArithmetic<FieldElement: PrimeFieldExt>
     + PrimeCurve
 {

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -9,7 +9,7 @@ use crate::{
 use core::{array, borrow::Borrow, iter::Sum, iter::zip};
 use elliptic_curve::{
     BatchNormalize, CurveGroup, Error, Generate, PublicKey, Result, Scalar,
-    array::typenum::Unsigned,
+    array::{sizes::U5, typenum::Unsigned},
     ctutils,
     group::{
         Group, GroupEncoding,
@@ -26,12 +26,23 @@ use elliptic_curve::{
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
 };
+use wnaf::WnafGroup;
 
 use crate::array::Array;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 #[cfg(feature = "serde")]
 use serdect::serde::{Deserialize, Serialize, de, ser};
+
+/// Default w-NAF window size to use.
+// TODO(tarcieri): per-curve customization?
+type DefaultWnafWindowSize = U5;
+
+/// `WnafBase` generic around an elliptic curve `C` using default window size for this curve.
+pub(crate) type WnafBase<C> = wnaf::WnafBase<ProjectivePoint<C>, DefaultWnafWindowSize>;
+
+/// `WnafScalar` generic around an elliptic curve `C` using default window size for this curve.
+pub(crate) type WnafScalar<C> = wnaf::WnafScalar<Scalar<C>, DefaultWnafWindowSize>;
 
 /// Point on a Weierstrass curve in projective coordinates.
 #[derive(Clone, Copy, Debug)]
@@ -118,9 +129,7 @@ where
 
     /// Returns `[k] self` computed in variable time.
     pub fn mul_vartime(&self, k: &Scalar<C>) -> Self {
-        let table = LookupTable::new(*self);
-        let digits = Radix16Decomposition::new(k);
-        lincomb_vartime::<C>(&[table], &[digits])
+        WnafBase::<C>::new(self) * WnafScalar::<C>::new(k)
     }
 }
 
@@ -365,6 +374,15 @@ where
 impl<C> PrimeCurve for ProjectivePoint<C> where C: PrimeCurveParams {}
 impl<C> PrimeGroup for ProjectivePoint<C> where C: PrimeCurveParams {}
 
+impl<C> WnafGroup for ProjectivePoint<C>
+where
+    C: PrimeCurveParams,
+{
+    fn recommended_wnaf_for_num_scalars(_num_scalars: usize) -> usize {
+        5 // TODO(tarcieri): better estimate based on `num_scalars`, curve-specific config
+    }
+}
+
 //
 // Batch trait impls
 //
@@ -468,16 +486,16 @@ where
 
     #[cfg(feature = "alloc")]
     fn lincomb_vartime(points_and_scalars: &[(Self, Scalar<C>)]) -> Self {
-        let tables: Vec<_> = points_and_scalars
+        let bases: Vec<_> = points_and_scalars
             .iter()
-            .map(|(point, _)| LookupTable::new(*point))
+            .map(|(point, _)| WnafBase::<C>::new(point))
             .collect();
-        let digits: Vec<_> = points_and_scalars
+        let scalars: Vec<_> = points_and_scalars
             .iter()
-            .map(|(_, scalar)| Radix16Decomposition::new(scalar))
+            .map(|(_, scalar)| WnafScalar::<C>::new(scalar))
             .collect();
 
-        lincomb_vartime::<C>(&tables, &digits)
+        WnafBase::multiscalar_mul(bases.iter().zip(scalars.iter()))
     }
 }
 
@@ -494,11 +512,9 @@ where
     }
 
     fn lincomb_vartime(points_and_scalars: &[(Self, Scalar<C>); N]) -> Self {
-        let tables: [_; N] = array::from_fn(|index| LookupTable::new(points_and_scalars[index].0));
-        let digits: [_; N] =
-            array::from_fn(|index| Radix16Decomposition::new(&points_and_scalars[index].1));
-
-        lincomb_vartime::<C>(&tables, &digits)
+        let bases = points_and_scalars.map(|(point, _)| WnafBase::<C>::new(&point));
+        let scalars = points_and_scalars.map(|(_, scalar)| WnafScalar::<C>::new(&scalar));
+        WnafBase::multiscalar_mul(bases.iter().zip(scalars.iter()))
     }
 }
 
@@ -523,33 +539,6 @@ fn lincomb<C: PrimeCurveParams>(
 
         for (table, digit) in zip(tables, digits) {
             q = q.add(&table.select(digit[i]));
-        }
-    }
-
-    q
-}
-
-fn lincomb_vartime<C: PrimeCurveParams>(
-    tables: &[LookupTable<ProjectivePoint<C>>],
-    digits: &[Radix16Decomposition<Radix16Digits<C>>],
-) -> ProjectivePoint<C> {
-    debug_assert_eq!(tables.len(), digits.len());
-    debug_assert!(!digits.is_empty());
-
-    let d = Radix16Digits::<C>::USIZE;
-    let mut q = ProjectivePoint::IDENTITY;
-
-    for (table, digit) in zip(tables, digits) {
-        q = q.add(&table.select_vartime(digit[d - 1]));
-    }
-
-    for i in (0..d - 1).rev() {
-        for _ in 0..4 {
-            q.double_in_place();
-        }
-
-        for (table, digit) in zip(tables, digits) {
-            q = q.add(&table.select_vartime(digit[i]));
         }
     }
 

--- a/sm2/src/arithmetic/scalar.rs
+++ b/sm2/src/arithmetic/scalar.rs
@@ -18,6 +18,7 @@ use elliptic_curve::{
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, CtOption},
 };
+use primeorder::wnaf;
 
 // Default backend: fiat-crypto
 cpubits! {
@@ -90,6 +91,8 @@ primefield::monty_field_reduce! {
 }
 
 elliptic_curve::scalar_impls!(Sm2, Scalar);
+
+wnaf::impl_wnaf_size_for_scalar!(Scalar);
 
 impl AsRef<Scalar> for Scalar {
     fn as_ref(&self) -> &Scalar {

--- a/wnaf/src/boxed.rs
+++ b/wnaf/src/boxed.rs
@@ -2,6 +2,7 @@
 
 use crate::{Digit, WnafGroup, le_repr, wnaf_form, wnaf_multi_exp, wnaf_table};
 use alloc::vec::Vec;
+use ff::PrimeField;
 use group::Group;
 
 #[cfg(doc)]
@@ -122,15 +123,12 @@ impl<G: WnafGroup> BoxedWnaf<(), Vec<G>, Vec<Digit>> {
         }
     }
 
-    pub fn scalar(
-        &mut self,
-        scalar: &<G as Group>::Scalar,
-    ) -> BoxedWnaf<usize, &mut Vec<G>, &[Digit]> {
+    pub fn scalar(&mut self, scalar: &G::Scalar) -> BoxedWnaf<usize, &mut Vec<G>, &[Digit]> {
         let window_size = 4;
 
         let repr = le_repr(scalar);
-        self.scalar.resize(repr.as_ref().len() * 8 + 1, 0);
-        let digits = wnaf_form(&mut self.scalar, repr, window_size);
+        let bit_len = init_storage::<G::Scalar>(&mut self.scalar, repr);
+        let digits = wnaf_form(&mut self.scalar, repr, bit_len, window_size);
         self.scalar.truncate(digits);
 
         BoxedWnaf {
@@ -182,20 +180,29 @@ impl<B, S: AsRef<[Digit]>> BoxedWnaf<usize, B, S> {
 }
 
 impl<B, S: AsMut<Vec<Digit>>> BoxedWnaf<usize, B, S> {
-    pub fn scalar<G: Group>(&mut self, scalar: &<G as Group>::Scalar) -> G
+    pub fn scalar<G: Group>(&mut self, scalar: &G::Scalar) -> G
     where
         B: AsRef<[G]>,
     {
         let repr = le_repr(scalar);
-        self.scalar.as_mut().resize(repr.as_ref().len() * 8 + 1, 0);
-        let digits = wnaf_form(self.scalar.as_mut(), repr, self.window_size);
+        let bit_len = init_storage::<G::Scalar>(self.scalar.as_mut(), repr);
+        let digits = wnaf_form(self.scalar.as_mut(), repr, bit_len, self.window_size);
         self.scalar.as_mut().truncate(digits);
         wnaf_exp(self.base.as_ref(), self.scalar.as_mut())
     }
 }
 
+/// Initialize storage for w-NAF `Digit`s.
+#[inline]
+fn init_storage<F: PrimeField>(digits: &mut Vec<Digit>, repr: F::Repr) -> usize {
+    let bit_len = (repr.as_ref().len() * 8).min(F::NUM_BITS as usize);
+    digits.resize(bit_len + 1, 0);
+    bit_len
+}
+
 /// Performs w-NAF exponentiation with the provided window table and w-NAF form scalar, whose
 /// lengths must match.
-pub(crate) fn wnaf_exp<G: Group>(table: &[G], wnaf: &[Digit]) -> G {
+#[inline]
+fn wnaf_exp<G: Group>(table: &[G], wnaf: &[Digit]) -> G {
     wnaf_multi_exp(core::iter::once((table, wnaf, wnaf.len())))
 }

--- a/wnaf/src/lib.rs
+++ b/wnaf/src/lib.rs
@@ -25,6 +25,7 @@ pub use crate::{
     scalar::WnafScalar,
     traits::{WindowSize, WnafGroup, WnafSize},
 };
+pub use array;
 pub use group::Group;
 
 #[cfg(feature = "alloc")]
@@ -66,12 +67,11 @@ fn wnaf_table<G: Group>(table: &mut [G], base: &G, window: usize) {
 /// Fills `wnaf` with the w-NAF representation of a little-endian scalar, and returns the
 /// number of digits written.
 #[allow(clippy::cast_possible_wrap)]
-fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut [Digit], c: S, window: usize) -> usize {
+fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut [Digit], c: S, bit_len: usize, window: usize) -> usize {
     debug_assert!(window >= 2);
     debug_assert!(window <= W_MAX);
-
-    let bit_len = c.as_ref().len() * 8 + 1;
-    debug_assert!(wnaf.len() > bit_len, "wnaf storage too small");
+    debug_assert!(bit_len < wnaf.len(), "wnaf storage too small");
+    debug_assert!(c.as_ref().len() <= bit_len.div_ceil(8), "input too large");
 
     let width = 1u64 << window;
     let window_mask = width - 1;
@@ -114,11 +114,15 @@ fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut [Digit], c: S, window: usize) -> usize {
                 (window_val as Digit).wrapping_sub(width as Digit)
             };
             cursor += 1;
-            for _ in 1..window {
+
+            let max_pos = bit_len.saturating_sub(carry as usize);
+            let skip = window.min(max_pos - pos);
+
+            for _ in 1..skip {
                 wnaf[cursor] = 0;
                 cursor += 1;
             }
-            pos += window;
+            pos += skip;
         }
     }
 

--- a/wnaf/src/scalar.rs
+++ b/wnaf/src/scalar.rs
@@ -54,11 +54,16 @@ impl<F: PrimeField + WnafSize, W: WindowSize> WnafScalar<F, W> {
     /// See that method for full documentation.
     ///
     /// # Panics
-    /// If `bytes*8+1 > S::USIZE`.
+    /// If `bytes` is larger than `F::Repr`.
     #[inline]
     pub fn init_from_le_bytes(&mut self, bytes: &[u8]) {
         debug_assert_eq!(F::NUM_BITS + 1, F::StorageSize::U32);
-        debug_assert!(bytes.len() * 8 + 1 <= F::StorageSize::USIZE);
-        self.digits = wnaf_form(&mut self.wnaf, bytes, W::USIZE);
+        debug_assert!(
+            bytes.len() <= F::NUM_BITS.div_ceil(8) as usize,
+            "input too large: {}",
+            bytes.len(),
+        );
+        let bit_len = (bytes.len() * 8).min(F::NUM_BITS as usize);
+        self.digits = wnaf_form(&mut self.wnaf, bytes, bit_len, W::USIZE);
     }
 }

--- a/wnaf/src/traits.rs
+++ b/wnaf/src/traits.rs
@@ -7,6 +7,13 @@ use array::{
 use ff::PrimeField;
 use group::Group;
 
+/// Allowed w-NAF window size: we use this to precompute the window point sizes, because it's
+/// currently not possible to write bounds for them.
+pub trait WindowSize: Unsigned {
+    /// Number of precomputed points in the window table: `1 << (Self::USIZE - 2)`.
+    type TableSize: ArraySize;
+}
+
 /// Extension trait on a [`Group`] that provides helpers used by [`crate::BoxedWnaf`].
 pub trait WnafGroup: Group {
     /// Recommends a wNAF window size given the number of scalars you intend to multiply
@@ -19,13 +26,6 @@ pub trait WnafGroup: Group {
 pub trait WnafSize: PrimeField {
     /// Number of digits in the w-NAF representation.
     type StorageSize: ArraySize;
-}
-
-/// Allowed w-NAF window size: we use this to precompute the window point sizes, because it's
-/// currently not possible to write bounds for them.
-pub trait WindowSize: Unsigned {
-    /// Number of precomputed points in the window table: `1 << (Self::USIZE - 2)`.
-    type TableSize: ArraySize;
 }
 
 // TODO(tarcieri): compute or failing that test window sizes
@@ -41,3 +41,13 @@ macro_rules! impl_window_sizes {
 
 // NOTE: the maximum size supported here should match the `W_MAX` constant
 impl_window_sizes!(U2 => U1, U3 => U2, U4 => U4, U5 => U8, U6 => U16, U7 => U32, U8 => U64);
+
+/// Write an impl of the `WnafSize` trait automatically based on the `PrimeField` impl.
+#[macro_export]
+macro_rules! impl_wnaf_size_for_scalar {
+    ($fe:ty) => {
+        impl $crate::WnafSize for $fe {
+            type StorageSize = $crate::array::typenum::U<{ (Self::NUM_BITS + 1) as usize }>;
+        }
+    };
+}


### PR DESCRIPTION
Adds a `WnafSize` trait to `wnaf` that `WnafScalar` can use to get the size of its w-NAF digit storage, along with an
`impl_wnaf_size_for_scalar!` macro that can even write an impl of it automatically based on its `PrimeField::NUM_BITS` (it goes through `typenum::U` so the macro the precompute it avoids adding the necessary typenum trait bounds to make that work.

This is now wired up as the one and only vartime (multi)scalar multiplication path in `primeorder`.

## `p256` benchmarks showing improvements:

```
ECDSA/P-256 (SHA-256)/verify
time:   [136.11 µs 136.26 µs 136.43 µs]
change: [−10.219% −9.9616% −9.7268%] (p = 0.00 < 0.05)

ProjectivePoint operations/lincomb_vartime (2-term)
time:   [135.27 µs 136.70 µs 138.44 µs]
change: [−7.5860% −6.5252% −4.9955%] (p = 0.00 < 0.05)

ProjectivePoint operations/mul_vartime
time:   [111.89 µs 112.22 µs 112.60 µs]
change: [−5.0897% −4.7222% −4.3106%] (p = 0.00 < 0.05)

ProjectivePoint operations/mul_by_generator_and_mul_add_vartime
time:   [133.88 µs 135.61 µs 139.02 µs]
change: [−8.7494% −7.7314% −5.9972%] (p = 0.00 < 0.05)
```