### PR TITLE
docs: make monty_field_element to_bytes byte-order agnostic

### DIFF
--- a/primefield/src/macros.rs
+++ b/primefield/src/macros.rs
@@ -202,9 +202,9 @@ macro_rules! monty_field_element {
                 Self($crate::MontyFieldElement::<$params, { <$params>::LIMBS }>::from_u64(w))
             }
 
-            /// Returns the big-endian encoding of this [`
+            /// Returns the canonical byte encoding of this [`
             #[doc = stringify!($fe)]
-            /// `].
+            /// `] using the field's configured byte order.
             pub fn to_bytes(self) -> $crate::MontyFieldBytes<$params, { <$params>::LIMBS }> {
                 self.0.to_bytes()
             }


### PR DESCRIPTION


Update the `to_bytes()` documentation generated by `primefield::monty_field_element!` to describe the configured byte order instead of hard-coding big-endian.

`MontyFieldElement::to_bytes()` selects the encoding based on `MOD::BYTE_ORDER`, and `bignp256` uses little-endian field parameters.


