### PR TITLE
`bignp256`: add precomputed tables and `bigint` backend

### DIFF
--- a/.github/workflows/bignp256.yml
+++ b/.github/workflows/bignp256.yml
@@ -88,6 +88,11 @@ jobs:
       - run: cargo test --release --target ${{ matrix.target }} --no-default-features
       - run: cargo test --release --target ${{ matrix.target }}
       - run: cargo test --release --target ${{ matrix.target }} --all-features
+      - env:
+          RUSTFLAGS: '--cfg bignp256_backend="bigint"'
+          RUSTDOCFLAGS: '--cfg bignp256_backend="bigint"'
+        run: cargo test --release --target ${{ matrix.target }} --all-features
+
 
   cross:
     strategy:

--- a/bignp256/Cargo.toml
+++ b/bignp256/Cargo.toml
@@ -50,9 +50,10 @@ alloc = ["elliptic-curve/alloc", "primeorder?/alloc"]
 std = ["alloc", "elliptic-curve/std", "getrandom", "primeorder?/std"]
 
 arithmetic = ["dep:primefield", "dep:primeorder", "elliptic-curve/arithmetic"]
-ecdsa = ["arithmetic", "dep:signature", "dep:belt-hash", "dep:bign-genk", "dep:belt-block", "belt-block/cipher", "belt-hash/oid"]
+ecdsa = ["arithmetic", "dep:signature", "dep:belt-hash", "dep:bign-genk", "dep:belt-block", "dep:digest", "belt-block/cipher", "belt-hash/oid"]
 getrandom = ["elliptic-curve/getrandom"]
 pem = ["elliptic-curve/pem", "sec1/pem", "pkcs8"]
+precomputed-tables = ["arithmetic", "primeorder/basepoint-table"]
 pkcs8 = ["elliptic-curve/pkcs8"]
 ecdh = ["arithmetic", "elliptic-curve/ecdh", "dep:digest", "dep:hkdf", "dep:hmac", "dep:belt-hash", "alloc"]
 serde = ["elliptic-curve/serde", "primeorder?/serde"]
@@ -61,7 +62,10 @@ swu = ["primeorder/hash2curve", "hash2curve", "belt-kwp"]
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
-check-cfg = ['cfg(cpubits, values("16", "32", "64"))']
+check-cfg = [
+    'cfg(cpubits, values("16", "32", "64"))',
+    'cfg(bignp256_backend, values("bigint", "fiat"))' # default: "fiat"
+]
 
 [[bench]]
 name = "field"

--- a/bignp256/src/arithmetic.rs
+++ b/bignp256/src/arithmetic.rs
@@ -7,13 +7,14 @@
 
 pub(crate) mod field;
 pub(crate) mod scalar;
+#[cfg(feature = "precomputed-tables")]
+pub(crate) mod tables;
 
 pub use self::{field::FieldElement, scalar::Scalar};
 pub use elliptic_curve::{CurveArithmetic, PrimeCurveArithmetic, hazmat::FieldArithmetic};
 pub use primeorder::{PrimeCurveParams, point_arithmetic};
 
 use crate::BignP256;
-use primeorder::mul_backend;
 
 /// Elliptic curve point in affine coordinates.
 pub type AffinePoint = primeorder::AffinePoint<BignP256>;
