### PR TITLE
Migrate to new `rfc6979::KGenerator` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,8 +428,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.17.0-rc.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c72d1455753a703ad4b90ed2a759f2bc4562024a303176439cf6e593b5ade4"
+source = "git+https://github.com/RustCrypto/signatures#ed4b91ce6ceb4cf6d44af9e6020efa97000c0f22"
 dependencies = [
  "der",
  "digest",
@@ -1125,9 +1124,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 [[package]]
 name = "rfc6979"
 version = "0.6.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9935425142ac6e252364413291d96c8bc9898d0876a801824c7af4eae397b689"
+source = "git+https://github.com/RustCrypto/signatures#ed4b91ce6ceb4cf6d44af9e6020efa97000c0f22"
 dependencies = [
+ "crypto-bigint",
  "ctutils",
  "hmac",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,6 @@ hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
 wnaf = { path = "wnaf" }
+
+ecdsa = { git = "https://github.com/RustCrypto/signatures" }
+rfc6979 = { git = "https://github.com/RustCrypto/signatures" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -36,7 +36,7 @@ getrandom = ["ecdsa?/getrandom", "elliptic-curve/getrandom"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa/serde", "elliptic-curve/serde"]
-sha256 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
+sha256 = ["ecdsa/digest", "sha2"]
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/bp256/src/r1/ecdsa.rs
+++ b/bp256/src/r1/ecdsa.rs
@@ -13,6 +13,6 @@ impl ecdsa::EcdsaCurve for BrainpoolP256r1 {
 }
 
 #[cfg(feature = "sha256")]
-impl ecdsa::hazmat::DigestAlgorithm for BrainpoolP256r1 {
+impl ecdsa::DigestAlgorithm for BrainpoolP256r1 {
     type Digest = sha2::Sha256;
 }

--- a/bp256/src/t1/ecdsa.rs
+++ b/bp256/src/t1/ecdsa.rs
@@ -13,6 +13,6 @@ impl ecdsa::EcdsaCurve for BrainpoolP256t1 {
 }
 
 #[cfg(feature = "sha256")]
-impl ecdsa::hazmat::DigestAlgorithm for BrainpoolP256t1 {
+impl ecdsa::DigestAlgorithm for BrainpoolP256t1 {
     type Digest = sha2::Sha256;
 }

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -36,7 +36,7 @@ getrandom = ["ecdsa?/getrandom", "elliptic-curve/getrandom"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 pkcs8 = ["ecdsa/pkcs8", "elliptic-curve/pkcs8"]
 serde = ["ecdsa/serde", "elliptic-curve/serde"]
-sha384 = ["ecdsa/digest", "ecdsa/hazmat", "sha2"]
+sha384 = ["ecdsa/digest", "sha2"]
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/bp384/src/r1/ecdsa.rs
+++ b/bp384/src/r1/ecdsa.rs
@@ -13,6 +13,6 @@ impl ecdsa::EcdsaCurve for BrainpoolP384r1 {
 }
 
 #[cfg(feature = "sha384")]
-impl ecdsa::hazmat::DigestAlgorithm for BrainpoolP384r1 {
+impl ecdsa::DigestAlgorithm for BrainpoolP384r1 {
     type Digest = sha2::Sha384;
 }

--- a/bp384/src/t1/ecdsa.rs
+++ b/bp384/src/t1/ecdsa.rs
@@ -13,6 +13,6 @@ impl ecdsa::EcdsaCurve for BrainpoolP384t1 {
 }
 
 #[cfg(feature = "sha384")]
-impl ecdsa::hazmat::DigestAlgorithm for BrainpoolP384t1 {
+impl ecdsa::DigestAlgorithm for BrainpoolP384t1 {
     type Digest = sha2::Sha384;
 }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -49,7 +49,7 @@ std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std", "getrandom", "primeorde
 
 arithmetic = ["elliptic-curve/arithmetic", "dep:primeorder"]
 critical-section = ["primeorder/critical-section", "precomputed-tables"]
-digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
+digest = ["ecdsa-core/digest"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm", "sha256"]
 hash2curve = ["arithmetic", "dep:hash2curve", "primeorder/hash2curve"]

--- a/k256/src/ecdsa.rs
+++ b/k256/src/ecdsa.rs
@@ -91,10 +91,9 @@ pub use ecdsa_core::{
     signature::{self, Error},
 };
 
-#[cfg(any(feature = "ecdsa", feature = "sha256"))]
-pub use ecdsa_core::hazmat;
-
 use crate::Secp256k1;
+#[cfg(feature = "sha256")]
+use ecdsa_core::DigestAlgorithm;
 
 /// ECDSA/secp256k1 signature (fixed-size)
 pub type Signature = ecdsa_core::Signature<Secp256k1>;
@@ -115,7 +114,7 @@ pub type SigningKey = ecdsa_core::SigningKey<Secp256k1>;
 pub type VerifyingKey = ecdsa_core::VerifyingKey<Secp256k1>;
 
 #[cfg(feature = "sha256")]
-impl hazmat::DigestAlgorithm for Secp256k1 {
+impl DigestAlgorithm for Secp256k1 {
     type Digest = sha2::Sha256;
 }
 

--- a/k256/src/schnorr.rs
+++ b/k256/src/schnorr.rs
@@ -321,6 +321,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn bip340_ext_sign_vectors() {
         // Test indexes 15-18 from https://github.com/bitcoin/bips/blob/master/bip-0340/test-vectors.csv
         //

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -37,7 +37,7 @@ alloc = ["elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "elliptic-curve/std", "getrandom", "primeorder?/std"]
 
 arithmetic = ["dep:primefield", "dep:primeorder", "elliptic-curve/arithmetic"]
-digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
+digest = ["ecdsa-core/digest"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm"]
 getrandom = ["ecdsa-core?/getrandom", "elliptic-curve/getrandom"]
 pem = ["elliptic-curve/pem", "pkcs8"]

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -38,7 +38,7 @@ alloc = ["elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "elliptic-curve/std", "getrandom", "primeorder?/std"]
 
 arithmetic = ["dep:primefield", "dep:primeorder", "elliptic-curve/arithmetic"]
-digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
+digest = ["ecdsa-core/digest"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm", "sha224"]
 getrandom = ["ecdsa-core?/getrandom", "elliptic-curve/getrandom"]

--- a/p224/src/ecdsa.rs
+++ b/p224/src/ecdsa.rs
@@ -66,7 +66,7 @@ pub type SigningKey = ecdsa_core::SigningKey<NistP224>;
 pub type VerifyingKey = ecdsa_core::VerifyingKey<NistP224>;
 
 #[cfg(feature = "sha224")]
-impl ecdsa_core::hazmat::DigestAlgorithm for NistP224 {
+impl ecdsa_core::DigestAlgorithm for NistP224 {
     type Digest = sha2::Sha224;
 }
 

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -43,7 +43,7 @@ alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std", "getrandom", "primeorder?/std"]
 
 arithmetic = ["dep:primefield", "dep:primeorder", "elliptic-curve/arithmetic"]
-digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
+digest = ["ecdsa-core/digest"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm", "sha256"]
 hash2curve = ["arithmetic", "dep:hash2curve", "primeorder/hash2curve"]

--- a/p256/src/ecdsa.rs
+++ b/p256/src/ecdsa.rs
@@ -69,7 +69,7 @@ pub type SigningKey = ecdsa_core::SigningKey<NistP256>;
 pub type VerifyingKey = ecdsa_core::VerifyingKey<NistP256>;
 
 #[cfg(feature = "sha256")]
-impl ecdsa_core::hazmat::DigestAlgorithm for NistP256 {
+impl ecdsa_core::DigestAlgorithm for NistP256 {
     type Digest = sha2::Sha256;
 }
 #[cfg(all(test, feature = "ecdsa"))]

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -50,7 +50,7 @@ arithmetic = [
     "elliptic-curve/arithmetic",
     "elliptic-curve/digest"
 ]
-digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
+digest = ["ecdsa-core/digest"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm", "sha384"]
 hash2curve = ["arithmetic", "dep:hash2curve", "primeorder/hash2curve"]

--- a/p384/src/ecdsa.rs
+++ b/p384/src/ecdsa.rs
@@ -66,7 +66,7 @@ pub type SigningKey = ecdsa_core::SigningKey<NistP384>;
 pub type VerifyingKey = ecdsa_core::VerifyingKey<NistP384>;
 
 #[cfg(feature = "sha384")]
-impl ecdsa_core::hazmat::DigestAlgorithm for NistP384 {
+impl ecdsa_core::DigestAlgorithm for NistP384 {
     type Digest = sha2::Sha384;
 }
 

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -43,7 +43,7 @@ alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std", "getrandom", "primeorder?/std"]
 
 arithmetic = ["dep:primefield", "dep:primeorder"]
-digest = ["ecdsa-core/digest", "ecdsa-core/hazmat"]
+digest = ["ecdsa-core/digest"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh"]
 ecdsa = ["arithmetic", "ecdsa-core/algorithm", "sha512"]
 hash2curve = ["arithmetic", "dep:hash2curve", "primeorder/hash2curve"]

--- a/p521/src/ecdsa.rs
+++ b/p521/src/ecdsa.rs
@@ -66,7 +66,7 @@ pub type SigningKey = ecdsa_core::SigningKey<NistP521>;
 pub type VerifyingKey = ecdsa_core::VerifyingKey<NistP521>;
 
 #[cfg(feature = "sha512")]
-impl ecdsa_core::hazmat::DigestAlgorithm for NistP521 {
+impl ecdsa_core::DigestAlgorithm for NistP521 {
     type Digest = sha2::Sha512;
 }
 

--- a/sm2/src/dsa/signing.rs
+++ b/sm2/src/dsa/signing.rs
@@ -16,13 +16,12 @@
 
 use super::{Signature, VerifyingKey};
 use crate::{
-    DistId, FieldBytes, NonZeroScalar, ProjectivePoint, PublicKey, Scalar, SecretKey, Sm2,
+    DistId, FieldBytes, NonZeroScalar, ProjectivePoint, PublicKey, Scalar, SecretKey, Sm2, U256,
 };
 use core::fmt::{self, Debug};
 use elliptic_curve::{
     Curve, Group, PrimeField,
     array::typenum::Unsigned,
-    field,
     ops::Reduce,
     point::AffineCoordinates,
     subtle::{Choice, ConstantTimeEq},
@@ -217,17 +216,27 @@ fn sign_prehash_rfc6979(secret_scalar: &Scalar, prehash: &[u8], data: &[u8]) -> 
     }
 
     // A2: calculate e=Hv(M~)
-    #[allow(deprecated)] // from_slice
-    let e = Scalar::reduce(FieldBytes::from_slice(prehash));
+    let e = bytes2scalar(prehash);
 
     // A3: pick a random number k in [1, n-1] via a random number generator
-    let k = Scalar::from_repr(rfc6979::generate_k::<Sm3, _>(
+    //
+    // NOTE: we use RFC6979 as our "random number generator", optionally supplemented with `data`.
+    // Though SM2DSA doesn't mandate use of RFC6979 it ensures `k` is generated in a uniformly
+    // random manner since the algorithm samples from the uniformly random outputs of HMAC-DRBG and
+    // uses rejection sampling to find `k` in `[1, n-1]` in an unbiased manner.
+    let mut kgen = rfc6979::KGenerator::<Sm3, U256>::new(
         &secret_scalar.to_repr(),
-        &field::uint_to_bytes::<Sm2>(&Sm2::ORDER),
         &e.to_bytes(),
         data,
-    ))
-    .unwrap();
+        &Sm2::ORDER,
+    );
+
+    // TODO(tarcieri): add a loop and retry `kgen.fill_next_k` until we succeed
+    let mut k_bytes = FieldBytes::default();
+    kgen.fill_next_k(&mut k_bytes);
+    let k = Scalar::from_repr(k_bytes)
+        .into_option()
+        .ok_or_else(Error::new)?;
 
     // A4: calculate the elliptic curve point (x1, y1)=[k]G
     let R = ProjectivePoint::mul_by_generator(&k).to_affine();
@@ -254,4 +263,17 @@ impl SignatureAlgorithmIdentifier for SigningKey {
 
     const SIGNATURE_ALGORITHM_IDENTIFIER: AlgorithmIdentifier<Self::Params> =
         Signature::ALGORITHM_IDENTIFIER;
+}
+
+/// Convert bytestring into a scalar, interpreting it as big endian, zero-padding or truncating it
+/// to the bit length of `n` (curve order) if necessary, and then reducing it mod `n`.
+fn bytes2scalar(mut bytes: &[u8]) -> Scalar {
+    // Compute number of bytes in `n` (curve order)
+    let n_bits = Sm2::ORDER.bits();
+    let n_bytes = n_bits.div_ceil(8) as usize;
+    if bytes.len() > n_bytes {
+        bytes = &bytes[..n_bytes];
+    }
+
+    <Scalar as Reduce<U256>>::reduce(&U256::from_be_slice_truncated(bytes, n_bits))
 }

--- a/sm2/src/lib.rs
+++ b/sm2/src/lib.rs
@@ -56,7 +56,6 @@ extern crate alloc;
 
 #[cfg(feature = "dsa")]
 pub mod dsa;
-
 #[cfg(feature = "pke")]
 pub mod pke;
 


### PR DESCRIPTION
This tests out the substantial changes made to the `rfc6979` crate in RustCrypto/signatures#1395, including a move to a new stateful API.

Most of these were behind the scenes but there are a couple important ones which impact all crates:
- `ecdsa::hazmat::DigestAlgorithm` => `ecdsa::DigestAlgorithm`
- There is no longer a `hazmat` feature on `ecdsa`