### PR TITLE
Bump `elliptic-curve` to v0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,8 +483,9 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0"
-source = "git+https://github.com/RustCrypto/traits#2586aefd53a08b6cb9b686a06c5723c93c2b2eb2"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,5 +67,3 @@ hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
 wnaf = { path = "wnaf" }
-
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14", features = ["sec1"] }
+elliptic-curve = { version = "0.14.1", features = ["sec1"] }
 
 # optional dependencies
 belt-block = { version = "0.2", optional = true }
@@ -40,7 +40,7 @@ signature = { version = "3", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.14", features = ["dev"] }
 proptest = "1"

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.22", optional = true, default-features = false, features = ["der"] }
@@ -24,7 +24,7 @@ sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa = { version = "0.17.0-rc.22", optional = true, default-features = false, features = ["der"] }
@@ -24,7 +24,7 @@ sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["dev"] }
 
 [features]
 default = ["pkcs8", "std"]

--- a/ed448-goldilocks/Cargo.toml
+++ b/ed448-goldilocks/Cargo.toml
@@ -16,7 +16,7 @@ This crate also includes signing and verifying of Ed448 signatures.
 """
 
 [dependencies]
-elliptic-curve = { version = "0.14", features = ["arithmetic", "pkcs8"] }
+elliptic-curve = { version = "0.14.1", features = ["arithmetic", "pkcs8"] }
 hash2curve = "0.14"
 rand_core = { version = "0.10", default-features = false }
 shake = { version = "0.1", default-features = false }

--- a/hash2curve/Cargo.toml
+++ b/hash2curve/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = { version = "0.11" }
-elliptic-curve = { version = "0.14", default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["arithmetic"] }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85"
 
 [dependencies]
 cpubits = "0.1"
-elliptic-curve = { version = "0.14", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 hash2curve = { version = "0.14", optional = true }
 
 # optional dependencies

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = "1"
-elliptic-curve = { version = "0.14", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 
 # optional dependencies
 ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14", default-features = false, features = ["arithmetic", "sec1"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["arithmetic", "sec1"] }
 primefield = "0.14"
 wnaf = { version = "0.14.0-rc.1", default-features = false }
 

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 fiat-crypto = { version = "0.3", default-features = false }
 rand_core = { version = "0.10", default-features = false }
 
@@ -33,7 +33,7 @@ sm3 = { version = "0.5", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-elliptic-curve = { version = "0.14", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["dev"] }
 hex-literal = "1"
 proptest = "1"
 


### PR DESCRIPTION
This added support for variable-time batch inversions and normalization.

Release PR: https://github.com/RustCrypto/traits/pull/2469