### PR TITLE
k256: extract `arithmetic::mul::glv` submodule

### DIFF
--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -34,10 +34,9 @@
 //! (Note that 'd' is also equal to the curve order here because `[a1,b1]` and `[a2,b2]` are found
 //! as outputs of the Extended Euclidean Algorithm on inputs 'order' and 'lambda').
 
-use super::{
-    ProjectivePoint,
-    scalar::{Scalar, WideScalar},
-};
+mod glv;
+
+use super::{ProjectivePoint, scalar::Scalar};
 use core::array;
 use elliptic_curve::{
     array::sizes::{U5, U33},
@@ -45,7 +44,7 @@ use elliptic_curve::{
     scalar::IsHigh,
     subtle::ConditionallySelectable,
 };
-use primeorder::{PrimeFieldExt, Radix16Decomposition};
+use primeorder::Radix16Decomposition;
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -64,150 +63,6 @@ type WnafBase = wnaf::WnafBase<ProjectivePoint, WnafWindowSize>;
 /// `WnafScalar` specialized for `k256`.
 type WnafScalar = wnaf::WnafScalar<Scalar, WnafWindowSize>;
 
-const MINUS_LAMBDA: Scalar = Scalar::from_bytes_unchecked(&[
-    0xac, 0x9c, 0x52, 0xb3, 0x3f, 0xa3, 0xcf, 0x1f, 0x5a, 0xd9, 0xe3, 0xfd, 0x77, 0xed, 0x9b, 0xa4,
-    0xa8, 0x80, 0xb9, 0xfc, 0x8e, 0xc7, 0x39, 0xc2, 0xe0, 0xcf, 0xc8, 0x10, 0xb5, 0x12, 0x83, 0xcf,
-]);
-
-const MINUS_B1: Scalar = Scalar::from_bytes_unchecked(&[
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0xe4, 0x43, 0x7e, 0xd6, 0x01, 0x0e, 0x88, 0x28, 0x6f, 0x54, 0x7f, 0xa9, 0x0a, 0xbf, 0xe4, 0xc3,
-]);
-
-const MINUS_B2: Scalar = Scalar::from_bytes_unchecked(&[
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe,
-    0x8a, 0x28, 0x0a, 0xc5, 0x07, 0x74, 0x34, 0x6d, 0xd7, 0x65, 0xcd, 0xa8, 0x3d, 0xb1, 0x56, 0x2c,
-]);
-
-const G1: Scalar = Scalar::from_bytes_unchecked(&[
-    0x30, 0x86, 0xd2, 0x21, 0xa7, 0xd4, 0x6b, 0xcd, 0xe8, 0x6c, 0x90, 0xe4, 0x92, 0x84, 0xeb, 0x15,
-    0x3d, 0xaa, 0x8a, 0x14, 0x71, 0xe8, 0xca, 0x7f, 0xe8, 0x93, 0x20, 0x9a, 0x45, 0xdb, 0xb0, 0x31,
-]);
-
-const G2: Scalar = Scalar::from_bytes_unchecked(&[
-    0xe4, 0x43, 0x7e, 0xd6, 0x01, 0x0e, 0x88, 0x28, 0x6f, 0x54, 0x7f, 0xa9, 0x0a, 0xbf, 0xe4, 0xc4,
-    0x22, 0x12, 0x08, 0xac, 0x9d, 0xf5, 0x06, 0xc6, 0x15, 0x71, 0xb4, 0xae, 0x8a, 0xc4, 0x7f, 0x71,
-]);
-
-/// Number of little-endian bytes to feed into `WnafScalar::from_le_bytes` for a GLV half-scalar.
-/// GLV guarantees magnitude < 2^128 (16 bytes).
-const GLV_LE_BYTES: usize = 16;
-
-/*
- * Proof for decompose_scalar's bounds.
- *
- * Let
- *  - epsilon1 = 2^256 * |g1/2^384 - b2/d|
- *  - epsilon2 = 2^256 * |g2/2^384 - (-b1)/d|
- *  - c1 = round(k*g1/2^384)
- *  - c2 = round(k*g2/2^384)
- *
- * Lemma 1: |c1 - k*b2/d| < 2^-1 + epsilon1
- *
- *    |c1 - k*b2/d|
- *  =
- *    |c1 - k*g1/2^384 + k*g1/2^384 - k*b2/d|
- * <=   {triangle inequality}
- *    |c1 - k*g1/2^384| + |k*g1/2^384 - k*b2/d|
- *  =
- *    |c1 - k*g1/2^384| + k*|g1/2^384 - b2/d|
- * <    {rounding in c1 and 0 <= k < 2^256}
- *    2^-1 + 2^256 * |g1/2^384 - b2/d|
- *  =   {definition of epsilon1}
- *    2^-1 + epsilon1
- *
- * Lemma 2: |c2 - k*(-b1)/d| < 2^-1 + epsilon2
- *
- *    |c2 - k*(-b1)/d|
- *  =
- *    |c2 - k*g2/2^384 + k*g2/2^384 - k*(-b1)/d|
- * <=   {triangle inequality}
- *    |c2 - k*g2/2^384| + |k*g2/2^384 - k*(-b1)/d|
- *  =
- *    |c2 - k*g2/2^384| + k*|g2/2^384 - (-b1)/d|
- * <    {rounding in c2 and 0 <= k < 2^256}
- *    2^-1 + 2^256 * |g2/2^384 - (-b1)/d|
- *  =   {definition of epsilon2}
- *    2^-1 + epsilon2
- *
- * Let
- *  - k1 = k - c1*a1 - c2*a2
- *  - k2 = - c1*b1 - c2*b2
- *
- * Lemma 3: |k1| < (a1 + a2 + 1)/2 < 2^128
- *
- *    |k1|
- *  =   {definition of k1}
- *    |k - c1*a1 - c2*a2|
- *  =   {(a1*b2 - b1*a2)/n = 1}
- *    |k*(a1*b2 - b1*a2)/n - c1*a1 - c2*a2|
- *  =
- *    |a1*(k*b2/n - c1) + a2*(k*(-b1)/n - c2)|
- * <=   {triangle inequality}
- *    a1*|k*b2/n - c1| + a2*|k*(-b1)/n - c2|
- * <    {Lemma 1 and Lemma 2}
- *    a1*(2^-1 + epsilon1) + a2*(2^-1 + epsilon2)
- * <    {rounding up to an integer}
- *    (a1 + a2 + 1)/2
- * <    {rounding up to a power of 2}
- *    2^128
- *
- * Lemma 4: |k2| < (-b1 + b2)/2 + 1 < 2^128
- *
- *    |k2|
- *  =   {definition of k2}
- *    |- c1*a1 - c2*a2|
- *  =   {(b1*b2 - b1*b2)/n = 0}
- *    |k*(b1*b2 - b1*b2)/n - c1*b1 - c2*b2|
- *  =
- *    |b1*(k*b2/n - c1) + b2*(k*(-b1)/n - c2)|
- * <=   {triangle inequality}
- *    (-b1)*|k*b2/n - c1| + b2*|k*(-b1)/n - c2|
- * <    {Lemma 1 and Lemma 2}
- *    (-b1)*(2^-1 + epsilon1) + b2*(2^-1 + epsilon2)
- * <    {rounding up to an integer}
- *    (-b1 + b2)/2 + 1
- * <    {rounding up to a power of 2}
- *    2^128
- *
- * Let
- *  - r2 = k2 mod n
- *  - r1 = k - r2*lambda mod n.
- *
- * Notice that r1 is defined such that r1 + r2 * lambda == k (mod n).
- *
- * Lemma 5: r1 == k1 mod n.
- *
- *    r1
- * ==   {definition of r1 and r2}
- *    k - k2*lambda
- * ==   {definition of k2}
- *    k - (- c1*b1 - c2*b2)*lambda
- * ==
- *    k + c1*b1*lambda + c2*b2*lambda
- * ==  {a1 + b1*lambda == 0 mod n and a2 + b2*lambda == 0 mod n}
- *    k - c1*a1 - c2*a2
- * ==  {definition of k1}
- *    k1
- *
- * From Lemma 3, Lemma 4, Lemma 5 and the definition of r2, we can conclude that
- *
- *  - either r1 < 2^128 or -r1 mod n < 2^128
- *  - either r2 < 2^128 or -r2 mod n < 2^128.
- *
- * Q.E.D.
- */
-
-/// Find r1 and r2 given k, such that r1 + r2 * lambda == k mod n.
-fn decompose_scalar(k: &Scalar) -> (Scalar, Scalar) {
-    // these _vartime calls are constant time since the shift amount is constant
-    let c1 = WideScalar::mul_shift_vartime(k, &G1, 384) * MINUS_B1;
-    let c2 = WideScalar::mul_shift_vartime(k, &G2, 384) * MINUS_B2;
-    let r2 = c1 + c2;
-    let r1 = k + r2 * MINUS_LAMBDA;
-    (r1, r2)
-}
-
 impl<const N: usize> LinearCombination<[(ProjectivePoint, Scalar); N]> for ProjectivePoint {
     fn lincomb(points_and_scalars: &[(ProjectivePoint, Scalar); N]) -> Self {
         let mut tables = [(LookupTable::default(), LookupTable::default()); N];
@@ -219,7 +74,7 @@ impl<const N: usize> LinearCombination<[(ProjectivePoint, Scalar); N]> for Proje
     fn lincomb_vartime(points_and_scalars: &[(ProjectivePoint, Scalar); N]) -> Self {
         let decomposed: [_; N] = array::from_fn(|i| {
             let (x, k) = &points_and_scalars[i];
-            decompose_glv_wnaf(x, k)
+            glv::decompose_wnaf(x, k)
         });
 
         lincomb_vartime_glv_wnaf(&decomposed)
@@ -246,7 +101,7 @@ impl LinearCombination<[(ProjectivePoint, Scalar)]> for ProjectivePoint {
     fn lincomb_vartime(points_and_scalars: &[(ProjectivePoint, Scalar)]) -> Self {
         let decomposed: Vec<_> = points_and_scalars
             .iter()
-            .map(|(x, k)| decompose_glv_wnaf(x, k))
+            .map(|(x, k)| glv::decompose_wnaf(x, k))
             .collect();
 
         lincomb_vartime_glv_wnaf(&decomposed)
@@ -260,7 +115,7 @@ fn lincomb(
     digits: &mut [(Radix16Decomposition<U33>, Radix16Decomposition<U33>)],
 ) -> ProjectivePoint {
     xks.iter().enumerate().for_each(|(i, (x, k))| {
-        let (r1, r2) = decompose_scalar(k);
+        let (r1, r2) = glv::decompose_scalar(k);
         let x_beta = x.endomorphism();
         let (r1_sign, r2_sign) = (r1.is_high(), r2.is_high());
 
@@ -308,7 +163,7 @@ fn lincomb(
 }
 
 /// Linear combination / multiscalar multiplication using inputs decomposed for the GLV endomorphism
-/// (using `decompose_glv_wnaf`) in combination with w-NAF scalar multiplication.
+/// (using `glv::decompose_wnaf`) in combination with w-NAF scalar multiplication.
 fn lincomb_vartime_glv_wnaf(
     decomposed_xks: &[([WnafBase; 2], [WnafScalar; 2])],
 ) -> ProjectivePoint {
@@ -385,41 +240,8 @@ fn mul(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
 fn mul_vartime(x: &ProjectivePoint, k: &Scalar) -> ProjectivePoint {
     let mut bases = [WnafBase::default(), WnafBase::default()];
     let mut scalars = [WnafScalar::default(), WnafScalar::default()];
-    decompose_glv_wnaf_into(x, k, &mut bases, &mut scalars);
+    glv::decompose_wnaf_into(x, k, &mut bases, &mut scalars);
     WnafBase::multiscalar_mul([(&bases[0], &scalars[0]), (&bases[1], &scalars[1])].into_iter())
-}
-
-/// GLV-decompose `k` for `x`: two `(WnafBase, WnafScalar)` pairs representing `r1 * self_signed`
-/// and `r2 * endomorphism(self_signed)`, with signs folded into the points.
-#[inline]
-fn decompose_glv_wnaf_into(
-    x: &ProjectivePoint,
-    k: &Scalar,
-    bases: &mut [WnafBase; 2],
-    scalars: &mut [WnafScalar; 2],
-) {
-    let (r1, r2) = decompose_scalar(k);
-    let r1_neg = bool::from(r1.is_high());
-    let r2_neg = bool::from(r2.is_high());
-    let r1 = if r1_neg { -r1 } else { r1 };
-    let r2 = if r2_neg { -r2 } else { r2 };
-    scalars[0].init_from_le_bytes(&r1.to_le_repr()[..GLV_LE_BYTES]);
-    scalars[1].init_from_le_bytes(&r2.to_le_repr()[..GLV_LE_BYTES]);
-
-    let p1 = if r1_neg { -*x } else { *x };
-    let p_beta = x.endomorphism();
-    let p2 = if r2_neg { -p_beta } else { p_beta };
-    bases[0].init_from_base(&p1);
-    bases[1].init_from_base(&p2);
-}
-
-/// Perform GLV decomposition and return the resulting w-NAF bases and scalars.
-#[inline]
-fn decompose_glv_wnaf(x: &ProjectivePoint, k: &Scalar) -> ([WnafBase; 2], [WnafScalar; 2]) {
-    let mut bases = [WnafBase::default(), WnafBase::default()];
-    let mut scalars = [WnafScalar::default(), WnafScalar::default()];
-    decompose_glv_wnaf_into(x, k, &mut bases, &mut scalars);
-    (bases, scalars)
 }
 
 impl Mul<Scalar> for ProjectivePoint {
@@ -478,8 +300,8 @@ impl MulByGeneratorVartime for ProjectivePoint {
 
     fn mul_by_generator_and_mul_add_vartime(a: &Self::Scalar, b: &Self::Scalar, p: &Self) -> Self {
         let decomposed = [
-            decompose_glv_wnaf(&ProjectivePoint::GENERATOR, a),
-            decompose_glv_wnaf(p, b),
+            glv::decompose_wnaf(&ProjectivePoint::GENERATOR, a),
+            glv::decompose_wnaf(p, b),
         ];
 
         lincomb_vartime_glv_wnaf(&decomposed)

--- a/k256/src/arithmetic/mul/glv.rs
+++ b/k256/src/arithmetic/mul/glv.rs
@@ -1,0 +1,189 @@
+//! Support for using secp256k1's GLV (Gallant-Lambert-Vanstone) endomorphism for accelerating
+//! scalar multiplication by decomposing scalars into smaller sub-scalars.
+
+use super::{WnafBase, WnafScalar};
+use crate::{ProjectivePoint, Scalar, arithmetic::scalar::WideScalar};
+use elliptic_curve::scalar::IsHigh;
+use primeorder::PrimeFieldExt;
+
+/// Negative endomorphism eigenvalue used for GLV scalar decomposition.
+const MINUS_LAMBDA: Scalar = Scalar::from_bytes_unchecked(&[
+    0xac, 0x9c, 0x52, 0xb3, 0x3f, 0xa3, 0xcf, 0x1f, 0x5a, 0xd9, 0xe3, 0xfd, 0x77, 0xed, 0x9b, 0xa4,
+    0xa8, 0x80, 0xb9, 0xfc, 0x8e, 0xc7, 0x39, 0xc2, 0xe0, 0xcf, 0xc8, 0x10, 0xb5, 0x12, 0x83, 0xcf,
+]);
+
+/// Negated lattice basis coefficient B1.
+const MINUS_B1: Scalar = Scalar::from_bytes_unchecked(&[
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0xe4, 0x43, 0x7e, 0xd6, 0x01, 0x0e, 0x88, 0x28, 0x6f, 0x54, 0x7f, 0xa9, 0x0a, 0xbf, 0xe4, 0xc3,
+]);
+
+/// Negated lattice basis coefficient B2.
+const MINUS_B2: Scalar = Scalar::from_bytes_unchecked(&[
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe,
+    0x8a, 0x28, 0x0a, 0xc5, 0x07, 0x74, 0x34, 0x6d, 0xd7, 0x65, 0xcd, 0xa8, 0x3d, 0xb1, 0x56, 0x2c,
+]);
+
+/// Lattice projection coefficient G1.
+const G1: Scalar = Scalar::from_bytes_unchecked(&[
+    0x30, 0x86, 0xd2, 0x21, 0xa7, 0xd4, 0x6b, 0xcd, 0xe8, 0x6c, 0x90, 0xe4, 0x92, 0x84, 0xeb, 0x15,
+    0x3d, 0xaa, 0x8a, 0x14, 0x71, 0xe8, 0xca, 0x7f, 0xe8, 0x93, 0x20, 0x9a, 0x45, 0xdb, 0xb0, 0x31,
+]);
+
+/// Lattice projection coefficient G2.
+const G2: Scalar = Scalar::from_bytes_unchecked(&[
+    0xe4, 0x43, 0x7e, 0xd6, 0x01, 0x0e, 0x88, 0x28, 0x6f, 0x54, 0x7f, 0xa9, 0x0a, 0xbf, 0xe4, 0xc4,
+    0x22, 0x12, 0x08, 0xac, 0x9d, 0xf5, 0x06, 0xc6, 0x15, 0x71, 0xb4, 0xae, 0x8a, 0xc4, 0x7f, 0x71,
+]);
+
+/// Number of little-endian bytes to feed into `WnafScalar::from_le_bytes` for a GLV half-scalar.
+/// GLV guarantees magnitude < 2^128 (16 bytes).
+const GLV_LE_BYTES: usize = 16;
+
+/*
+ * Proof for decompose_scalar's bounds.
+ *
+ * Let
+ *  - epsilon1 = 2^256 * |g1/2^384 - b2/d|
+ *  - epsilon2 = 2^256 * |g2/2^384 - (-b1)/d|
+ *  - c1 = round(k*g1/2^384)
+ *  - c2 = round(k*g2/2^384)
+ *
+ * Lemma 1: |c1 - k*b2/d| < 2^-1 + epsilon1
+ *
+ *    |c1 - k*b2/d|
+ *  =
+ *    |c1 - k*g1/2^384 + k*g1/2^384 - k*b2/d|
+ * <=   {triangle inequality}
+ *    |c1 - k*g1/2^384| + |k*g1/2^384 - k*b2/d|
+ *  =
+ *    |c1 - k*g1/2^384| + k*|g1/2^384 - b2/d|
+ * <    {rounding in c1 and 0 <= k < 2^256}
+ *    2^-1 + 2^256 * |g1/2^384 - b2/d|
+ *  =   {definition of epsilon1}
+ *    2^-1 + epsilon1
+ *
+ * Lemma 2: |c2 - k*(-b1)/d| < 2^-1 + epsilon2
+ *
+ *    |c2 - k*(-b1)/d|
+ *  =
+ *    |c2 - k*g2/2^384 + k*g2/2^384 - k*(-b1)/d|
+ * <=   {triangle inequality}
+ *    |c2 - k*g2/2^384| + |k*g2/2^384 - k*(-b1)/d|
+ *  =
+ *    |c2 - k*g2/2^384| + k*|g2/2^384 - (-b1)/d|
+ * <    {rounding in c2 and 0 <= k < 2^256}
+ *    2^-1 + 2^256 * |g2/2^384 - (-b1)/d|
+ *  =   {definition of epsilon2}
+ *    2^-1 + epsilon2
+ *
+ * Let
+ *  - k1 = k - c1*a1 - c2*a2
+ *  - k2 = - c1*b1 - c2*b2
+ *
+ * Lemma 3: |k1| < (a1 + a2 + 1)/2 < 2^128
+ *
+ *    |k1|
+ *  =   {definition of k1}
+ *    |k - c1*a1 - c2*a2|
+ *  =   {(a1*b2 - b1*a2)/n = 1}
+ *    |k*(a1*b2 - b1*a2)/n - c1*a1 - c2*a2|
+ *  =
+ *    |a1*(k*b2/n - c1) + a2*(k*(-b1)/n - c2)|
+ * <=   {triangle inequality}
+ *    a1*|k*b2/n - c1| + a2*|k*(-b1)/n - c2|
+ * <    {Lemma 1 and Lemma 2}
+ *    a1*(2^-1 + epsilon1) + a2*(2^-1 + epsilon2)
+ * <    {rounding up to an integer}
+ *    (a1 + a2 + 1)/2
+ * <    {rounding up to a power of 2}
+ *    2^128
+ *
+ * Lemma 4: |k2| < (-b1 + b2)/2 + 1 < 2^128
+ *
+ *    |k2|
+ *  =   {definition of k2}
+ *    |- c1*a1 - c2*a2|
+ *  =   {(b1*b2 - b1*b2)/n = 0}
+ *    |k*(b1*b2 - b1*b2)/n - c1*b1 - c2*b2|
+ *  =
+ *    |b1*(k*b2/n - c1) + b2*(k*(-b1)/n - c2)|
+ * <=   {triangle inequality}
+ *    (-b1)*|k*b2/n - c1| + b2*|k*(-b1)/n - c2|
+ * <    {Lemma 1 and Lemma 2}
+ *    (-b1)*(2^-1 + epsilon1) + b2*(2^-1 + epsilon2)
+ * <    {rounding up to an integer}
+ *    (-b1 + b2)/2 + 1
+ * <    {rounding up to a power of 2}
+ *    2^128
+ *
+ * Let
+ *  - r2 = k2 mod n
+ *  - r1 = k - r2*lambda mod n.
+ *
+ * Notice that r1 is defined such that r1 + r2 * lambda == k (mod n).
+ *
+ * Lemma 5: r1 == k1 mod n.
+ *
+ *    r1
+ * ==   {definition of r1 and r2}
+ *    k - k2*lambda
+ * ==   {definition of k2}
+ *    k - (- c1*b1 - c2*b2)*lambda
+ * ==
+ *    k + c1*b1*lambda + c2*b2*lambda
+ * ==  {a1 + b1*lambda == 0 mod n and a2 + b2*lambda == 0 mod n}
+ *    k - c1*a1 - c2*a2
+ * ==  {definition of k1}
+ *    k1
+ *
+ * From Lemma 3, Lemma 4, Lemma 5 and the definition of r2, we can conclude that
+ *
+ *  - either r1 < 2^128 or -r1 mod n < 2^128
+ *  - either r2 < 2^128 or -r2 mod n < 2^128.
+ *
+ * Q.E.D.
+ */
+
+/// Find r1 and r2 given k, such that r1 + r2 * lambda == k mod n.
+pub(super) fn decompose_scalar(k: &Scalar) -> (Scalar, Scalar) {
+    // these _vartime calls are constant time since the shift amount is constant
+    let c1 = WideScalar::mul_shift_vartime(k, &G1, 384) * MINUS_B1;
+    let c2 = WideScalar::mul_shift_vartime(k, &G2, 384) * MINUS_B2;
+    let r2 = c1 + c2;
+    let r1 = k + r2 * MINUS_LAMBDA;
+    (r1, r2)
+}
+
+/// Perform GLV decomposition and return the resulting w-NAF bases and scalars.
+#[inline]
+pub(super) fn decompose_wnaf(x: &ProjectivePoint, k: &Scalar) -> ([WnafBase; 2], [WnafScalar; 2]) {
+    let mut bases = [WnafBase::default(), WnafBase::default()];
+    let mut scalars = [WnafScalar::default(), WnafScalar::default()];
+    decompose_wnaf_into(x, k, &mut bases, &mut scalars);
+    (bases, scalars)
+}
+
+/// GLV-decompose `k` for `x`: two `(WnafBase, WnafScalar)` pairs representing `r1 * self_signed`
+/// and `r2 * endomorphism(self_signed)`, with signs folded into the points.
+#[inline]
+pub(super) fn decompose_wnaf_into(
+    x: &ProjectivePoint,
+    k: &Scalar,
+    bases: &mut [WnafBase; 2],
+    scalars: &mut [WnafScalar; 2],
+) {
+    let (r1, r2) = decompose_scalar(k);
+    let r1_neg = bool::from(r1.is_high());
+    let r2_neg = bool::from(r2.is_high());
+    let r1 = if r1_neg { -r1 } else { r1 };
+    let r2 = if r2_neg { -r2 } else { r2 };
+    scalars[0].init_from_le_bytes(&r1.to_le_repr()[..GLV_LE_BYTES]);
+    scalars[1].init_from_le_bytes(&r2.to_le_repr()[..GLV_LE_BYTES]);
+
+    let p1 = if r1_neg { -*x } else { *x };
+    let p_beta = x.endomorphism();
+    let p2 = if r2_neg { -p_beta } else { p_beta };
+    bases[0].init_from_base(&p1);
+    bases[1].init_from_base(&p2);
+}


### PR DESCRIPTION
Extracts a submodule containing the implementation details of how we leverage the GLV endomorphism