### PR TITLE
bp256+bp384: use explicit `a = -3` for brainpoolP*t1

### DIFF
--- a/bp256/src/t1/arithmetic.rs
+++ b/bp256/src/t1/arithmetic.rs
@@ -32,12 +32,10 @@ impl FieldArithmetic for BrainpoolP256t1 {
 }
 
 impl PrimeCurveParams for BrainpoolP256t1 {
-    type PointArithmetic = point_arithmetic::EquationAIsGeneric;
+    type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
     type Backend = mul_backend::VariableOnly;
 
-    const EQUATION_A: FieldElement = FieldElement::from_hex_vartime(
-        "a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5374",
-    );
+    const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();
     const EQUATION_B: FieldElement = FieldElement::from_hex_vartime(
         "662c61c430d84ea4fe66a7733d0b76b7bf93ebc4af2f49256ae58101fee92b04",
     );

--- a/bp384/src/t1/arithmetic.rs
+++ b/bp384/src/t1/arithmetic.rs
@@ -32,12 +32,10 @@ impl PrimeCurveArithmetic for BrainpoolP384t1 {
 }
 
 impl PrimeCurveParams for BrainpoolP384t1 {
-    type PointArithmetic = point_arithmetic::EquationAIsGeneric;
+    type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
     type Backend = mul_backend::VariableOnly;
 
-    const EQUATION_A: FieldElement = FieldElement::from_hex_vartime(
-        "8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec50",
-    );
+    const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();
     const EQUATION_B: FieldElement = FieldElement::from_hex_vartime(
         "7f519eada7bda81bd826dba647910f8c4b9346ed8ccdc64e4b1abd11756dce1d2074aa263b88805ced70355a33b471ee",
     );


### PR DESCRIPTION
Makes the constants more explicit and uses the optimized formulas