@@ -37,7 +38,10 @@ impl PrimeCurveArithmetic for BignP256 {
 
 impl PrimeCurveParams for BignP256 {
     type PointArithmetic = point_arithmetic::EquationAIsGeneric;
-    type Backend = mul_backend::VariableOnly;
+    #[cfg(not(feature = "precomputed-tables"))]
+    type Backend = primeorder::mul_backend::VariableOnly;
+    #[cfg(feature = "precomputed-tables")]
+    type Backend = tables::backend::PrecomputedTables;
 
     const EQUATION_A: Self::FieldElement = FieldElement::from_hex_vartime(
         "40FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",

--- a/bignp256/src/arithmetic/field.rs
+++ b/bignp256/src/arithmetic/field.rs
@@ -15,13 +15,16 @@
 
 use crate::U256;
 use elliptic_curve::{
-    bigint::cpubits,
     ff::PrimeField,
     ops::BatchInvert,
     subtle::{Choice, ConstantTimeEq, CtOption},
 };
 
+#[cfg(not(bignp256_backend = "bigint"))]
+use elliptic_curve::bigint::cpubits;
+
 // TODO(tarcieri): remove this when we can use `const _` to silence warnings
+#[cfg(not(bignp256_backend = "bigint"))]
 cpubits! {
     32 => {
         #[path = "field/bignp256_32.rs"]
@@ -53,6 +56,7 @@ cpubits! {
     }
 }
 
+#[cfg(not(bignp256_backend = "bigint"))]
 use self::field_impl::*;
 
 /// Constant representing the modulus: p = 2^{256} − 189
@@ -74,6 +78,14 @@ primefield::monty_field_element! {
     doc: "Element in the bign-curve256v1 finite field modulo p = 2^{256} − 189"
 }
 
+#[cfg(bignp256_backend = "bigint")]
+primefield::monty_field_arithmetic! {
+    name: FieldElement,
+    params: FieldParams,
+    uint: U256
+}
+
+#[cfg(not(bignp256_backend = "bigint"))]
 primefield::fiat_monty_field_arithmetic! {
     name: FieldElement,
     params: FieldParams,
@@ -98,12 +110,15 @@ impl BatchInvert for FieldElement {}
 #[cfg(test)]
 mod tests {
     use super::{FieldElement, U256};
+    #[cfg(not(bignp256_backend = "bigint"))]
     use super::{
         FieldParams, fiat_bignp256_montgomery_domain_field_element, fiat_bignp256_msat,
         fiat_bignp256_non_montgomery_domain_field_element, fiat_bignp256_to_montgomery,
     };
 
     primefield::test_primefield!(FieldElement, U256);
+
+    #[cfg(not(bignp256_backend = "bigint"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: FieldElement,
         params: FieldParams,

--- a/bignp256/src/arithmetic/scalar.rs
+++ b/bignp256/src/arithmetic/scalar.rs
@@ -5,7 +5,6 @@
 use crate::{BignP256, ORDER_HEX, U256};
 use elliptic_curve::{
     Curve as _,
-    bigint::cpubits,
     ff::PrimeField,
     scalar::{FromUintUnchecked, IsHigh},
     subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, CtOption},
@@ -13,6 +12,10 @@ use elliptic_curve::{
 use primefield::ByteOrder;
 use primeorder::wnaf;
 
+#[cfg(not(bignp256_backend = "bigint"))]
+use elliptic_curve::bigint::cpubits;
+
+#[cfg(not(bignp256_backend = "bigint"))]
 cpubits! {
     32 => {
         #[path = "scalar/bignp256_scalar_32.rs"]
@@ -44,6 +47,7 @@ cpubits! {
     }
 }
 
+#[cfg(not(bignp256_backend = "bigint"))]
 use self::scalar_impl::*;
 
 #[cfg(doc)]
@@ -65,6 +69,14 @@ primefield::monty_field_element! {
     doc: "Element in the bign-curve256v1 scalar field modulo n"
 }
 
+#[cfg(bignp256_backend = "bigint")]
+primefield::monty_field_arithmetic! {
+    name: Scalar,
+    params: ScalarParams,
+    uint: U256
+}
+
+#[cfg(not(bignp256_backend = "bigint"))]
 primefield::fiat_monty_field_arithmetic! {
     name: Scalar,
     params: ScalarParams,
@@ -118,6 +130,7 @@ impl IsHigh for Scalar {
 #[cfg(test)]
 mod tests {
     use super::{Scalar, U256};
+    #[cfg(not(bignp256_backend = "bigint"))]
     use super::{
         ScalarParams, fiat_bignp256_scalar_montgomery_domain_field_element,
         fiat_bignp256_scalar_msat, fiat_bignp256_scalar_non_montgomery_domain_field_element,
@@ -125,6 +138,8 @@ mod tests {
     };
 
     primefield::test_primefield!(Scalar, U256);
+
+    #[cfg(not(bignp256_backend = "bigint"))]
     primefield::test_fiat_monty_field_arithmetic!(
         name: Scalar,
         params: ScalarParams,

--- a/bignp256/src/arithmetic/tables.rs
+++ b/bignp256/src/arithmetic/tables.rs
@@ -1,0 +1,43 @@
+//! Precomputed tables (optional).
+
+use super::BignP256;
+use crate::ProjectivePoint;
+use primeorder::PrimeCurveWithBasepointTable;
+
+/// Window size for the basepoint table (1 + 32-byte modulus)
+pub(super) const WINDOW_SIZE: usize = 33;
+
+/// Basepoint table for multiples of bign-curve256v1's generator.
+pub(super) type BasepointTable = primeorder::BasepointTable<ProjectivePoint, WINDOW_SIZE>;
+
+/// Lazily computed basepoint table.
+pub(super) static BASEPOINT_TABLE: BasepointTable = BasepointTable::new();
+
+impl PrimeCurveWithBasepointTable<WINDOW_SIZE> for BignP256 {
+    const BASEPOINT_TABLE: &'static BasepointTable = &BASEPOINT_TABLE;
+}
+
+/// Workaround for rust-lang/rust#140653 to support MSRV 1.85, mirroring `p256`: we can't use
+/// `primeorder::mul_backend::PrecomputedTables` until MSRV 1.90.
+// TODO(tarcieri): remove this and switch to `primeorder::mul_backend::PrecomputedTables` when MSRV 1.90
+pub(crate) mod backend {
+    use super::BASEPOINT_TABLE;
+    use crate::{BignP256, ProjectivePoint, Scalar};
+    use primeorder::MulBackend;
+
+    /// Backend based on precomputed tables.
+    #[derive(Clone, Copy, Debug)]
+    pub struct PrecomputedTables;
+
+    impl MulBackend<BignP256> for PrecomputedTables {
+        #[inline]
+        fn mul_by_generator(k: &Scalar) -> ProjectivePoint {
+            BASEPOINT_TABLE.mul(k)
+        }
+
+        #[inline]
+        fn mul_by_generator_vartime(k: &Scalar) -> ProjectivePoint {
+            BASEPOINT_TABLE.mul_vartime(k)
+        }
+    }
+}


### PR DESCRIPTION
- add `precomputed-tables` feature
- add bigint backend
- fix digest feature for ecdsa
- add tests for bigint backend