### PR TITLE
wnaf v0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,7 +1387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1542,7 +1542,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wnaf"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "ff",
  "group",

--- a/wnaf/CHANGELOG.md
+++ b/wnaf/CHANGELOG.md
@@ -4,5 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.14.0 (2026-07-02)
+## 0.14.1 (2026-09-03)
+### Changed
+- Use `primefield` bounds to determine scalar representation endianness ([#1913])
+
+[#1913]: https://github.com/RustCrypto/elliptic-curves/pull/1913
+
+## 0.14.0 (2026-07-02) [YANKED]
+Note: this release was yanked to a breaking bounds change we hope does not cause issues in practice.
+
 Initial release. Version number synchronized with `elliptic-curve`.

--- a/wnaf/Cargo.toml
+++ b/wnaf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wnaf"
-version = "0.14.0"
+version = "0.14.1"
 description = """
 wNAF (w-ary non-adjacent form) variable-time scalar multiplication implemented generically
 over elliptic curve groups with full `no_alloc` support, including multiscalar multiplication using


### PR DESCRIPTION
This release contains a breaking change (#1913) to use `primefield` traits for determining endianness. The original hope was that the existing `ff` traits could be used instead (zkcrypto/ff#158), but we ended up having to ship our own traits (#1809) due to inaction from upstream.

This is a release blocker for `bignp256` which needs little endian support, so we're making this change hoping that despite being breaking it should be compatible with all existing usages. We can re-evaluate if that winds up not being the case.

The `wnaf` v0.14.0 release will be yanked accordingly to mandate the new bounds.