### PR TITLE
wnaf: handle scalar representation endianness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,6 +1535,7 @@ dependencies = [
  "ff",
  "group",
  "hybrid-array",
+ "primefield",
 ]
 
 [[package]]

--- a/bignp256/tests/projective.rs
+++ b/bignp256/tests/projective.rs
@@ -8,6 +8,7 @@ use bignp256::{
 };
 use elliptic_curve::{
     group::{GroupEncoding, ff::PrimeField},
+    ops::{LinearCombination, MulVartime},
     sec1::{self, ToSec1Point},
 };
 use primeorder::{Double, test_projective_arithmetic};
@@ -24,4 +25,28 @@ test_projective_arithmetic!(
 fn projective_identity_to_bytes() {
     // This is technically an invalid SEC1 encoding, but is preferable to panicking.
     assert_eq!([0; 33], ProjectivePoint::IDENTITY.to_bytes().as_slice());
+}
+
+#[test]
+fn projective_vartime_scalar_multiplication() {
+    let generator = ProjectivePoint::GENERATOR;
+
+    assert_eq!(generator.mul_vartime(&Scalar::ONE), generator);
+    assert_eq!(
+        generator.mul_vartime(&Scalar::from(2u64)),
+        generator.double()
+    );
+}
+
+#[test]
+fn projective_vartime_linear_combination() {
+    let generator = ProjectivePoint::GENERATOR;
+    let terms = [(generator, Scalar::ONE), (generator, Scalar::ONE)];
+
+    assert_eq!(ProjectivePoint::lincomb_vartime(&terms), generator.double());
+    #[cfg(feature = "alloc")]
+    assert_eq!(
+        ProjectivePoint::lincomb_vartime(terms.as_slice()),
+        generator.double()
+    );
 }

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -3,8 +3,8 @@
 #![allow(clippy::needless_range_loop, clippy::op_ref)]
 
 use crate::{
-    AffinePoint, ArraySize, Field, LookupTable, MulBackend, PrimeCurveParams, PrimeFieldExt,
-    Radix16Decomposition, Radix16Digits, point_arithmetic::PointArithmetic,
+    AffinePoint, ArraySize, Field, LookupTable, MulBackend, PrimeCurveParams, Radix16Decomposition,
+    Radix16Digits, point_arithmetic::PointArithmetic,
 };
 use core::{array, borrow::Borrow, iter::Sum, iter::zip};
 use elliptic_curve::{
@@ -43,11 +43,6 @@ pub(crate) type WnafBase<C> = wnaf::WnafBase<ProjectivePoint<C>, DefaultWnafWind
 
 /// `WnafScalar` generic around an elliptic curve `C` using default window size for this curve.
 pub(crate) type WnafScalar<C> = wnaf::WnafScalar<Scalar<C>, DefaultWnafWindowSize>;
-
-fn wnaf_scalar<C: PrimeCurveParams>(scalar: &Scalar<C>) -> WnafScalar<C> {
-    let repr = scalar.to_le_repr();
-    WnafScalar::<C>::from_le_bytes(repr.as_ref())
-}
 
 /// Point on a Weierstrass curve in projective coordinates.
 #[derive(Clone, Copy, Debug)]
@@ -145,7 +140,7 @@ where
     #[inline]
     #[must_use]
     pub fn mul_vartime(&self, k: &Scalar<C>) -> Self {
-        WnafBase::<C>::new(self) * wnaf_scalar::<C>(k)
+        WnafBase::<C>::new(self) * WnafScalar::<C>::new(k)
     }
 }
 
@@ -508,7 +503,7 @@ where
             .collect();
         let scalars: Vec<_> = points_and_scalars
             .iter()
-            .map(|(_, scalar)| wnaf_scalar::<C>(scalar))
+            .map(|(_, scalar)| WnafScalar::<C>::new(scalar))
             .collect();
 
         WnafBase::multiscalar_mul(bases.iter().zip(scalars.iter()))
@@ -529,7 +524,7 @@ where
 
     fn lincomb_vartime(points_and_scalars: &[(Self, Scalar<C>); N]) -> Self {
         let bases = points_and_scalars.map(|(point, _)| WnafBase::<C>::new(&point));
-        let scalars = points_and_scalars.map(|(_, scalar)| wnaf_scalar::<C>(&scalar));
+        let scalars = points_and_scalars.map(|(_, scalar)| WnafScalar::<C>::new(&scalar));
         WnafBase::multiscalar_mul(bases.iter().zip(scalars.iter()))
     }
 }

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -3,8 +3,8 @@
 #![allow(clippy::needless_range_loop, clippy::op_ref)]
 
 use crate::{
-    AffinePoint, ArraySize, Field, LookupTable, MulBackend, PrimeCurveParams, Radix16Decomposition,
-    Radix16Digits, point_arithmetic::PointArithmetic,
+    AffinePoint, ArraySize, Field, LookupTable, MulBackend, PrimeCurveParams, PrimeFieldExt,
+    Radix16Decomposition, Radix16Digits, point_arithmetic::PointArithmetic,
 };
 use core::{array, borrow::Borrow, iter::Sum, iter::zip};
 use elliptic_curve::{
@@ -43,6 +43,11 @@ pub(crate) type WnafBase<C> = wnaf::WnafBase<ProjectivePoint<C>, DefaultWnafWind
 
 /// `WnafScalar` generic around an elliptic curve `C` using default window size for this curve.
 pub(crate) type WnafScalar<C> = wnaf::WnafScalar<Scalar<C>, DefaultWnafWindowSize>;
+
+fn wnaf_scalar<C: PrimeCurveParams>(scalar: &Scalar<C>) -> WnafScalar<C> {
+    let repr = scalar.to_le_repr();
+    WnafScalar::<C>::from_le_bytes(repr.as_ref())
+}
 
 /// Point on a Weierstrass curve in projective coordinates.
 #[derive(Clone, Copy, Debug)]
@@ -140,7 +145,7 @@ where
     #[inline]
     #[must_use]
     pub fn mul_vartime(&self, k: &Scalar<C>) -> Self {
-        WnafBase::<C>::new(self) * WnafScalar::<C>::new(k)
+        WnafBase::<C>::new(self) * wnaf_scalar::<C>(k)
     }
 }
 
