### PR TITLE
Bump `ecdsa` to v0.17.0-rc.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,8 +427,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.22"
-source = "git+https://github.com/RustCrypto/signatures#ed4b91ce6ceb4cf6d44af9e6020efa97000c0f22"
+version = "0.17.0-rc.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa0176db12735e38bffeaa3c19ba4470216007496b2088632369bcee6eb5069"
 dependencies = [
  "der",
  "digest",
@@ -1123,11 +1124,11 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rfc6979"
-version = "0.6.0-pre.0"
-source = "git+https://github.com/RustCrypto/signatures#ed4b91ce6ceb4cf6d44af9e6020efa97000c0f22"
+version = "0.6.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b056b3ce73e99ed2e78481b3db9c30722b1eab738e25b71ca57c9d9285e6276"
 dependencies = [
  "crypto-bigint",
- "ctutils",
  "hmac",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,3 @@ hash2curve = { path = "hash2curve" }
 primefield = { path = "primefield" }
 primeorder = { path = "primeorder" }
 wnaf = { path = "wnaf" }
-
-ecdsa = { git = "https://github.com/RustCrypto/signatures" }
-rfc6979 = { git = "https://github.com/RustCrypto/signatures" }

--- a/bp256/Cargo.toml
+++ b/bp256/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.22", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.23", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14", optional = true }
 primeorder = { version = "0.14.0-rc.14", optional = true }
 sha2 = { version = "0.11", optional = true, default-features = false }

--- a/bp384/Cargo.toml
+++ b/bp384/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa = { version = "0.17.0-rc.22", optional = true, default-features = false, features = ["der"] }
+ecdsa = { version = "0.17.0-rc.23", optional = true, default-features = false, features = ["der"] }
 primefield = { version = "0.14", optional = true }
 primeorder = { version = "0.14.0-rc.14", optional = true }
 sha2 = { version = "0.11", optional = true, default-features = false }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -24,7 +24,7 @@ elliptic-curve = { version = "0.14.1", default-features = false, features = ["se
 hash2curve = { version = "0.14", optional = true }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.23", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primeorder = { version = "0.14.0-rc.14", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
@@ -34,7 +34,7 @@ wnaf = { version = "0.14.0-rc.1", default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.23", package = "ecdsa", default-features = false, features = ["dev"] }
 hex = "0.4.3"
 hex-literal = "1"
 num-bigint = "0.4"

--- a/p192/Cargo.toml
+++ b/p192/Cargo.toml
@@ -20,14 +20,14 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.23", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14", optional = true }
 primeorder = { version = "0.14.0-rc.14", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.23", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.14", features = ["dev"] }
 

--- a/p224/Cargo.toml
+++ b/p224/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.23", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14", optional = true }
 primeorder = { version = "0.14.0-rc.14", optional = true }
@@ -28,7 +28,7 @@ serdect = { version = "0.4", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
-ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.23", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.14", features = ["dev"] }
 

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.23", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14", optional = true }
@@ -31,7 +31,7 @@ sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.23", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primefield = { version = "0.14" }
 primeorder = { version = "0.14.0-rc.14", features = ["dev"] }

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.85"
 elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.23", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14", optional = true }
@@ -34,7 +34,7 @@ fiat-crypto = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.23", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.14", features = ["dev"] }
 proptest = "1.11"

--- a/p521/Cargo.toml
+++ b/p521/Cargo.toml
@@ -21,7 +21,7 @@ base16ct = "1"
 elliptic-curve = { version = "0.14.1", default-features = false, features = ["sec1"] }
 
 # optional dependencies
-ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+ecdsa-core = { version = "0.17.0-rc.23", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hash2curve = { version = "0.14", optional = true }
 hex-literal = { version = "1", optional = true }
 primefield = { version = "0.14", optional = true }
@@ -32,7 +32,7 @@ sha2 = { version = "0.11", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-ecdsa-core = { version = "0.17.0-rc.22", package = "ecdsa", default-features = false, features = ["dev"] }
+ecdsa-core = { version = "0.17.0-rc.23", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "1"
 primeorder = { version = "0.14.0-rc.14", features = ["dev"] }
 proptest = "1.11"

--- a/sm2/Cargo.toml
+++ b/sm2/Cargo.toml
@@ -26,7 +26,7 @@ rand_core = { version = "0.10", default-features = false }
 der = { version = "0.8", optional = true }
 primefield = { version = "0.14", optional = true }
 primeorder = { version = "0.14.0-rc.14", optional = true }
-rfc6979 = { version = "0.6.0-pre.0", optional = true }
+rfc6979 = { version = "0.6.0-rc.0", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 signature = { version = "3", optional = true, features = ["rand_core"] }
 sm3 = { version = "0.5", optional = true, default-features = false }


### PR DESCRIPTION
This includes the newly rewritten `rfc6979` v0.6.0-rc.0