### PR TITLE
k256: remove duplicate ecdsa CI build

### DIFF
--- a/.github/workflows/k256.yml
+++ b/.github/workflows/k256.yml
@@ -52,7 +52,6 @@ jobs:
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features schnorr
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features serde
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features sha256
-      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdsa
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdsa,sha256
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features critical-section,ecdh,ecdsa,group-digest,pem,pkcs8,schnorr,serde,sha256
 


### PR DESCRIPTION
## Summary

- Remove a duplicate `k256` CI build step for `--no-default-features --features ecdsa`
- Keep the existing standalone `ecdsa` build and the `ecdsa,sha256` coverage intact

## Rationale

The `k256` workflow was running the exact same ARM/no_std `ecdsa` build command twice:

```text
cargo build --target thumbv7em-none-eabi --release --no-default-features --features ecdsa