@@ -503,7 +508,7 @@ where
             .collect();
         let scalars: Vec<_> = points_and_scalars
             .iter()
-            .map(|(_, scalar)| WnafScalar::<C>::new(scalar))
+            .map(|(_, scalar)| wnaf_scalar::<C>(scalar))
             .collect();
 
         WnafBase::multiscalar_mul(bases.iter().zip(scalars.iter()))
@@ -524,7 +529,7 @@ where
 
     fn lincomb_vartime(points_and_scalars: &[(Self, Scalar<C>); N]) -> Self {
         let bases = points_and_scalars.map(|(point, _)| WnafBase::<C>::new(&point));
-        let scalars = points_and_scalars.map(|(_, scalar)| WnafScalar::<C>::new(&scalar));
+        let scalars = points_and_scalars.map(|(_, scalar)| wnaf_scalar::<C>(&scalar));
         WnafBase::multiscalar_mul(bases.iter().zip(scalars.iter()))
     }
 }

--- a/wnaf/Cargo.toml
+++ b/wnaf/Cargo.toml
@@ -23,6 +23,7 @@ rust-version = "1.85"
 array = { version = "0.4.13", package = "hybrid-array" }
 ff = { version = "0.14", default-features = false }
 group = { version = "0.14", default-features = false }
+primefield = { version = "0.14", default-features = false }
 
 [features]
 default = ["alloc"]

--- a/wnaf/src/boxed.rs
+++ b/wnaf/src/boxed.rs
@@ -4,6 +4,7 @@ use crate::{Digit, WnafGroup, le_repr, wnaf_form, wnaf_multi_exp, wnaf_table};
 use alloc::vec::Vec;
 use ff::PrimeField;
 use group::Group;
+use primefield::PrimeFieldExt;
 
 #[cfg(doc)]
 use crate::{WnafBase, WnafScalar};
