### PR TITLE
docs(ed448): fix extended coordinate terminology

### DIFF
--- a/ed448-goldilocks/src/edwards/extended.rs
+++ b/ed448-goldilocks/src/edwards/extended.rs
@@ -36,7 +36,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 #[cfg(feature = "alloc")]
 use alloc::{boxed::Box, vec::Vec};
 
-/// Represent points on the (untwisted) edwards curve using Extended Homogenous Projective Co-ordinates
+/// Represent points on the (untwisted) Edwards curve using extended homogeneous projective coordinates
 /// (x, y) -> (X/Z, Y/Z, Z, T)
 /// a = 1, d = -39081
 /// XXX: Make this more descriptive


### PR DESCRIPTION
Uses the conventional spelling and capitalization for Edwards extended homogeneous projective coordinates in the `ed448-goldilocks` point representation documentation. 

This is a rustdoc-only correction and does not alter the coordinate representation or implementation. 

`cargo fmt --all -- --check` passes.