### PR TITLE
fix `cargo doc` E0080 on MSRV 1.85 (p256/p384/p521/sm2/k256)

### DIFF
--- a/k256/src/arithmetic/tables.rs
+++ b/k256/src/arithmetic/tables.rs
@@ -18,5 +18,7 @@ type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
 pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
 
 impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for Secp256k1 {
+    /// Workaround for rust-lang/rust#140653: hide from rustdoc const-eval (E0080) until MSRV 1.90
+    #[doc(hidden)]
     const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
 }

--- a/p256/src/arithmetic/tables.rs
+++ b/p256/src/arithmetic/tables.rs
@@ -14,6 +14,8 @@ pub(super) type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WIN
 pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
 
 impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for NistP256 {
+    /// Workaround for rust-lang/rust#140653: hide from rustdoc const-eval (E0080) until MSRV 1.90
+    #[doc(hidden)]
     const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
 }
 

--- a/p384/src/arithmetic/tables.rs
+++ b/p384/src/arithmetic/tables.rs
@@ -14,6 +14,8 @@ pub(super) type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WIN
 pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
 
 impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for NistP384 {
+    /// Workaround for rust-lang/rust#140653: hide from rustdoc const-eval (E0080) until MSRV 1.90
+    #[doc(hidden)]
     const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
 }
 

--- a/p521/src/arithmetic/tables.rs
+++ b/p521/src/arithmetic/tables.rs
@@ -14,6 +14,8 @@ pub(super) type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WIN
 pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
 
 impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for NistP521 {
+    /// Workaround for rust-lang/rust#140653: hide from rustdoc const-eval (E0080) until MSRV 1.90
+    #[doc(hidden)]
     const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
 }
 

--- a/sm2/src/arithmetic/tables.rs
+++ b/sm2/src/arithmetic/tables.rs
@@ -14,6 +14,8 @@ pub(super) type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WIN
 pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
 
 impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for Sm2 {
+    /// Workaround for rust-lang/rust#140653: hide from rustdoc const-eval (E0080) until MSRV 1.90
+    #[doc(hidden)]
     const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
 }
 


### PR DESCRIPTION
Fixes #1909.

`cargo doc` fails on the published `p256`/`p384`/`p521`/`sm2`/`k256` 0.14.x crates when building with Rust 1.85-1.89 (`E0080` at `src/arithmetic/tables.rs`).

This adds `#[doc(hidden)]` to the offending associated const in all five affected crates (p256, p384, p521, sm2, k256).  
Hiding the const from rustdoc prevents the const evaluator from running on it, resolving `E0080` while keeping MSRV 1.85.  
The const remains usable at runtime; only its doc rendering is suppressed.

```bash
docker run --rm rust:1.85.0 bash -c '
  apt-get update -qq && apt-get install -y -qq git >/dev/null
  git clone --depth 1 --branch feat/fix-doc-e0080-rust140653 https://github.com/Warfront1/elliptic-curves.git /repo
  cd /repo
  cargo doc --workspace --all-features
'
```

The underlying rustc issue ([rust-lang/rust#140653](https://github.com/rust-lang/rust/issues/140653)) is fixed in Rust 1.90 ([rust-lang/rust#140942](https://github.com/rust-lang/rust/pull/140942)).  
When MSRV is bumped to 1.90, this `#[doc(hidden)]` workaround can be removed.