@@ -126,7 +127,10 @@ impl<G: WnafGroup> BoxedWnaf<(), Vec<G>, Vec<Digit>> {
     }
 
     /// Construct wNAF context for `scalar`.
-    pub fn scalar(&mut self, scalar: &G::Scalar) -> BoxedWnaf<usize, &mut Vec<G>, &[Digit]> {
+    pub fn scalar(&mut self, scalar: &G::Scalar) -> BoxedWnaf<usize, &mut Vec<G>, &[Digit]>
+    where
+        G::Scalar: PrimeFieldExt,
+    {
         let window_size = 4;
 
         let repr = le_repr(scalar);
@@ -187,6 +191,7 @@ impl<B, S: AsMut<Vec<Digit>>> BoxedWnaf<usize, B, S> {
     pub fn scalar<G: Group>(&mut self, scalar: &G::Scalar) -> G
     where
         B: AsRef<[G]>,
+        G::Scalar: PrimeFieldExt,
     {
         let repr = le_repr(scalar);
         let bit_len = init_storage::<G::Scalar>(self.scalar.as_mut(), repr);

--- a/wnaf/src/lib.rs
+++ b/wnaf/src/lib.rs
@@ -32,7 +32,7 @@ pub use group::Group;
 pub use crate::boxed::BoxedWnaf;
 
 use crate::limb_buffer::LimbBuffer;
-use ff::PrimeField;
+use primefield::PrimeFieldExt;
 
 /// Type used to represent wNAF digits.
 ///
@@ -194,9 +194,6 @@ where
 }
 
 /// Get the little endian representation of a field, namely a scalar.
-fn le_repr<F: PrimeField>(fe: &F) -> F::Repr {
-    let mut ret = fe.to_repr();
-    // TODO(tarcieri): determine endianness via `PrimeField` trait. See zkcrypto/rfcs#4
-    ret.as_mut().reverse();
-    ret
+fn le_repr<F: PrimeFieldExt>(fe: &F) -> F::Repr {
+    fe.to_le_repr()
 }

--- a/wnaf/src/traits.rs
+++ b/wnaf/src/traits.rs
@@ -4,8 +4,8 @@ use array::{
     ArraySize,
     typenum::{U1, U2, U3, U4, U5, U6, U7, U8, U16, U32, U64, Unsigned},
 };
-use ff::PrimeField;
 use group::Group;
+use primefield::PrimeFieldExt;
 
 /// Allowed wNAF window size: we use this to precompute the window point sizes, because it's
 /// currently not possible to write bounds for them.
@@ -23,7 +23,7 @@ pub trait WnafGroup: Group {
 
 /// Size of the wNAF representation: this should be the type-level equivalent of
 /// `PrimeField::NUM_BITS + 1`, which includes an extra entry for any remaining carry.
-pub trait WnafSize: PrimeField {
+pub trait WnafSize: PrimeFieldExt {
     /// Number of digits in the wNAF representation.
     type StorageSize: ArraySize;
 }


### PR DESCRIPTION
## Summary

Fix variable-time scalar multiplication for curves whose `PrimeField::Repr` is little-endian.

`WnafScalar::new()` assumes that `PrimeField::to_repr()` is big-endian and unconditionally reverses it. Since representation endianness is implementation-specific and `bignp256::Scalar` is already little-endian, this caused its scalars to be interpreted with the wrong value.

This change:

- converts primeorder scalars with `PrimeFieldExt::to_le_repr()`
- constructs wNAF scalars using `WnafScalar::from_le_bytes()`
- applies the conversion to `mul_vartime` and both `lincomb_vartime` paths
- adds bignp256 regression tests for scalar multiplication and linear combinations

## Testing

- `cargo test -p bignp256 --all-features`
- `cargo test -p bignp256 --no-default-features --features arithmetic,test-vectors`
- `cargo test -p primeorder --all-features`
- `cargo clippy -p bignp256 --all-targets --all-features -- -D warnings`
- `cargo clippy -p primeorder --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`