### PR TITLE
x448: simplify the low-order assertion

### DIFF
--- a/x448/src/lib.rs
+++ b/x448/src/lib.rs
@@ -312,7 +312,7 @@ mod test {
         // If by chance, a low order point is generated, the clamping function will
         // remove it.
         let low_order = alice_pub.0.is_low_order() || bob_pub.0.is_low_order();
-        assert!(low_order == false);
+        assert!(!low_order);
 
         // Both Alice and Bob perform the DH key exchange.
         // As mentioned above, we unwrap because both Parties are using the API correctly.


### PR DESCRIPTION

Replace assert!(low_order == false) with the idiomatic assert!(!low_order) in the X448 random Diffie-Hellman test.


The assertion checks the same boolean condition directly and avoids an unnecessary comparison. Test behavior is unchanged.