### PR TITLE
p256: vendor and fix workspace-level lints

### DIFF
--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -57,9 +57,7 @@ serde = ["ecdsa-core?/serde", "elliptic-curve/serde", "primeorder?/serde", "serd
 sha256 = ["digest", "sha2"]
 test-vectors = ["dep:hex-literal"]
 
-[lints.rust.unexpected_cfgs]
-level = "warn"
-check-cfg = ['cfg(cpubits, values("16", "32", "64"))']
+
 
 [[bench]]
 name = "ecdsa"
@@ -77,6 +75,52 @@ harness = false
 [[bench]]
 name = "scalar"
 harness = false
+
+# NOTE: can't use `lints.workspace` because we override `lints.rust.unexpected_cfgs`
+[lints.clippy]
+borrow_as_ptr = "warn"
+cast_lossless = "warn"
+cast_possible_truncation = "warn"
+cast_possible_wrap = "warn"
+cast_precision_loss = "warn"
+cast_sign_loss = "warn"
+checked_conversions = "warn"
+from_iter_instead_of_collect = "warn"
+implicit_saturating_sub = "warn"
+manual_assert = "warn"
+map_unwrap_or = "warn"
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
+mod_module_files = "warn"
+must_use_candidate = "warn"
+needless_range_loop = "allow"
+ptr_as_ptr = "warn"
+redundant_closure_for_method_calls = "warn"
+ref_as_ptr = "warn"
+return_self_not_must_use = "warn"
+semicolon_if_nothing_returned = "warn"
+trivially_copy_pass_by_ref = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"
+undocumented_unsafe_blocks = "warn"
+unnecessary_safety_comment = "warn"
+unwrap_in_result = "warn"
+unwrap_used = "warn"
+
+# NOTE: can't use `lints.workspace` because we override `lints.rust.unexpected_cfgs`
+[lints.rust]
+missing_copy_implementations = "warn"
+missing_debug_implementations = "warn"
+missing_docs = "warn"
+trivial_casts = "warn"
+trivial_numeric_casts = "warn"
+unused_lifetimes = "warn"
+unused_qualifications = "warn"
+
+# NOTE: these are the only lints we explicitly want to configure for p256
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(cpubits, values("16", "32", "64"))']
 
 [package.metadata.docs.rs]
 all-features = true

--- a/p256/LICENSE-MIT
+++ b/p256/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2023 RustCrypto Developers
+Copyright (c) 2020-2026 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/p256/benches/ecdsa.rs
+++ b/p256/benches/ecdsa.rs
@@ -1,5 +1,7 @@
 //! p256 ECDSA benchmarks
 
+#![allow(missing_docs, clippy::unwrap_used, reason = "benchmark")]
+
 use criterion::{criterion_group, criterion_main};
 use hex_literal::hex;
 use p256::ecdsa::{Signature, SigningKey};

--- a/p256/benches/field.rs
+++ b/p256/benches/field.rs
@@ -1,5 +1,7 @@
 //! secp256r1 field element benchmarks
 
+#![allow(missing_docs, clippy::unwrap_used, reason = "benchmark")]
+
 use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
@@ -26,7 +28,7 @@ fn test_field_element_y() -> FieldElement {
 fn bench_field_element_mul<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let x = test_field_element_x();
     let y = test_field_element_y();
-    group.bench_function("mul", |b| b.iter(|| &x * &y));
+    group.bench_function("mul", |b| b.iter(|| x * y));
 }
 
 fn bench_field_element_square<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {

--- a/p256/benches/point.rs
+++ b/p256/benches/point.rs
@@ -1,5 +1,8 @@
 //! p256 `ProjectivePoint` benchmarks
 
+#![allow(missing_docs, clippy::unwrap_used, reason = "benchmark")]
+
+use core::hint::black_box;
 use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
@@ -12,7 +15,6 @@ use p256::{
         subtle::ConstantTimeEq,
     },
 };
-use std::hint::black_box;
 
 fn test_scalar_x() -> Scalar {
     Scalar::from_repr(
@@ -41,10 +43,10 @@ fn bench_point_lincomb<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 
     group.bench_function("lincomb (2-term, naive)", |b| b.iter(|| (p * s) + (p * s)));
     group.bench_function("lincomb (2-term)", |b| {
-        b.iter(|| ProjectivePoint::lincomb(&[(p, s), (p, s)]))
+        b.iter(|| ProjectivePoint::lincomb(&[(p, s), (p, s)]));
     });
     group.bench_function("lincomb_vartime (2-term)", |b| {
-        b.iter(|| ProjectivePoint::lincomb_vartime(&[(p, s), (p, s)]))
+        b.iter(|| ProjectivePoint::lincomb_vartime(&[(p, s), (p, s)]));
     });
 }
 
@@ -53,7 +55,7 @@ fn bench_point_mul<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let s = test_scalar_x();
     group.bench_function("mul", |b| b.iter(|| black_box(p) * black_box(s)));
     group.bench_function("mul_vartime", |b| {
-        b.iter(|| black_box(p).mul_vartime(&black_box(s)))
+        b.iter(|| black_box(p).mul_vartime(&black_box(s)));
     });
 }
 
@@ -61,13 +63,13 @@ fn bench_point_mul_by_generator<M: Measurement>(group: &mut BenchmarkGroup<'_, M
     let x = test_scalar_x();
     let y = test_scalar_y();
     group.bench_function("ProjectivePoint::GENERATOR * scalar", |b| {
-        b.iter(|| ProjectivePoint::GENERATOR * &black_box(x))
+        b.iter(|| ProjectivePoint::GENERATOR * black_box(x));
     });
     group.bench_function("mul_by_generator", |b| {
-        b.iter(|| ProjectivePoint::mul_by_generator(&black_box(x)))
+        b.iter(|| ProjectivePoint::mul_by_generator(&black_box(x)));
     });
     group.bench_function("mul_by_generator_vartime", |b| {
-        b.iter(|| ProjectivePoint::mul_by_generator_vartime(&black_box(x)))
+        b.iter(|| ProjectivePoint::mul_by_generator_vartime(&black_box(x)));
     });
     group.bench_function("mul_by_generator_and_mul_add_vartime", |b| {
         b.iter(|| {
@@ -76,7 +78,7 @@ fn bench_point_mul_by_generator<M: Measurement>(group: &mut BenchmarkGroup<'_, M
                 &black_box(y),
                 &black_box(ProjectivePoint::GENERATOR),
             )
-        })
+        });
     });
 }
 
@@ -84,10 +86,10 @@ fn bench_point_normalize<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let p = ProjectivePoint::GENERATOR;
     let points = [p, p];
     group.bench_function("batch_normalize (2p)", |b| {
-        b.iter(|| ProjectivePoint::batch_normalize(&black_box(points)))
+        b.iter(|| ProjectivePoint::batch_normalize(&black_box(points)));
     });
     group.bench_function("batch_normalize_vartime (2p)", |b| {
-        b.iter(|| ProjectivePoint::batch_normalize_vartime(&black_box(points)))
+        b.iter(|| ProjectivePoint::batch_normalize_vartime(&black_box(points)));
     });
     group.bench_function("normalize (1p)", |b| b.iter(|| black_box(p).to_affine()));
 }
@@ -102,7 +104,7 @@ fn bench_point(c: &mut Criterion) {
     bench_point_normalize(&mut group);
 
     group.bench_function("ct_eq", |b| {
-        b.iter(|| ProjectivePoint::GENERATOR.ct_eq(&ProjectivePoint::GENERATOR))
+        b.iter(|| ProjectivePoint::GENERATOR.ct_eq(&ProjectivePoint::GENERATOR));
     });
 
     group.finish();

--- a/p256/benches/scalar.rs
+++ b/p256/benches/scalar.rs
@@ -1,11 +1,13 @@
 //! secp256r1 scalar arithmetic benchmarks
 
+#![allow(missing_docs, clippy::unwrap_used, reason = "benchmark")]
+
+use core::hint::black_box;
 use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
 use hex_literal::hex;
 use p256::{Scalar, elliptic_curve::PrimeField};
-use std::hint::black_box;
 
 fn test_scalar_x() -> Scalar {
     Scalar::from_repr(

--- a/p256/src/arithmetic/hash2curve.rs
+++ b/p256/src/arithmetic/hash2curve.rs
@@ -118,8 +118,13 @@ mod tests {
             / NonZero::new(U256::from_u8(4)).unwrap();
 
         assert_eq!(
-            Array::from_iter(params.c1.iter().rev().flat_map(|v| v.to_be_bytes())),
-            c1.to_be_byte_array()
+            c1.to_be_byte_array(),
+            params
+                .c1
+                .iter()
+                .rev()
+                .flat_map(|v| v.to_be_bytes())
+                .collect::<Array<_, _>>(),
         );
 
         let c2 = FieldElement::from_u64(10).sqrt().unwrap();

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -60,32 +60,38 @@ impl Scalar {
     pub const ONE: Self = Self(U256::ONE);
 
     /// Returns the SEC1 encoding of this scalar.
+    #[must_use]
     pub fn to_bytes(&self) -> FieldBytes {
         self.0.to_be_byte_array()
     }
 
     /// Returns self + rhs mod n
+    #[must_use]
     pub const fn add(&self, rhs: &Self) -> Self {
         Self(self.0.add_mod(&rhs.0, NistP256::ORDER.as_nz_ref()))
     }
 
     /// Returns 2*self.
+    #[must_use]
     pub const fn double(&self) -> Self {
         self.add(self)
     }
 
     /// Returns self - rhs mod n.
+    #[must_use]
     pub const fn sub(&self, rhs: &Self) -> Self {
         Self(self.0.sub_mod(&rhs.0, NistP256::ORDER.as_nz_ref()))
     }
 
     /// Returns self * rhs mod n
+    #[must_use]
     pub const fn multiply(&self, rhs: &Self) -> Self {
         let (lo, hi) = self.0.widening_mul(&rhs.0);
         Self(barrett_reduce(lo, hi))
     }
 
     /// Returns self * self mod n
+    #[must_use]
     pub const fn square(&self) -> Self {
         // Schoolbook multiplication.
         self.multiply(self)
@@ -94,6 +100,7 @@ impl Scalar {
     /// Right shifts the scalar.
     ///
     /// Note: not constant-time with respect to the `shift` parameter.
+    #[must_use]
     pub const fn shr_vartime(&self, shift: u32) -> Scalar {
         Self(self.0.unbounded_shr_vartime(shift))
     }
@@ -131,6 +138,7 @@ impl Scalar {
     /// **This operation is variable time with respect to the exponent `exp`.**
     ///
     /// If the exponent is fixed, this operation is constant time.
+    #[must_use]
     pub const fn pow_vartime<const RHS_LIMBS: usize>(&self, exp: &Uint<RHS_LIMBS>) -> Self {
         let mut res = Self::ONE;
         let mut i = RHS_LIMBS;
@@ -157,6 +165,7 @@ impl Scalar {
     /// **This operation is variable time with respect to the exponent `n`.**
     ///
     /// If the exponent is fixed, this operation is constant time.
+    #[must_use]
     pub const fn sqn_vartime(&self, n: usize) -> Self {
         let mut x = *self;
         let mut i = 0;
@@ -168,11 +177,13 @@ impl Scalar {
     }
 
     /// Is integer representing equivalence class odd?
+    #[must_use]
     pub fn is_odd(&self) -> Choice {
         self.0.is_odd().into()
     }
 
     /// Is integer representing equivalence class even?
+    #[must_use]
     pub fn is_even(&self) -> Choice {
         !self.is_odd()
     }
@@ -355,6 +366,7 @@ impl IsHigh for Scalar {
 impl Shr<usize> for Scalar {
     type Output = Self;
 
+    #[allow(clippy::cast_possible_truncation, reason = "TODO")]
     fn shr(self, rhs: usize) -> Self::Output {
         self.shr_vartime(rhs as u32)
     }
@@ -363,6 +375,7 @@ impl Shr<usize> for Scalar {
 impl Shr<usize> for &Scalar {
     type Output = Scalar;
 
+    #[allow(clippy::cast_possible_truncation, reason = "TODO")]
     fn shr(self, rhs: usize) -> Self::Output {
         self.shr_vartime(rhs as u32)
     }

--- a/p256/src/arithmetic/tables.rs
+++ b/p256/src/arithmetic/tables.rs
@@ -27,6 +27,7 @@ pub(crate) mod backend {
     use primeorder::MulBackend;
 
     /// Backend based on precomputed tables.
+    #[derive(Clone, Copy, Debug)]
     pub struct PrecomputedTables;
 
     impl MulBackend<NistP256> for PrecomputedTables {
@@ -63,7 +64,7 @@ mod tests {
     proptest! {
         #[test]
         fn basepoint_table_mul(x in scalar()) {
-            let expected = ProjectivePoint::GENERATOR * &x;
+            let expected = ProjectivePoint::GENERATOR * x;
             let actual = BASEPOINT_TABLE.mul(&x);
             prop_assert_eq!(expected, actual);
         }
@@ -72,7 +73,7 @@ mod tests {
     proptest! {
         #[test]
         fn basepoint_table_mul_vartime(x in scalar()) {
-            let expected = ProjectivePoint::GENERATOR * &x;
+            let expected = ProjectivePoint::GENERATOR * x;
             let actual = BASEPOINT_TABLE.mul_vartime(&x);
             prop_assert_eq!(expected, actual);
         }

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -5,15 +5,6 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![forbid(unsafe_code)]
-#![warn(
-    clippy::mod_module_files,
-    clippy::unwrap_used,
-    missing_docs,
-    rust_2018_idioms,
-    unused_lifetimes,
-    unused_qualifications
-)]
 
 //! ## `serde` support
 //!

--- a/p256/tests/affine.rs
+++ b/p256/tests/affine.rs
@@ -82,7 +82,7 @@ fn compact_round_trip() {
 
     let point = AffinePoint::from_sec1_point(&pubkey).unwrap();
     let res = point.to_compact_encoded_point().unwrap();
-    assert_eq!(res, pubkey)
+    assert_eq!(res, pubkey);
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn uncompact_to_compact() {
 
     let point = AffinePoint::from_sec1_point(&pubkey).unwrap();
     let res = point.to_compact_encoded_point().unwrap();
-    assert_eq!(res.as_bytes(), COMPACT_BASEPOINT)
+    assert_eq!(res.as_bytes(), COMPACT_BASEPOINT);
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn identity_encoding() {
         AffinePoint::from_bytes(&AffinePoint::IDENTITY.to_bytes())
             .unwrap()
             .is_identity()
-    ))
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Because `p256` overrides `lints.rust.unexpected_cfgs`, we can't actually use `lints.workspace = true`.

So this vendors the lints with a note as to why. Supposedly future Rust versions will make it possible to use workspace-level lints with select overrides.